### PR TITLE
Make effectful types nullable in the schema

### DIFF
--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -1,0 +1,32 @@
+package caliban.schema
+
+import caliban.introspection.adt.{ __DeprecatedArgs, __Type, __TypeKind }
+import caliban.schema.SchemaSpecUtils._
+import zio.test.Assertion._
+import zio.test._
+import zio.{ Task, UIO }
+
+object SchemaSpec
+    extends DefaultRunnableSpec(
+      suite("SchemaSpec")(
+        test("effectful field") {
+          assert(
+            introspect[EffectfulFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()),
+            isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR)))
+          )
+        },
+        test("infallible effectful field") {
+          assert(
+            introspect[InfallibleFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()),
+            isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL)))
+          )
+        }
+      )
+    )
+
+object SchemaSpecUtils {
+  case class EffectfulFieldSchema(q: Task[Int])
+  case class InfallibleFieldSchema(q: UIO[Int])
+
+  def introspect[Q](implicit schema: Schema[Any, Q]): __Type = schema.toType(false)
+}

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -20,7 +20,8 @@ A => B|A and B
 (A, B)|Object with 2 fields `_1` and `_2`
 Either[A, B]|Object with 2 nullable fields `left` and `right`
 Map[A, B]| List of Object with 2 fields `key` and `value`
-ZIO[R, E, A]|A
+UIO[R, A]|A
+ZIO[R, E, A]|Nullable A
 ZStream[R, E, A]|A
 
 See the [Custom Types](#custom-types) section to find out how to support your own types.


### PR DESCRIPTION
This partially addresses #76 — effectful fields in the schema become nullable unless they are infallible. In case of an error, the `null` value is returned, letting the rest of the query succeed.

The second part of the issue is more tricky, as it requires some way to accumulate errors together with the result.