### PR TITLE
Support for combining GraphQL objects

### DIFF
--- a/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -1,36 +1,39 @@
 package caliban
 
 import akka.http.scaladsl.model.MediaTypes.`application/json`
-import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
+import akka.http.scaladsl.model.{ HttpEntity, HttpResponse }
 import akka.http.scaladsl.server.Route
 import caliban.Value.NullValue
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.syntax._
-import zio.{Runtime, URIO}
+import zio.{ Runtime, URIO }
 
 import scala.concurrent.ExecutionContext
 
 object AkkaHttpAdapter extends FailFastCirceSupport {
 
-
-  private def execute[R, Q, M, S, E](
-                                      interpreter: GraphQL[R, Q, M, S, E],
-                                      query: GraphQLRequest
-                                    ): URIO[R, GraphQLResponse[E]] =
+  private def execute[R, E](
+    interpreter: GraphQLInterpreter[R, E],
+    query: GraphQLRequest
+  ): URIO[R, GraphQLResponse[E]] =
     interpreter.execute(query.query, query.operationName, query.variables.getOrElse(Map()))
 
-  def makeHttpService[R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E])(implicit ec: ExecutionContext, runtime: Runtime[R]): Route = {
+  def makeHttpService[R, E](
+    interpreter: GraphQLInterpreter[R, E]
+  )(implicit ec: ExecutionContext, runtime: Runtime[R]): Route = {
     import akka.http.scaladsl.server.Directives._
     post {
-        entity(as[GraphQLRequest]) { request =>
-          complete({
-            runtime.unsafeRunToFuture(
+      entity(as[GraphQLRequest]) { request =>
+        complete({
+          runtime
+            .unsafeRunToFuture(
               execute(interpreter, request)
                 .foldCause(cause => GraphQLResponse(NullValue, cause.defects).asJson, _.asJson)
-              .map(gqlResult => HttpResponse(200, entity = HttpEntity(`application/json`, gqlResult.toString())) ))
-              .future
-          })
-        }
+                .map(gqlResult => HttpResponse(200, entity = HttpEntity(`application/json`, gqlResult.toString())))
+            )
+            .future
+        })
       }
     }
+  }
 }

--- a/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
+++ b/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
@@ -137,7 +137,7 @@ class GraphQLBenchmarks {
     character: CharacterArgs => UIO[Option[Character]]
   )
 
