### PR TITLE
Add missing types from nested input fields

### DIFF
--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -53,7 +53,8 @@ object Types {
       case _ =>
         val map1 = t.name.fold(existingTypes)(name => existingTypes.updated(name, t))
         val embeddedTypes =
-          t.fields(__DeprecatedArgs(Some(true))).getOrElse(Nil).flatMap(f => f.`type` :: f.args.map(_.`type`))
+          t.fields(__DeprecatedArgs(Some(true))).getOrElse(Nil).flatMap(f => f.`type` :: f.args.map(_.`type`)) ++
+            t.inputFields.getOrElse(Nil).map(_.`type`)
         val map2 = embeddedTypes.foldLeft(map1) {
           case (types, f) =>
             val t = innerType(f())

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -20,6 +20,16 @@ object SchemaSpec
             introspect[InfallibleFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()),
             isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL)))
           )
+        },
+        test("nested input fields") {
+          case class Queries(a: A => Unit)
+          case class A(b: B)
+          case class B(c: C)
+          case class C(d: Int)
+          assert(
+            Types.collectTypes(introspect[Queries]).keys,
+            contains("BInput") && contains("CInput")
+          )
         }
       )
     )


### PR DESCRIPTION
Fixes #98 

Types embedded in input fields were not properly gathered during introspection.