### PR TITLE
Extend CalibanError with Product and Serializable

### DIFF
--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -3,7 +3,7 @@ package caliban
 /**
  * The base type for all Caliban errors.
  */
-sealed trait CalibanError extends Throwable {
+sealed trait CalibanError extends Throwable with Product with Serializable {
   def msg: String
 }
 


### PR DESCRIPTION
This is a bit speculative admittedly but is done fairly often in OSS code base.

So that its inference in GraphQL.scala (l36 `val prepare = for {...` has only `CalibanError` in error channel instead of `CalibanError with Product with Serializable` so if we eventually construct lists of those we don't have the `Product with Serializable` wart in them.