### PR TITLE
Implement validations

### DIFF
--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -7,6 +7,7 @@ import caliban.introspection.Introspector
 import caliban.introspection.adt._
 import caliban.parsing.adt.ExecutableDefinition.{ FragmentDefinition, OperationDefinition }
 import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
+import caliban.parsing.adt.Type.NamedType
 import caliban.parsing.adt.Value.{ NullValue, VariableValue }
 import caliban.parsing.adt.{ Directive, Document, OperationType, Selection, Type, Value }
 import caliban.schema.{ RootType, Types }
@@ -14,44 +15,45 @@ import zio.IO
 
 object Validator {
 
+  case class Context(
+    document: Document,
+    rootType: RootType,
+    operations: List[OperationDefinition],
+    fragments: Map[String, FragmentDefinition],
+    selectionSets: List[Selection]
+  )
+
   /**
    * Verifies that the given document is valid for this type. Fails with a [[caliban.CalibanError.ValidationError]] otherwise.
    */
   def validate(document: Document, rootType: RootType): IO[ValidationError, Unit] = {
     val (operations, fragments) = collectOperationsAndFragments(document)
     for {
-      _                 <- validateOperationNameUniqueness(operations)
-      _                 <- validateLoneAnonymousOperation(operations)
-      fragmentMap       <- validateFragments(fragments)
-      selectionSets     = collectSelectionSets(operations.flatMap(_.selectionSet) ++ fragments.flatMap(_.selectionSet))
-      _                 <- validateDirectives(selectionSets)
-      _                 <- validateFragmentSpreads(selectionSets, fragments)
-      _                 <- validateVariables(operations, fragments, rootType)
-      _                 <- validateSubscriptionOperation(operations, fragmentMap)
-      typesForFragments = collectTypesValidForFragments(rootType)
-      _                 <- validateDocumentFields(document, rootType, typesForFragments)
+      fragmentMap   <- validateFragments(fragments)
+      selectionSets = collectSelectionSets(operations.flatMap(_.selectionSet) ++ fragments.flatMap(_.selectionSet))
+      context       = Context(document, rootType, operations, fragmentMap, selectionSets)
+      _             <- validateOperationNameUniqueness(operations)
+      _             <- validateLoneAnonymousOperation(operations)
+      _             <- validateDirectives(selectionSets)
+      _             <- validateFragmentSpreads(context)
+      _             <- validateVariables(context)
+      _             <- validateSubscriptionOperation(context)
+      _             <- validateDocumentFields(context)
     } yield ()
   }
 
-  private def collectOperationsAndFragments(
-    document: Document
-  ): (List[OperationDefinition], List[FragmentDefinition]) =
+  private def collectOperationsAndFragments(document: Document): (List[OperationDefinition], List[FragmentDefinition]) =
     document.definitions.foldLeft((List.empty[OperationDefinition], List.empty[FragmentDefinition])) {
       case ((operations, fragments), o: OperationDefinition) => (o :: operations, fragments)
       case ((operations, fragments), f: FragmentDefinition)  => (operations, f :: fragments)
     }
 
-  private def collectTypesValidForFragments(rootType: RootType): Map[String, __Type] =
-    rootType.types.filter {
-      case (_, t) => t.kind == __TypeKind.OBJECT || t.kind == __TypeKind.INTERFACE || t.kind == __TypeKind.UNION
-    }
-
-  private def collectVariablesUsed(selectionSet: List[Selection], fragments: List[FragmentDefinition]): Set[String] = {
+  private def collectVariablesUsed(context: Context, selectionSet: List[Selection]): Set[String] = {
     def collectValues(selectionSet: List[Selection]): List[Value] =
       selectionSet.flatMap {
         case FragmentSpread(name, directives) =>
-          directives.flatMap(_.arguments.values) ++ fragments
-            .find(_.name == name)
+          directives.flatMap(_.arguments.values) ++ context.fragments
+            .get(name)
             .map(f => f.directives.flatMap(_.arguments.values) ++ collectValues(f.selectionSet))
             .getOrElse(Nil)
         case Field(_, _, arguments, directives, selectionSet) =>
@@ -96,12 +98,8 @@ object Validator {
 
   }
 
-  private def validateVariables(
-    definitions: List[OperationDefinition],
-    fragments: List[FragmentDefinition],
-    rootType: RootType
-  ): IO[ValidationError, Unit] =
-    IO.foreach(definitions)(
+  private def validateVariables(context: Context): IO[ValidationError, Unit] =
+    IO.foreach(context.operations)(
         op =>
           IO.foreach(op.variableDefinitions.groupBy(_.name)) {
             case (name, variables) =>
@@ -115,7 +113,7 @@ object Validator {
               )
           } *> IO.foreach(op.variableDefinitions) { v =>
             val t = Type.innerType(v.variableType)
-            IO.whenCase(rootType.types.get(t).map(_.kind)) {
+            IO.whenCase(context.rootType.types.get(t).map(_.kind)) {
               case Some(__TypeKind.OBJECT) | Some(__TypeKind.UNION) | Some(__TypeKind.INTERFACE) =>
                 IO.fail(
                   ValidationError(
@@ -125,7 +123,7 @@ object Validator {
                 )
             }
           } *> {
-            val variableUsages = collectVariablesUsed(op.selectionSet, fragments)
+            val variableUsages = collectVariablesUsed(context, op.selectionSet)
             IO.foreach(variableUsages)(
               v =>
                 IO.when(!op.variableDefinitions.exists(_.name == v))(
@@ -154,104 +152,121 @@ object Validator {
   private def collectFragmentSpreads(selectionSet: List[Selection]): List[FragmentSpread] =
     selectionSet.collect { case f: FragmentSpread => f }
 
-  private def validateFragmentSpreads(
-    selectionSets: List[Selection],
-    fragments: List[FragmentDefinition]
-  ): IO[ValidationError, Unit] = {
-    val spreads       = collectFragmentSpreads(selectionSets)
-    val spreadNames   = spreads.map(_.name).toSet
-    val fragmentNames = fragments.map(_.name).toSet
-    IO.foreach(fragments)(
-      f =>
-        if (!spreadNames.contains(f.name))
-          IO.fail(
-            ValidationError(
-              s"Fragment '${f.name}' is not used in any spread.",
-              "Defined fragments must be used within a document."
-            )
-          )
-        else if (detectCycles(f, fragments))
-          IO.fail(
-            ValidationError(
-              s"Fragment '${f.name}' forms a cycle.",
-              "The graph of fragment spreads must not form any cycles including spreading itself. Otherwise an operation could infinitely spread or infinitely execute on cycles in the underlying data."
-            )
-          )
-        else IO.unit
-    ) *> IO
-      .foreach(spreadNames)(
-        spread =>
-          IO.when(!fragmentNames.contains(spread))(
+  private def validateFragmentSpreads(context: Context): IO[ValidationError, Unit] = {
+    val spreads     = collectFragmentSpreads(context.selectionSets)
+    val spreadNames = spreads.map(_.name).toSet
+    IO.foreach(context.fragments.values)(
+        f =>
+          if (!spreadNames.contains(f.name))
             IO.fail(
               ValidationError(
-                s"Fragment spread '$spread' is not defined.",
-                "Named fragment spreads must refer to fragments defined within the document. It is a validation error if the target of a spread is not defined."
+                s"Fragment '${f.name}' is not used in any spread.",
+                "Defined fragments must be used within a document."
               )
             )
-          )
+          else if (detectCycles(context, f))
+            IO.fail(
+              ValidationError(
+                s"Fragment '${f.name}' forms a cycle.",
+                "The graph of fragment spreads must not form any cycles including spreading itself. Otherwise an operation could infinitely spread or infinitely execute on cycles in the underlying data."
+              )
+            )
+          else IO.unit
       )
       .unit
   }
 
-  private def detectCycles(
-    fragment: FragmentDefinition,
-    fragments: List[FragmentDefinition],
-    visited: Set[String] = Set()
-  ): Boolean = {
+  private def detectCycles(context: Context, fragment: FragmentDefinition, visited: Set[String] = Set()): Boolean = {
     val selectionSets     = collectSelectionSets(fragment.selectionSet)
     val descendantSpreads = collectFragmentSpreads(selectionSets)
     descendantSpreads.exists(
       s =>
         visited.contains(s.name) ||
-          fragments.find(_.name == s.name).fold(false)(f => detectCycles(f, fragments, visited + s.name))
+          context.fragments.get(s.name).fold(false)(f => detectCycles(context, f, visited + s.name))
     )
   }
 
-  private def validateDocumentFields(
-    document: Document,
-    rootType: RootType,
-    typesForFragments: Map[String, __Type]
-  ): IO[ValidationError, Unit] =
-    IO.foreach(document.definitions) {
+  private def validateDocumentFields(context: Context): IO[ValidationError, Unit] =
+    IO.foreach(context.document.definitions) {
         case OperationDefinition(opType, _, _, _, selectionSet) =>
           opType match {
-            case OperationType.Query => validateFields(selectionSet, rootType.queryType)
+            case OperationType.Query => validateFields(context, selectionSet, context.rootType.queryType)
             case OperationType.Mutation =>
-              rootType.mutationType.fold[IO[ValidationError, Unit]](
+              context.rootType.mutationType.fold[IO[ValidationError, Unit]](
                 IO.fail(ValidationError("Mutation operations are not supported on this schema.", ""))
-              )(validateFields(selectionSet, _))
+              )(validateFields(context, selectionSet, _))
             case OperationType.Subscription =>
-              rootType.subscriptionType.fold[IO[ValidationError, Unit]](
+              context.rootType.subscriptionType.fold[IO[ValidationError, Unit]](
                 IO.fail(ValidationError("Subscription operations are not supported on this schema.", ""))
-              )(validateFields(selectionSet, _))
+              )(validateFields(context, selectionSet, _))
           }
-        case FragmentDefinition(name, typeCondition, _, selectionSet) =>
-          IO.fromOption(typesForFragments.get(typeCondition.name))
-            .mapError(
-              _ =>
-                ValidationError(
-                  s"Fragment '$name' targets an invalid type: '${typeCondition.name}'.",
-                  "Fragments must be specified on types that exist in the schema. This applies for both named and inline fragments. If they are not defined in the schema, the query does not validate."
-                )
-            )
-            .flatMap(t => validateFields(selectionSet, t) *> validateFragmentType(Some(name), t))
+        case _: FragmentDefinition => IO.unit
       }
       .unit
 
-  private def validateFields(selectionSet: List[Selection], currentType: __Type): IO[ValidationError, Unit] =
+  private def validateFields(
+    context: Context,
+    selectionSet: List[Selection],
+    currentType: __Type
+  ): IO[ValidationError, Unit] =
     IO.foreach(selectionSet) {
-      case f: Field          => validateField(f, currentType)
-      case _: FragmentSpread => IO.unit
+      case f: Field => validateField(context, f, currentType)
+      case FragmentSpread(name, _) =>
+        context.fragments.get(name) match {
+          case None =>
+            IO.fail(
+              ValidationError(
+                s"Fragment spread '$name' is not defined.",
+                "Named fragment spreads must refer to fragments defined within the document. It is a validation error if the target of a spread is not defined."
+              )
+            )
+          case Some(fragment) =>
+            validateSpread(context, Some(name), currentType, Some(fragment.typeCondition), fragment.selectionSet)
+        }
       case InlineFragment(typeCondition, _, selectionSet) =>
-        (typeCondition match {
-          case Some(onType) =>
-            IO.fromOption(currentType.possibleTypes.getOrElse(Nil).find(_.name.contains(onType.name)))
-              .mapError(_ => ValidationError(s"Inline Fragment on invalid type '${onType.name}'.", ""))
-          case None => IO.succeed(currentType)
-        }).flatMap(t => validateFields(selectionSet, t) *> validateFragmentType(None, t))
+        validateSpread(context, None, currentType, typeCondition, selectionSet)
     } *> validateLeafFieldSelection(selectionSet, currentType)
 
-  private def validateField(field: Field, currentType: __Type): IO[ValidationError, Unit] =
+  private def validateSpread(
+    context: Context,
+    name: Option[String],
+    currentType: __Type,
+    typeCondition: Option[NamedType],
+    selectionSet: List[Selection]
+  ): IO[ValidationError, Unit] =
+    typeCondition.fold[Option[__Type]](Some(currentType))(t => context.rootType.types.get(t.name)) match {
+      case Some(fragmentType) =>
+        validateFragmentType(name, fragmentType) *> {
+          val possibleTypes         = getPossibleTypes(currentType).flatMap(_.name)
+          val possibleFragmentTypes = getPossibleTypes(fragmentType).flatMap(_.name)
+          val applicableTypes       = possibleTypes intersect possibleFragmentTypes
+          IO.when(applicableTypes.isEmpty)(
+            IO.fail(
+              ValidationError(
+                s"${name.fold("Inline fragment spread")(n => s"Fragment spread '$n'")} is not possible: possible types are '${possibleTypes
+                  .mkString(", ")}' and possible fragment types are '${possibleFragmentTypes.mkString(", ")}'.",
+                "Fragments are declared on a type and will only apply when the runtime object type matches the type condition. They also are spread within the context of a parent type. A fragment spread is only valid if its type condition could ever apply within the parent type."
+              )
+            )
+          ) *> validateFields(context, selectionSet, fragmentType)
+        }
+      case None =>
+        IO.fail(
+          ValidationError(
+            s"${name.fold("Inline fragment spread")(n => s"Fragment spread '$n'")} targets an invalid type: '${typeCondition.map(_.name).getOrElse("?")}'.",
+            "Fragments must be specified on types that exist in the schema. This applies for both named and inline fragments. If they are not defined in the schema, the query does not validate."
+          )
+        )
+    }
+
+  private def getPossibleTypes(t: __Type): List[__Type] =
+    t.kind match {
+      case __TypeKind.OBJECT                       => List(t)
+      case __TypeKind.INTERFACE | __TypeKind.UNION => t.possibleTypes.getOrElse(Nil)
+      case _                                       => Nil
+    }
+
+  private def validateField(context: Context, field: Field, currentType: __Type): IO[ValidationError, Unit] =
     IO.when(field.name != "__typename") {
       IO.fromOption(currentType.fields(__DeprecatedArgs(Some(true))).getOrElse(Nil).find(_.name == field.name))
         .mapError(
@@ -262,23 +277,25 @@ object Validator {
             )
         )
         .flatMap { f =>
-          validateFields(field.selectionSet, Types.innerType(f.`type`())) *>
+          validateFields(context, field.selectionSet, Types.innerType(f.`type`())) *>
             validateArguments(field, f, currentType)
         }
     }
 
   private def validateArguments(field: Field, f: __Field, currentType: __Type): IO[ValidationError, List[Unit]] =
-    IO.foreach(field.arguments.keys)(
-      arg =>
-        IO.when(!f.args.exists(_.name == arg))(
-          IO.fail(
-            ValidationError(
-              s"Argument '$arg' is not defined on field '${field.name}' of type '${currentType.name.getOrElse("")}'.",
-              "Every argument provided to a field or directive must be defined in the set of possible arguments of that field or directive."
+    IO.foreach(field.arguments) {
+      case (arg, argValue) =>
+        f.args.find(_.name == arg) match {
+          case None =>
+            IO.fail(
+              ValidationError(
+                s"Argument '$arg' is not defined on field '${field.name}' of type '${currentType.name.getOrElse("")}'.",
+                "Every argument provided to a field or directive must be defined in the set of possible arguments of that field or directive."
+              )
             )
-          )
-        )
-    ) *>
+          case Some(inputValue) => validateInputValues(inputValue, argValue)
+        }
+    } *>
       IO.foreach(f.args.filter(a => a.`type`().kind == __TypeKind.NON_NULL && a.defaultValue.isEmpty))(
         arg =>
           IO.when(field.arguments.get(arg.name).forall(_ == NullValue))(
@@ -291,6 +308,45 @@ object Validator {
             )
           )
       )
+
+  private def validateInputValues(inputValue: __InputValue, argValue: Value): IO[ValidationError, Unit] = {
+    val t           = inputValue.`type`()
+    val inputType   = if (t.kind == __TypeKind.NON_NULL) t.ofType.getOrElse(t) else t
+    val inputFields = inputType.inputFields.getOrElse(Nil)
+    argValue match {
+      case Value.ObjectValue(fields) =>
+        IO.foreach(fields) {
+          case (k, v) =>
+            inputFields.find(_.name == k) match {
+              case None =>
+                IO.fail(
+                  ValidationError(
+                    s"Input field '$k' is not defined on type '${inputType.name.getOrElse("?")}'.",
+                    "Every input field provided in an input object value must be defined in the set of possible fields of that input object’s expected type."
+                  )
+                )
+              case Some(value) => validateInputValues(value, v)
+            }
+        } *> IO
+          .foreach(inputFields)(
+            inputField =>
+              IO.when(
+                inputField.defaultValue.isEmpty &&
+                  inputField.`type`().kind == __TypeKind.NON_NULL &&
+                  !fields.contains(inputField.name)
+              )(
+                IO.fail(
+                  ValidationError(
+                    s"Required field '${inputField.name}' on object '${inputType.name.getOrElse("?")}' was not provided.",
+                    "Input object fields may be required. Much like a field may have required arguments, an input object may have required fields. An input field is required if it has a non‐null type and does not have a default value. Otherwise, the input object field is optional."
+                  )
+                )
+              )
+          )
+          .unit
+      case _ => IO.unit
+    }
+  }
 
   private def validateLeafFieldSelection(selections: List[Selection], currentType: __Type): IO[ValidationError, Unit] =
     IO.whenCase(currentType.kind) {
@@ -350,14 +406,11 @@ object Validator {
         } else IO.succeed(fragmentMap.updated(fragment.name, fragment))
     }
 
-  private def validateSubscriptionOperation(
-    operations: List[OperationDefinition],
-    fragments: Map[String, FragmentDefinition]
-  ): IO[ValidationError, Unit] =
+  private def validateSubscriptionOperation(context: Context): IO[ValidationError, Unit] =
     IO.fromOption(
-        operations
+        context.operations
           .filter(_.operationType == OperationType.Subscription)
-          .find(op => Executor.mergeSelectionSet(op.selectionSet, "", fragments, Map()).length > 1)
+          .find(op => Executor.mergeSelectionSet(op.selectionSet, "", context.fragments, Map()).length > 1)
       )
       .map(
         op =>
@@ -374,7 +427,8 @@ object Validator {
       case _ =>
         IO.fail(
           ValidationError(
-            s"Fragment '${name.getOrElse("inline")}' is defined on invalid type '${targetType.name.getOrElse("")}'",
+            s"${name.fold("Inline fragment")(n => s"Fragment '$n'")} is defined on invalid type '${targetType.name
+              .getOrElse("")}'",
             "Fragments can only be declared on unions, interfaces, and objects. They are invalid on scalars. They can only be applied on non‐leaf fields. This rule applies to both inline and named fragments."
           )
         )

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -128,7 +128,25 @@ object ValidationSpec
                  }
                }
               }""")
-          check(query, "Inline Fragment on invalid type 'Boolean'.")
+          check(
+            query,
+            "Inline fragment is defined on invalid type 'Boolean'"
+          )
+        },
+        testM("fragment on impossible type") {
+          val query = gqldoc("""
+             query {
+               characters {
+                 name
+                 ... on Role {
+                    name
+                 }
+               }
+              }""")
+          check(
+            query,
+            "Inline fragment spread is not possible: possible types are 'Character' and possible fragment types are 'Captain, Engineer, Mechanic, Pilot'."
+          )
         },
         testM("fragment unused") {
           val query = gqldoc("""
@@ -212,6 +230,20 @@ object ValidationSpec
                }
               }""")
           check(query, "Variable 'x' is not used.")
+        },
+        testM("invalid input field") {
+          val query = gqldoc("""
+             query {
+               exists(character: { unknown: "" })
+             }""")
+          check(query, "Input field 'unknown' is not defined on type 'CharacterInput'.")
+        },
+        testM("required input field not defined") {
+          val query = gqldoc("""
+             query {
+               exists(character: { name: "name" })
+             }""")
+          check(query, "Required field 'nicknames' on object 'CharacterInput' was not provided.")
         }
       )
     })

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -244,6 +244,24 @@ object ValidationSpec
                exists(character: { name: "name" })
              }""")
           check(query, "Required field 'nicknames' on object 'CharacterInput' was not provided.")
+        },
+        testM("directive used in wrong location") {
+          val query = gqldoc("""
+             query @skip(if: true) {
+               characters {
+                 name
+               }
+             }""")
+          check(query, "Directive 'skip' is used in invalid location 'QUERY'.")
+        },
+        testM("directive used twice") {
+          val query = gqldoc("""
+             query {
+               characters {
+                 name @skip(if: true) @skip(if: true)
+               }
+             }""")
+          check(query, "Directive 'skip' is defined twice.")
         }
       )
     })


### PR DESCRIPTION
Part of #7
- [x] https://graphql.github.io/graphql-spec/June2018/#sec-Fragment-spread-is-possible
- [x] https://graphql.github.io/graphql-spec/June2018/#sec-Input-Object-Field-Names
- [x] https://graphql.github.io/graphql-spec/June2018/#sec-Input-Object-Field-Uniqueness
- [x] https://graphql.github.io/graphql-spec/June2018/#sec-Input-Object-Required-Fields
- [x] https://graphql.github.io/graphql-spec/June2018/#sec-Directives-Are-In-Valid-Locations
- [x] https://graphql.github.io/graphql-spec/June2018/#sec-Directives-Are-Unique-Per-Location