### PR TITLE
Http4s simple integration

### DIFF
--- a/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -2,11 +2,11 @@ package caliban
 
 import caliban.ResponseValue._
 import caliban.Value._
-import cats.data.{Kleisli, OptionT}
+import cats.data.{ Kleisli, OptionT }
 import cats.effect.Effect
 import cats.effect.syntax.all._
 import cats.~>
-import fs2.{Pipe, Stream}
+import fs2.{ Pipe, Stream }
 import io.circe.derivation.deriveDecoder
 import io.circe._
 import io.circe.parser._
@@ -95,17 +95,18 @@ object Http4sAdapter {
     }
   }
 
-  def executeRequest[R0, R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E], provideEnv: R0 => R): HttpApp[RIO[R0, *]] = Kleisli {
-    req =>
+  def executeRequest[R0, R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E], provideEnv: R0 => R): HttpApp[RIO[R0, *]] =
+    Kleisli { req =>
       object dsl extends Http4sDsl[RIO[R0, *]]
       import dsl._
       for {
         query <- req.attemptAs[GraphQLRequest].value.absolve
-        result <- execute(interpreter, query).provideSome[R0](provideEnv)
-          .foldCause(cause => GraphQLResponse(NullValue, cause.defects).asJson, _.asJson)
+        result <- execute(interpreter, query)
+                   .provideSome[R0](provideEnv)
+                   .foldCause(cause => GraphQLResponse(NullValue, cause.defects).asJson, _.asJson)
         response <- Ok(result)
       } yield response
-  }
+    }
 
   def makeWebSocketService[R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E]): HttpRoutes[RIO[R, *]] = {
 

--- a/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -2,11 +2,11 @@ package caliban
 
 import caliban.ResponseValue._
 import caliban.Value._
-import cats.data.OptionT
+import cats.data.{Kleisli, OptionT}
 import cats.effect.Effect
 import cats.effect.syntax.all._
 import cats.~>
-import fs2.{ Pipe, Stream }
+import fs2.{Pipe, Stream}
 import io.circe.derivation.deriveDecoder
 import io.circe._
 import io.circe.parser._
@@ -93,6 +93,18 @@ object Http4sAdapter {
           response <- Ok(result)
         } yield response
     }
+  }
+
+  def executeRequest[R0, R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E], provideEnv: R0 => R): HttpApp[RIO[R0, *]] = Kleisli {
+    req =>
+      object dsl extends Http4sDsl[RIO[R0, *]]
+      import dsl._
+      for {
+        query <- req.attemptAs[GraphQLRequest].value.absolve
+        result <- execute(interpreter, query).provideSome[R0](provideEnv)
+          .foldCause(cause => GraphQLResponse(NullValue, cause.defects).asJson, _.asJson)
+        response <- Ok(result)
+      } yield response
   }
 
   def makeWebSocketService[R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E]): HttpRoutes[RIO[R, *]] = {


### PR DESCRIPTION
This allows for simple integrations where we can do things like:
```
HttpRoutes
            .of[RIO[ZEnv, *]] {
              case req @ POST -> Root / "api" / "graphql" => {
                val token: Task[Token] =
                  UIO(req.headers.get(Authorization).map(_.value).toRight("No `Authorization` header").flatMap(auth.decodeTokenPayload)).absolve
                    .mapError(AuthException)
                Http4sAdapter.executeRequest(
                  graphql.schema.interpreter,
                  (env: ZEnv) =>
                    new Console with Clock with Auth with Storage {
                      override val console: Console.Service[Any] = env.console
                      override val clock: Clock.Service[Any] = env.clock
                      override def auth: Auth.Service = AuthServiceFromToken(token)
                      override def storage: StorageBase[Task] = _storage
                    }
                )(req)
              }
              case GET -> Root / "graphiql" => staticResource("static/graphiql.html")
              case GET -> Root / "login.html" => staticResource("static/login.html")
            }
            .orNotFound
```