### PR TITLE
rename ObjectValue to StreamValue in text.

### DIFF
--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -146,4 +146,4 @@ val subscriptions = Subscriptions(???)
 val api = graphQL(RootResolver(queries, mutations, subscriptions))
 ```
 
-All the fields of the subscription root case class MUST return `ZStream` or `? => ZStream` objects. When a subscription request is received, an output stream of `ResponseValue` will be returned wrapped in an `StreamValue`.
+All the fields of the subscription root case class MUST return `ZStream` or `? => ZStream` objects. When a subscription request is received, an output stream of `ResponseValue` (a `StreamValue`) will be returned wrapped inside an `ObjectValue `.

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -146,4 +146,4 @@ val subscriptions = Subscriptions(???)
 val api = graphQL(RootResolver(queries, mutations, subscriptions))
 ```
 
-All the fields of the subscription root case class MUST return `ZStream` or `? => ZStream` objects. When a subscription request is received, an output stream of `ResponseValue` will be returned wrapped in an `ObjectValue`.
+All the fields of the subscription root case class MUST return `ZStream` or `? => ZStream` objects. When a subscription request is received, an output stream of `ResponseValue` will be returned wrapped in an `StreamValue`.

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -146,4 +146,4 @@ val subscriptions = Subscriptions(???)
 val api = graphQL(RootResolver(queries, mutations, subscriptions))
 ```
 
-All the fields of the subscription root case class MUST return `ZStream` or `? => ZStream` objects. When a subscription request is received, an output stream of `ResponseValue` (a `StreamValue`) will be returned wrapped inside an `ObjectValue `.
+All the fields of the subscription root case class MUST return `ZStream` or `? => ZStream` objects. When a subscription request is received, an output stream of `ResponseValue` (a `StreamValue`) will be returned wrapped inside an `ObjectValue`.


### PR DESCRIPTION
`ObjectValue` wraps up a `List` and current doc says `ObjectValue` whereas here we are talking about `ZStream`.