### PR TITLE
Add OptionT and fs2.Stream Schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,8 @@ lazy val catsInterop = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-interop-cats" % "2.0.0.0-RC10",
-      "org.typelevel" %%% "cats-effect"      % "2.0.0"
+      "org.typelevel" %%% "cats-effect"      % "2.0.0",
+      "co.fs2"        %%% "fs2-core"         % "2.1.0"
     )
   )
   .dependsOn(core)

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -1,9 +1,16 @@
 package caliban.interop.cats
 
-import caliban.schema.Schema
+import caliban.introspection.adt.__Type
+import caliban.schema.Step.QueryStep
+import caliban.schema.{ Schema, Step }
 import caliban.{ GraphQL, GraphQLInterpreter, GraphQLResponse, InputValue }
+import cats.data.OptionT
 import cats.effect.{ Async, Effect }
-import zio.Runtime
+import zio.stream.ZStream
+import zio.{ Runtime, Task }
+import zquery.ZQuery
+import cats.effect.implicits._
+import zio.interop.catz._
 
 package object implicits {
 
@@ -31,4 +38,26 @@ package object implicits {
 
   implicit def effectSchema[F[_]: Effect, R, A](implicit ev: Schema[R, A]): Schema[R, F[A]] =
     CatsInterop.schema
+
+  implicit def optionTSchema[F[_]: Effect, R, A](implicit ev: Schema[R, Option[A]]): Schema[R, OptionT[F, A]] =
+    new Schema[R, OptionT[F, A]] {
+      override def toType(isInput: Boolean): __Type =
+        ev.toType(isInput)
+
+      override def optional: Boolean =
+        ev.optional
+
+      override def resolve(value: OptionT[F, A]): Step[R] =
+        QueryStep(ZQuery.fromEffect(value.value.toIO.to[Task].map(ev.resolve)))
+    }
+
+  implicit def fs2StreamSchema[F[_]: Effect, R, A](
+    implicit ev: Schema[R, ZStream[R, Throwable, A]]
+  ): Schema[R, fs2.Stream[F, A]] =
+    new Schema[R, fs2.Stream[F, A]] {
+      override def optional: Boolean                        = ev.optional
+      override def toType(isInput: Boolean = false): __Type = ev.toType(isInput)
+      override def resolve(value: fs2.Stream[F, A]): Step[R] =
+        ev.resolve(ZStream.fromIterator(value.compile.toVector.toIO.to[Task].map(_.iterator)))
+    }
 }


### PR DESCRIPTION
**Target and solved questions**

Add the Schema for `cats.data.OptionT` and and `fs2.Stream` so that users can use these two data types in Query, Mutation and Subscription directly.

**Problems**

* Because I cannot find a way to convert from `fs2.Stream` to `ZStream` directly, so I just convert `fs2.Stream` to a Vector and then change it to `ZStream`. I have no idea if there will be any performance issue