### PR TITLE
Add cats-effect interop module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.10! coreJVM/test http4s/compile examples/compile
+      - run: sbt ++2.12.10! coreJVM/test http4s/compile examples/compile catsInteropJVM/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.1! coreJVM/test http4s/compile examples/compile
+      - run: sbt ++2.13.1! coreJVM/test http4s/compile examples/compile catsInteropJVM/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -49,7 +49,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.10! coreJS/test
+      - run: sbt ++2.12.10! coreJS/test catsInteropJS/compile
       - save_cache:
           key: sbtcache
           paths:

--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,18 @@ lazy val coreJS = core.js.settings(
   libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3" % Test
 )
 
+lazy val catsInterop = crossProject(JSPlatform, JVMPlatform)
+  .in(file("interop/cats"))
+  .settings(name := "caliban-cats")
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Seq("org.typelevel" %%% "cats-effect" % "2.0.0")
+  )
+  .jsConfigure(_.dependsOn(coreJS))
+  .jvmConfigure(_.dependsOn(coreJVM))
+lazy val catsInteropJVM = catsInterop.jvm
+lazy val catsInteropJS  = catsInterop.js
+
 lazy val http4s = project
   .in(file("http4s"))
   .settings(name := "caliban-http4s")
@@ -93,23 +105,11 @@ lazy val http4s = project
   )
   .dependsOn(coreJVM)
 
-lazy val catsInterop = project
-  .in(file("interop/cats"))
-  .settings(name := "caliban-cats")
-  .settings(commonSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "dev.zio"       %% "zio"         % "1.0.0-RC15",
-      "org.typelevel" %% "cats-effect" % "2.0.0"
-    )
-  )
-  .dependsOn(coreJVM)
-
 lazy val examples = project
   .in(file("examples"))
   .settings(commonSettings)
   .settings(skip in publish := true)
-  .dependsOn(http4s, catsInterop)
+  .dependsOn(http4s, catsInteropJVM)
 
 lazy val benchmarks = project
   .in(file("benchmarks"))

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val root = project
   .enablePlugins(ScalaJSPlugin)
   .settings(skip in publish := true)
   .settings(historyPath := None)
-  .aggregate(coreJVM, coreJS, http4s)
+  .aggregate(coreJVM, coreJS, http4s, catsInteropJVM, catsInteropJS)
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
@@ -73,14 +73,14 @@ lazy val coreJS = core.js.settings(
 )
 
 lazy val catsInterop = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
   .in(file("interop/cats"))
   .settings(name := "caliban-cats")
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq("org.typelevel" %%% "cats-effect" % "2.0.0")
   )
-  .jsConfigure(_.dependsOn(coreJS))
-  .jvmConfigure(_.dependsOn(coreJVM))
+  .dependsOn(core)
 lazy val catsInteropJVM = catsInterop.jvm
 lazy val catsInteropJS  = catsInterop.js
 
@@ -103,7 +103,7 @@ lazy val http4s = project
       )
     )
   )
-  .dependsOn(coreJVM)
+  .dependsOn(coreJVM, catsInteropJVM)
 
 lazy val examples = project
   .in(file("examples"))

--- a/build.sbt
+++ b/build.sbt
@@ -7,14 +7,19 @@ inThisBuild(
   List(
     organization := "com.github.ghostdogpr",
     homepage := Some(url("https://github.com/ghostdogpr/caliban")),
-    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    licenses := List(
+      "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
+    ),
     scalaVersion := mainScala,
     parallelExecution in Test := false,
     pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),
     pgpPublicRing := file("/tmp/public.asc"),
     pgpSecretRing := file("/tmp/secret.asc"),
     scmInfo := Some(
-      ScmInfo(url("https://github.com/ghostdogpr/caliban/"), "scm:git:git@github.com:ghostdogpr/caliban.git")
+      ScmInfo(
+        url("https://github.com/ghostdogpr/caliban/"),
+        "scm:git:git@github.com:ghostdogpr/caliban.git"
+      )
     ),
     developers := List(
       Developer(
@@ -32,7 +37,10 @@ ThisBuild / publishTo := sonatypePublishToBundle.value
 
 name := "caliban"
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
-addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
+addCommandAlias(
+  "check",
+  "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck"
+)
 
 lazy val root = project
   .in(file("."))
@@ -58,10 +66,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
     )
   )
-  .jvmSettings(
-    fork in Test := true,
-    fork in run := true
-  )
+  .jvmSettings(fork in Test := true, fork in run := true)
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js.settings(
   libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3" % Test
@@ -80,7 +85,22 @@ lazy val http4s = project
       "org.http4s"    %% "http4s-blaze-server" % "0.21.0-M5",
       "io.circe"      %% "circe-parser"        % "0.12.2",
       "io.circe"      %% "circe-derivation"    % "0.12.0-M7",
-      compilerPlugin(("org.typelevel" %% "kind-projector" % "0.11.0").cross(CrossVersion.full))
+      compilerPlugin(
+        ("org.typelevel" %% "kind-projector" % "0.11.0")
+          .cross(CrossVersion.full)
+      )
+    )
+  )
+  .dependsOn(coreJVM)
+
+lazy val catsInterop = project
+  .in(file("interop/cats"))
+  .settings(name := "caliban-cats")
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio"       %% "zio"         % "1.0.0-RC15",
+      "org.typelevel" %% "cats-effect" % "2.0.0"
     )
   )
   .dependsOn(coreJVM)
