### PR TITLE
Ability to wrap query execution

### DIFF
--- a/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
+++ b/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
@@ -144,7 +144,7 @@ class GraphQLBenchmarks {
     )
   )
 
-  val interpreter: GraphQL[Any, Query, Unit, Unit] = graphQL(resolver)
+  val interpreter: GraphQL[Any, Query, Unit, Unit, CalibanError] = graphQL(resolver)
 
   @Benchmark
   def simpleCaliban(): Unit = {

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -26,7 +26,12 @@ object CalibanError {
   /**
    * Describes an error that happened while executing a query.
    */
-  case class ExecutionError(msg: String, innerThrowable: Option[Throwable] = None) extends CalibanError {
-    override def toString: String = s"""Execution error: $msg ${innerThrowable.map(_.toString).getOrElse("")}"""
+  case class ExecutionError(msg: String, fieldName: Option[String] = None, innerThrowable: Option[Throwable] = None)
+      extends CalibanError {
+    override def toString: String = {
+      val field = fieldName.fold("")(f => s" on field '$f'")
+      val inner = innerThrowable.fold("")(e => s"\n${e.toString}")
+      s"Execution error$field: $msg$inner"
+    }
   }
 }

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -23,7 +23,7 @@ trait GraphQL[-R, -Q, -M, -S, +E] { self =>
   /**
    * Parses and validates the provided query against this interpreter.
    * @param query a string containing the GraphQL query.
-   * @return an effect that either fails with an `E` or succeeds with `Unit`
+   * @return an effect that either fails with a [[CalibanError]] or succeeds with `Unit`
    */
   def check(query: String): IO[CalibanError, Unit]
 

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -12,31 +12,20 @@ import caliban.validation.Validator
 import zio.{ IO, ZIO }
 
 /**
- * A `GraphQL[R, Q, M, S]` represents a GraphQL interpreter for a query type `Q`, a mutation type `M`
- * and a subscription type `S`, requiring a ZIO environment of type `R` to be ran.
+ * A `GraphQL[R, Q, M, S, E]` represents a GraphQL interpreter for a query type `Q`, a mutation type `M`
+ * and a subscription type `S`, whose execution requires a ZIO environment of type `R` and can fail with an `E`.
  *
  * It is intended to be created only once, typically when you start your server.
  * The introspection schema will be generated when this class is instantiated.
  */
-class GraphQL[-R, -Q, -M, -S](schema: RootSchema[R, Q, M, S]) {
-
-  private val rootType = RootType(schema.query.opType, schema.mutation.map(_.opType), schema.subscription.map(_.opType))
-  private val introspectionRootSchema: RootSchema[Any, __Introspection, Nothing, Nothing] =
-    Introspector.introspect(rootType)
-  private val introspectionRootType = RootType(introspectionRootSchema.query.opType, None, None)
+trait GraphQL[-R, -Q, -M, -S, +E] { self =>
 
   /**
    * Parses and validates the provided query against this interpreter.
    * @param query a string containing the GraphQL query.
-   * @return an effect that either fails with a [[CalibanError]] or succeeds with `Unit`
+   * @return an effect that either fails with an `E` or succeeds with `Unit`
    */
-  def check(query: String): IO[CalibanError, Unit] =
-    for {
-      document       <- Parser.parseQuery(query)
-      intro          = Introspector.isIntrospection(document)
-      typeToValidate = if (intro) introspectionRootType else rootType
-      _              <- Validator.validate(document, typeToValidate)
-    } yield ()
+  def check(query: String): IO[CalibanError, Unit]
 
   /**
    * Parses, validates and finally runs the provided query against this interpreter.
@@ -44,27 +33,52 @@ class GraphQL[-R, -Q, -M, -S](schema: RootSchema[R, Q, M, S]) {
    * @param operationName the operation to run in case the query contains multiple operations.
    * @param variables a list of variables.
    * @param skipValidation skips the validation step if true
-   * @return an effect that either fails with a [[CalibanError]] or succeeds with a [[ResponseValue]]
+   * @return an effect that either fails with an `E` or succeeds with a [[ResponseValue]]
    */
   def execute(
     query: String,
     operationName: Option[String] = None,
     variables: Map[String, Value] = Map(),
     skipValidation: Boolean = false
-  ): ZIO[R, CalibanError, ResponseValue] =
-    for {
-      document        <- Parser.parseQuery(query)
-      intro           = Introspector.isIntrospection(document)
-      typeToValidate  = if (intro) introspectionRootType else rootType
-      schemaToExecute = if (intro) introspectionRootSchema else schema
-      _               <- IO.when(!skipValidation)(Validator.validate(document, typeToValidate))
-      result          <- Executor.executeRequest(document, schemaToExecute, operationName, variables)
-    } yield result
+  ): ZIO[R, E, ResponseValue]
 
   /**
    * Returns a string that renders the interpreter types into the GraphQL format.
    */
-  def render: String = renderTypes(rootType.types)
+  def render: String
+
+  /**
+   * Changes the error channel of the `execute` method.
+   * This can be used to customize error messages.
+   * @param f a function from the current error type `E` to another type `E2`
+   * @return a new GraphQL interpreter with error type `E2`
+   */
+  def mapError[E2](f: E => E2): GraphQL[R, Q, M, S, E2] = wrapExecutionWith(_.mapError(f))
+
+  /**
+   * Eliminates the ZIO environment R requirement of the interpreter.
+   * @param r a value of type `R`
+   * @return a new GraphQL interpreter with R = `Any`
+   */
+  def provide(r: R): GraphQL[Any, Q, M, S, E] = wrapExecutionWith(_.provide(r))
+
+  /**
+   * Wraps the `execute` method of the interpreter with the given function.
+   * This can be used to customize errors, add global timeouts or logging functions.
+   * @param f a function from `ZIO[R, E, ResponseValue]` to `ZIO[R2, E2, ResponseValue]`
+   * @return a new GraphQL interpreter
+   */
+  def wrapExecutionWith[R2, E2](f: ZIO[R, E, ResponseValue] => ZIO[R2, E2, ResponseValue]): GraphQL[R2, Q, M, S, E2] =
+    new GraphQL[R2, Q, M, S, E2] {
+      override def check(query: String): IO[CalibanError, Unit] = self.check(query)
+      override def execute(
+        query: String,
+        operationName: Option[String],
+        variables: Map[String, Value],
+        skipValidation: Boolean
+      ): ZIO[R2, E2, ResponseValue] = f(self.execute(query, operationName, variables, skipValidation))
+      override def render: String   = self.render
+    }
 }
 
 object GraphQL {
@@ -79,13 +93,41 @@ object GraphQL {
     implicit querySchema: Schema[R, Q],
     mutationSchema: Schema[R, M],
     subscriptionSchema: Schema[R, S]
-  ): GraphQL[R, Q, M, S] =
-    new GraphQL[R, Q, M, S](
-      RootSchema(
+  ): GraphQL[R, Q, M, S, CalibanError] =
+    new GraphQL[R, Q, M, S, CalibanError] {
+      val schema: RootSchema[R, Q, M, S] = RootSchema(
         Operation(querySchema.toType(), querySchema.resolve(resolver.queryResolver)),
         resolver.mutationResolver.map(r => Operation(mutationSchema.toType(), mutationSchema.resolve(r))),
         resolver.subscriptionResolver.map(r => Operation(subscriptionSchema.toType(), subscriptionSchema.resolve(r)))
       )
-    )
+      val rootType = RootType(schema.query.opType, schema.mutation.map(_.opType), schema.subscription.map(_.opType))
+      val introspectionRootSchema: RootSchema[Any, __Introspection, Nothing, Nothing] =
+        Introspector.introspect(rootType)
+      val introspectionRootType = RootType(introspectionRootSchema.query.opType, None, None)
 
+      def check(query: String): IO[CalibanError, Unit] =
+        for {
+          document       <- Parser.parseQuery(query)
+          intro          = Introspector.isIntrospection(document)
+          typeToValidate = if (intro) introspectionRootType else rootType
+          _              <- Validator.validate(document, typeToValidate)
+        } yield ()
+
+      def execute(
+        query: String,
+        operationName: Option[String] = None,
+        variables: Map[String, Value] = Map(),
+        skipValidation: Boolean = false
+      ): ZIO[R, CalibanError, ResponseValue] =
+        for {
+          document        <- Parser.parseQuery(query)
+          intro           = Introspector.isIntrospection(document)
+          typeToValidate  = if (intro) introspectionRootType else rootType
+          schemaToExecute = if (intro) introspectionRootSchema else schema
+          _               <- IO.when(!skipValidation)(Validator.validate(document, typeToValidate))
+          result          <- Executor.executeRequest(document, schemaToExecute, operationName, variables)
+        } yield result
+
+      def render: String = renderTypes(rootType.types)
+    }
 }

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -87,7 +87,7 @@ object ArgBuilder {
             )
             .mapError {
               case e: ExecutionError => e
-              case e                 => ExecutionError("Exception during argument building", Some(e))
+              case e                 => ExecutionError("Exception during argument building", None, Some(e))
             }
       )
 

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -13,8 +13,8 @@ object Step {
   case class ListStep[-R](steps: List[Step[R]])                         extends Step[R]
   case class FunctionStep[-R](step: Map[String, Value] => Step[R])      extends Step[R]
   case class ObjectStep[-R](name: String, fields: Map[String, Step[R]]) extends Step[R]
-  case class QueryStep[-R](query: ZQuery[R, ExecutionError, Step[R]])   extends Step[R]
-  case class StreamStep[-R](inner: ZStream[R, ExecutionError, Step[R]]) extends Step[R]
+  case class QueryStep[-R](query: ZQuery[R, Throwable, Step[R]])        extends Step[R]
+  case class StreamStep[-R](inner: ZStream[R, Throwable, Step[R]])      extends Step[R]
 
   // PureStep is both a Step and a ReducedStep so it is defined outside this object
   // This is to avoid boxing/unboxing pure values during step reduction

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -216,6 +216,12 @@ object ExecutionSpec
              }""")
 
           assertM(interpreter.execute(query).map(_.toString), equalTo("""{"either":{"left":null,"right":"ok"}}"""))
+        },
+        testM("mapError") {
+          case class Test(either: Either[Int, String])
+          val interpreter = graphQL(RootResolver(Test(Right("ok")))).mapError(_ => "my custom error")
+          val query       = """query{}"""
+          assertM(interpreter.execute(query).run, fails(equalTo("my custom error")))
         }
       )
     )

--- a/examples/src/main/scala/caliban/optimizations/NaiveTest.scala
+++ b/examples/src/main/scala/caliban/optimizations/NaiveTest.scala
@@ -81,8 +81,8 @@ object NaiveTest extends App with GenericSchema[Console] {
   implicit val firstArgsSchema: Schema[Any, FirstArgs]           = Schema.gen[FirstArgs]
   implicit lazy val user: Schema[Console, User]                  = gen[User]
 
-  val resolver                                           = Queries(args => getUser(args.id))
-  val interpreter: GraphQL[Console, Queries, Unit, Unit] = GraphQL.graphQL(RootResolver(resolver))
+  val resolver    = Queries(args => getUser(args.id))
+  val interpreter = GraphQL.graphQL(RootResolver(resolver))
 
   override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, Int] =
     interpreter.execute(query).catchAll(err => putStrLn(err.toString)).as(0)

--- a/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
+++ b/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
@@ -122,8 +122,8 @@ object OptimizedTest extends App with GenericSchema[Console] {
   implicit val firstArgsSchema: Schema[Any, FirstArgs]           = Schema.gen[FirstArgs]
   implicit lazy val user: Schema[Console, User]                  = gen[User]
 
-  val resolver                                           = Queries(args => getUser(args.id))
-  val interpreter: GraphQL[Console, Queries, Unit, Unit] = GraphQL.graphQL(RootResolver(resolver))
+  val resolver    = Queries(args => getUser(args.id))
+  val interpreter = GraphQL.graphQL(RootResolver(resolver))
 
   override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, Int] =
     interpreter.execute(query).catchAll(err => putStrLn(err.toString)).as(0)

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -3,7 +3,7 @@ package caliban.interop.cats
 import caliban.introspection.adt.__Type
 import caliban.parsing.adt.Value
 import caliban.schema.Step.QueryStep
-import caliban.schema.{ GenericSchema, Schema, Step }
+import caliban.schema.{ Schema, Step }
 import caliban.{ GraphQL, ResponseValue }
 import cats.effect.implicits._
 import cats.effect.{ Async, Effect }
@@ -44,12 +44,6 @@ object CatsInterop {
         ev.optional
 
       override def resolve(value: F[A]): Step[R] =
-        QueryStep(
-          ZQuery.fromEffect(
-            value.toIO
-              .to[Task]
-              .bimap(GenericSchema.effectfulExecutionError, ev.resolve)
-          )
-        )
+        QueryStep(ZQuery.fromEffect(value.toIO.to[Task].map(ev.resolve)))
     }
 }

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -15,7 +15,7 @@ import zquery.ZQuery
 
 object CatsInterop {
 
-  def executeAsync[F[_]: Async, R, Q, M, S](graphQL: GraphQL[R, Q, M, S])(
+  def executeAsync[F[_]: Async, R, Q, M, S, E](graphQL: GraphQL[R, Q, M, S, E])(
     query: String,
     operationName: Option[String] = None,
     variables: Map[String, Value] = Map(),
@@ -28,8 +28,8 @@ object CatsInterop {
       runtime.unsafeRunAsync(execution)(exit => cb(exit.toEither))
     }
 
-  def checkAsync[F[_]: Async, R, Q, M, S](
-    graphQL: GraphQL[R, Q, M, S]
+  def checkAsync[F[_]: Async, R, Q, M, S, E](
+    graphQL: GraphQL[R, Q, M, S, E]
   )(query: String)(implicit runtime: Runtime[R]): F[Unit] =
     Async[F].async { cb =>
       runtime.unsafeRunAsync(graphQL.execute(query))(exit => cb(exit.toEither.void))

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -8,8 +8,8 @@ import zio.Runtime
 
 package object implicits {
 
-  implicit class CatsEffectGraphQL[R, Q, M, S](
-    underlying: GraphQL[R, Q, M, S]
+  implicit class CatsEffectGraphQL[R, Q, M, S, E](
+    underlying: GraphQL[R, Q, M, S, E]
   ) {
 
     def executeAsync[F[_]: Async](


### PR DESCRIPTION
- Added the ability to hook any function around the `execute` method of the GraphQL interpreter using method `wrapExecutionWith`. This can be used to customize errors, eliminate the environment requirement, add a general timeout, logging, etc. Added helpers for `mapError` and `provide`.
- Added `fieldName` in `ExecutionError` for better error diagnostics

TODO: update docs

cc @ochrons