### PR TITLE
replace map.getOrElse with fold when considering options

### DIFF
--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -13,7 +13,7 @@ object CalibanError {
    * Describes an error that happened while parsing a query.
    */
   case class ParsingError(msg: String, innerThrowable: Option[Throwable] = None) extends CalibanError {
-    override def toString: String = s"""Parsing error: $msg ${innerThrowable.map(_.toString).getOrElse("")}"""
+    override def toString: String = s"""Parsing error: $msg ${innerThrowable.fold("")(_.toString)}"""
   }
 
   /**

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -73,10 +73,12 @@ object Rendering {
   private def isBuiltinScalar(name: String): Boolean =
     name == "Int" || name == "Float" || name == "String" || name == "Boolean" || name == "ID"
 
-  private[caliban] def renderTypeName(fieldType: __Type): String =
+  private[caliban] def renderTypeName(fieldType: __Type): String = {
+    lazy val renderedTypeName = fieldType.ofType.fold("null")(renderTypeName)
     fieldType.kind match {
-      case __TypeKind.NON_NULL => s"${fieldType.ofType.fold("null")(renderTypeName)}!"
-      case __TypeKind.LIST     => s"[${fieldType.ofType.fold("null")(renderTypeName)}]"
+      case __TypeKind.NON_NULL => renderedTypeName + "!"
+      case __TypeKind.LIST     => s"[$renderedTypeName]"
       case _                   => s"${fieldType.name.getOrElse("null")}"
     }
+  }
 }

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -15,20 +15,25 @@ object Rendering {
           case __TypeKind.NON_NULL => None
           case __TypeKind.LIST     => None
           case __TypeKind.UNION =>
-            Some(s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)} = ${t.possibleTypes
-              .getOrElse(Nil)
-              .flatMap(_.name)
-              .mkString(" | ")}""")
+            val renderedTypes: String =
+              t.possibleTypes
+                .fold(List.empty[String])(_.flatMap(_.name))
+                .mkString(" | ")
+            Some(s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)} = $renderedTypes""")
           case _ =>
+            val renderedFields: String = t
+              .fields(__DeprecatedArgs())
+              .fold(List.empty[String])(_.map(renderField))
+              .mkString("\n  ")
+            val renderedInputFields: String = t.inputFields
+              .fold(List.empty[String])(_.map(renderInputValue))
+              .mkString("\n  ")
+            val renderedEnumValues = t
+              .enumValues(__DeprecatedArgs())
+              .fold(List.empty[String])(_.map(renderEnumValue))
+              .mkString("\n  ")
             Some(s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)} {
-                    |  ${t.fields(__DeprecatedArgs()).getOrElse(Nil).map(renderField).mkString("\n  ")}${t.inputFields
-                      .getOrElse(Nil)
-                      .map(renderInputValue)
-                      .mkString("\n  ")}${t
-                      .enumValues(__DeprecatedArgs())
-                      .getOrElse(Nil)
-                      .map(renderEnumValue)
-                      .mkString("\n  ")}
+                    |  ${renderedFields}${renderedInputFields}${renderedEnumValues}
                     |}""".stripMargin)
         }
     }.mkString("\n\n")
@@ -70,8 +75,8 @@ object Rendering {
 
   private[caliban] def renderTypeName(fieldType: __Type): String =
     fieldType.kind match {
-      case __TypeKind.NON_NULL => s"${fieldType.ofType.map(renderTypeName).getOrElse("null")}!"
-      case __TypeKind.LIST     => s"[${fieldType.ofType.map(renderTypeName).getOrElse("null")}]"
+      case __TypeKind.NON_NULL => s"${fieldType.ofType.fold("null")(renderTypeName)}!"
+      case __TypeKind.LIST     => s"[${fieldType.ofType.fold("null")(renderTypeName)}]"
       case _                   => s"${fieldType.name.getOrElse("null")}"
     }
 }

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -39,7 +39,9 @@ object Value {
     def apply(v: Long): IntValue   = LongNumber(v)
     def apply(v: BigInt): IntValue = BigIntNumber(v)
     def apply(s: String): IntValue =
-      Try(IntNumber(s.toInt)).orElse(Try(LongNumber(s.toLong))).getOrElse(BigIntNumber(BigInt(s)))
+      Try(IntNumber(s.toInt)) orElse
+        Try(LongNumber(s.toLong)) getOrElse
+        BigIntNumber(BigInt(s))
 
     case class IntNumber(value: Int) extends IntValue {
       override def toInt: Int       = value

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -113,8 +113,7 @@ object Executor {
               alias.getOrElse(name) ->
                 fields
                   .get(name)
-                  .map(reduceStep(_, f, arguments))
-                  .getOrElse(NullStep)
+                  .fold(NullStep: ReducedStep[R])(reduceStep(_, f, arguments))
           }
           reduceObject(items)
         case QueryStep(inner) =>
@@ -173,7 +172,11 @@ object Executor {
       case (k, v) =>
         k -> (v match {
           case InputValue.VariableValue(name) =>
-            variableValues.get(name) orElse variableDefinitions.find(_.name == name).flatMap(_.defaultValue) getOrElse v
+            lazy val defaultInputValue = (for {
+              definition <- variableDefinitions.find(_.name == name)
+              inputValue <- definition.defaultValue
+            } yield inputValue) getOrElse v
+            variableValues.getOrElse(name, defaultInputValue)
           case value => value
         })
     }

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -32,24 +32,22 @@ object Field {
           val t = fieldType
             .fields(__DeprecatedArgs(Some(true)))
             .flatMap(_.find(_.name == name))
-            .map(_.`type`())
-            .map(Types.innerType)
-            .getOrElse(Types.string) // only case where it's not found is __typename
+            .fold(Types.string)(f => Types.innerType(f.`type`())) // default only case where it's not found is __typename
           val field = loop(selectionSet, t)
           (
             List(Field(name, t, Some(fieldType), alias, field.fields, field.conditionalFields, arguments)),
             Map.empty[String, List[Field]]
           )
         case FragmentSpread(name, directives) if checkDirectives(directives, variableValues) =>
+          lazy val default = (Nil, Map.empty[String, List[Field]])
           fragments
             .get(name)
-            .map { f =>
+            .fold(default) { f =>
               val t =
                 fieldType.possibleTypes.flatMap(_.find(_.name.contains(f.typeCondition.name))).getOrElse(fieldType)
               val field = loop(f.selectionSet, t)
               (Nil, combineMaps(List(field.conditionalFields, Map(f.typeCondition.name -> field.fields))))
             }
-            .getOrElse((Nil, Map.empty[String, List[Field]]))
         case InlineFragment(typeCondition, directives, selectionSet) if checkDirectives(directives, variableValues) =>
           val t = fieldType.possibleTypes
             .flatMap(_.find(_.name.exists(typeCondition.map(_.name).contains)))

--- a/core/src/main/scala/caliban/parsing/Parser.scala
+++ b/core/src/main/scala/caliban/parsing/Parser.scala
@@ -82,7 +82,7 @@ object Parser {
       case _ :: tail =>
         tail.foldLeft(Option.empty[Int]) {
           case (commonIndent, line) =>
-            val indent = "[ \t]*".r.findPrefixOf(line).map(_.length).getOrElse(0)
+            val indent = "[ \t]*".r.findPrefixOf(line).fold(0)(_.length)
             if (indent < line.length && commonIndent.fold(true)(_ > indent)) Some(indent) else commonIndent
         }
     }

--- a/core/src/main/scala/caliban/schema/RootType.scala
+++ b/core/src/main/scala/caliban/schema/RootType.scala
@@ -4,8 +4,9 @@ import caliban.introspection.adt.__Type
 import caliban.schema.Types.collectTypes
 
 case class RootType(queryType: __Type, mutationType: Option[__Type], subscriptionType: Option[__Type]) {
+  val empty = Map.empty[String, __Type]
   val types: Map[String, __Type] =
     collectTypes(queryType) ++
-      mutationType.map(collectTypes(_)).getOrElse(Map()) ++
-      subscriptionType.map(collectTypes(_)).getOrElse(Map())
+      mutationType.fold(empty)(collectTypes(_)) ++
+      subscriptionType.fold(empty)(collectTypes(_))
 }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -227,7 +227,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
             arg1.build(InputValue.ObjectValue(args)) match {
               case Left(error)  => QueryStep(ZQuery.fail(error))
               case Right(value) => ev2.resolve(f(value))
-          }
+            }
         )
     }
   implicit def futureSchema[A](implicit ev: Schema[R, A]): Schema[R, Future[A]] =
@@ -297,7 +297,7 @@ trait DerivationSchema[R] {
                   () =>
                     if (p.typeclass.optional) p.typeclass.toType(isInput) else makeNonNull(p.typeclass.toType(isInput)),
                   None
-              )
+                )
             )
             .toList
         )
@@ -316,7 +316,7 @@ trait DerivationSchema[R] {
                     if (p.typeclass.optional) p.typeclass.toType(isInput) else makeNonNull(p.typeclass.toType(isInput)),
                   p.annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
                   p.annotations.collectFirst { case GQLDeprecated(reason) => reason }
-              )
+                )
             )
             .toList
         )
@@ -381,7 +381,7 @@ trait DerivationSchema[R] {
                     () => makeScalar("Boolean")
                   )
                 )
-            )
+              )
           )
         case _ => t
       }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -227,7 +227,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
             arg1.build(InputValue.ObjectValue(args)) match {
               case Left(error)  => QueryStep(ZQuery.fail(error))
               case Right(value) => ev2.resolve(f(value))
-            }
+          }
         )
     }
   implicit def futureSchema[A](implicit ev: Schema[R, A]): Schema[R, Future[A]] =
@@ -297,7 +297,7 @@ trait DerivationSchema[R] {
                   () =>
                     if (p.typeclass.optional) p.typeclass.toType(isInput) else makeNonNull(p.typeclass.toType(isInput)),
                   None
-                )
+              )
             )
             .toList
         )
@@ -316,7 +316,7 @@ trait DerivationSchema[R] {
                     if (p.typeclass.optional) p.typeclass.toType(isInput) else makeNonNull(p.typeclass.toType(isInput)),
                   p.annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
                   p.annotations.collectFirst { case GQLDeprecated(reason) => reason }
-                )
+              )
             )
             .toList
         )
@@ -329,9 +329,16 @@ trait DerivationSchema[R] {
   def dispatch[T](ctx: SealedTrait[Typeclass, T]): Typeclass[T] = new Typeclass[T] {
     override def toType(isInput: Boolean = false): __Type = {
       val subtypes =
-        ctx.subtypes.map(s => s.typeclass.toType() -> s.annotations).toList.sortBy(_._1.name.getOrElse(""))
+        ctx.subtypes
+          .map(s => s.typeclass.toType() -> s.annotations)
+          .toList
+          .sortBy {
+            case (tpe, _) => tpe.name.getOrElse("")
+          }
       val isEnum = subtypes.forall {
-        case (t, _) if t.fields(__DeprecatedArgs(Some(true))).forall(_.isEmpty) && t.inputFields.forall(_.isEmpty) =>
+        case (t, _)
+            if t.fields(__DeprecatedArgs(Some(true))).forall(_.isEmpty)
+              && t.inputFields.forall(_.isEmpty) =>
           true
         case _ => false
       }
@@ -374,7 +381,7 @@ trait DerivationSchema[R] {
                     () => makeScalar("Boolean")
                   )
                 )
-              )
+            )
           )
         case _ => t
       }

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -63,7 +63,7 @@ object Types {
         t.possibleTypes.getOrElse(Nil).foldLeft(map2) { case (types, subtype) => collectTypes(subtype, types) }
     }
 
-  def innerType(t: __Type): __Type = t.ofType.map(innerType).getOrElse(t)
+  def innerType(t: __Type): __Type = t.ofType.fold(t)(innerType)
 
   def name(t: __Type): String =
     (t.kind match {

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -181,7 +181,7 @@ object Validator {
                       "Variables are scoped on a per‐operation basis. That means that any variable used within the context of an operation must be defined at the top level of that operation"
                     )
                   )
-              )
+                )
             ) *> IO.foreach(op.variableDefinitions)(
               v =>
                 IO.when(!variableUsages.contains(v.name))(
@@ -191,9 +191,9 @@ object Validator {
                       "All variables defined by an operation must be used in that operation or a fragment transitively included by that operation. Unused variables cause a validation error."
                     )
                   )
-              )
+                )
             )
-        }
+          }
       )
       .unit
 
@@ -323,7 +323,7 @@ object Validator {
             ValidationError(
               s"Field '${field.name}' does not exist on type '${Rendering.renderTypeName(currentType)}'.",
               "The target field of a field selection must be defined on the scoped type of the selection set. There are no limitations on alias names."
-          )
+            )
         )
         .flatMap { f =>
           validateFields(context, field.selectionSet, Types.innerType(f.`type`())) *>
@@ -355,7 +355,7 @@ object Validator {
                 "Arguments can be required. An argument is required if the argument type is non‐null and does not have a default value. Otherwise, the argument is optional."
               )
             )
-        )
+          )
       )
 
   private def validateInputValues(inputValue: __InputValue, argValue: InputValue): IO[ValidationError, Unit] = {
@@ -390,7 +390,7 @@ object Validator {
                     "Input object fields may be required. Much like a field may have required arguments, an input object may have required fields. An input field is required if it has a non‐null type and does not have a default value. Otherwise, the input object field is optional."
                   )
                 )
-            )
+              )
           )
           .unit
       case _ => IO.unit


### PR DESCRIPTION
 (but avoided extensions such http4s and akkahttp, but could volunteer to do similarly there)

I did a few other things along the way.

Fusing 2 consecutive maps (Field.loop), which avoids two traversals

Occasionally add temporary variables typically for String formatting to ease legibility

Broke down some long lines into multiple lines (quite often!)

Refactored a bit `resolveVariables` which was a long one liner, similarly `schema.dispatch.toType`

Took out evaluation of strings outside of one-liner formatting considerations in `Rendering.renderTypes` to ease legibility

Broke down one liner of `IntValue.apply` that has `Try` and `orElse `in it and made it similar to other code in project