@@ -89,7 +109,7 @@ lazy val examples = project
   .in(file("examples"))
   .settings(commonSettings)
   .settings(skip in publish := true)
-  .dependsOn(http4s)
+  .dependsOn(http4s, catsInterop)
 
 lazy val benchmarks = project
   .in(file("benchmarks"))

--- a/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
+++ b/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
@@ -9,7 +9,7 @@ object ExampleCatsInterop extends IOApp {
 
   import caliban.interop.cats.implicits._
 
-  implicit val runtime = new DefaultRuntime {}
+  implicit val runtime = CatsInterop.defaultZioRuntime
 
   case class Number(value: Int)
 

--- a/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
+++ b/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
@@ -1,0 +1,34 @@
+package caliban.interop.cats
+
+import caliban.GraphQL.graphQL
+import caliban.RootResolver
+import cats.effect.{ExitCode, IO, IOApp}
+import zio.DefaultRuntime
+
+object ExampleCatsInterop extends IOApp {
+
+  import caliban.interop.cats.implicits._
+
+  implicit val runtime = new DefaultRuntime {}
+
+  case class Number(value: Int)
+
+  case class Queries(numbers: List[Number])
+
+  val query = """
+  {
+    numbers {
+      value
+    }
+  }"""
+
+  override def run(args: List[String]): IO[ExitCode] = {
+    val queries = Queries(List(1, 2, 3, 4).map(Number))
+    val interpreter = graphQL(RootResolver(queries))
+
+    for {
+      result <- interpreter.executeAsync[IO](query)
+      _ <- IO(println(result))
+    } yield ExitCode.Success
+  }
+}

--- a/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
+++ b/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
@@ -9,7 +9,7 @@ object ExampleCatsInterop extends IOApp {
 
   import caliban.interop.cats.implicits._
 
-  implicit val runtime = CatsInterop.defaultZioRuntime
+  implicit val runtime = new DefaultRuntime {}
 
   case class Number(value: Int)
 

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -9,8 +9,6 @@ import zio.{ DefaultRuntime, Runtime }
 
 object CatsInterop {
 
-  val defaultZioRuntime = new DefaultRuntime {}
-
   def executeAsync[F[_]: Async, R, Q, M, S](graphQL: GraphQL[R, Q, M, S])(
     query: String,
     operationName: Option[String] = None,

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -3,9 +3,9 @@ package caliban.interop.cats
 import cats.instances.either._
 import cats.syntax.functor._
 import caliban.parsing.adt.Value
-import caliban.{GraphQL, ResponseValue}
+import caliban.{ GraphQL, ResponseValue }
 import cats.effect.Async
-import zio.{DefaultRuntime, Runtime}
+import zio.{ DefaultRuntime, Runtime }
 
 object CatsInterop {
 

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -1,11 +1,11 @@
 package caliban.interop.cats
 
-import cats.instances.either._
-import cats.syntax.functor._
 import caliban.parsing.adt.Value
 import caliban.{ GraphQL, ResponseValue }
 import cats.effect.Async
-import zio.{ DefaultRuntime, Runtime }
+import cats.instances.either._
+import cats.syntax.functor._
+import zio.Runtime
 
 object CatsInterop {
 

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -1,0 +1,22 @@
+package caliban.interop.cats
+
+import caliban.parsing.adt.Value
+import caliban.{GraphQL, ResponseValue}
+import cats.effect.Async
+import zio.Runtime
+
+object CatsInterop {
+
+  def executeAsync[F[_]: Async, R, Q, M, S](graphQL: GraphQL[R, Q, M, S])(
+    query: String,
+    operationName: Option[String] = None,
+    variables: Map[String, Value] = Map(),
+    skipValidation: Boolean = false
+  )(implicit runtime: Runtime[R]): F[ResponseValue] =
+    Async[F].async { cb =>
+      val execution =
+        graphQL.execute(query, operationName, variables, skipValidation)
+
+      runtime.unsafeRunAsync(execution)(exit => cb(exit.toEither))
+    }
+}

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -3,9 +3,11 @@ package caliban.interop.cats
 import caliban.parsing.adt.Value
 import caliban.{GraphQL, ResponseValue}
 import cats.effect.Async
-import zio.Runtime
+import zio.{DefaultRuntime, Runtime}
 
 object CatsInterop {
+
+  val defaultZioRuntime = new DefaultRuntime {}
 
   def executeAsync[F[_]: Async, R, Q, M, S](graphQL: GraphQL[R, Q, M, S])(
     query: String,
@@ -18,5 +20,12 @@ object CatsInterop {
         graphQL.execute(query, operationName, variables, skipValidation)
 
       runtime.unsafeRunAsync(execution)(exit => cb(exit.toEither))
+    }
+
+  def checkAsync[F[_]: Async, R, Q, M, S](
+    graphQL: GraphQL[R, Q, M, S]
+  )(query: String)(implicit runtime: Runtime[R]): F[Unit] =
+    Async[F].async { cb =>
+      runtime.unsafeRunAsync(graphQL.execute(query))(exit => cb(exit.toEither))
     }
 }

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -1,5 +1,7 @@
 package caliban.interop.cats
 
+import cats.instances.either._
+import cats.syntax.functor._
 import caliban.parsing.adt.Value
 import caliban.{GraphQL, ResponseValue}
 import cats.effect.Async
@@ -26,6 +28,6 @@ object CatsInterop {
     graphQL: GraphQL[R, Q, M, S]
   )(query: String)(implicit runtime: Runtime[R]): F[Unit] =
     Async[F].async { cb =>
-      runtime.unsafeRunAsync(graphQL.execute(query))(exit => cb(exit.toEither))
+      runtime.unsafeRunAsync(graphQL.execute(query))(exit => cb(exit.toEither.void))
     }
 }

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -23,5 +23,10 @@ package object implicits {
         variables,
         skipValidation
       )
+
+    def checkAsync[F[_]: Async](
+      query: String
+    )(implicit runtime: Runtime[R]): F[Unit] =
+      CatsInterop.checkAsync(underlying)(query)
   }
 }

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -1,0 +1,27 @@
+package caliban.interop.cats
+
+import caliban.parsing.adt.Value
+import caliban.{GraphQL, ResponseValue}
+import cats.effect.Async
+import zio.Runtime
+
+package object implicits {
+
+  implicit class CatsEffectGraphQL[R, Q, M, S](
+    underlying: GraphQL[R, Q, M, S]
+  ) {
+
+    def executeAsync[F[_]: Async](
+      query: String,
+      operationName: Option[String] = None,
+      variables: Map[String, Value] = Map(),
+      skipValidation: Boolean = false
+    )(implicit runtime: Runtime[R]): F[ResponseValue] =
+      CatsInterop.executeAsync(underlying)(
+        query,
+        operationName,
+        variables,
+        skipValidation
+      )
+  }
+}

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -1,7 +1,7 @@
 package caliban.interop.cats
 
 import caliban.parsing.adt.Value
-import caliban.{GraphQL, ResponseValue}
+import caliban.{ GraphQL, ResponseValue }
 import cats.effect.Async
 import zio.Runtime
 


### PR DESCRIPTION
Goes some of the way to fix #37 and is based on the @ghostdogpr comment there. The design is to add an `executeAsync[F[_]: Async]` method to `GraphQL` instances via an implicit class. I've also included an example usage (in an `IOApp`) to the examples project. Hope it helps!