### PR TITLE
ZQuery: Support Request Failures

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -117,7 +117,7 @@ object Executor {
           ReducedStep.QueryStep(
             inner
               .map(reduceStep(_, selectionSet, arguments, fieldName))
-              .mapError("CalibanExecutionError")(GenericSchema.effectfulExecutionError(fieldName, _))
+              .mapError(GenericSchema.effectfulExecutionError(fieldName, _))
           )
         case StreamStep(stream) =>
           ReducedStep.StreamStep(

--- a/core/src/main/scala/zquery/BlockedRequest.scala
+++ b/core/src/main/scala/zquery/BlockedRequest.scala
@@ -10,20 +10,22 @@ import zio.Ref
  * results will be of the type requested.
  */
 private[zquery] sealed trait BlockedRequest[+A] {
-  type Value
+  type Failure
+  type Success
 
-  def request: Request[Value]
+  def request: Request[Failure, Success]
 
-  def result: Ref[Option[Value]]
+  def result: Ref[Option[Either[Failure, Success]]]
 }
 
 private[zquery] object BlockedRequest {
 
-  def apply[A, B](request0: A, result0: Ref[Option[B]])(
-    implicit ev: A <:< Request[B]
+  def apply[E, A, B](request0: A, result0: Ref[Option[Either[E, B]]])(
+    implicit ev: A <:< Request[E, B]
   ): BlockedRequest[A] =
     new BlockedRequest[A] {
-      type Value = B
+      type Failure = E
+      type Success = B
 
       val request = request0
 

--- a/core/src/main/scala/zquery/Cache.scala
+++ b/core/src/main/scala/zquery/Cache.scala
@@ -14,7 +14,7 @@ class Cache private (private val state: Ref[Map[Any, Any]]) {
    * Inserts a request and a `Ref` that will contain the result of the request
    * when it is executed into the cache.
    */
-  final def insert[A](request: Request[A], result: Ref[Option[A]]): UIO[Unit] =
+  final def insert[E, A](request: Request[E, A], result: Ref[Option[Either[E, A]]]): UIO[Unit] =
     state.update(_ + (request -> result)).unit
 
   /**
@@ -23,8 +23,8 @@ class Cache private (private val state: Ref[Map[Any, Any]]) {
    * been executed yet, or `Some(Ref(Some(value)))` if the request has been
    * executed.
    */
-  final def lookup[A](request: Request[A]): UIO[Option[Ref[Option[A]]]] =
-    state.get.map(_.get(request).asInstanceOf[Option[Ref[Option[A]]]])
+  final def lookup[E, A](request: Request[E, A]): UIO[Option[Ref[Option[Either[E, A]]]]] =
+    state.get.map(_.get(request).asInstanceOf[Option[Ref[Option[Either[E, A]]]]])
 }
 
 object Cache {

--- a/core/src/main/scala/zquery/CompletedRequestMap.scala
+++ b/core/src/main/scala/zquery/CompletedRequestMap.scala
@@ -2,14 +2,14 @@ package zquery
 
 /**
  * A `CompletedRequestMap` is a universally quantified mapping from requests
- * of type `Request[A]` to results of type `A` for all types `A`. The
- * guarantee is that for any request of type `Request[A]`, if there is a
- * corresponding value in the map, that value is of type `A`. This is used by
- * the library to support data sources that return different result types for
- * different requests while guaranteeing that results will be of the type
- * requested.
+ * of type `Request[E, A]` to results of type `Either[E, A[` for all types `E`
+ * and `A`. The guarantee is that for any request of type `Request[E, A]`, if
+ * there is a corresponding value in the map, that value is of type
+ * `Either[E, A]`. This is used by the library to support data sources that
+ * return different result types for different requests while guaranteeing that
+ * results will be of the type requested.
  */
-final class CompletedRequestMap private (private val map: Map[Any, Any]) { self =>
+final class CompletedRequestMap private (private val map: Map[Any, Either[Any, Any]]) { self =>
 
   final def ++(that: CompletedRequestMap): CompletedRequestMap =
     new CompletedRequestMap(self.map ++ that.map)
@@ -17,14 +17,14 @@ final class CompletedRequestMap private (private val map: Map[Any, Any]) { self 
   /**
    * Appends the specified result to the completed requests map.
    */
-  final def insert[A](request: Request[A])(result: A): CompletedRequestMap =
+  final def insert[E, A](request: Request[E, A])(result: Either[E, A]): CompletedRequestMap =
     new CompletedRequestMap(self.map + (request -> result))
 
   /**
    * Retrieves the result of the specified request if it exists.
    */
-  final def lookup[A](request: Request[A]): Option[A] =
-    map.get(request).asInstanceOf[Option[A]]
+  final def lookup[E, A](request: Request[E, A]): Option[Either[E, A]] =
+    map.get(request).asInstanceOf[Option[Either[E, A]]]
 }
 
 object CompletedRequestMap {

--- a/core/src/main/scala/zquery/DataSourceFunction.scala
+++ b/core/src/main/scala/zquery/DataSourceFunction.scala
@@ -1,35 +1,35 @@
 package zquery
 
 /**
- * A `DataSourceFunction[R, E, R1, E1]` is a universally quantified function
- * from values of type `DataSource[R, E, A]` to values of type
- * `DataSource[R1, E1, A]` for all types `A`. This is used internally by the
- * library to describe functions for transforming data sources that do not
- * change the type of requests that a data source is able to execute.
+ * A `DataSourceFunction[R, R1]` is a universally quantified function from
+ * values of type `DataSource[R, A]` to values of type `DataSource[R1, A]` for
+ * all types `A`. This is used internally by the library to describe functions
+ * for transforming data sources that do not change the type of requests that a
+ * data source is able to execute.
  */
-trait DataSourceFunction[+R, -E, -R1, +E1] { self =>
+trait DataSourceFunction[+R, -R1] { self =>
 
-  def apply[A](dataSource: DataSource.Service[R, E, A]): DataSource.Service[R1, E1, A]
+  def apply[A](dataSource: DataSource.Service[R, A]): DataSource.Service[R1, A]
 
   /**
    * A symbolic alias for `compose`.
    */
-  final def <<<[R0, E0](that: DataSourceFunction[R0, E0, R, E]): DataSourceFunction[R0, E0, R1, E1] =
+  final def <<<[R0](that: DataSourceFunction[R0, R]): DataSourceFunction[R0, R1] =
     self compose that
 
   /**
    * A symbolic alias for `andThen`.
    */
-  final def >>>[R2, E2](that: DataSourceFunction[R1, E1, R2, E2]): DataSourceFunction[R, E, R2, E2] =
+  final def >>>[R2](that: DataSourceFunction[R1, R2]): DataSourceFunction[R, R2] =
     self andThen that
 
   /**
    * Creates a new data source function by applying this data source function
    * followed by that data source function.
    */
-  final def andThen[R2, E2](that: DataSourceFunction[R1, E1, R2, E2]): DataSourceFunction[R, E, R2, E2] =
-    new DataSourceFunction[R, E, R2, E2] {
-      def apply[A](dataSource: DataSource.Service[R, E, A]): DataSource.Service[R2, E2, A] =
+  final def andThen[R2](that: DataSourceFunction[R1, R2]): DataSourceFunction[R, R2] =
+    new DataSourceFunction[R, R2] {
+      def apply[A](dataSource: DataSource.Service[R, A]): DataSource.Service[R2, A] =
         that(self(dataSource))
     }
 
@@ -37,9 +37,9 @@ trait DataSourceFunction[+R, -E, -R1, +E1] { self =>
    * Creates a new data source function by applying that data source function
    * followed by this data source function.
    */
-  final def compose[R0, E0](that: DataSourceFunction[R0, E0, R, E]): DataSourceFunction[R0, E0, R1, E1] =
-    new DataSourceFunction[R0, E0, R1, E1] {
-      def apply[A](dataSource: DataSource.Service[R0, E0, A]): DataSource.Service[R1, E1, A] =
+  final def compose[R0](that: DataSourceFunction[R0, R]): DataSourceFunction[R0, R1] =
+    new DataSourceFunction[R0, R1] {
+      def apply[A](dataSource: DataSource.Service[R0, A]): DataSource.Service[R1, A] =
         self(that(dataSource))
     }
 }
@@ -47,29 +47,19 @@ trait DataSourceFunction[+R, -E, -R1, +E1] { self =>
 object DataSourceFunction {
 
   /**
-   * A data source function that maps failures produced by a data source using
-   * the specified function.
-   */
-  final def mapError[R, E, E1](name: String)(f: E => E1): DataSourceFunction[R, E, R, E1] =
-    new DataSourceFunction[R, E, R, E1] {
-      def apply[A](dataSource: DataSource.Service[R, E, A]): DataSource.Service[R, E1, A] =
-        dataSource.mapError(name)(f)
-    }
-
-  /**
    * A data source function that provides a data source with its required
    * environment.
    */
-  final def provide[R, E](name: String)(r: R): DataSourceFunction[R, E, Any, E] =
+  final def provide[R](name: String)(r: R): DataSourceFunction[R, Any] =
     provideSome(s"_ => $name")(_ => r)
 
   /**
    * A data source function that provides a data sources with part of its
    * required environment.
    */
-  final def provideSome[R, R1, E](name: String)(f: R1 => R): DataSourceFunction[R, E, R1, E] =
-    new DataSourceFunction[R, E, R1, E] {
-      def apply[A](dataSource: DataSource.Service[R, E, A]): DataSource.Service[R1, E, A] =
+  final def provideSome[R, R1](name: String)(f: R1 => R): DataSourceFunction[R, R1] =
+    new DataSourceFunction[R, R1] {
+      def apply[A](dataSource: DataSource.Service[R, A]): DataSource.Service[R1, A] =
         dataSource.provideSome(name)(f)
     }
 }

--- a/core/src/main/scala/zquery/QueryFailure.scala
+++ b/core/src/main/scala/zquery/QueryFailure.scala
@@ -3,7 +3,7 @@ package zquery
 /**
  * `QueryFailure` keeps track of details relevant to query failures.
  */
-final case class QueryFailure(dataSource: DataSource.Service[Nothing, Any, Nothing], request: Request[Any])
+final case class QueryFailure(dataSource: DataSource.Service[Nothing, Nothing], request: Request[Any, Any])
     extends Throwable(null, null, true, false) {
   override final def getMessage: String =
     s"Data source ${dataSource.identifier} did not complete request ${request.toString}."

--- a/core/src/main/scala/zquery/Request.scala
+++ b/core/src/main/scala/zquery/Request.scala
@@ -1,14 +1,15 @@
 package zquery
 
 /**
- * A `Request[A]` is a request from a data source for a value of type `A`.
+ * A `Request[E, A]` is a request from a data source for a value of type `A`
+ * that may fail with an `E`.
  *
  * {{{
- * sealed trait UserRequest[+A] extends Request[A]
+ * sealed trait UserRequest[+A] extends Request[Nothing, A]
  *
  * case object GetAllIds                 extends UserRequest[List[Int]]
  * final case class GetNameById(id: Int) extends UserRequest[String]
  *
  * }}}
  */
-trait Request[+A]
+trait Request[+E, +A]

--- a/core/src/main/scala/zquery/Result.scala
+++ b/core/src/main/scala/zquery/Result.scala
@@ -1,14 +1,24 @@
 package zquery
 
+import zio.Cause
+
 import zquery.Result._
 
 /**
  * A `Result[R, E, A]` is the result of running one step of a `ZQuery`. A
- * result may either by done with a value `A` or blocked on a set of requests
- * to data sources that require an environment `R`, may fail with an `E`, and
- * may succeed with an `A`.
+ * result may either by done with a value `A`, blocked on a set of requests
+ * to data sources that require an environment `R`, or failed with an `E`.
  */
 private[zquery] sealed trait Result[-R, +E, +A] {
+
+  /**
+   * Folds over the successful or failed result.
+   */
+  final def fold[B](failure: E => B, success: A => B): Result[R, Nothing, B] = this match {
+    case Blocked(br, c) => blocked(br, c.fold(failure, success))
+    case Done(a)        => done(success(a))
+    case Fail(e)        => e.failureOrCause.fold(e => done(failure(e)), c => fail(c))
+  }
 
   /**
    * Maps the specified function over the successful value of this result.
@@ -16,14 +26,16 @@ private[zquery] sealed trait Result[-R, +E, +A] {
   final def map[B](f: A => B): Result[R, E, B] = this match {
     case Blocked(br, c) => blocked(br, c.map(f))
     case Done(a)        => done(f(a))
+    case Fail(e)        => fail(e)
   }
 
   /**
    * Maps the specified function over the failed value of this result.
    */
-  final def mapError[E1](name: String)(f: E => E1): Result[R, E1, A] = this match {
-    case Blocked(br, c) => blocked(br.mapDataSources(DataSourceFunction.mapError(name)(f)), c.mapError(name)(f))
+  final def mapError[E1](f: E => E1): Result[R, E1, A] = this match {
+    case Blocked(br, c) => blocked(br, c.mapError(f))
     case Done(a)        => done(a)
+    case Fail(e)        => fail(e.map(f))
   }
 
   /**
@@ -38,6 +50,7 @@ private[zquery] sealed trait Result[-R, +E, +A] {
   final def provideSome[R0](name: String)(f: R0 => R): Result[R0, E, A] = this match {
     case Blocked(br, c) => blocked(br.mapDataSources(DataSourceFunction.provideSome(name)(f)), c.provideSome(name)(f))
     case Done(a)        => done(a)
+    case Fail(e)        => fail(e)
   }
 }
 
@@ -47,7 +60,7 @@ private[zquery] object Result {
    * Constructs a result that is blocked on the specified requests with the
    * specified continuation.
    */
-  final def blocked[R, E, A](blockedRequests: BlockedRequestMap[R, E], continue: ZQuery[R, E, A]): Result[R, E, A] =
+  final def blocked[R, E, A](blockedRequests: BlockedRequestMap[R], continue: ZQuery[R, E, A]): Result[R, E, A] =
     Blocked(blockedRequests, continue)
 
   /**
@@ -56,8 +69,22 @@ private[zquery] object Result {
   final def done[A](value: A): Result[Any, Nothing, A] =
     Done(value)
 
-  final case class Blocked[-R, +E, +A](blockedRequests: BlockedRequestMap[R, E], continue: ZQuery[R, E, A])
+  /**
+   * Constructs a result that is failed with the specified `Cause`.
+   */
+  final def fail[E](cause: Cause[E]): Result[Any, E, Nothing] =
+    Fail(cause)
+
+  /**
+   * Lifts an `Either` into a result.
+   */
+  final def fromEither[E, A](either: Either[E, A]): Result[Any, E, A] =
+    either.fold(e => Result.fail(Cause.fail(e)), a => Result.done(a))
+
+  final case class Blocked[-R, +E, +A](blockedRequests: BlockedRequestMap[R], continue: ZQuery[R, E, A])
       extends Result[R, E, A]
 
-  final case class Done[A](value: A) extends Result[Any, Nothing, A]
+  final case class Done[+A](value: A) extends Result[Any, Nothing, A]
+
+  final case class Fail[+E](cause: Cause[E]) extends Result[Any, E, Nothing]
 }

--- a/core/src/main/scala/zquery/ZQuery.scala
+++ b/core/src/main/scala/zquery/ZQuery.scala
@@ -287,7 +287,7 @@ object ZQuery {
    * Constructs a query from an effect.
    */
   final def fromEffect[R, E, A](effect: ZIO[R, E, A]): ZQuery[R, E, A] =
-    ZQuery(effect.fold(e => Result.fail(Cause.fail(e)), a => Result.done(a)))
+    ZQuery(effect.foldCause(Result.fail, Result.done))
 
   /**
    * Constructs a query from a request, requiring an environment containing a

--- a/core/src/main/scala/zquery/ZQuery.scala
+++ b/core/src/main/scala/zquery/ZQuery.scala
@@ -1,6 +1,6 @@
 package zquery
 
-import zio.{ Ref, ZIO }
+import zio.{ Cause, Ref, ZIO }
 
 /**
  * A `ZQuery[R, E, A]` is a purely functional description of an effectual query
@@ -39,7 +39,7 @@ sealed trait ZQuery[-R, +E, +A] { self =>
   /**
    * Executes one step of this query.
    */
-  protected def step(cache: Cache): ZIO[R, E, Result[R, E, A]]
+  protected def step(cache: Cache): ZIO[R, Nothing, Result[R, E, A]]
 
   /**
    * A symbolic alias for `zipParRight`.
@@ -92,11 +92,23 @@ sealed trait ZQuery[-R, +E, +A] { self =>
    */
   final def flatMap[R1 <: R, E1 >: E, B](f: A => ZQuery[R1, E1, B]): ZQuery[R1, E1, B] =
     new ZQuery[R1, E1, B] {
-      def step(cache: Cache): ZIO[R1, E1, Result[R1, E1, B]] =
+      def step(cache: Cache): ZIO[R1, Nothing, Result[R1, E1, B]] =
         self.step(cache).flatMap {
           case Result.Blocked(br, c) => ZIO.succeed(Result.blocked(br, c.flatMap(f)))
           case Result.Done(a)        => f(a).step(cache)
+          case Result.Fail(e)        => ZIO.succeed(Result.fail(e))
         }
+    }
+
+  /**
+   * Folds over the failed or successful result of this query to yield a query
+   * that does not fail, but succeeds with the value returned by the left or
+   * right function passed to `fold`.
+   */
+  final def fold[B](failure: E => B, success: A => B): ZQuery[R, Nothing, B] =
+    new ZQuery[R, Nothing, B] {
+      def step(cache: Cache): ZIO[R, Nothing, Result[R, Nothing, B]] =
+        self.step(cache).map(_.fold(failure, success))
     }
 
   /**
@@ -104,17 +116,17 @@ sealed trait ZQuery[-R, +E, +A] { self =>
    */
   final def map[B](f: A => B): ZQuery[R, E, B] =
     new ZQuery[R, E, B] {
-      def step(cache: Cache): ZIO[R, E, Result[R, E, B]] =
+      def step(cache: Cache): ZIO[R, Nothing, Result[R, E, B]] =
         self.step(cache).map(_.map(f))
     }
 
   /**
    * Maps the specified function over the failed result of this query.
    */
-  final def mapError[E1](name: String)(f: E => E1): ZQuery[R, E1, A] =
+  final def mapError[E1](f: E => E1): ZQuery[R, E1, A] =
     new ZQuery[R, E1, A] {
-      def step(cache: Cache): ZIO[R, E1, Result[R, E1, A]] =
-        self.step(cache).bimap(f, _.mapError(name)(f))
+      def step(cache: Cache): ZIO[R, Nothing, Result[R, E1, A]] =
+        self.step(cache).map(_.mapError(f))
     }
 
   /**
@@ -128,7 +140,7 @@ sealed trait ZQuery[-R, +E, +A] { self =>
    */
   final def provideSome[R0](name: String)(f: R0 => R): ZQuery[R0, E, A] =
     new ZQuery[R0, E, A] {
-      def step(cache: Cache): ZIO[R0, E, Result[R0, E, A]] =
+      def step(cache: Cache): ZIO[R0, Nothing, Result[R0, E, A]] =
         self.step(cache).provideSome(f).map(_.provideSome(name)(f))
     }
 
@@ -147,6 +159,7 @@ sealed trait ZQuery[-R, +E, +A] { self =>
     step(cache).flatMap {
       case Result.Blocked(br, c) => br.run *> c.runCache(cache)
       case Result.Done(a)        => ZIO.succeed(a)
+      case Result.Fail(e)        => ZIO.halt(e)
     }
 
   /**
@@ -218,12 +231,15 @@ sealed trait ZQuery[-R, +E, +A] { self =>
    */
   final def zipWithPar[R1 <: R, E1 >: E, B, C](that: ZQuery[R1, E1, B])(f: (A, B) => C): ZQuery[R1, E1, C] =
     new ZQuery[R1, E1, C] {
-      def step(cache: Cache): ZIO[R1, E1, Result[R1, E1, C]] =
+      def step(cache: Cache): ZIO[R1, Nothing, Result[R1, E1, C]] =
         self.step(cache).zip(that.step(cache)).map {
           case (Result.Blocked(br1, c1), Result.Blocked(br2, c2)) => Result.blocked(br1 ++ br2, c1.zipWithPar(c2)(f))
           case (Result.Blocked(br, c), Result.Done(_))            => Result.blocked(br, c.zipWithPar(that)(f))
           case (Result.Done(_), Result.Blocked(br, c))            => Result.blocked(br, self.zipWithPar(c)(f))
           case (Result.Done(a), Result.Done(b))                   => Result.done(f(a, b))
+          case (Result.Fail(e1), Result.Fail(e2))                 => Result.fail(Cause.Both(e1, e2))
+          case (Result.Fail(e), _)                                => Result.fail(e)
+          case (_, Result.Fail(e))                                => Result.fail(e)
         }
     }
 }
@@ -249,7 +265,7 @@ object ZQuery {
    * Constructs a query that fails with the specified error.
    */
   final def fail[E](error: E): ZQuery[Any, E, Nothing] =
-    ZQuery(ZIO.fail(error))
+    ZQuery(ZIO.succeed(Result.fail(Cause.fail(error))))
 
   /**
    * Performs a query for each element in a collection, collecting the results
@@ -271,7 +287,7 @@ object ZQuery {
    * Constructs a query from an effect.
    */
   final def fromEffect[R, E, A](effect: ZIO[R, E, A]): ZQuery[R, E, A] =
-    ZQuery(effect.map(Result.done))
+    ZQuery(effect.fold(e => Result.fail(Cause.fail(e)), a => Result.done(a)))
 
   /**
    * Constructs a query from a request, requiring an environment containing a
@@ -282,8 +298,8 @@ object ZQuery {
    */
   final def fromRequest[R, E, A, B](
     request: A
-  )(implicit ev: A <:< Request[B]): ZQuery[R with DataSource[R, E, A], E, B] =
-    ZQuery.fromEffect(ZIO.environment[DataSource[R, E, A]]).flatMap(r => fromRequestWith(request)(r.dataSource))
+  )(implicit ev: A <:< Request[E, B]): ZQuery[R with DataSource[R, A], E, B] =
+    ZQuery.fromEffect(ZIO.environment[DataSource[R, A]]).flatMap(r => fromRequestWith(request)(r.dataSource))
 
   /**
    * Constructs a query from a request and a data source. Queries must be
@@ -292,33 +308,33 @@ object ZQuery {
    */
   final def fromRequestWith[R, E, A, B](
     request: A
-  )(dataSource: DataSource.Service[R, E, A])(implicit ev: A <:< Request[B]): ZQuery[R, E, B] =
+  )(dataSource: DataSource.Service[R, A])(implicit ev: A <:< Request[E, B]): ZQuery[R, E, B] =
     new ZQuery[R, E, B] {
-      def step(cache: Cache): ZIO[R, E, Result[R, E, B]] =
+      def step(cache: Cache): ZIO[R, Nothing, Result[R, E, B]] =
         cache.lookup(request).flatMap {
           case None =>
             for {
-              ref <- Ref.make(Option.empty[B])
+              ref <- Ref.make(Option.empty[Either[E, B]])
               _   <- cache.insert(request, ref)
             } yield Result.blocked(
               BlockedRequestMap(dataSource, BlockedRequest(request, ref)),
               ZQuery {
                 ref.get.flatMap {
                   case None    => ZIO.die(QueryFailure(dataSource, request))
-                  case Some(b) => ZIO.succeed(Result.done(b))
+                  case Some(b) => ZIO.succeed(Result.fromEither(b))
                 }
               }
             )
           case Some(ref) =>
             ref.get.map {
-              case Some(b) => Result.done(b)
+              case Some(b) => Result.fromEither(b)
               case None =>
                 Result.blocked(
                   BlockedRequestMap.empty,
                   ZQuery {
                     ref.get.flatMap {
                       case None    => ZIO.die(QueryFailure(dataSource, request))
-                      case Some(b) => ZIO.succeed(Result.done(b))
+                      case Some(b) => ZIO.succeed(Result.fromEither(b))
                     }
                   }
                 )
@@ -335,9 +351,9 @@ object ZQuery {
   /**
    * Constructs a query from an effect that returns a result.
    */
-  private final def apply[R, E, A](step0: ZIO[R, E, Result[R, E, A]]): ZQuery[R, E, A] =
+  private final def apply[R, E, A](step0: ZIO[R, Nothing, Result[R, E, A]]): ZQuery[R, E, A] =
     new ZQuery[R, E, A] {
-      def step(cache: Cache): ZIO[R, E, Result[R, E, A]] =
+      def step(cache: Cache): ZIO[R, Nothing, Result[R, E, A]] =
         step0
     }
 }

--- a/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
+++ b/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
@@ -56,49 +56,49 @@ object OptimizedTest extends App with GenericSchema[Console] {
     args => getViewerFriendIdsAttendingEvent(id, args.first).flatMap(ZQuery.foreachPar(_)(getUser))
   )
 
-  case class GetUser(id: Int) extends Request[User]
-  val UserDataSource: DataSource.Service[Console, Nothing, GetUser] = DataSource.Service("UserDataSource") { requests =>
+  case class GetUser(id: Int) extends Request[Nothing, User]
+  val UserDataSource: DataSource.Service[Console, GetUser] = DataSource.Service("UserDataSource") { requests =>
     requests.toList match {
-      case head :: Nil => putStrLn("getUser").as(CompletedRequestMap.empty.insert(head)(fakeUser(head.id)))
+      case head :: Nil => putStrLn("getUser").as(CompletedRequestMap.empty.insert(head)(Right(fakeUser(head.id))))
       case list =>
         putStrLn("getUsers").as(list.foldLeft(CompletedRequestMap.empty) {
-          case (map, req) => map.insert(req)(fakeUser(req.id))
+          case (map, req) => map.insert(req)(Right(fakeUser(req.id)))
         })
     }
   }
 
-  case class GetEvent(id: Int) extends Request[Event]
-  val EventDataSource: DataSource.Service[Console, Nothing, GetEvent] =
+  case class GetEvent(id: Int) extends Request[Nothing, Event]
+  val EventDataSource: DataSource.Service[Console, GetEvent] =
     fromFunctionBatchedM("EventDataSource") { requests =>
       putStrLn("getEvents").as(requests.map(r => fakeEvent(r.id)))
     }
 
-  case class GetViewerMetadataForEvents(id: Int) extends Request[ViewerMetadata]
-  val ViewerMetadataDataSource: DataSource.Service[Console, Nothing, GetViewerMetadataForEvents] =
+  case class GetViewerMetadataForEvents(id: Int) extends Request[Nothing, ViewerMetadata]
+  val ViewerMetadataDataSource: DataSource.Service[Console, GetViewerMetadataForEvents] =
     fromFunctionBatchedM("ViewerMetadataDataSource") { requests =>
       putStrLn("getViewerMetadataForEvents").as(requests.map(_ => ViewerMetadata("")))
     }
 
-  case class GetVenue(id: Int) extends Request[Venue]
-  val VenueDataSource: DataSource.Service[Console, Nothing, GetVenue] =
+  case class GetVenue(id: Int) extends Request[Nothing, Venue]
+  val VenueDataSource: DataSource.Service[Console, GetVenue] =
     fromFunctionBatchedM("VenueDataSource") { requests =>
       putStrLn("getVenues").as(requests.map(_ => Venue("venue")))
     }
 
-  case class GetTags(ids: List[Int]) extends Request[List[Tag]]
-  val TagsDataSource: DataSource.Service[Console, Nothing, GetTags] =
+  case class GetTags(ids: List[Int]) extends Request[Nothing, List[Tag]]
+  val TagsDataSource: DataSource.Service[Console, GetTags] =
     fromFunctionBatchedM("TagsDataSource") { requests =>
       putStrLn("getTags").as(requests.map(_.ids.map(id => Tag(id.toString))))
     }
 
-  case class GetViewerFriendIdsAttendingEvent(id: Int, first: Int) extends Request[List[Int]]
-  val ViewerFriendDataSource: DataSource.Service[Console, Nothing, GetViewerFriendIdsAttendingEvent] =
+  case class GetViewerFriendIdsAttendingEvent(id: Int, first: Int) extends Request[Nothing, List[Int]]
+  val ViewerFriendDataSource: DataSource.Service[Console, GetViewerFriendIdsAttendingEvent] =
     fromFunctionBatchedM("ViewerFriendDataSource") { requests =>
       putStrLn("getViewerFriendIdsAttendingEvent").as(requests.map(r => (1 to r.first).toList))
     }
 
-  case class GetUpcomingEventIdsForUser(id: Int, first: Int) extends Request[List[Int]]
-  val UpcomingEventDataSource: DataSource.Service[Console, Nothing, GetUpcomingEventIdsForUser] =
+  case class GetUpcomingEventIdsForUser(id: Int, first: Int) extends Request[Nothing, List[Int]]
+  val UpcomingEventDataSource: DataSource.Service[Console, GetUpcomingEventIdsForUser] =
     fromFunctionBatchedM("UpcomingEventDataSource") { requests =>
       putStrLn("getUpcomingEventIdsForUser").as(requests.map(r => (1 to r.first).toList))
     }


### PR DESCRIPTION
Refactors `ZQuery` to support request failures, allowing a data source to respond to certain requests with a specified type of failure `E` while responding to other requests with a value `A`. This allows the query author to potentially recover from or ignore certain failures using combinators such as `fold`.