-  val resolver = RootResolver(
+  val resolver: RootResolver[Query, Unit, Unit] = RootResolver(
     Query(
       args => UIO(Data.characters.filter(c => args.origin.forall(c.origin == _))),
       args => UIO(Data.characters.find(c => c.name == args.name))
@@ -148,14 +148,14 @@ class GraphQLBenchmarks {
 
   @Benchmark
   def simpleCaliban(): Unit = {
-    val io = interpreter.execute(simpleQuery).map(_.toString)
+    val io = interpreter.execute(simpleQuery)
     zioRuntime.unsafeRun(io)
     ()
   }
 
   @Benchmark
   def introspectCaliban(): Unit = {
-    val io = interpreter.execute(fullIntrospectionQuery).map(_.toString)
+    val io = interpreter.execute(fullIntrospectionQuery)
     zioRuntime.unsafeRun(io)
     ()
   }
@@ -195,10 +195,10 @@ class GraphQLBenchmarks {
     )
   )
 
-  val OriginArg = Argument("origin", OptionInputType(OriginEnum))
-  val NameArg   = Argument("name", StringType)
+  val OriginArg: Argument[Option[Origin]] = Argument("origin", OptionInputType(OriginEnum))
+  val NameArg: Argument[String]           = Argument("name", StringType)
 
-  val QueryType = ObjectType(
+  val QueryType: ObjectType[Unit, Unit] = ObjectType(
     "Query",
     fields[Unit, Unit](
       Field(
@@ -216,7 +216,7 @@ class GraphQLBenchmarks {
     )
   )
 
-  val schema = Schema(QueryType)
+  val schema: Schema[Unit, Unit] = Schema(QueryType)
 
   implicit val executionContext: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
 

--- a/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
+++ b/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
@@ -144,7 +144,7 @@ class GraphQLBenchmarks {
     )
   )
 
-  val interpreter: GraphQL[Any, Query, Unit, Unit, CalibanError] = graphQL(resolver)
+  val interpreter: GraphQL[Any, CalibanError] = graphQL(resolver)
 
   @Benchmark
   def simpleCaliban(): Unit = {

--- a/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
+++ b/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
@@ -144,7 +144,7 @@ class GraphQLBenchmarks {
     )
   )
 
-  val interpreter: GraphQL[Any, CalibanError] = graphQL(resolver)
+  val interpreter: GraphQLInterpreter[Any, CalibanError] = graphQL(resolver).interpreter
 
   @Benchmark
   def simpleCaliban(): Unit = {

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -86,15 +86,20 @@ trait GraphQL[-R] { self =>
 
   /**
    * Merges this GraphQL API with another GraphQL API.
-   * In case of conflicts (same field declared on both APIs), fields from the this API will be favored.
+   * In case of conflicts (same field declared on both APIs), fields from `that` API will be used.
    * @param that another GraphQL API object
    * @return a new GraphQL API
    */
-  final def |+|[R1 <: R](that: GraphQL[R1]): GraphQL[R1] =
+  final def combine[R1 <: R](that: GraphQL[R1]): GraphQL[R1] =
     new GraphQL[R1] {
       override val schema: RootSchema[R1]                  = self.schema |+| that.schema
       override val queryAnalyzers: List[QueryAnalyzer[R1]] = self.queryAnalyzers ++ that.queryAnalyzers
     }
+
+  /**
+   * Operator alias for `combine`.
+   */
+  final def |+|[R1 <: R](that: GraphQL[R1]): GraphQL[R1] = combine(that)
 
   /**
    * Renames the root queries, mutations and subscriptions objects.

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -11,103 +11,122 @@ import caliban.validation.Validator
 import zio.{ IO, URIO }
 
 /**
- * A `GraphQL[-R, +E]` represents a GraphQL interpreter whose execution requires
- * a ZIO environment of type `R` and can fail with an `E`.
+ * A `GraphQL[-R]` represents a GraphQL API whose execution requires a ZIO environment of type `R`.
  *
  * It is intended to be created only once, typically when you start your server.
  * The introspection schema will be generated when this class is instantiated.
  */
-trait GraphQL[-R, +E] { self =>
+trait GraphQL[-R] { self =>
+
+  protected val schema: RootSchema[R]
+  protected val queryAnalyzers: List[QueryAnalyzer[R]]
+
+  private lazy val rootType: RootType =
+    RootType(schema.query.opType, schema.mutation.map(_.opType), schema.subscription.map(_.opType))
+  private lazy val introspectionRootSchema: RootSchema[Any] = Introspector.introspect(rootType)
+  private lazy val introspectionRootType: RootType          = RootType(introspectionRootSchema.query.opType, None, None)
+
+  private final def execute(
+    query: String,
+    operationName: Option[String],
+    variables: Map[String, InputValue],
+    skipValidation: Boolean
+  ): URIO[R, GraphQLResponse[CalibanError]] = {
+
+    val prepare = for {
+      document        <- Parser.parseQuery(query)
+      intro           = Introspector.isIntrospection(document)
+      typeToValidate  = if (intro) introspectionRootType else rootType
+      schemaToExecute = if (intro) introspectionRootSchema else schema
+      _               <- IO.when(!skipValidation)(Validator.validate(document, typeToValidate))
+    } yield (document, schemaToExecute)
+
+    prepare.foldM(
+      Executor.fail,
+      req => Executor.executeRequest(req._1, req._2, operationName, variables, queryAnalyzers)
+    )
+  }
 
   /**
-   * Parses and validates the provided query against this interpreter.
+   * Parses and validates the provided query against this API.
    * @param query a string containing the GraphQL query.
    * @return an effect that either fails with a [[CalibanError]] or succeeds with `Unit`
    */
-  def check(query: String): IO[CalibanError, Unit]
+  final def check(query: String): IO[CalibanError, Unit] =
+    for {
+      document       <- Parser.parseQuery(query)
+      intro          = Introspector.isIntrospection(document)
+      typeToValidate = if (intro) introspectionRootType else rootType
+      _              <- Validator.validate(document, typeToValidate)
+    } yield ()
 
   /**
-   * Parses, validates and finally runs the provided query against this interpreter.
-   * @param query a string containing the GraphQL query.
-   * @param operationName the operation to run in case the query contains multiple operations.
-   * @param variables a list of variables.
-   * @param skipValidation skips the validation step if true
-   * @return an effect that either fails with an `E` or succeeds with a [[ResponseValue]]
+   * Returns a string that renders the API types into the GraphQL format.
    */
-  def execute[R1 <: R](
-    query: String,
-    operationName: Option[String] = None,
-    variables: Map[String, InputValue] = Map(),
-    skipValidation: Boolean = false,
-    queryAnalyzers: List[QueryAnalyzer[R1]] = Nil
-  ): URIO[R1, GraphQLResponse[E]]
+  final def render: String = renderTypes(rootType.types)
 
   /**
-   * Returns a string that renders the interpreter types into the GraphQL format.
+   * Creates an interpreter from your API. A GraphQLInterpreter is a wrapper around your API that allows
+   * adding some middleware around the query execution.
    */
-  def render: String
-
-  /**
-   * Changes the error channel of the `execute` method.
-   * This can be used to customize error messages.
-   * @param f a function from the current error type `E` to another type `E2`
-   * @return a new GraphQL interpreter with error type `E2`
-   */
-  def mapError[E2](f: E => E2): GraphQL[R, E2] =
-    wrapExecutionWith(_.map(res => GraphQLResponse(res.data, res.errors.map(f))))
-
-  /**
-   * Eliminates the ZIO environment R requirement of the interpreter.
-   * @param r a value of type `R`
-   * @return a new GraphQL interpreter with R = `Any`
-   */
-  def provide(r: R): GraphQL[Any, E] = wrapExecutionWith(_.provide(r))
-
-  /**
-   * Wraps the `execute` method of the interpreter with the given function.
-   * This can be used to customize errors, add global timeouts or logging functions.
-   * @param f a function from `URIO[R, GraphQLResponse[E]]` to `URIO[R2, GraphQLResponse[E2]]`
-   * @return a new GraphQL interpreter
-   */
-  def wrapExecutionWith[R2, E2](
-    f: URIO[R, GraphQLResponse[E]] => URIO[R2, GraphQLResponse[E2]]
-  ): GraphQL[R2, E2] =
-    new GraphQL[R2, E2] {
-      override def check(query: String): IO[CalibanError, Unit] = self.check(query)
-      override def execute[R1 <: R2](
-        query: String,
-        operationName: Option[String],
-        variables: Map[String, InputValue],
-        skipValidation: Boolean,
-        queryAnalyzers: List[QueryAnalyzer[R1]] = Nil
-      ): URIO[R2, GraphQLResponse[E2]] = f(self.execute(query, operationName, variables, skipValidation))
-      override def render: String      = self.render
-    }
+  final def interpreter: GraphQLInterpreter[R, CalibanError] =
+    (query: String, operationName: Option[String], variables: Map[String, InputValue], skipValidation: Boolean) =>
+      self.execute(query, operationName, variables, skipValidation)
 
   /**
    * Attaches a function that will analyze each query before execution, possibly modify or reject it.
    * @param queryAnalyzer a function from `Field` to `ZIO[R, CalibanError, Field]`
-   * @return  a new GraphQL interpreter
+   * @return a new GraphQL API
    */
-  def withQueryAnalyzer[R2 <: R](queryAnalyzer: QueryAnalyzer[R2]): GraphQL[R2, E] =
-    new GraphQL[R2, E] {
-      override def check(query: String): IO[CalibanError, Unit] = self.check(query)
-      override def execute[R1 <: R2](
-        query: String,
-        operationName: Option[String],
-        variables: Map[String, InputValue],
-        skipValidation: Boolean,
-        queryAnalyzers: List[QueryAnalyzer[R1]]
-      ): URIO[R1, GraphQLResponse[E]] =
-        self.execute(query, operationName, variables, skipValidation, queryAnalyzer :: queryAnalyzers)
-      override def render: String = self.render
+  final def withQueryAnalyzer[R2 <: R](queryAnalyzer: QueryAnalyzer[R2]): GraphQL[R2] =
+    new GraphQL[R2] {
+      override val schema: RootSchema[R2]                  = self.schema
+      override val queryAnalyzers: List[QueryAnalyzer[R2]] = queryAnalyzer :: self.queryAnalyzers
     }
+
+  /**
+   * Merges this GraphQL API with another GraphQL API.
+   * In case of conflicts (same field declared on both APIs), fields from the this API will be favored.
+   * @param that another GraphQL API object
+   * @return a new GraphQL API
+   */
+  final def |+|[R1 <: R](that: GraphQL[R1]): GraphQL[R1] =
+    new GraphQL[R1] {
+      override val schema: RootSchema[R1]                  = self.schema |+| that.schema
+      override val queryAnalyzers: List[QueryAnalyzer[R1]] = self.queryAnalyzers ++ that.queryAnalyzers
+    }
+
+  /**
+   * Renames the root queries, mutations and subscriptions objects.
+   * @param queriesName a new name for the root queries object
+   * @param mutationsName a new name for the root mutations object
+   * @param subscriptionsName a new name for the root subscriptions object
+   * @return a new GraphQL API
+   */
+  final def rename(
+    queriesName: Option[String] = None,
+    mutationsName: Option[String] = None,
+    subscriptionsName: Option[String] = None
+  ): GraphQL[R] = new GraphQL[R] {
+    override protected val schema: RootSchema[R] = self.schema.copy(
+      query = queriesName.fold(self.schema.query)(
+        name => self.schema.query.copy(opType = self.schema.query.opType.copy(name = Some(name)))
+      ),
+      mutation = mutationsName.fold(self.schema.mutation)(
+        name => self.schema.mutation.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
+      ),
+      subscription = subscriptionsName.fold(self.schema.subscription)(
+        name => self.schema.subscription.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
+      )
+    )
+    override protected val queryAnalyzers: List[QueryAnalyzer[R]] = self.queryAnalyzers
+  }
 }
 
 object GraphQL {
 
   /**
-   * Builds a GraphQL interpreter for the given resolver.
+   * Builds a GraphQL API for the given resolver.
    *
    * It requires an instance of [[caliban.schema.Schema]] for each operation type.
    * This schema will be derived by Magnolia automatically.
@@ -116,48 +135,12 @@ object GraphQL {
     implicit querySchema: Schema[R, Q],
     mutationSchema: Schema[R, M],
     subscriptionSchema: Schema[R, S]
-  ): GraphQL[R, CalibanError] =
-    new GraphQL[R, CalibanError] {
-      val schema: RootSchema[R] = RootSchema(
-        Operation(querySchema.toType(), querySchema.resolve(resolver.queryResolver)),
-        resolver.mutationResolver.map(r => Operation(mutationSchema.toType(), mutationSchema.resolve(r))),
-        resolver.subscriptionResolver.map(r => Operation(subscriptionSchema.toType(), subscriptionSchema.resolve(r)))
-      )
-      val rootType: RootType =
-        RootType(schema.query.opType, schema.mutation.map(_.opType), schema.subscription.map(_.opType))
-      val introspectionRootSchema: RootSchema[Any] = Introspector.introspect(rootType)
-      val introspectionRootType: RootType          = RootType(introspectionRootSchema.query.opType, None, None)
-
-      def check(query: String): IO[CalibanError, Unit] =
-        for {
-          document       <- Parser.parseQuery(query)
-          intro          = Introspector.isIntrospection(document)
-          typeToValidate = if (intro) introspectionRootType else rootType
-          _              <- Validator.validate(document, typeToValidate)
-        } yield ()
-
-      def execute[R1 <: R](
-        query: String,
-        operationName: Option[String] = None,
-        variables: Map[String, InputValue] = Map(),
-        skipValidation: Boolean = false,
-        queryAnalyzers: List[QueryAnalyzer[R1]] = Nil
-      ): URIO[R1, GraphQLResponse[CalibanError]] = {
-
-        val prepare = for {
-          document        <- Parser.parseQuery(query)
-          intro           = Introspector.isIntrospection(document)
-          typeToValidate  = if (intro) introspectionRootType else rootType
-          schemaToExecute = if (intro) introspectionRootSchema else schema
-          _               <- IO.when(!skipValidation)(Validator.validate(document, typeToValidate))
-        } yield (document, schemaToExecute)
-
-        prepare.foldM(
-          Executor.fail,
-          req => Executor.executeRequest(req._1, req._2, operationName, variables, queryAnalyzers)
-        )
-      }
-
-      def render: String = renderTypes(rootType.types)
-    }
+  ): GraphQL[R] = new GraphQL[R] {
+    val schema: RootSchema[R] = RootSchema(
+      Operation(querySchema.toType(), querySchema.resolve(resolver.queryResolver)),
+      resolver.mutationResolver.map(r => Operation(mutationSchema.toType(), mutationSchema.resolve(r))),
+      resolver.subscriptionResolver.map(r => Operation(subscriptionSchema.toType(), subscriptionSchema.resolve(r)))
+    )
+    val queryAnalyzers: List[QueryAnalyzer[R]] = Nil
+  }
 }

--- a/core/src/main/scala/caliban/GraphQLInterpreter.scala
+++ b/core/src/main/scala/caliban/GraphQLInterpreter.scala
@@ -1,0 +1,56 @@
+package caliban
+
+import zio.URIO
+
+/**
+ * A `GraphQLInterpreter[-R, +E]` represents a GraphQL interpreter whose execution requires
+ * a ZIO environment of type `R` and can fail with an `E`.
+ *
+ * It is a wrapper around a `GraphQL` API definition that allows adding some middleware around
+ * query execution, and possibly transform the environment or the error type.
+ */
+trait GraphQLInterpreter[-R, +E] { self =>
+
+  /**
+   * Parses, validates and finally runs the provided query against this interpreter.
+   * @param query a string containing the GraphQL query.
+   * @param operationName the operation to run in case the query contains multiple operations.
+   * @param variables a list of variables.
+   * @param skipValidation skips the validation step if true
+   * @return an effect that either fails with an `E` or succeeds with a [[ResponseValue]]
+   */
+  def execute(
+    query: String,
+    operationName: Option[String] = None,
+    variables: Map[String, InputValue] = Map(),
+    skipValidation: Boolean = false
+  ): URIO[R, GraphQLResponse[E]]
+
+  /**
+   * Changes the error channel of the `execute` method.
+   * This can be used to customize error messages.
+   * @param f a function from the current error type `E` to another type `E2`
+   * @return a new GraphQL interpreter with error type `E2`
+   */
+  final def mapError[E2](f: E => E2): GraphQLInterpreter[R, E2] =
+    wrapExecutionWith(_.map(res => GraphQLResponse(res.data, res.errors.map(f))))
+
+  /**
+   * Eliminates the ZIO environment R requirement of the interpreter.
+   * @param r a value of type `R`
+   * @return a new GraphQL interpreter with R = `Any`
+   */
+  final def provide(r: R): GraphQLInterpreter[Any, E] = wrapExecutionWith(_.provide(r))
+
+  /**
+   * Wraps the `execute` method of the interpreter with the given function.
+   * This can be used to customize errors, add global timeouts or logging functions.
+   * @param f a function from `URIO[R, GraphQLResponse[E]]` to `URIO[R2, GraphQLResponse[E2]]`
+   * @return a new GraphQL interpreter
+   */
+  final def wrapExecutionWith[R2, E2](
+    f: URIO[R, GraphQLResponse[E]] => URIO[R2, GraphQLResponse[E2]]
+  ): GraphQLInterpreter[R2, E2] =
+    (query: String, operationName: Option[String], variables: Map[String, InputValue], skipValidation: Boolean) =>
+      f(self.execute(query, operationName, variables, skipValidation))
+}

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -23,9 +23,9 @@ object Executor {
    * @param operationName the operation to run in case the query contains multiple operations.
    * @param variables a list of variables.
    */
-  def executeRequest[R, Q, M, S](
+  def executeRequest[R](
     document: Document,
-    schema: RootSchema[R, Q, M, S],
+    schema: RootSchema[R],
     operationName: Option[String] = None,
     variables: Map[String, InputValue] = Map(),
     queryAnalyzers: List[QueryAnalyzer[R]] = Nil

--- a/core/src/main/scala/caliban/execution/QueryAnalyzer.scala
+++ b/core/src/main/scala/caliban/execution/QueryAnalyzer.scala
@@ -19,7 +19,7 @@ object QueryAnalyzer {
    * @param interpreter a GraphQL interpreter
    * @return a new GraphQL interpreter
    */
-  def maxDepth[R, Q, M, S, E](maxDepth: Int)(interpreter: GraphQL[R, Q, M, S, E]): GraphQL[R, Q, M, S, E] =
+  def maxDepth[R, E](maxDepth: Int)(interpreter: GraphQL[R, E]): GraphQL[R, E] =
     interpreter.withQueryAnalyzer(checkMaxDepth(maxDepth))
 
   /**
@@ -44,7 +44,7 @@ object QueryAnalyzer {
    * @param interpreter a GraphQL interpreter
    * @return a new GraphQL interpreter
    */
-  def maxFields[R, Q, M, S, E](maxFields: Int)(interpreter: GraphQL[R, Q, M, S, E]): GraphQL[R, Q, M, S, E] =
+  def maxFields[R, E](maxFields: Int)(interpreter: GraphQL[R, E]): GraphQL[R, E] =
     interpreter.withQueryAnalyzer(checkMaxFields(maxFields))
 
   /**

--- a/core/src/main/scala/caliban/execution/QueryAnalyzer.scala
+++ b/core/src/main/scala/caliban/execution/QueryAnalyzer.scala
@@ -14,13 +14,13 @@ object QueryAnalyzer {
   type QueryAnalyzer[-R] = Field => ZIO[R, CalibanError, Field]
 
   /**
-   * Attaches to the given GraphQL interpreter a function that checks that each query depth is under a given max.
+   * Attaches to the given GraphQL API definition a function that checks that each query depth is under a given max.
    * @param maxDepth the max allowed depth for a query
-   * @param interpreter a GraphQL interpreter
-   * @return a new GraphQL interpreter
+   * @param api a GraphQL API definition
+   * @return a new GraphQL API definition
    */
-  def maxDepth[R, E](maxDepth: Int)(interpreter: GraphQL[R, E]): GraphQL[R, E] =
-    interpreter.withQueryAnalyzer(checkMaxDepth(maxDepth))
+  def maxDepth[R, E](maxDepth: Int)(api: GraphQL[R]): GraphQL[R] =
+    api.withQueryAnalyzer(checkMaxDepth(maxDepth))
 
   /**
    * Checks that the given field's depth is under a given max
@@ -39,13 +39,13 @@ object QueryAnalyzer {
   }
 
   /**
-   * Attaches to the given GraphQL interpreter a function that checks that each query has a limited number of fields.
+   * Attaches to the given GraphQL API definition a function that checks that each query has a limited number of fields.
    * @param maxFields the max allowed number of fields for a query
-   * @param interpreter a GraphQL interpreter
-   * @return a new GraphQL interpreter
+   * @param api a GraphQL API definition
+   * @return a new GraphQL API definition
    */
-  def maxFields[R, E](maxFields: Int)(interpreter: GraphQL[R, E]): GraphQL[R, E] =
-    interpreter.withQueryAnalyzer(checkMaxFields(maxFields))
+  def maxFields[R, E](maxFields: Int)(api: GraphQL[R]): GraphQL[R] =
+    api.withQueryAnalyzer(checkMaxFields(maxFields))
 
   /**
    * Checks that the given field has a limited number of fields

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -33,7 +33,7 @@ object Introspector {
   /**
    * Generates a schema for introspecting the given type.
    */
-  def introspect(rootType: RootType): RootSchema[Any, __Introspection, Nothing, Nothing] = {
+  def introspect(rootType: RootType): RootSchema[Any] = {
     val types = rootType.types.updated("Boolean", Types.boolean).values.toList.sortBy(_.name.getOrElse(""))
     val resolver = __Introspection(
       __Schema(rootType.queryType, rootType.mutationType, rootType.subscriptionType, types, directives),

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -10,4 +10,19 @@ case class __Type(
   enumValues: __DeprecatedArgs => Option[List[__EnumValue]] = _ => None,
   inputFields: Option[List[__InputValue]] = None,
   ofType: Option[__Type] = None
-)
+) {
+  def |+|(that: __Type): __Type = __Type(
+    kind,
+    (name ++ that.name).reduceOption((a, b) => s"${a}With$b"),
+    (description ++ that.description).reduceOption((a, b) => s"$a\n$b"),
+    args =>
+      (fields(args) ++ that.fields(args)).reduceOption((a, b) => a ++ b.filterNot(f => a.exists(_.name == f.name))),
+    (interfaces ++ that.interfaces).reduceOption((a, b) => a ++ b.filterNot(t => a.exists(_.name == t.name))),
+    (possibleTypes ++ that.possibleTypes).reduceOption((a, b) => a ++ b.filterNot(t => a.exists(_.name == t.name))),
+    args =>
+      (enumValues(args) ++ that.enumValues(args))
+        .reduceOption((a, b) => a ++ b.filterNot(v => a.exists(_.name == v.name))),
+    (inputFields ++ that.inputFields).reduceOption((a, b) => a ++ b.filterNot(t => a.exists(_.name == t.name))),
+    (ofType ++ that.ofType).reduceOption(_ |+| _)
+  )
+}

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -16,13 +16,13 @@ case class __Type(
     (name ++ that.name).reduceOption((a, b) => s"${a}With$b"),
     (description ++ that.description).reduceOption((a, b) => s"$a\n$b"),
     args =>
-      (fields(args) ++ that.fields(args)).reduceOption((a, b) => a ++ b.filterNot(f => a.exists(_.name == f.name))),
-    (interfaces ++ that.interfaces).reduceOption((a, b) => a ++ b.filterNot(t => a.exists(_.name == t.name))),
-    (possibleTypes ++ that.possibleTypes).reduceOption((a, b) => a ++ b.filterNot(t => a.exists(_.name == t.name))),
+      (fields(args) ++ that.fields(args)).reduceOption((a, b) => a.filterNot(f => b.exists(_.name == f.name)) ++ b),
+    (interfaces ++ that.interfaces).reduceOption((a, b) => a.filterNot(t => b.exists(_.name == t.name)) ++ b),
+    (possibleTypes ++ that.possibleTypes).reduceOption((a, b) => a.filterNot(t => b.exists(_.name == t.name)) ++ b),
     args =>
       (enumValues(args) ++ that.enumValues(args))
-        .reduceOption((a, b) => a ++ b.filterNot(v => a.exists(_.name == v.name))),
-    (inputFields ++ that.inputFields).reduceOption((a, b) => a ++ b.filterNot(t => a.exists(_.name == t.name))),
+        .reduceOption((a, b) => a.filterNot(v => b.exists(_.name == v.name)) ++ b),
+    (inputFields ++ that.inputFields).reduceOption((a, b) => a.filterNot(t => b.exists(_.name == t.name)) ++ b),
     (ofType ++ that.ofType).reduceOption(_ |+| _)
   )
 }

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -13,8 +13,8 @@ case class __Type(
 ) {
   def |+|(that: __Type): __Type = __Type(
     kind,
-    (name ++ that.name).reduceOption((a, b) => s"${a}With$b"),
-    (description ++ that.description).reduceOption((a, b) => s"$a\n$b"),
+    (name ++ that.name).reduceOption((_, b) => b),
+    (description ++ that.description).reduceOption((_, b) => b),
     args =>
       (fields(args) ++ that.fields(args)).reduceOption((a, b) => a.filterNot(f => b.exists(_.name == f.name)) ++ b),
     (interfaces ++ that.interfaces).reduceOption((a, b) => a.filterNot(t => b.exists(_.name == t.name)) ++ b),

--- a/core/src/main/scala/caliban/schema/RootSchema.scala
+++ b/core/src/main/scala/caliban/schema/RootSchema.scala
@@ -3,14 +3,14 @@ package caliban.schema
 import caliban.introspection.adt.__Type
 import caliban.schema.RootSchema.Operation
 
-case class RootSchema[-R, Query, Mutation, Subscription](
-  query: Operation[R, Query],
-  mutation: Option[Operation[R, Mutation]],
-  subscription: Option[Operation[R, Subscription]]
+case class RootSchema[-R](
+  query: Operation[R],
+  mutation: Option[Operation[R]],
+  subscription: Option[Operation[R]]
 )
 
 object RootSchema {
 
-  case class Operation[-R, T](opType: __Type, plan: Step[R])
+  case class Operation[-R](opType: __Type, plan: Step[R])
 
 }

--- a/core/src/main/scala/caliban/schema/RootSchema.scala
+++ b/core/src/main/scala/caliban/schema/RootSchema.scala
@@ -7,10 +7,20 @@ case class RootSchema[-R](
   query: Operation[R],
   mutation: Option[Operation[R]],
   subscription: Option[Operation[R]]
-)
+) {
+  def |+|[R1 <: R](that: RootSchema[R1]): RootSchema[R1] =
+    RootSchema(
+      query |+| that.query,
+      (mutation ++ that.mutation).reduceOption(_ |+| _),
+      (subscription ++ that.subscription).reduceOption(_ |+| _)
+    )
+}
 
 object RootSchema {
 
-  case class Operation[-R](opType: __Type, plan: Step[R])
+  case class Operation[-R](opType: __Type, plan: Step[R]) {
+    def |+|[R1 <: R](that: Operation[R1]): Operation[R1] =
+      Operation(opType |+| that.opType, Step.mergeRootSteps(plan, that.plan))
+  }
 
 }

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -27,7 +27,7 @@ object Step {
    */
   def mergeRootSteps[R](step1: Step[R], step2: Step[R]): Step[R] = (step1, step2) match {
     case (ObjectStep(name, fields1), ObjectStep(_, fields2)) =>
-      ObjectStep(name, fields2 ++ fields1) // fields1 override fields2 in case of conflict
+      ObjectStep(name, fields1 ++ fields2) // fields2 override fields1 in case of conflict
     case _ => step1
   }
 }

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -28,7 +28,7 @@ object Step {
   def mergeRootSteps[R](step1: Step[R], step2: Step[R]): Step[R] = (step1, step2) match {
     case (ObjectStep(name, fields1), ObjectStep(_, fields2)) =>
       ObjectStep(name, fields1 ++ fields2) // fields2 override fields1 in case of conflict
-    case _ => step1
+    case _ => step2
   }
 }
 

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -21,6 +21,15 @@ object Step {
   val PureStep: caliban.schema.PureStep.type = caliban.schema.PureStep
 
   val NullStep: PureStep = PureStep(NullValue)
+
+  /**
+   * Merge 2 root steps. Root steps are supposed to be objects so we ignore other cases.
+   */
+  def mergeRootSteps[R](step1: Step[R], step2: Step[R]): Step[R] = (step1, step2) match {
+    case (ObjectStep(name, fields1), ObjectStep(_, fields2)) =>
+      ObjectStep(name, fields2 ++ fields1) // fields1 override fields2 in case of conflict
+    case _ => step1
+  }
 }
 
 sealed trait ReducedStep[-R]

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -14,7 +14,7 @@ object ExecutionSpec
     extends DefaultRunnableSpec(
       suite("ExecutionSpec")(
         testM("skip directive") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
             query test {
               amos: character(name: "Amos Burton") {
@@ -29,7 +29,7 @@ object ExecutionSpec
           )
         },
         testM("simple query with fields") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
             {
               characters {
@@ -45,7 +45,7 @@ object ExecutionSpec
           )
         },
         testM("arguments") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
             {
               characters(origin: MARS) {
@@ -62,7 +62,7 @@ object ExecutionSpec
           )
         },
         testM("arguments with list coercion") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
             {
               charactersIn(names: "Alex Kamal") {
@@ -76,7 +76,7 @@ object ExecutionSpec
           )
         },
         testM("aliases") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
              {
                amos: character(name: "Amos Burton") {
@@ -95,7 +95,7 @@ object ExecutionSpec
           )
         },
         testM("fragment") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
              {
                amos: character(name: "Amos Burton") {
@@ -113,7 +113,7 @@ object ExecutionSpec
           )
         },
         testM("inline fragment") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
              {
                amos: character(name: "Amos Burton") {
@@ -132,7 +132,7 @@ object ExecutionSpec
           )
         },
         testM("effectful query") {
-          val interpreter = graphQL(resolverIO)
+          val interpreter = graphQL(resolverIO).interpreter
           val query       = gqldoc("""
                {
                  characters {
@@ -148,7 +148,7 @@ object ExecutionSpec
           )
         },
         testM("mutation") {
-          val interpreter = graphQL(resolverWithMutation)
+          val interpreter = graphQL(resolverWithMutation).interpreter
           val query       = gqldoc("""
                mutation {
                  deleteCharacter(name: "Amos Burton")
@@ -157,7 +157,7 @@ object ExecutionSpec
           assertM(interpreter.execute(query).map(_.data.toString), equalTo("""{"deleteCharacter":{}}"""))
         },
         testM("variable") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
              query test($name: String!){
                amos: character(name: $name) {
@@ -171,7 +171,7 @@ object ExecutionSpec
           )
         },
         testM("skip directive") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
              query test{
                amos: character(name: "Amos Burton") {
@@ -183,7 +183,7 @@ object ExecutionSpec
           assertM(interpreter.execute(query).map(_.data.toString), equalTo("""{"amos":{"name":"Amos Burton"}}"""))
         },
         testM("include directive") {
-          val interpreter = graphQL(resolver)
+          val interpreter = graphQL(resolver).interpreter
           val query       = gqldoc("""
              query test($included: Boolean!){
                amos: character(name: "Amos Burton") {
@@ -199,7 +199,7 @@ object ExecutionSpec
         },
         testM("test Map") {
           case class Test(map: Map[Int, String])
-          val interpreter = graphQL(RootResolver(Test(Map(3 -> "ok"))))
+          val interpreter = graphQL(RootResolver(Test(Map(3 -> "ok")))).interpreter
           val query       = gqldoc("""
              {
                map {
@@ -212,7 +212,7 @@ object ExecutionSpec
         },
         testM("test Either") {
           case class Test(either: Either[Int, String])
-          val interpreter = graphQL(RootResolver(Test(Right("ok"))))
+          val interpreter = graphQL(RootResolver(Test(Right("ok")))).interpreter
           val query       = gqldoc("""
              {
                either {
@@ -226,7 +226,7 @@ object ExecutionSpec
         testM("test UUID") {
           case class IdArgs(id: UUID)
           case class Queries(test: IdArgs => UUID)
-          val interpreter = graphQL(RootResolver(Queries(_.id)))
+          val interpreter = graphQL(RootResolver(Queries(_.id))).interpreter
           val query       = gqldoc("""
              {
                test(id: "be722453-d97d-48c2-b535-9badd1b5d4c9")
@@ -239,7 +239,7 @@ object ExecutionSpec
         },
         testM("mapError") {
           case class Test(either: Either[Int, String])
-          val interpreter = graphQL(RootResolver(Test(Right("ok")))).mapError(_ => "my custom error")
+          val interpreter = graphQL(RootResolver(Test(Right("ok")))).interpreter.mapError(_ => "my custom error")
           val query       = """query{}"""
           assertM(interpreter.execute(query).map(_.errors), equalTo(List("my custom error")))
         },
@@ -247,7 +247,7 @@ object ExecutionSpec
           case class A(b: B)
           case class B(c: Int)
           case class Test(a: A)
-          val interpreter = QueryAnalyzer.maxFields(2)(graphQL(RootResolver(Test(A(B(2))))))
+          val interpreter = QueryAnalyzer.maxFields(2)(graphQL(RootResolver(Test(A(B(2)))))).interpreter
           val query       = gqldoc("""
               {
                 a {
@@ -265,7 +265,7 @@ object ExecutionSpec
           case class A(b: B)
           case class B(c: Int)
           case class Test(a: A)
-          val interpreter = QueryAnalyzer.maxFields(2)(graphQL(RootResolver(Test(A(B(2))))))
+          val interpreter = QueryAnalyzer.maxFields(2)(graphQL(RootResolver(Test(A(B(2)))))).interpreter
           val query       = gqldoc("""
               query test {
                 a {
@@ -288,7 +288,7 @@ object ExecutionSpec
           case class A(b: B)
           case class B(c: Int)
           case class Test(a: A)
-          val interpreter = QueryAnalyzer.maxDepth(2)(graphQL(RootResolver(Test(A(B(2))))))
+          val interpreter = QueryAnalyzer.maxDepth(2)(graphQL(RootResolver(Test(A(B(2)))))).interpreter
           val query       = gqldoc("""
               {
                 a {
@@ -300,6 +300,22 @@ object ExecutionSpec
           assertM(
             interpreter.execute(query).map(_.errors),
             equalTo(List(ValidationError("Query is too deep: 3. Max depth: 2.", "")))
+          )
+        },
+        testM("merge 2 APIs") {
+          case class Test(name: String)
+          case class Test2(id: Int)
+          val api1        = graphQL(RootResolver(Test("name")))
+          val api2        = graphQL(RootResolver(Test2(2)))
+          val interpreter = (api1 |+| api2).interpreter
+          val query =
+            """query{
+              |  name
+              |  id
+              |}""".stripMargin
+          assertM(
+            interpreter.execute(query).map(_.data.toString),
+            equalTo("""{"name":"name","id":2}""")
           )
         }
       )

--- a/core/src/test/scala/caliban/introspection/IntrospectionSpec.scala
+++ b/core/src/test/scala/caliban/introspection/IntrospectionSpec.scala
@@ -104,7 +104,7 @@ object IntrospectionSpec
               }
                 """)
 
-          val interpreter = graphQL(resolverIO)
+          val interpreter = graphQL(resolverIO).interpreter
 
           assertM(
             interpreter.execute(fullIntrospectionQuery).map(_.data.toString),

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -10,7 +10,7 @@ import zio.test._
 
 object ValidationSpec
     extends DefaultRunnableSpec({
-      val interpreter = graphQL(resolverWithSubscription)
+      val interpreter = graphQL(resolverWithSubscription).interpreter
       def check(query: String, expectedMessage: String): UIO[TestResult] = {
         val io = interpreter.execute(query).map(_.errors.headOption)
         assertM(io, isSome(hasField[CalibanError, String]("msg", _.msg, equalTo(expectedMessage))))

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ To run the examples without the rest of the project, add this to your build.sbt:
 libraryDependencies ++= Seq(
   "com.github.ghostdogpr" %% "caliban" % "0.3.1",
   "com.github.ghostdogpr" %% "caliban-http4s" % "0.3.1",
+  "com.github.ghostdogpr" %% "caliban-akka-http" % "0.3.1",
   "com.github.ghostdogpr" %% "caliban-cats" % "0.3.1"
 )
 ```

--- a/examples/src/main/scala/caliban/ExampleApp.scala
+++ b/examples/src/main/scala/caliban/ExampleApp.scala
@@ -37,9 +37,7 @@ object ExampleApp extends CatsApp with GenericSchema[Console with Clock] {
   implicit val characterArgsSchema  = gen[CharacterArgs]
   implicit val charactersArgsSchema = gen[CharactersArgs]
 
-  def makeInterpreter(
-    service: ExampleService
-  ): GraphQL[Console with Clock, Queries, Mutations, Subscriptions, CalibanError] =
+  def makeInterpreter(service: ExampleService): GraphQL[Console with Clock, CalibanError] =
     maxDepth(30)(
       maxFields(200)(
         graphQL(

--- a/examples/src/main/scala/caliban/ExampleApp.scala
+++ b/examples/src/main/scala/caliban/ExampleApp.scala
@@ -23,17 +23,12 @@ object ExampleApp extends CatsApp with GenericSchema[Console with Clock] {
 
   case class Queries(
     @GQLDescription("Return all characters from a given origin")
-    characters: CharactersArgs => URIO[Console, List[Character]]
-  )
-  case class Mutations(deleteCharacter: CharacterArgs => URIO[Console, Boolean])
-  case class Subscriptions(characterDeleted: ZStream[Console, Nothing, String])
-
-  case class Queries2(
+    characters: CharactersArgs => URIO[Console, List[Character]],
     @GQLDeprecated("Use `characters`")
     character: CharacterArgs => URIO[Console, Option[Character]]
   )
-
-  case class Queries3(character: Int)
+  case class Mutations(deleteCharacter: CharacterArgs => URIO[Console, Boolean])
+  case class Subscriptions(characterDeleted: ZStream[Console, Nothing, String])
 
   type ExampleTask[A] = RIO[Console with Clock, A]
 
@@ -42,23 +37,21 @@ object ExampleApp extends CatsApp with GenericSchema[Console with Clock] {
   implicit val characterArgsSchema  = gen[CharacterArgs]
   implicit val charactersArgsSchema = gen[CharactersArgs]
 
-  def makeApi(service: ExampleService): GraphQL[Console with Clock] = {
-    val api1 = graphQL(
-      RootResolver(
-        Queries(args => service.getCharacters(args.origin)),
-        Mutations(args => service.deleteCharacter(args.name)),
-        Subscriptions(service.deletedEvents)
-      )
-    )
-    val api2 = graphQL(RootResolver(Queries2(args => service.findCharacter(args.name))))
-    val api3 = graphQL(RootResolver(Queries3(2)))
-
+  def makeApi(service: ExampleService): GraphQL[Console with Clock] =
     maxDepth(30)(
       maxFields(200)(
-        (api1 |+| api2 |+| api3).rename(queriesName = Some("Queries"))
+        graphQL(
+          RootResolver(
+            Queries(
+              args => service.getCharacters(args.origin),
+              args => service.findCharacter(args.name)
+            ),
+            Mutations(args => service.deleteCharacter(args.name)),
+            Subscriptions(service.deletedEvents)
+          )
+        )
       )
     )
-  }
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
     (for {

--- a/examples/src/main/scala/caliban/akkahttp/ExampleApp.scala
+++ b/examples/src/main/scala/caliban/akkahttp/ExampleApp.scala
@@ -4,69 +4,74 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
-import caliban.ExampleData.{Character, CharacterArgs, CharactersArgs, Role, sampleCharacters}
+import caliban.ExampleData.{ sampleCharacters, Character, CharacterArgs, CharactersArgs, Role }
 import caliban.GraphQL.graphQL
-import caliban.schema.Annotations.{GQLDeprecated, GQLDescription}
+import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
 import caliban.schema.GenericSchema
-import caliban.{AkkaHttpAdapter, ExampleService, RootResolver}
+import caliban.{ AkkaHttpAdapter, ExampleService, RootResolver }
 import zio.clock.Clock
 import zio.console.Console
 import zio.stream.ZStream
-import zio.{DefaultRuntime, URIO}
+import zio.{ DefaultRuntime, URIO }
 
 import scala.io.StdIn
 
 object ExampleApp extends App with GenericSchema[Console with Clock] {
 
-  implicit val system = ActorSystem()
-  implicit val materializer = ActorMaterializer()
+  implicit val system           = ActorSystem()
+  implicit val materializer     = ActorMaterializer()
   implicit val executionContext = system.dispatcher
-  implicit val defaultRuntime = new DefaultRuntime {}
+  implicit val defaultRuntime   = new DefaultRuntime {}
 
-  implicit val roleSchema = gen[Role]
-  implicit val characterSchema = gen[Character]
-  implicit val characterArgsSchema = gen[CharacterArgs]
+  implicit val roleSchema           = gen[Role]
+  implicit val characterSchema      = gen[Character]
+  implicit val characterArgsSchema  = gen[CharacterArgs]
   implicit val charactersArgsSchema = gen[CharactersArgs]
 
   case class Queries(
-                      @GQLDescription("Return all characters from a given origin")
-                      characters: CharactersArgs => URIO[Console, List[Character]],
-                      @GQLDeprecated("Use `characters`")
-                      character: CharacterArgs => URIO[Console, Option[Character]]
-                    )
+    @GQLDescription("Return all characters from a given origin")
+    characters: CharactersArgs => URIO[Console, List[Character]],
+    @GQLDeprecated("Use `characters`")
+    character: CharacterArgs => URIO[Console, Option[Character]]
+  )
   case class Mutations(deleteCharacter: CharacterArgs => URIO[Console, Boolean])
   case class Subscriptions(characterDeleted: ZStream[Console, Nothing, String])
 
-  val interpreter = defaultRuntime.unsafeRun(ExampleService.make(sampleCharacters).map(service => {
-    graphQL(
-      RootResolver(
-        Queries(
-          args => service.getCharacters(args.origin),
-          args => service.findCharacter(args.name)
-        ),
-        Mutations(args => service.deleteCharacter(args.name)),
-        Subscriptions(service.deletedEvents)))
-  }))
+  val interpreter = defaultRuntime.unsafeRun(
+    ExampleService
+      .make(sampleCharacters)
+      .map(service => {
+        graphQL(
+          RootResolver(
+            Queries(
+              args => service.getCharacters(args.origin),
+              args => service.findCharacter(args.name)
+            ),
+            Mutations(args => service.deleteCharacter(args.name)),
+            Subscriptions(service.deletedEvents)
+          )
+        ).interpreter
+      })
+  )
 
   /**
    * curl -X POST \
-   * http://localhost:8080/api/graphql \
-   * -H 'Host: localhost:8080' \
+   * http://localhost:8088/api/graphql \
+   * -H 'Host: localhost:8088' \
    * -H 'Content-Type: application/json' \
    * -d '{
    * "query": "query { characters { name }}"
    * }'
    */
-
   val route =
-      path("api" / "graphql") {
-        AkkaHttpAdapter.makeHttpService(interpreter)
-      } ~ path("graphiql") {
-        getFromResource("graphiql.html")
-      }
+    path("api" / "graphql") {
+      AkkaHttpAdapter.makeHttpService(interpreter)
+    } ~ path("graphiql") {
+      getFromResource("graphiql.html")
+    }
 
-  val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
-  println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
+  val bindingFuture = Http().bindAndHandle(route, "localhost", 8088)
+  println(s"Server online at http://localhost:8088/\nPress RETURN to stop...")
   StdIn.readLine()
   bindingFuture
     .flatMap(_.unbind())

--- a/examples/src/main/scala/caliban/http4s/ExampleApp.scala
+++ b/examples/src/main/scala/caliban/http4s/ExampleApp.scala
@@ -3,9 +3,9 @@ package caliban.http4s
 import caliban.ExampleData._
 import caliban.GraphQL._
 import caliban.execution.QueryAnalyzer._
-import caliban.schema.Annotations.{GQLDeprecated, GQLDescription}
+import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
 import caliban.schema.GenericSchema
-import caliban.{CalibanError, ExampleService, GraphQL, Http4sAdapter, RootResolver}
+import caliban.{ ExampleService, GraphQL, Http4sAdapter, RootResolver }
 import cats.data.Kleisli
 import cats.effect.Blocker
 import org.http4s.StaticFile
@@ -16,7 +16,7 @@ import org.http4s.server.middleware.CORS
 import zio._
 import zio.blocking.Blocking
 import zio.clock.Clock
-import zio.console.{Console, putStrLn}
+import zio.console.{ putStrLn, Console }
 import zio.interop.catz._
 import zio.stream.ZStream
 

--- a/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
+++ b/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
@@ -19,7 +19,7 @@ object ExampleCatsInterop extends IOApp {
   val randomNumber = IO(scala.util.Random.nextInt()).map(Number)
 
   val queries     = Queries(numbers, randomNumber)
-  val interpreter = graphQL(RootResolver(queries))
+  val interpreter = graphQL(RootResolver(queries)).interpreter
 
   val query = """
   {

--- a/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
+++ b/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
@@ -19,7 +19,8 @@ object ExampleCatsInterop extends IOApp {
   val randomNumber = IO(scala.util.Random.nextInt()).map(Number)
 
   val queries     = Queries(numbers, randomNumber)
-  val interpreter = graphQL(RootResolver(queries)).interpreter
+  val api         = graphQL(RootResolver(queries))
+  val interpreter = api.interpreter
 
   val query = """
   {
@@ -34,6 +35,7 @@ object ExampleCatsInterop extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] =
     for {
+      _      <- api.checkAsync[IO](query)
       result <- interpreter.executeAsync[IO](query)
       _      <- IO(println(result.data))
     } yield ExitCode.Success

--- a/examples/src/main/scala/caliban/optimizations/NaiveTest.scala
+++ b/examples/src/main/scala/caliban/optimizations/NaiveTest.scala
@@ -82,7 +82,7 @@ object NaiveTest extends App with GenericSchema[Console] {
   implicit lazy val user: Schema[Console, User]                  = gen[User]
 
   val resolver    = Queries(args => getUser(args.id))
-  val interpreter = GraphQL.graphQL(RootResolver(resolver))
+  val interpreter = GraphQL.graphQL(RootResolver(resolver)).interpreter
 
   override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, Int] =
     interpreter.execute(query).map(_.errors.length)

--- a/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
+++ b/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
@@ -123,7 +123,7 @@ object OptimizedTest extends App with GenericSchema[Console] {
   implicit lazy val user: Schema[Console, User]                  = gen[User]
 
   val resolver    = Queries(args => getUser(args.id))
-  val interpreter = GraphQL.graphQL(RootResolver(resolver))
+  val interpreter = GraphQL.graphQL(RootResolver(resolver)).interpreter
 
   override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, Int] =
     interpreter.execute(query).map(_.errors.length)

--- a/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -21,24 +21,18 @@ import zio.interop.catz._
 
 object Http4sAdapter {
 
-  private def execute[R, Q, M, S, E](
-    interpreter: GraphQL[R, Q, M, S, E],
-    query: GraphQLRequest
-  ): URIO[R, GraphQLResponse[E]] =
+  private def execute[R, E](interpreter: GraphQL[R, E], query: GraphQLRequest): URIO[R, GraphQLResponse[E]] =
     interpreter.execute(query.query, query.operationName, query.variables.getOrElse(Map()))
 
-  private def executeToJson[R, Q, M, S, E](
-    interpreter: GraphQL[R, Q, M, S, E],
-    query: GraphQLRequest
-  ): URIO[R, Json] =
+  private def executeToJson[R, E](interpreter: GraphQL[R, E], query: GraphQLRequest): URIO[R, Json] =
     execute(interpreter, query)
       .foldCause(cause => GraphQLResponse(NullValue, cause.defects).asJson, _.asJson)
 
   @deprecated("Use makeHttpService instead", "0.4.0")
-  def makeRestService[R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E]): HttpRoutes[RIO[R, *]] =
+  def makeRestService[R, E](interpreter: GraphQL[R, E]): HttpRoutes[RIO[R, *]] =
     makeHttpService(interpreter)
 
-  def makeHttpService[R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E]): HttpRoutes[RIO[R, *]] = {
+  def makeHttpService[R, E](interpreter: GraphQL[R, E]): HttpRoutes[RIO[R, *]] = {
     object dsl extends Http4sDsl[RIO[R, *]]
     import dsl._
 
@@ -52,7 +46,7 @@ object Http4sAdapter {
     }
   }
 
-  def executeRequest[R0, R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E], provideEnv: R0 => R): HttpApp[RIO[R0, *]] =
+  def executeRequest[R0, R, E](interpreter: GraphQL[R, E], provideEnv: R0 => R): HttpApp[RIO[R0, *]] =
     Kleisli { req =>
       object dsl extends Http4sDsl[RIO[R0, *]]
       import dsl._
@@ -63,7 +57,7 @@ object Http4sAdapter {
       } yield response
     }
 
-  def makeWebSocketService[R, Q, M, S, E](interpreter: GraphQL[R, Q, M, S, E]): HttpRoutes[RIO[R, *]] = {
+  def makeWebSocketService[R, E](interpreter: GraphQL[R, E]): HttpRoutes[RIO[R, *]] = {
 
     object dsl extends Http4sDsl[RIO[R, *]]
     import dsl._
@@ -172,24 +166,24 @@ object Http4sAdapter {
       .dimap((req: Request[F]) => req.mapK(toTask))((res: Response[Task]) => res.mapK(toF))
   }
 
-  def makeWebSocketServiceF[F[_], Q, M, S, E](
-    interpreter: GraphQL[Any, Q, M, S, E]
+  def makeWebSocketServiceF[F[_], E](
+    interpreter: GraphQL[Any, E]
   )(implicit F: Effect[F], runtime: Runtime[Any]): HttpRoutes[F] =
-    wrapRoute(makeWebSocketService[Any, Q, M, S, E](interpreter))
+    wrapRoute(makeWebSocketService[Any, E](interpreter))
 
   @deprecated("Use makeHttpServiceF instead", "0.4.0")
-  def makeRestServiceF[F[_], Q, M, S, E](
-    interpreter: GraphQL[Any, Q, M, S, E]
+  def makeRestServiceF[F[_], E](
+    interpreter: GraphQL[Any, E]
   )(implicit F: Effect[F], runtime: Runtime[Any]): HttpRoutes[F] =
     makeHttpServiceF(interpreter)
 
-  def makeHttpServiceF[F[_], Q, M, S, E](
-    interpreter: GraphQL[Any, Q, M, S, E]
+  def makeHttpServiceF[F[_], E](
+    interpreter: GraphQL[Any, E]
   )(implicit F: Effect[F], runtime: Runtime[Any]): HttpRoutes[F] =
-    wrapRoute(makeHttpService[Any, Q, M, S, E](interpreter))
+    wrapRoute(makeHttpService[Any, E](interpreter))
 
-  def executeRequestF[F[_], Q, M, S, E](
-    interpreter: GraphQL[Any, Q, M, S, E]
+  def executeRequestF[F[_], E](
+    interpreter: GraphQL[Any, E]
   )(implicit F: Effect[F], runtime: Runtime[Any]): HttpApp[F] =
-    wrapApp(executeRequest[Any, Any, Q, M, S, E](interpreter, identity))
+    wrapApp(executeRequest[Any, Any, E](interpreter, identity))
 }

--- a/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -21,18 +21,18 @@ import zio.interop.catz._
 
 object Http4sAdapter {
 
-  private def execute[R, E](interpreter: GraphQL[R, E], query: GraphQLRequest): URIO[R, GraphQLResponse[E]] =
+  private def execute[R, E](interpreter: GraphQLInterpreter[R, E], query: GraphQLRequest): URIO[R, GraphQLResponse[E]] =
     interpreter.execute(query.query, query.operationName, query.variables.getOrElse(Map()))
 
-  private def executeToJson[R, E](interpreter: GraphQL[R, E], query: GraphQLRequest): URIO[R, Json] =
+  private def executeToJson[R, E](interpreter: GraphQLInterpreter[R, E], query: GraphQLRequest): URIO[R, Json] =
     execute(interpreter, query)
       .foldCause(cause => GraphQLResponse(NullValue, cause.defects).asJson, _.asJson)
 
   @deprecated("Use makeHttpService instead", "0.4.0")
-  def makeRestService[R, E](interpreter: GraphQL[R, E]): HttpRoutes[RIO[R, *]] =
+  def makeRestService[R, E](interpreter: GraphQLInterpreter[R, E]): HttpRoutes[RIO[R, *]] =
     makeHttpService(interpreter)
 
-  def makeHttpService[R, E](interpreter: GraphQL[R, E]): HttpRoutes[RIO[R, *]] = {
+  def makeHttpService[R, E](interpreter: GraphQLInterpreter[R, E]): HttpRoutes[RIO[R, *]] = {
     object dsl extends Http4sDsl[RIO[R, *]]
     import dsl._
 
@@ -46,7 +46,7 @@ object Http4sAdapter {
     }
   }
 
-  def executeRequest[R0, R, E](interpreter: GraphQL[R, E], provideEnv: R0 => R): HttpApp[RIO[R0, *]] =
+  def executeRequest[R0, R, E](interpreter: GraphQLInterpreter[R, E], provideEnv: R0 => R): HttpApp[RIO[R0, *]] =
     Kleisli { req =>
       object dsl extends Http4sDsl[RIO[R0, *]]
       import dsl._
@@ -57,7 +57,7 @@ object Http4sAdapter {
       } yield response
     }
 
-  def makeWebSocketService[R, E](interpreter: GraphQL[R, E]): HttpRoutes[RIO[R, *]] = {
+  def makeWebSocketService[R, E](interpreter: GraphQLInterpreter[R, E]): HttpRoutes[RIO[R, *]] = {
 
     object dsl extends Http4sDsl[RIO[R, *]]
     import dsl._
@@ -167,23 +167,23 @@ object Http4sAdapter {
   }
 
   def makeWebSocketServiceF[F[_], E](
-    interpreter: GraphQL[Any, E]
+    interpreter: GraphQLInterpreter[Any, E]
   )(implicit F: Effect[F], runtime: Runtime[Any]): HttpRoutes[F] =
     wrapRoute(makeWebSocketService[Any, E](interpreter))
 
   @deprecated("Use makeHttpServiceF instead", "0.4.0")
   def makeRestServiceF[F[_], E](
-    interpreter: GraphQL[Any, E]
+    interpreter: GraphQLInterpreter[Any, E]
   )(implicit F: Effect[F], runtime: Runtime[Any]): HttpRoutes[F] =
     makeHttpServiceF(interpreter)
 
   def makeHttpServiceF[F[_], E](
-    interpreter: GraphQL[Any, E]
+    interpreter: GraphQLInterpreter[Any, E]
   )(implicit F: Effect[F], runtime: Runtime[Any]): HttpRoutes[F] =
     wrapRoute(makeHttpService[Any, E](interpreter))
 
   def executeRequestF[F[_], E](
-    interpreter: GraphQL[Any, E]
+    interpreter: GraphQLInterpreter[Any, E]
   )(implicit F: Effect[F], runtime: Runtime[Any]): HttpApp[F] =
     wrapApp(executeRequest[Any, Any, E](interpreter, identity))
 }

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -14,7 +14,7 @@ import zquery.ZQuery
 
 object CatsInterop {
 
-  def executeAsync[F[_]: Async, R, Q, M, S, E](graphQL: GraphQL[R, Q, M, S, E])(
+  def executeAsync[F[_]: Async, R, E](graphQL: GraphQL[R, E])(
     query: String,
     operationName: Option[String] = None,
     variables: Map[String, InputValue] = Map(),
@@ -27,8 +27,8 @@ object CatsInterop {
       runtime.unsafeRunAsync(execution)(exit => cb(exit.toEither))
     }
 
-  def checkAsync[F[_]: Async, R, Q, M, S, E](
-    graphQL: GraphQL[R, Q, M, S, E]
+  def checkAsync[F[_]: Async, R, E](
+    graphQL: GraphQL[R, E]
   )(query: String)(implicit runtime: Runtime[R]): F[Unit] =
     Async[F].async { cb =>
       runtime.unsafeRunAsync(graphQL.execute(query))(exit => cb(exit.toEither.void))

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -6,8 +6,6 @@ import caliban.schema.{ Schema, Step }
 import caliban.{ GraphQL, GraphQLInterpreter, GraphQLResponse, InputValue }
 import cats.effect.implicits._
 import cats.effect.{ Async, Effect }
-import cats.instances.either._
-import cats.syntax.functor._
 import zio.interop.catz._
 import zio.{ Runtime, _ }
 import zquery.ZQuery
@@ -29,7 +27,7 @@ object CatsInterop {
 
   def checkAsync[F[_]: Async, R](graphQL: GraphQL[R])(query: String)(implicit runtime: Runtime[R]): F[Unit] =
     Async[F].async { cb =>
-      runtime.unsafeRunAsync(graphQL.check(query))(exit => cb(exit.toEither.void))
+      runtime.unsafeRunAsync(graphQL.check(query))(exit => cb(exit.toEither))
     }
 
   def schema[F[_]: Effect, R, A](implicit ev: Schema[R, A]): Schema[R, F[A]] =

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -1,13 +1,13 @@
 package caliban.interop.cats
 
 import caliban.schema.Schema
-import caliban.{ GraphQL, GraphQLResponse, InputValue }
+import caliban.{ GraphQL, GraphQLInterpreter, GraphQLResponse, InputValue }
 import cats.effect.{ Async, Effect }
 import zio.Runtime
 
 package object implicits {
 
-  implicit class CatsEffectGraphQL[R, E](underlying: GraphQL[R, E]) {
+  implicit class CatsEffectGraphQLInterpreter[R, E](underlying: GraphQLInterpreter[R, E]) {
 
     def executeAsync[F[_]: Async](
       query: String,
@@ -21,6 +21,9 @@ package object implicits {
         variables,
         skipValidation
       )
+  }
+
+  implicit class CatsEffectGraphQL[R, E](underlying: GraphQL[R]) {
 
     def checkAsync[F[_]: Async](query: String)(implicit runtime: Runtime[R]): F[Unit] =
       CatsInterop.checkAsync(underlying)(query)

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -7,9 +7,7 @@ import zio.Runtime
 
 package object implicits {
 
-  implicit class CatsEffectGraphQL[R, Q, M, S, E](
-    underlying: GraphQL[R, Q, M, S, E]
-  ) {
+  implicit class CatsEffectGraphQL[R, E](underlying: GraphQL[R, E]) {
 
     def executeAsync[F[_]: Async](
       query: String,
@@ -24,9 +22,7 @@ package object implicits {
         skipValidation
       )
 
-    def checkAsync[F[_]: Async](
-      query: String
-    )(implicit runtime: Runtime[R]): F[Unit] =
+    def checkAsync[F[_]: Async](query: String)(implicit runtime: Runtime[R]): F[Unit] =
       CatsInterop.checkAsync(underlying)(query)
   }
 

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -20,8 +20,9 @@ libraryDependencies += "com.github.ghostdogpr" %% "caliban" % "0.3.1"
 The following modules are optional:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-http4s" % "0.3.1" // routes for http4s
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-cats"   % "0.3.1" // interop with cats effect
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-http4s" % "0.3.1"    // routes for http4s
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-akka-http" % "0.3.1" // routes for akka-http
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-cats"   % "0.3.1"    // interop with cats effect
 ```
 
 Note that Caliban is also available for ScalaJS.
@@ -109,7 +110,7 @@ A `CalibanError` can be:
 - a `ValidationError`: the query was parsed but does not match the schema
 - an `ExecutionError`: an error happened while executing the query
 
-Caliban itself is not tied to any web framework, you are free to expose this function using the protocol and library of your choice. The [caliban-http4s](https://github.com/ghostdogpr/caliban/tree/master/http4s) module provides an `Http4sAdapter` that exposes an interpreter over HTTP and WebSocket using http4s.
+Caliban itself is not tied to any web framework, you are free to expose this function using the protocol and library of your choice. The [caliban-http4s](https://github.com/ghostdogpr/caliban/tree/master/http4s) module provides an `Http4sAdapter` that exposes an interpreter over HTTP and WebSocket using http4s. There is also a [caliban-akka-http](https://github.com/ghostdogpr/caliban/tree/master/akka-http) that provides similar functionality for Akka HTTP.
 
 ::: tip Combining GraphQL APIs
 You don't have to define all your root fields into a single case class: you can use smaller case classes and combine `GraphQL` objects using the `|+|` operator.

--- a/vuepress/docs/docs/examples.md
+++ b/vuepress/docs/docs/examples.md
@@ -1,2 +1,2 @@
 # Examples
-A sample project showing how to serve a simple GraphQL schema over HTTP and WebSocket using [http4s](https://github.com/http4s/http4s) is available in the [examples](https://github.com/ghostdogpr/caliban/tree/master/examples/) folder.
+A sample project showing how to serve a simple GraphQL schema over HTTP and WebSocket using [http4s](https://github.com/http4s/http4s) or [Akka HTTP](https://doc.akka.io/docs/akka-http/current/index.html) is available in the [examples](https://github.com/ghostdogpr/caliban/tree/master/examples/) folder.

--- a/vuepress/docs/docs/interop.md
+++ b/vuepress/docs/docs/interop.md
@@ -25,7 +25,7 @@ object ExampleCatsInterop extends IOApp {
   case class Queries(numbers: List[Int], randomNumber: IO[Int])
 
   val queries     = Queries(List(1, 2, 3, 4), IO(scala.util.Random.nextInt()))
-  val interpreter = graphQL(RootResolver(queries))
+  val interpreter = graphQL(RootResolver(queries)).interpreter
 
   val query = """
   {

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -13,16 +13,16 @@ It is used internally to implement `mapError` (customize errors) and `provide` (
 
 ```scala
 // create an interpreter
-val i: GraphQL[MyEnv, CalibanError] = graphqQL(...)
+val i: GraphQLInterpreter[MyEnv, CalibanError] = graphqQL(...).interpreter
 
 // change error type to String
-val i2: GraphQL[MyEnv, String] = i.mapError(_.toString)
+val i2: GraphQLInterpreter[MyEnv, String] = i.mapError(_.toString)
 
 // provide the environment
-val i3: GraphQL[Any, CalibanError] = i.provide(myEnv)
+val i3: GraphQLInterpreter[Any, CalibanError] = i.provide(myEnv)
 
 // add a timeout on every query execution
-val i4: GraphQL[MyEnv with Clock, CalibanError] =
+val i4: GraphQLInterpreter[MyEnv with Clock, CalibanError] =
   i.wrapExecutionWith(
     _.timeout(30 seconds).map(
       _.getOrElse(GraphQLResponse(NullValue, List(ExecutionError("Timeout!"))))

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -13,16 +13,16 @@ It is used internally to implement `mapError` (customize errors) and `provide` (
 
 ```scala
 // create an interpreter
-val i: GraphQL[MyEnv, Queries, Unit, Unit, CalibanError] = graphqQL(...)
+val i: GraphQL[MyEnv, CalibanError] = graphqQL(...)
 
 // change error type to String
-val i2: GraphQL[MyEnv, Queries, Unit, Unit, String] = i.mapError(_.toString)
+val i2: GraphQL[MyEnv, String] = i.mapError(_.toString)
 
 // provide the environment
-val i3: GraphQL[Any, Queries, Unit, Unit, CalibanError] = i.provide(myEnv)
+val i3: GraphQL[Any, CalibanError] = i.provide(myEnv)
 
 // add a timeout on every query execution
-val i4: GraphQL[MyEnv with Clock, Queries, Unit, Unit, CalibanError] =
+val i4: GraphQL[MyEnv with Clock, CalibanError] =
   i.wrapExecutionWith(
     _.timeout(30 seconds).map(
       _.getOrElse(GraphQLResponse(NullValue, List(ExecutionError("Timeout!"))))

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -33,7 +33,7 @@ See the [Custom Types](#custom-types) section to find out how to support your ow
 
 If you want Caliban to support other standard types, feel free to [file an issue](https://github.com/ghostdogpr/caliban/issues) or even a PR.
 
-::: warning
+::: warning Schema derivation issues
 Magnolia (the library used to derive the schema at compile-time) sometimes has some trouble generating schemas with a lot of nested types, or types reused in multiple places.
 to deal with this, you can declare schemas for your case classes and sealed traits explicitly:
 

--- a/vuepress/docs/docs/validation.md
+++ b/vuepress/docs/docs/validation.md
@@ -12,7 +12,7 @@ val query = gqldoc("""
   }""")
 ```
 
-At **runtime**, it is possible to validate a query against your schema by calling the method `check` on your interpreter.
+At **runtime**, it is possible to validate a query against your schema by calling the method `check` on your API.
 
 ```scala
 def check(query: String): IO[CalibanError, Unit]


### PR DESCRIPTION
This PR changes a few things:
- `GraphQL[R, Q, M, S, E]` is simplified into `GraphQL[R]`.
- `GraphQLInterpreter[R, E]` is introduced. It's a wrapper around `GraphQL` that allows changing the R, the E and running any wrapper around execution. It's obtained by just calling `.interpreter` on the `GraphQL` object. The `execute` method is available on this object.
- It is now possible to combine `GraphQL` objects with `|+|`. This allows splitting a large API into smaller chunks and work around Scala limitation of 22 fields.

Example:
```scala
val api1 = graphQL(...)
val api2 = graphQL(...)
val api = api1 |+| api2
```