### PR TITLE
Improvements to ZQuery

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -118,9 +118,10 @@ object Executor {
           reduceObject(items)
         case QueryStep(inner) =>
           ReducedStep.QueryStep(
-            inner
-              .map(reduceStep(_, currentField, arguments))
-              .mapError(GenericSchema.effectfulExecutionError(currentField.name, _))
+            inner.bimap(
+              GenericSchema.effectfulExecutionError(currentField.name, _),
+              reduceStep(_, currentField, arguments)
+            )
           )
         case StreamStep(stream) =>
           ReducedStep.StreamStep(

--- a/core/src/main/scala/zquery/BlockedRequestMap.scala
+++ b/core/src/main/scala/zquery/BlockedRequestMap.scala
@@ -7,13 +7,13 @@ import zio.ZIO
  * requests from those data sources.
  */
 private[zquery] final class BlockedRequestMap[-R](
-  private val map: Map[DataSource.Service[Any, Any], Vector[BlockedRequest[Any]]]
+  private val map: Map[DataSource[Any, Any], Vector[BlockedRequest[Any]]]
 ) { self =>
 
   def ++[R1 <: R](that: BlockedRequestMap[R1]): BlockedRequestMap[R1] =
     new BlockedRequestMap(
       (self.map.toVector ++ that.map.toVector)
-        .foldLeft[Map[DataSource.Service[Any, Any], Vector[BlockedRequest[Any]]]](Map()) {
+        .foldLeft[Map[DataSource[Any, Any], Vector[BlockedRequest[Any]]]](Map()) {
           case (acc, (key, value)) =>
             acc + (key -> acc.get(key).fold(value)(_ ++ value))
         }
@@ -25,7 +25,7 @@ private[zquery] final class BlockedRequestMap[-R](
    * preserve the request type of each data source.
    */
   def mapDataSources[R1](f: DataSourceFunction[R, R1]): BlockedRequestMap[R1] =
-    new BlockedRequestMap(self.map.map { case (k, v) => (f(k).asInstanceOf[DataSource.Service[Any, Any]], v) })
+    new BlockedRequestMap(self.map.map { case (k, v) => (f(k).asInstanceOf[DataSource[Any, Any]], v) })
 
   /**
    * Executes all requests, submitting batched requests to each data source in
@@ -50,11 +50,11 @@ object BlockedRequestMap {
    * specified data source to the specified request.
    */
   def apply[R, E, K](
-    dataSource: DataSource.Service[R, K],
+    dataSource: DataSource[R, K],
     blockedRequest: BlockedRequest[K]
   ): BlockedRequestMap[R] =
     new BlockedRequestMap(
-      Map(dataSource.asInstanceOf[DataSource.Service[Any, Any]] -> Vector(blockedRequest))
+      Map(dataSource.asInstanceOf[DataSource[Any, Any]] -> Vector(blockedRequest))
     )
 
   /**
@@ -62,6 +62,6 @@ object BlockedRequestMap {
    */
   val empty: BlockedRequestMap[Any] =
     new BlockedRequestMap(
-      Map.empty[DataSource.Service[Any, Any], Vector[BlockedRequest[Any]]]
+      Map.empty[DataSource[Any, Any], Vector[BlockedRequest[Any]]]
     )
 }

--- a/core/src/main/scala/zquery/BlockedRequestMap.scala
+++ b/core/src/main/scala/zquery/BlockedRequestMap.scala
@@ -24,7 +24,7 @@ private[zquery] final class BlockedRequestMap[-R](
    * can change the environment and error types of data sources but must
    * preserve the request type of each data source.
    */
-  final def mapDataSources[R1](f: DataSourceFunction[R, R1]): BlockedRequestMap[R1] =
+  def mapDataSources[R1](f: DataSourceFunction[R, R1]): BlockedRequestMap[R1] =
     new BlockedRequestMap(self.map.map { case (k, v) => (f(k).asInstanceOf[DataSource.Service[Any, Any]], v) })
 
   /**

--- a/core/src/main/scala/zquery/Cache.scala
+++ b/core/src/main/scala/zquery/Cache.scala
@@ -1,6 +1,6 @@
 package zquery
 
-import zio.{ Ref, UIO }
+import zio.{ IO, Ref, UIO }
 
 /**
  * A `Cache` maintains an internal state with a mapping from requests to `Ref`s
@@ -8,13 +8,13 @@ import zio.{ Ref, UIO }
  * is used internally by the library to provide deduplication and caching of
  * requests.
  */
-class Cache private (private val state: Ref[Map[Any, Any]]) {
+final class Cache private (private val state: Ref[Map[Any, Any]]) {
 
   /**
    * Inserts a request and a `Ref` that will contain the result of the request
    * when it is executed into the cache.
    */
-  final def insert[E, A](request: Request[E, A], result: Ref[Option[Either[E, A]]]): UIO[Unit] =
+  def insert[E, A](request: Request[E, A], result: Ref[Option[Either[E, A]]]): UIO[Unit] =
     state.update(_ + (request -> result)).unit
 
   /**
@@ -23,8 +23,8 @@ class Cache private (private val state: Ref[Map[Any, Any]]) {
    * been executed yet, or `Some(Ref(Some(value)))` if the request has been
    * executed.
    */
-  final def lookup[E, A](request: Request[E, A]): UIO[Option[Ref[Option[Either[E, A]]]]] =
-    state.get.map(_.get(request).asInstanceOf[Option[Ref[Option[Either[E, A]]]]])
+  def lookup[E, A](request: Request[E, A]): IO[Unit, Ref[Option[Either[E, A]]]] =
+    state.get.map(_.get(request).asInstanceOf[Option[Ref[Option[Either[E, A]]]]]).get
 }
 
 object Cache {

--- a/core/src/main/scala/zquery/CompletedRequestMap.scala
+++ b/core/src/main/scala/zquery/CompletedRequestMap.scala
@@ -11,19 +11,19 @@ package zquery
  */
 final class CompletedRequestMap private (private val map: Map[Any, Either[Any, Any]]) { self =>
 
-  final def ++(that: CompletedRequestMap): CompletedRequestMap =
+  def ++(that: CompletedRequestMap): CompletedRequestMap =
     new CompletedRequestMap(self.map ++ that.map)
 
   /**
    * Appends the specified result to the completed requests map.
    */
-  final def insert[E, A](request: Request[E, A])(result: Either[E, A]): CompletedRequestMap =
+  def insert[E, A](request: Request[E, A])(result: Either[E, A]): CompletedRequestMap =
     new CompletedRequestMap(self.map + (request -> result))
 
   /**
    * Retrieves the result of the specified request if it exists.
    */
-  final def lookup[E, A](request: Request[E, A]): Option[Either[E, A]] =
+  def lookup[E, A](request: Request[E, A]): Option[Either[E, A]] =
     map.get(request).asInstanceOf[Option[Either[E, A]]]
 }
 

--- a/core/src/main/scala/zquery/DataSource.scala
+++ b/core/src/main/scala/zquery/DataSource.scala
@@ -22,198 +22,191 @@ import zio.{ NeedsEnv, ZIO }
  * sources must provide requests for all results received or fail with an `E`.
  * Failure to do so will cause a query to die with a `QueryFailure` when run.
  */
-trait DataSource[-R, -A] {
-  def dataSource: DataSource.Service[R, A]
+trait DataSource[-R, -A] { self =>
+
+  /**
+   * The data source's identifier.
+   */
+  val identifier: String
+
+  /**
+   * Execute a collection of requests. Data sources are guaranteed that the
+   * collection will contain at least one request and that all requests will be
+   * unique when they are called by `ZQuery`.
+   */
+  def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap]
+
+  /**
+   * Returns a new data source that executes requests of type `B` using the
+   * specified function to transform `B` requests into requests that this data
+   * source can execute.
+   */
+  final def contramap[B](f: Described[B => A]): DataSource[R, B] =
+    new DataSource[R, B] {
+      val identifier = s"${self.identifier}.contramap(${f.description})"
+      def run(requests: Iterable[B]): ZIO[R, Nothing, CompletedRequestMap] =
+        self.run(requests.map(f.value))
+    }
+
+  /**
+   * Returns a new data source that executes requests of type `B` using the
+   * specified effectual function to transform `B` requests into requests that
+   * this data source can execute.
+   */
+  final def contramapM[R1 <: R, B](f: Described[B => ZIO[R1, Nothing, A]]): DataSource[R1, B] =
+    new DataSource[R1, B] {
+      val identifier = s"${self.identifier}.contramapM(${f.description})"
+      def run(requests: Iterable[B]): ZIO[R1, Nothing, CompletedRequestMap] =
+        ZIO.foreach(requests)(f.value).flatMap(self.run)
+    }
+
+  /**
+   * Returns a new data source that executes requests of type `C` using the
+   * specified function to transform `C` requests into requests that either
+   * this data source or that data source can execute.
+   */
+  final def eitherWith[R1 <: R, B, C](
+    that: DataSource[R1, B]
+  )(f: Described[C => Either[A, B]]): DataSource[R1, C] =
+    new DataSource[R1, C] {
+      val identifier = s"${self.identifier}.eitherWith(${that.identifier})(${f.description})"
+      def run(requests: Iterable[C]): ZIO[R1, Nothing, CompletedRequestMap] = {
+        val (as, bs) = requests.foldLeft((List.empty[A], List.empty[B])) {
+          case ((as, bs), c) =>
+            f.value(c) match {
+              case Left(a)  => (a :: as, bs)
+              case Right(b) => (as, b :: bs)
+            }
+        }
+        self.run(as).zipWithPar(that.run(bs))(_ ++ _)
+      }
+    }
+
+  override final def equals(that: Any): Boolean = that match {
+    case that: DataSource[_, _] => this.identifier == that.identifier
+  }
+
+  override final def hashCode: Int =
+    identifier.hashCode
+
+  /**
+   * Provides this data source with its required environment.
+   */
+  final def provide(r: Described[R])(implicit ev: NeedsEnv[R]): DataSource[Any, A] =
+    provideSome(Described(_ => r.value, s"_ => ${r.description}"))
+
+  /**
+   * Provides this data source with part of its required environment.
+   */
+  final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): DataSource[R0, A] =
+    new DataSource[R0, A] {
+      val identifier = s"${self.identifier}.provideSome(${f.description})"
+      def run(requests: Iterable[A]): ZIO[R0, Nothing, CompletedRequestMap] =
+        self.run(requests).provideSome(f.value)
+    }
+
+  override final def toString: String =
+    identifier
 }
 
 object DataSource {
 
-  trait Service[-R, -A] { self =>
-
-    /**
-     * The data source's identifier.
-     */
-    val identifier: String
-
-    /**
-     * Execute a collection of requests. Data sources are guaranteed that the
-     * collection will contain at least one request and that all requests will
-     * be unique when they are called by `ZQuery`.
-     */
-    def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap]
-
-    /**
-     * Returns a new data source that executes requests of type `B` using the
-     * specified function to transform `B` requests into requests that this
-     * data source can execute.
-     */
-    final def contramap[B](f: Described[B => A]): DataSource.Service[R, B] =
-      new DataSource.Service[R, B] {
-        val identifier = s"${self.identifier}.contramap(${f.description})"
-        def run(requests: Iterable[B]): ZIO[R, Nothing, CompletedRequestMap] =
-          self.run(requests.map(f.value))
-      }
-
-    /**
-     * Returns a new data source that executes requests of type `B` using the
-     * specified effectual function to transform `B` requests into requests
-     * that this data source can execute.
-     */
-    final def contramapM[R1 <: R, B](f: Described[B => ZIO[R1, Nothing, A]]): DataSource.Service[R1, B] =
-      new DataSource.Service[R1, B] {
-        val identifier = s"${self.identifier}.contramapM(${f.description})"
-        def run(requests: Iterable[B]): ZIO[R1, Nothing, CompletedRequestMap] =
-          ZIO.foreach(requests)(f.value).flatMap(self.run)
-      }
-
-    /**
-     * Returns a new data source that executes requests of type `C` using the
-     * specified function to transform `C` requests into requests that either
-     * this data source or that data source can execute.
-     */
-    final def eitherWith[R1 <: R, B, C](
-      that: DataSource.Service[R1, B]
-    )(f: Described[C => Either[A, B]]): DataSource.Service[R1, C] =
-      new DataSource.Service[R1, C] {
-        val identifier = s"${self.identifier}.eitherWith(${that.identifier})(${f.description})"
-        def run(requests: Iterable[C]): ZIO[R1, Nothing, CompletedRequestMap] = {
-          val (as, bs) = requests.foldLeft((List.empty[A], List.empty[B])) {
-            case ((as, bs), c) =>
-              f.value(c) match {
-                case Left(a)  => (a :: as, bs)
-                case Right(b) => (as, b :: bs)
-              }
-          }
-          self.run(as).zipWithPar(that.run(bs))(_ ++ _)
-        }
-      }
-
-    override final def equals(that: Any): Boolean = that match {
-      case that: DataSource.Service[_, _] => this.identifier == that.identifier
+  /**
+   * Constructs a data source from a function taking a collection of requests
+   * and returning a `CompletedRequestMap`.
+   */
+  def apply[R, A](name: String)(f: Iterable[A] => ZIO[R, Nothing, CompletedRequestMap]): DataSource[R, A] =
+    new DataSource[R, A] {
+      val identifier = name
+      def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        f(requests)
     }
 
-    override final def hashCode: Int =
-      identifier.hashCode
+  /**
+   * Constructs a data source from a pure function.
+   */
+  def fromFunction[A, B](
+    name: String
+  )(f: A => B)(implicit ev: A <:< Request[Nothing, B]): DataSource[Any, A] =
+    new DataSource[Any, A] {
+      val identifier = name
+      def run(requests: Iterable[A]): ZIO[Any, Nothing, CompletedRequestMap] =
+        ZIO.succeed(requests.foldLeft(CompletedRequestMap.empty)((map, k) => map.insert(k)(Right(f(k)))))
+    }
 
-    /**
-     * Provides this data source with its required environment.
-     */
-    final def provide(r: Described[R])(implicit ev: NeedsEnv[R]): DataSource.Service[Any, A] =
-      provideSome(Described(_ => r.value, s"_ => ${r.description}"))
+  /**
+   * Constructs a data source from a pure function that takes a list of
+   * requests and returns a list of results of the same size. Each item in the
+   * result list must correspond to the item at the same index in the request
+   * list.
+   */
+  def fromFunctionBatched[A, B](
+    name: String
+  )(f: Iterable[A] => Iterable[B])(implicit ev: A <:< Request[Nothing, B]): DataSource[Any, A] =
+    fromFunctionBatchedM(name)(f andThen ZIO.succeed)
 
-    /**
-     * Provides this data source with part of its required environment.
-     */
-    final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): DataSource.Service[R0, A] =
-      new DataSource.Service[R0, A] {
-        val identifier = s"${self.identifier}.provideSome(${f.description})"
-        def run(requests: Iterable[A]): ZIO[R0, Nothing, CompletedRequestMap] =
-          self.run(requests).provideSome(f.value)
-      }
-
-    override final def toString: String =
-      identifier
-  }
-
-  object Service {
-
-    /**
-     * Constructs a data source from a function taking a collection of
-     * requests and returning a `CompletedRequestMap`.
-     */
-    def apply[R, A](name: String)(f: Iterable[A] => ZIO[R, Nothing, CompletedRequestMap]): DataSource.Service[R, A] =
-      new DataSource.Service[R, A] {
-        val identifier = name
-        def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap] =
-          f(requests)
-      }
-
-    /**
-     * Constructs a data source from a pure function.
-     */
-    def fromFunction[A, B](
-      name: String
-    )(f: A => B)(implicit ev: A <:< Request[Nothing, B]): DataSource.Service[Any, A] =
-      new DataSource.Service[Any, A] {
-        val identifier = name
-        def run(requests: Iterable[A]): ZIO[Any, Nothing, CompletedRequestMap] =
-          ZIO.succeed(requests.foldLeft(CompletedRequestMap.empty)((map, k) => map.insert(k)(Right(f(k)))))
-      }
-
-    /**
-     * Constructs a data source from a pure function that takes a list of
-     * requests and returns a list of results of the same size. Each item in
-     * the result list must correspond to the item at the same index in the
-     * request list.
-     */
-    def fromFunctionBatched[A, B](
-      name: String
-    )(f: Iterable[A] => Iterable[B])(implicit ev: A <:< Request[Nothing, B]): DataSource.Service[Any, A] =
-      fromFunctionBatchedM(name)(f andThen ZIO.succeed)
-
-    /**
-     * Constructs a data source from an effectual function that takes a list of
-     * requests and returns a list of results of the same size. Each item in
-     * the result list must correspond to the item at the same index in the
-     * request list.
-     */
-    def fromFunctionBatchedM[R, E, A, B](
-      name: String
-    )(f: Iterable[A] => ZIO[R, Nothing, Iterable[B]])(implicit ev: A <:< Request[E, B]): DataSource.Service[R, A] =
-      new DataSource.Service[R, A] {
-        val identifier = name
-        def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap] =
-          f(requests).map { results =>
-            (requests zip results).foldLeft(CompletedRequestMap.empty) {
-              case (map, (k, v)) => map.insert(k)(Right(v))
-            }
+  /**
+   * Constructs a data source from an effectual function that takes a list of
+   * requests and returns a list of results of the same size. Each item in the
+   * result list must correspond to the item at the same index in the request
+   * list.
+   */
+  def fromFunctionBatchedM[R, E, A, B](
+    name: String
+  )(f: Iterable[A] => ZIO[R, Nothing, Iterable[B]])(implicit ev: A <:< Request[E, B]): DataSource[R, A] =
+    new DataSource[R, A] {
+      val identifier = name
+      def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        f(requests).map { results =>
+          (requests zip results).foldLeft(CompletedRequestMap.empty) {
+            case (map, (k, v)) => map.insert(k)(Right(v))
           }
-      }
+        }
+    }
 
-    /**
-     * Constructs a data source from a function that takes a list of requests
-     * and returns a list of results of the same size. Uses the specified
-     * function to associate each result with the corresponding effect,
-     * allowing the function to return the list of results in a different order
-     * than the list of requests.
-     */
-    def fromFunctionBatchedWith[A, B](
-      name: String
-    )(f: Iterable[A] => Iterable[B], g: B => Request[Nothing, B]): DataSource.Service[Any, A] =
-      fromFunctionBatchedWithM(name)(f andThen ZIO.succeed, g)
+  /**
+   * Constructs a data source from a function that takes a list of requests and
+   * returns a list of results of the same size. Uses the specified function to
+   * associate each result with the corresponding effect, allowing the function
+   * to return the list of results in a different order than the list of
+   * requests.
+   */
+  def fromFunctionBatchedWith[A, B](
+    name: String
+  )(f: Iterable[A] => Iterable[B], g: B => Request[Nothing, B]): DataSource[Any, A] =
+    fromFunctionBatchedWithM(name)(f andThen ZIO.succeed, g)
 
-    /**
-     * Constructs a data source from an effectual function that takes a list of
-     * requests and returns a list of results of the same size. Uses the
-     * specified function to associate each result with the corresponding
-     * effect, allowing the function to return the list of results in a
-     * different order than the list of requests.
-     */
-    def fromFunctionBatchedWithM[R, E, A, B](
-      name: String
-    )(f: Iterable[A] => ZIO[R, Nothing, Iterable[B]], g: B => Request[E, B]): DataSource.Service[R, A] =
-      new DataSource.Service[R, A] {
-        val identifier = name
-        def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap] =
-          f(requests).map { results =>
-            results.map(b => (g(b), b)).foldLeft(CompletedRequestMap.empty) {
-              case (map, (k, v)) => map.insert(k)(Right(v))
-            }
+  /**
+   * Constructs a data source from an effectual function that takes a list of
+   * requests and returns a list of results of the same size. Uses the
+   * specified function to associate each result with the corresponding effect,
+   * allowing the function to return the list of results in a different order
+   * than the list of requests.
+   */
+  def fromFunctionBatchedWithM[R, E, A, B](
+    name: String
+  )(f: Iterable[A] => ZIO[R, Nothing, Iterable[B]], g: B => Request[E, B]): DataSource[R, A] =
+    new DataSource[R, A] {
+      val identifier = name
+      def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        f(requests).map { results =>
+          results.map(b => (g(b), b)).foldLeft(CompletedRequestMap.empty) {
+            case (map, (k, v)) => map.insert(k)(Right(v))
           }
-      }
+        }
+    }
 
-    /**
-     * Constructs a data source from an effectual function.
-     */
-    def fromFunctionM[R, E, A, B](
-      name: String
-    )(f: A => ZIO[R, Nothing, B])(implicit ev: A <:< Request[E, B]): DataSource.Service[R, A] =
-      new DataSource.Service[R, A] {
-        val identifier = name
-        def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap] =
-          ZIO
-            .foreachPar(requests)(k => ZIO.succeed(k).zip(f(k)))
-            .map(_.foldLeft(CompletedRequestMap.empty) { case (map, (k, v)) => map.insert(k)(Right(v)) })
-      }
-  }
+  /**
+   * Constructs a data source from an effectual function.
+   */
+  def fromFunctionM[R, E, A, B](
+    name: String
+  )(f: A => ZIO[R, Nothing, B])(implicit ev: A <:< Request[E, B]): DataSource[R, A] =
+    new DataSource[R, A] {
+      val identifier = name
+      def run(requests: Iterable[A]): ZIO[R, Nothing, CompletedRequestMap] =
+        ZIO
+          .foreachPar(requests)(k => ZIO.succeed(k).zip(f(k)))
+          .map(_.foldLeft(CompletedRequestMap.empty) { case (map, (k, v)) => map.insert(k)(Right(v)) })
+    }
 }

--- a/core/src/main/scala/zquery/DataSourceFunction.scala
+++ b/core/src/main/scala/zquery/DataSourceFunction.scala
@@ -50,16 +50,16 @@ object DataSourceFunction {
    * A data source function that provides a data source with its required
    * environment.
    */
-  final def provide[R](name: String)(r: R): DataSourceFunction[R, Any] =
-    provideSome(s"_ => $name")(_ => r)
+  def provide[R](r: Described[R]): DataSourceFunction[R, Any] =
+    provideSome(Described(_ => r.value, s"_ => ${r.description}"))
 
   /**
    * A data source function that provides a data sources with part of its
    * required environment.
    */
-  final def provideSome[R, R1](name: String)(f: R1 => R): DataSourceFunction[R, R1] =
+  def provideSome[R, R1](f: Described[R1 => R]): DataSourceFunction[R, R1] =
     new DataSourceFunction[R, R1] {
       def apply[A](dataSource: DataSource.Service[R, A]): DataSource.Service[R1, A] =
-        dataSource.provideSome(name)(f)
+        dataSource.provideSome(f)
     }
 }

--- a/core/src/main/scala/zquery/DataSourceFunction.scala
+++ b/core/src/main/scala/zquery/DataSourceFunction.scala
@@ -9,7 +9,7 @@ package zquery
  */
 trait DataSourceFunction[+R, -R1] { self =>
 
-  def apply[A](dataSource: DataSource.Service[R, A]): DataSource.Service[R1, A]
+  def apply[A](dataSource: DataSource[R, A]): DataSource[R1, A]
 
   /**
    * A symbolic alias for `compose`.
@@ -29,7 +29,7 @@ trait DataSourceFunction[+R, -R1] { self =>
    */
   final def andThen[R2](that: DataSourceFunction[R1, R2]): DataSourceFunction[R, R2] =
     new DataSourceFunction[R, R2] {
-      def apply[A](dataSource: DataSource.Service[R, A]): DataSource.Service[R2, A] =
+      def apply[A](dataSource: DataSource[R, A]): DataSource[R2, A] =
         that(self(dataSource))
     }
 
@@ -39,7 +39,7 @@ trait DataSourceFunction[+R, -R1] { self =>
    */
   final def compose[R0](that: DataSourceFunction[R0, R]): DataSourceFunction[R0, R1] =
     new DataSourceFunction[R0, R1] {
-      def apply[A](dataSource: DataSource.Service[R0, A]): DataSource.Service[R1, A] =
+      def apply[A](dataSource: DataSource[R0, A]): DataSource[R1, A] =
         self(that(dataSource))
     }
 }
@@ -59,7 +59,7 @@ object DataSourceFunction {
    */
   def provideSome[R, R1](f: Described[R1 => R]): DataSourceFunction[R, R1] =
     new DataSourceFunction[R, R1] {
-      def apply[A](dataSource: DataSource.Service[R, A]): DataSource.Service[R1, A] =
+      def apply[A](dataSource: DataSource[R, A]): DataSource[R1, A] =
         dataSource.provideSome(f)
     }
 }

--- a/core/src/main/scala/zquery/Described.scala
+++ b/core/src/main/scala/zquery/Described.scala
@@ -1,0 +1,17 @@
+package zquery
+
+/**
+ * A `Described[A]` is a value of type `A` along with a string description of
+ * that value. The description may be used to generate a hash associated with
+ * the value, so values that are equal should have the same description and
+ * values that are not equal should have different descriptions.
+ */
+final case class Described[+A](value: A, description: String)
+
+object Described {
+
+  implicit class AnySyntax[A](private val value: A) extends AnyVal {
+    def ?(description: String): Described[A] =
+      Described(value, description)
+  }
+}

--- a/core/src/main/scala/zquery/QueryFailure.scala
+++ b/core/src/main/scala/zquery/QueryFailure.scala
@@ -5,6 +5,6 @@ package zquery
  */
 final case class QueryFailure(dataSource: DataSource.Service[Nothing, Nothing], request: Request[Any, Any])
     extends Throwable(null, null, true, false) {
-  override final def getMessage: String =
+  override def getMessage: String =
     s"Data source ${dataSource.identifier} did not complete request ${request.toString}."
 }

--- a/core/src/main/scala/zquery/QueryFailure.scala
+++ b/core/src/main/scala/zquery/QueryFailure.scala
@@ -3,7 +3,7 @@ package zquery
 /**
  * `QueryFailure` keeps track of details relevant to query failures.
  */
-final case class QueryFailure(dataSource: DataSource.Service[Nothing, Nothing], request: Request[Any, Any])
+final case class QueryFailure(dataSource: DataSource[Nothing, Nothing], request: Request[Any, Any])
     extends Throwable(null, null, true, false) {
   override def getMessage: String =
     s"Data source ${dataSource.identifier} did not complete request ${request.toString}."

--- a/core/src/main/scala/zquery/ZQuery.scala
+++ b/core/src/main/scala/zquery/ZQuery.scala
@@ -1,6 +1,6 @@
 package zquery
 
-import zio.{ Cause, Ref, ZIO }
+import zio.{ CanFail, Cause, NeedsEnv, Ref, ZIO }
 
 /**
  * A `ZQuery[R, E, A]` is a purely functional description of an effectual query
@@ -84,6 +84,14 @@ sealed trait ZQuery[-R, +E, +A] { self =>
     flatMap(f)
 
   /**
+   * Returns a query whose failure and success have been lifted into an
+   * `Either`. The resulting query cannot fail, because the failure case has
+   * been exposed as part of the `Either` success case.
+   */
+  final def either(implicit ev: CanFail[E]): ZQuery[R, Nothing, Either[E, A]] =
+    fold(Left(_), Right(_))
+
+  /**
    * Returns a query that models execution of this query, followed by passing
    * its result to the specified function that returns a query. Requests
    * composed with `flatMap` or combinators derived from it will be executed
@@ -105,7 +113,7 @@ sealed trait ZQuery[-R, +E, +A] { self =>
    * that does not fail, but succeeds with the value returned by the left or
    * right function passed to `fold`.
    */
-  final def fold[B](failure: E => B, success: A => B): ZQuery[R, Nothing, B] =
+  final def fold[B](failure: E => B, success: A => B)(implicit ev: CanFail[E]): ZQuery[R, Nothing, B] =
     new ZQuery[R, Nothing, B] {
       def step(cache: Cache): ZIO[R, Nothing, Result[R, Nothing, B]] =
         self.step(cache).map(_.fold(failure, success))
@@ -123,7 +131,7 @@ sealed trait ZQuery[-R, +E, +A] { self =>
   /**
    * Maps the specified function over the failed result of this query.
    */
-  final def mapError[E1](f: E => E1): ZQuery[R, E1, A] =
+  final def mapError[E1](f: E => E1)(implicit ev: CanFail[E]): ZQuery[R, E1, A] =
     new ZQuery[R, E1, A] {
       def step(cache: Cache): ZIO[R, Nothing, Result[R, E1, A]] =
         self.step(cache).map(_.mapError(f))
@@ -132,16 +140,16 @@ sealed trait ZQuery[-R, +E, +A] { self =>
   /**
    * Provides this query with its required environment.
    */
-  final def provide(name: String)(r: R): ZQuery[Any, E, A] =
-    provideSome(s"_ => $name")(_ => r)
+  final def provide(r: Described[R])(implicit ev: NeedsEnv[R]): ZQuery[Any, E, A] =
+    provideSome(Described(_ => r.value, s"_ => ${r.description}"))
 
   /**
    * Provides this query with part of its required environment.
    */
-  final def provideSome[R0](name: String)(f: R0 => R): ZQuery[R0, E, A] =
+  final def provideSome[R0](f: Described[R0 => R])(implicit ev: NeedsEnv[R]): ZQuery[R0, E, A] =
     new ZQuery[R0, E, A] {
       def step(cache: Cache): ZIO[R0, Nothing, Result[R0, E, A]] =
-        self.step(cache).provideSome(f).map(_.provideSome(name)(f))
+        self.step(cache).provideSome(f.value).map(_.provideSome(f))
     }
 
   /**
@@ -251,20 +259,20 @@ object ZQuery {
    * their results. Requests will be executed sequentially and will not be
    * batched.
    */
-  final def collectAll[R, E, A](as: Iterable[ZQuery[R, E, A]]): ZQuery[R, E, List[A]] =
+  def collectAll[R, E, A](as: Iterable[ZQuery[R, E, A]]): ZQuery[R, E, List[A]] =
     foreach(as)(identity)
 
   /**
    * Collects a collection of queries into a query returning a collection of
    * their results. All requests will be batched.
    */
-  final def collectAllPar[R, E, A](as: Iterable[ZQuery[R, E, A]]): ZQuery[R, E, List[A]] =
+  def collectAllPar[R, E, A](as: Iterable[ZQuery[R, E, A]]): ZQuery[R, E, List[A]] =
     foreachPar(as)(identity)
 
   /**
    * Constructs a query that fails with the specified error.
    */
-  final def fail[E](error: E): ZQuery[Any, E, Nothing] =
+  def fail[E](error: E): ZQuery[Any, E, Nothing] =
     ZQuery(ZIO.succeed(Result.fail(Cause.fail(error))))
 
   /**
@@ -272,7 +280,7 @@ object ZQuery {
    * into a query returning a collection of their results. Requests will be
    * executed sequentially and will not be batched.
    */
-  final def foreach[R, E, A, B](as: Iterable[A])(f: A => ZQuery[R, E, B]): ZQuery[R, E, List[B]] =
+  def foreach[R, E, A, B](as: Iterable[A])(f: A => ZQuery[R, E, B]): ZQuery[R, E, List[B]] =
     as.foldRight[ZQuery[R, E, List[B]]](ZQuery.succeed(Nil))((a, bs) => f(a).zipWith(bs)(_ :: _))
 
   /**
@@ -280,13 +288,13 @@ object ZQuery {
    * into a query returning a collection of their results. All requests will be
    * batched.
    */
-  final def foreachPar[R, E, A, B](as: Iterable[A])(f: A => ZQuery[R, E, B]): ZQuery[R, E, List[B]] =
+  def foreachPar[R, E, A, B](as: Iterable[A])(f: A => ZQuery[R, E, B]): ZQuery[R, E, List[B]] =
     as.foldRight[ZQuery[R, E, List[B]]](ZQuery.succeed(Nil))((a, bs) => f(a).zipWithPar(bs)(_ :: _))
 
   /**
    * Constructs a query from an effect.
    */
-  final def fromEffect[R, E, A](effect: ZIO[R, E, A]): ZQuery[R, E, A] =
+  def fromEffect[R, E, A](effect: ZIO[R, E, A]): ZQuery[R, E, A] =
     ZQuery(effect.foldCause(Result.fail, Result.done))
 
   /**
@@ -296,7 +304,7 @@ object ZQuery {
    * committing to a particular implementation of the data source too early,
    * allowing, for example, for live and test implementations.
    */
-  final def fromRequest[R, E, A, B](
+  def fromRequest[R, E, A, B](
     request: A
   )(implicit ev: A <:< Request[E, B]): ZQuery[R with DataSource[R, A], E, B] =
     ZQuery.fromEffect(ZIO.environment[DataSource[R, A]]).flatMap(r => fromRequestWith(request)(r.dataSource))
@@ -306,54 +314,90 @@ object ZQuery {
    * constructed with `fromRequestWith` or combinators derived from it for
    * optimizations to be applied.
    */
-  final def fromRequestWith[R, E, A, B](
+  def fromRequestWith[R, E, A, B](
     request: A
   )(dataSource: DataSource.Service[R, A])(implicit ev: A <:< Request[E, B]): ZQuery[R, E, B] =
     new ZQuery[R, E, B] {
       def step(cache: Cache): ZIO[R, Nothing, Result[R, E, B]] =
-        cache.lookup(request).flatMap {
-          case None =>
-            for {
-              ref <- Ref.make(Option.empty[Either[E, B]])
-              _   <- cache.insert(request, ref)
-            } yield Result.blocked(
-              BlockedRequestMap(dataSource, BlockedRequest(request, ref)),
-              ZQuery {
-                ref.get.flatMap {
-                  case None    => ZIO.die(QueryFailure(dataSource, request))
-                  case Some(b) => ZIO.succeed(Result.fromEither(b))
-                }
-              }
-            )
-          case Some(ref) =>
-            ref.get.map {
-              case Some(b) => Result.fromEither(b)
-              case None =>
-                Result.blocked(
-                  BlockedRequestMap.empty,
-                  ZQuery {
-                    ref.get.flatMap {
-                      case None    => ZIO.die(QueryFailure(dataSource, request))
-                      case Some(b) => ZIO.succeed(Result.fromEither(b))
-                    }
+        cache
+          .lookup(request)
+          .foldM(
+            _ =>
+              for {
+                ref <- Ref.make(Option.empty[Either[E, B]])
+                _   <- cache.insert(request, ref)
+              } yield Result.blocked(
+                BlockedRequestMap(dataSource, BlockedRequest(request, ref)),
+                ZQuery {
+                  ref.get.flatMap {
+                    case None    => ZIO.die(QueryFailure(dataSource, request))
+                    case Some(b) => ZIO.succeed(Result.fromEither(b))
                   }
-                )
-            }
-        }
+                }
+              ),
+            ref =>
+              ref.get.map {
+                case Some(b) => Result.fromEither(b)
+                case None =>
+                  Result.blocked(
+                    BlockedRequestMap.empty,
+                    ZQuery {
+                      ref.get.flatMap {
+                        case None    => ZIO.die(QueryFailure(dataSource, request))
+                        case Some(b) => ZIO.succeed(Result.fromEither(b))
+                      }
+                    }
+                  )
+              }
+          )
     }
+
+  /**
+   * Performs a query for each element in a collection, collecting the results
+   * into a collection of failed results and a collection of successful
+   * results. Requests will be executed sequentially and will not be batched.
+   */
+  def partitionM[R, E, A, B](
+    as: Iterable[A]
+  )(f: A => ZQuery[R, E, B])(implicit ev: CanFail[E]): ZQuery[R, Nothing, (List[E], List[B])] =
+    ZQuery.foreach(as)(f(_).either).map(partitionMap(_)(identity))
+
+  /**
+   * Performs a query for each element in a collection, collecting the results
+   * into a collection of failed results and a collection of successful
+   * results. All requests will be batched.
+   */
+  def partitionMPar[R, E, A, B](
+    as: Iterable[A]
+  )(f: A => ZQuery[R, E, B])(implicit ev: CanFail[E]): ZQuery[R, Nothing, (List[E], List[B])] =
+    ZQuery.foreachPar(as)(f(_).either).map(partitionMap(_)(identity))
 
   /**
    *  Constructs a query that succeeds with the specified value.
    */
-  final def succeed[A](value: A): ZQuery[Any, Nothing, A] =
+  def succeed[A](value: A): ZQuery[Any, Nothing, A] =
     ZQuery(ZIO.succeed(Result.done(value)))
 
   /**
    * Constructs a query from an effect that returns a result.
    */
-  private final def apply[R, E, A](step0: ZIO[R, Nothing, Result[R, E, A]]): ZQuery[R, E, A] =
+  private def apply[R, E, A](step0: ZIO[R, Nothing, Result[R, E, A]]): ZQuery[R, E, A] =
     new ZQuery[R, E, A] {
       def step(cache: Cache): ZIO[R, Nothing, Result[R, E, A]] =
         step0
+    }
+
+  /**
+   * Partitions the elements of a collection using the specified function.
+   */
+  private def partitionMap[E, A, B](
+    as: Iterable[A]
+  )(f: A => Either[E, B])(implicit ev: CanFail[E]): (List[E], List[B]) =
+    as.foldRight((List.empty[E], List.empty[B])) {
+      case (a, (es, bs)) =>
+        f(a).fold(
+          e => (e :: es, bs),
+          b => (es, b :: bs)
+        )
     }
 }

--- a/core/src/main/scala/zquery/ZQuery.scala
+++ b/core/src/main/scala/zquery/ZQuery.scala
@@ -298,25 +298,13 @@ object ZQuery {
     ZQuery(effect.foldCause(Result.fail, Result.done))
 
   /**
-   * Constructs a query from a request, requiring an environment containing a
-   * data source able to execute the request. This is useful to express the
-   * dependency on a data source in a more idiomatic style and to defer
-   * committing to a particular implementation of the data source too early,
-   * allowing, for example, for live and test implementations.
+   * Constructs a query from a request and a data source. Queries must be
+   * constructed with `fromRequest` or combinators derived from it for
+   * optimizations to be applied.
    */
   def fromRequest[R, E, A, B](
     request: A
-  )(implicit ev: A <:< Request[E, B]): ZQuery[R with DataSource[R, A], E, B] =
-    ZQuery.fromEffect(ZIO.environment[DataSource[R, A]]).flatMap(r => fromRequestWith(request)(r.dataSource))
-
-  /**
-   * Constructs a query from a request and a data source. Queries must be
-   * constructed with `fromRequestWith` or combinators derived from it for
-   * optimizations to be applied.
-   */
-  def fromRequestWith[R, E, A, B](
-    request: A
-  )(dataSource: DataSource.Service[R, A])(implicit ev: A <:< Request[E, B]): ZQuery[R, E, B] =
+  )(dataSource: DataSource[R, A])(implicit ev: A <:< Request[E, B]): ZQuery[R, E, B] =
     new ZQuery[R, E, B] {
       def step(cache: Cache): ZIO[R, Nothing, Result[R, E, B]] =
         cache

--- a/core/src/test/scala/zquery/ZQuerySpec.scala
+++ b/core/src/test/scala/zquery/ZQuerySpec.scala
@@ -52,7 +52,7 @@ object ZQuerySpecUtil {
   final case class GetNameById(id: Int) extends UserRequest[String]
 
   val UserRequestDataSource =
-    DataSource.Service[Console, UserRequest[Any]]("UserRequestDataSource") { requests =>
+    DataSource[Console, UserRequest[Any]]("UserRequestDataSource") { requests =>
       console.putStrLn("Running query") *> ZIO.succeed {
         requests.foldLeft(CompletedRequestMap.empty) {
           case (completedRequests, GetAllIds) => completedRequests.insert(GetAllIds)(Right(userIds))
@@ -63,10 +63,10 @@ object ZQuerySpecUtil {
     }
 
   val getAllUserIds: ZQuery[Console, Nothing, List[Int]] =
-    ZQuery.fromRequestWith(GetAllIds)(UserRequestDataSource)
+    ZQuery.fromRequest(GetAllIds)(UserRequestDataSource)
 
   def getUserNameById(id: Int): ZQuery[Console, Nothing, String] =
-    ZQuery.fromRequestWith(GetNameById(id))(UserRequestDataSource)
+    ZQuery.fromRequest(GetNameById(id))(UserRequestDataSource)
 
   val getAllUserNames: ZQuery[Console, Nothing, List[String]] =
     for {

--- a/core/src/test/scala/zquery/ZQuerySpec.scala
+++ b/core/src/test/scala/zquery/ZQuerySpec.scala
@@ -18,6 +18,7 @@ object ZQuerySpec
           } yield assert(log, hasSize(equalTo(2)))
         },
         testM("mapError does not prevent batching") {
+          import zio.CanFail.canFail
           val a = getUserNameById(1).zip(getUserNameById(2)).mapError(identity)
           val b = getUserNameById(3).zip(getUserNameById(4)).mapError(identity)
           for {

--- a/vuepress/docs/docs/optimization.md
+++ b/vuepress/docs/docs/optimization.md
@@ -43,7 +43,7 @@ case class GetUserName(id: Int) extends Request[Throwable, String]
 Now let's build the corresponding `DataSource`. We need to implement the following functions:
 
 ```scala
-val UserDataSource = new DataSource.Service[Any, GetUserName] {
+val UserDataSource = new DataSource[Any, GetUserName] {
   override val identifier: String = ???
   override def run(requests: Iterable[GetUserName]): ZIO[Any, Throwable, CompletedRequestMap] = ???
 }
@@ -77,18 +77,18 @@ override def run(requests: Iterable[GetUserName]): ZIO[Any, Nothing, CompletedRe
 }
 ```
 
-Now to build a `ZQuery` from it, we can use `ZQuery.fromRequestWith` and just pass the request and the data source:
+Now to build a `ZQuery` from it, we can use `ZQuery.fromRequest` and just pass the request and the data source:
 
 ```scala
 def getUserNameById(id: Int): ZQuery[Any, Throwable, String] =
-  ZQuery.fromRequestWith(GetUserName(id))(UserDataSource)
+  ZQuery.fromRequest(GetUserName(id))(UserDataSource)
 ```
 
 To run a `ZQuery`, simply use `ZQuery#run` which will return a `ZIO[R, E, A]`.
 
 ## ZQuery constructors and operators
 
-There are several ways to create a `ZQuery`. We've seen `ZQuery.fromRequestWith`, but you can also:
+There are several ways to create a `ZQuery`. We've seen `ZQuery.fromRequest`, but you can also:
 
 - create from a pure value with `ZQuery.succeed`
 - create from an effect value with `ZQuery.fromEffect`


### PR DESCRIPTION
Various improvements to `ZQuery` including:

- Adds new data source constructors `fromFunctionBatchedWith` and `fromFunctionBatchedWithM` that make it easier to construct batched data sources that don't return results in the same order as requests by providing a function to associate results with requests as suggested by @fokot.
- Adds `partitionM` and `partitionMPar` methods on `ZQuery` that allow for performing a collection of queries and getting back a collection of all successes along with a collection of all failures
- Adds a new `Described` data type to clean up and clarify the contract around needing to provide names for certain combinators such as `provide` and `provideSome`.
- Miscellaneous cleanup including adding `CanFail` and `NeedsEnv` to appropriate combinators and removing unnecessary `final` modifiers.

One thing I would appreciate feedback on is how much users are working with data sources in the environment. I am thinking we could simplify `DataSource` somewhat by not using the module pattern and just having all the methods on `DataSource` versus `DataSource.Service`. That would mean that users could still put the `DataSource` in the environment but it would not come "baked in" like it is today. The nice thing would be this would mean you wouldn't have to write `DataSource.Service` everywhere but if people are using it as an environmental effect then we should leave as is.