### PR TITLE
fix(error): Correctly encode the error message.

### DIFF
--- a/core/src/main/scala/caliban/GraphQLResponse.scala
+++ b/core/src/main/scala/caliban/GraphQLResponse.scala
@@ -16,11 +16,12 @@ private object GraphQLResponceCirce {
   import io.circe._
   import io.circe.syntax._
   val graphQLResponseEncoder: Encoder[GraphQLResponse[CalibanError]] = Encoder
-    .instance[GraphQLResponse[CalibanError]](
-      response =>
+    .instance[GraphQLResponse[CalibanError]] {
+      case GraphQLResponse(data, Nil) => Json.obj("data" -> data.asJson)
+      case GraphQLResponse(data, errors) =>
         Json.obj(
-          "data"   -> response.data.asJson,
-          "errors" -> Json.fromValues(response.errors.map(err => Json.fromString(err.toString)))
+          "data"   -> data.asJson,
+          "errors" -> Json.fromValues(errors.map(err => Json.obj("message" -> Json.fromString(err.toString))))
         )
-    )
+    }
 }

--- a/core/src/test/scala/caliban/GraphQLResponseSpec.scala
+++ b/core/src/test/scala/caliban/GraphQLResponseSpec.scala
@@ -1,5 +1,6 @@
 package caliban
 
+import caliban.CalibanError.ExecutionError
 import caliban.Value._
 import io.circe._
 import io.circe.syntax._
@@ -13,7 +14,20 @@ object GraphQLResponseSpec
           val response = GraphQLResponse(StringValue("data"), Nil)
           assert(
             response.asJson,
-            equalTo(Json.obj("data" -> Json.fromString("data"), "errors" -> Json.arr()))
+            equalTo(Json.obj("data" -> Json.fromString("data")))
+          )
+        },
+        test("should include error only if non-empty") {
+          val response = GraphQLResponse(StringValue("data"), List(ExecutionError("Resolution failed")))
+
+          assert(
+            response.asJson,
+            equalTo(
+              Json.obj(
+                "data"   -> Json.fromString("data"),
+                "errors" -> Json.arr(Json.obj("message" -> Json.fromString("Execution error: Resolution failed")))
+              )
+            )
           )
         }
       )


### PR DESCRIPTION
This makes errors rendered by the `Circe` encoder more [spec compliant](https://graphql.github.io/graphql-spec/June2018/#sec-Errors). Note there are still some pieces missing from the error handling but which require a larger footprint to change.