### PR TITLE
Wrappers + Apollo Tracing

### DIFF
--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -28,12 +28,11 @@ object CalibanError {
    */
   case class ExecutionError(
     msg: String,
-    fieldName: Option[String] = None,
     path: List[Either[String, Int]] = Nil,
     innerThrowable: Option[Throwable] = None
   ) extends CalibanError {
     override def toString: String = {
-      val field = fieldName.fold("")(f => s" on field '$f'")
+      val field = path.lastOption.fold("")(f => s" on field '$f'")
       val inner = innerThrowable.fold("")(e => s" with ${e.toString}")
       s"Execution error$field: $msg$inner"
     }

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -26,8 +26,12 @@ object CalibanError {
   /**
    * Describes an error that happened while executing a query.
    */
-  case class ExecutionError(msg: String, fieldName: Option[String] = None, innerThrowable: Option[Throwable] = None)
-      extends CalibanError {
+  case class ExecutionError(
+    msg: String,
+    fieldName: Option[String] = None,
+    path: List[Either[String, Int]] = Nil,
+    innerThrowable: Option[Throwable] = None
+  ) extends CalibanError {
     override def toString: String = {
       val field = fieldName.fold("")(f => s" on field '$f'")
       val inner = innerThrowable.fold("")(e => s" with ${e.toString}")

--- a/core/src/main/scala/caliban/GraphQLInterpreter.scala
+++ b/core/src/main/scala/caliban/GraphQLInterpreter.scala
@@ -33,7 +33,7 @@ trait GraphQLInterpreter[-R, +E] { self =>
    * @return a new GraphQL interpreter with error type `E2`
    */
   final def mapError[E2](f: E => E2): GraphQLInterpreter[R, E2] =
-    wrapExecutionWith(_.map(res => GraphQLResponse(res.data, res.errors.map(f))))
+    wrapExecutionWith(_.map(res => GraphQLResponse(res.data, res.errors.map(f), res.extensions)))
 
   /**
    * Eliminates the ZIO environment R requirement of the interpreter.

--- a/core/src/main/scala/caliban/GraphQLResponse.scala
+++ b/core/src/main/scala/caliban/GraphQLResponse.scala
@@ -1,6 +1,6 @@
 package caliban
 
-import caliban.CalibanError.{ ExecutionError, ParsingError, ValidationError }
+import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue.ObjectValue
 import caliban.interop.circe._
 
@@ -34,8 +34,7 @@ private object GraphQLResponseCirce {
 
   private def handleError(err: CalibanError): Json =
     err match {
-      case _: ParsingError | _: ValidationError => Json.obj("message" -> Json.fromString(err.toString))
-      case ExecutionError(_, _, path, _) =>
+      case ExecutionError(_, path, _) if path.nonEmpty =>
         Json.obj(
           "message" -> Json.fromString(err.toString),
           "path" -> Json.fromValues(path.map {
@@ -43,6 +42,7 @@ private object GraphQLResponseCirce {
             case Right(value) => Json.fromInt(value)
           })
         )
+      case _ => Json.obj("message" -> Json.fromString(err.toString))
     }
 
 }

--- a/core/src/main/scala/caliban/GraphQLResponse.scala
+++ b/core/src/main/scala/caliban/GraphQLResponse.scala
@@ -1,27 +1,48 @@
 package caliban
 
+import caliban.CalibanError.{ ExecutionError, ParsingError, ValidationError }
+import caliban.ResponseValue.ObjectValue
 import caliban.interop.circe._
 
 /**
  * Represents the result of a GraphQL query, containing a data object and a list of errors.
  */
-case class GraphQLResponse[+E](data: ResponseValue, errors: List[E])
+case class GraphQLResponse[+E](data: ResponseValue, errors: List[E], extensions: Option[ObjectValue] = None)
 
 object GraphQLResponse {
   implicit def circeEncoder[F[_]: IsCirceEncoder, E]: F[GraphQLResponse[E]] =
-    GraphQLResponceCirce.graphQLResponseEncoder.asInstanceOf[F[GraphQLResponse[E]]]
+    GraphQLResponseCirce.graphQLResponseEncoder.asInstanceOf[F[GraphQLResponse[E]]]
 }
 
-private object GraphQLResponceCirce {
+private object GraphQLResponseCirce {
   import io.circe._
   import io.circe.syntax._
   val graphQLResponseEncoder: Encoder[GraphQLResponse[CalibanError]] = Encoder
     .instance[GraphQLResponse[CalibanError]] {
-      case GraphQLResponse(data, Nil) => Json.obj("data" -> data.asJson)
-      case GraphQLResponse(data, errors) =>
+      case GraphQLResponse(data, Nil, None) => Json.obj("data" -> data.asJson)
+      case GraphQLResponse(data, Nil, Some(extensions)) =>
+        Json.obj("data" -> data.asJson, "extensions" -> extensions.asInstanceOf[ResponseValue].asJson)
+      case GraphQLResponse(data, errors, None) =>
+        Json.obj("data" -> data.asJson, "errors" -> Json.fromValues(errors.map(handleError)))
+      case GraphQLResponse(data, errors, Some(extensions)) =>
         Json.obj(
-          "data"   -> data.asJson,
-          "errors" -> Json.fromValues(errors.map(err => Json.obj("message" -> Json.fromString(err.toString))))
+          "data"       -> data.asJson,
+          "errors"     -> Json.fromValues(errors.map(handleError)),
+          "extensions" -> extensions.asInstanceOf[ResponseValue].asJson
         )
     }
+
+  private def handleError(err: CalibanError): Json =
+    err match {
+      case _: ParsingError | _: ValidationError => Json.obj("message" -> Json.fromString(err.toString))
+      case ExecutionError(_, _, path, _) =>
+        Json.obj(
+          "message" -> Json.fromString(err.toString),
+          "path" -> Json.fromValues(path.map {
+            case Left(value)  => Json.fromString(value)
+            case Right(value) => Json.fromInt(value)
+          })
+        )
+    }
+
 }

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -135,17 +135,11 @@ object Executor {
           reduceObject(items, fieldWrappers)
         case QueryStep(inner) =>
           ReducedStep.QueryStep(
-            inner.bimap(
-              GenericSchema.effectfulExecutionError(currentField.name, path, _),
-              reduceStep(_, currentField, arguments, path)
-            )
+            inner.bimap(GenericSchema.effectfulExecutionError(path, _), reduceStep(_, currentField, arguments, path))
           )
         case StreamStep(stream) =>
           ReducedStep.StreamStep(
-            stream.bimap(
-              GenericSchema.effectfulExecutionError(currentField.name, path, _),
-              reduceStep(_, currentField, arguments, path)
-            )
+            stream.bimap(GenericSchema.effectfulExecutionError(path, _), reduceStep(_, currentField, arguments, path))
           )
       }
 
@@ -254,8 +248,8 @@ object Executor {
     fieldWrappers: List[FieldWrapper[R]]
   ): ReducedStep[R] =
     if (!fieldWrappers.exists(_.wrapPureValues) && items.map(_._2).forall(_.isInstanceOf[PureStep]))
-      PureStep(ObjectValue(items.asInstanceOf[List[(String, PureStep)]].map {
-        case (k, v) => k -> v.value
+      PureStep(ObjectValue(items.asInstanceOf[List[(String, PureStep, FieldInfo)]].map {
+        case (k, v, _) => (k, v.value)
       }))
     else ReducedStep.ObjectStep(items)
 

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -231,12 +231,7 @@ object Executor {
   }
 
   private def fieldInfo(field: Field, path: List[Either[String, Int]]): FieldInfo =
-    FieldInfo(
-      field.alias.getOrElse(field.name),
-      path,
-      field.parentType.flatMap(_.name).getOrElse(""), // TODO should go up to catch [] and !
-      field.fieldType.name.getOrElse("")              // TODO should go up to catch [] and !
-    )
+    FieldInfo(field.alias.getOrElse(field.name), path, field.parentType, field.fieldType)
 
   private def reduceList[R](list: List[ReducedStep[R]]): ReducedStep[R] =
     if (list.forall(_.isInstanceOf[PureStep]))

--- a/core/src/main/scala/caliban/execution/FieldInfo.scala
+++ b/core/src/main/scala/caliban/execution/FieldInfo.scala
@@ -1,0 +1,3 @@
+package caliban.execution
+
+case class FieldInfo(fieldName: String, path: List[Either[String, Int]], parentType: String, returnType: String)

--- a/core/src/main/scala/caliban/execution/FieldInfo.scala
+++ b/core/src/main/scala/caliban/execution/FieldInfo.scala
@@ -1,3 +1,5 @@
 package caliban.execution
 
-case class FieldInfo(fieldName: String, path: List[Either[String, Int]], parentType: String, returnType: String)
+import caliban.introspection.adt.__Type
+
+case class FieldInfo(fieldName: String, path: List[Either[String, Int]], parentType: Option[__Type], returnType: __Type)

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -418,8 +418,9 @@ trait DerivationSchema[R] {
 
 object GenericSchema {
 
-  def effectfulExecutionError(fieldName: String, e: Throwable): ExecutionError = e match {
-    case e: ExecutionError => e
-    case other             => ExecutionError("Effect failure", Some(fieldName), Some(other))
-  }
+  def effectfulExecutionError(fieldName: String, path: List[Either[String, Int]], e: Throwable): ExecutionError =
+    e match {
+      case e: ExecutionError => e
+      case other             => ExecutionError("Effect failure", Some(fieldName), path, Some(other))
+    }
 }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -418,9 +418,9 @@ trait DerivationSchema[R] {
 
 object GenericSchema {
 
-  def effectfulExecutionError(fieldName: String, path: List[Either[String, Int]], e: Throwable): ExecutionError =
+  def effectfulExecutionError(path: List[Either[String, Int]], e: Throwable): ExecutionError =
     e match {
       case e: ExecutionError => e
-      case other             => ExecutionError("Effect failure", Some(fieldName), path, Some(other))
+      case other             => ExecutionError("Effect failure", path, Some(other))
     }
 }

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -3,6 +3,7 @@ package caliban.schema
 import caliban.CalibanError.ExecutionError
 import caliban.{ InputValue, ResponseValue }
 import caliban.Value.NullValue
+import caliban.execution.FieldInfo
 import zio.stream.ZStream
 import zquery.ZQuery
 
@@ -36,7 +37,7 @@ sealed trait ReducedStep[-R]
 
 object ReducedStep {
   case class ListStep[-R](steps: List[ReducedStep[R]])                         extends ReducedStep[R]
-  case class ObjectStep[-R](fields: List[(String, ReducedStep[R])])            extends ReducedStep[R]
+  case class ObjectStep[-R](fields: List[(String, ReducedStep[R], FieldInfo)]) extends ReducedStep[R]
   case class QueryStep[-R](query: ZQuery[R, ExecutionError, ReducedStep[R]])   extends ReducedStep[R]
   case class StreamStep[-R](inner: ZStream[R, ExecutionError, ReducedStep[R]]) extends ReducedStep[R]
 

--- a/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
@@ -1,0 +1,178 @@
+package caliban.wrappers
+
+import java.time.{ Instant, ZoneId }
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
+import caliban.{ GraphQL, ResponseValue }
+import caliban.ResponseValue.{ ListValue, ObjectValue }
+import caliban.Value.{ IntValue, StringValue }
+import caliban.wrappers.Wrapper.{ FieldWrapper, OverallWrapper, ParsingWrapper, ValidationWrapper }
+import zio.clock.Clock
+import zio.clock
+import zio.duration.Duration
+import zio.{ FiberRef, UIO }
+import zquery.ZQuery
+
+object ApolloTracing {
+
+  private val dateFormatter: DateTimeFormatter = DateTimeFormatter
+    .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    .withZone(ZoneId.of("UTC"))
+
+  case class Parsing(startOffset: Long = 0, duration: Duration = Duration.Zero) {
+    def toResponseValue: ResponseValue =
+      ObjectValue(List("startOffset" -> IntValue(startOffset), "duration" -> IntValue(duration.toNanos)))
+  }
+  case class Validation(startOffset: Long = 0, duration: Duration = Duration.Zero) {
+    def toResponseValue: ResponseValue =
+      ObjectValue(List("startOffset" -> IntValue(startOffset), "duration" -> IntValue(duration.toNanos)))
+  }
+  case class Resolver(
+    path: List[Either[String, Int]] = Nil,
+    parentType: String = "",
+    fieldName: String = "",
+    returnType: String = "",
+    startOffset: Long = 0,
+    duration: Duration = Duration.Zero
+  ) {
+    def toResponseValue: ResponseValue =
+      ObjectValue(
+        List(
+          "path" -> ListValue((Left(fieldName) :: path).reverse.map {
+            case Left(s)  => StringValue(s)
+            case Right(i) => IntValue(i)
+          }),
+          "parentType"  -> StringValue(parentType),
+          "fieldName"   -> StringValue(fieldName),
+          "returnType"  -> StringValue(returnType),
+          "startOffset" -> IntValue(startOffset),
+          "duration"    -> IntValue(duration.toNanos)
+        )
+      )
+  }
+  case class Execution(resolvers: List[Resolver] = Nil) {
+    def toResponseValue: ResponseValue =
+      ObjectValue(List("resolvers" -> ListValue(resolvers.sortBy(_.startOffset).map(_.toResponseValue))))
+  }
+  case class Tracing(
+    version: Int = 1,
+    startTime: Long = 0,
+    endTime: Long = 0,
+    startTimeMonotonic: Long = 0,
+    duration: Duration = Duration.Zero,
+    parsing: Parsing = Parsing(),
+    validation: Validation = Validation(),
+    execution: Execution = Execution()
+  ) {
+    def toResponseValue: ResponseValue =
+      ObjectValue(
+        List(
+          "version"    -> IntValue(version),
+          "startTime"  -> StringValue(dateFormatter.format(Instant.ofEpochMilli(startTime))),
+          "endTime"    -> StringValue(dateFormatter.format(Instant.ofEpochMilli(endTime))),
+          "duration"   -> IntValue(duration.toNanos),
+          "parsing"    -> parsing.toResponseValue,
+          "validation" -> validation.toResponseValue,
+          "execution"  -> execution.toResponseValue
+        )
+      )
+  }
+
+  def apolloTracing[R](api: GraphQL[R]): UIO[GraphQL[Clock with R]] =
+    FiberRef
+      .make(Tracing())
+      .map(
+        ref =>
+          api
+            .withWrapper(apolloTracingOverallWrapper(ref))
+            .withWrapper(apolloTracingParsingWrapper(ref))
+            .withWrapper(apolloTracingValidationWrapper(ref))
+            .withWrapper(apolloTracingFieldWrapper(ref))
+      )
+
+  private def apolloTracingOverallWrapper(ref: FiberRef[Tracing]): OverallWrapper[Clock] = OverallWrapper {
+    case (io, _) =>
+      for {
+        nanoTime    <- clock.nanoTime
+        currentTime <- clock.currentTime(TimeUnit.MILLISECONDS)
+        _           <- ref.update(_.copy(startTime = currentTime, startTimeMonotonic = nanoTime))
+        result <- io.timed.flatMap {
+                   case (duration, result) =>
+                     for {
+                       endTime <- clock.currentTime(TimeUnit.MILLISECONDS)
+                       _       <- ref.update(_.copy(duration = duration, endTime = endTime))
+                       tracing <- ref.get
+                     } yield result.copy(
+                       extensions = Some(
+                         ObjectValue(
+                           ("tracing" -> tracing.toResponseValue) ::
+                             result.extensions.fold(List.empty[(String, ResponseValue)])(_.fields)
+                         )
+                       )
+                     )
+                 }
+      } yield result
+  }
+
+  private def apolloTracingParsingWrapper(ref: FiberRef[Tracing]): ParsingWrapper[Clock] = ParsingWrapper {
+    case (io, _) =>
+      for {
+        start              <- clock.nanoTime
+        (duration, result) <- io.timed
+        _ <- ref.update(
+              state =>
+                state.copy(
+                  parsing = state.parsing.copy(startOffset = start - state.startTimeMonotonic, duration = duration)
+                )
+            )
+      } yield result
+  }
+
+  private def apolloTracingValidationWrapper(ref: FiberRef[Tracing]): ValidationWrapper[Clock] = ValidationWrapper {
+    case (io, _) =>
+      for {
+        start              <- clock.nanoTime
+        (duration, result) <- io.timed
+        _ <- ref.update(
+              state =>
+                state.copy(
+                  validation =
+                    state.validation.copy(startOffset = start - state.startTimeMonotonic, duration = duration)
+                )
+            )
+      } yield result
+  }
+
+  private def apolloTracingFieldWrapper(ref: FiberRef[Tracing]): FieldWrapper[Clock] = FieldWrapper(
+    {
+      case (query, fieldInfo) =>
+        for {
+          start    <- ZQuery.fromEffect(clock.nanoTime)
+          result   <- query
+          end      <- ZQuery.fromEffect(clock.nanoTime)
+          duration = Duration.fromNanos(end - start)
+          _ <- ZQuery.fromEffect(
+                ref
+                  .update(
+                    state =>
+                      state.copy(
+                        execution = state.execution.copy(
+                          resolvers =
+                            Resolver(
+                              path = fieldInfo.path,
+                              parentType = fieldInfo.parentType,
+                              fieldName = fieldInfo.fieldName,
+                              returnType = fieldInfo.returnType,
+                              startOffset = start - state.startTimeMonotonic,
+                              duration = duration
+                            ) :: state.execution.resolvers
+                        )
+                      )
+                  )
+              )
+        } yield result
+    },
+    wrapPureValues = true
+  )
+
+}

--- a/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
@@ -3,7 +3,7 @@ package caliban.wrappers
 import java.time.{ Instant, ZoneId }
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
-import caliban.{ GraphQL, ResponseValue }
+import caliban.{ GraphQL, Rendering, ResponseValue }
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.Value.{ IntValue, StringValue }
 import caliban.wrappers.Wrapper.{ FieldWrapper, OverallWrapper, ParsingWrapper, ValidationWrapper }
@@ -160,9 +160,9 @@ object ApolloTracing {
                           resolvers =
                             Resolver(
                               path = fieldInfo.path,
-                              parentType = fieldInfo.parentType,
+                              parentType = fieldInfo.parentType.fold("")(Rendering.renderTypeName),
                               fieldName = fieldInfo.fieldName,
-                              returnType = fieldInfo.returnType,
+                              returnType = Rendering.renderTypeName(fieldInfo.returnType),
                               startOffset = start - state.startTimeMonotonic,
                               duration = duration
                             ) :: state.execution.resolvers

--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -1,0 +1,62 @@
+package caliban.wrappers
+
+import caliban.CalibanError.{ ParsingError, ValidationError }
+import caliban.execution.FieldInfo
+import caliban.parsing.adt.Document
+import caliban.{ CalibanError, GraphQLResponse, ResponseValue }
+import zio.{ IO, ZIO }
+import zquery.ZQuery
+
+sealed trait Wrapper[-R]
+
+object Wrapper {
+
+  type WrappingFunction[-R, E, A, Info] = (IO[E, A], Info) => ZIO[R, E, A]
+
+  case class OverallWrapper[-R](f: WrappingFunction[R, Nothing, GraphQLResponse[CalibanError], String])
+      extends Wrapper[R]
+  case class ParsingWrapper[-R](f: WrappingFunction[R, ParsingError, Document, String])     extends Wrapper[R]
+  case class ValidationWrapper[-R](f: WrappingFunction[R, ValidationError, Unit, Document]) extends Wrapper[R]
+  case class ExecutionWrapper[-R](f: WrappingFunction[R, Nothing, GraphQLResponse[CalibanError], Document])
+      extends Wrapper[R]
+  case class FieldWrapper[-R](
+    f: (ZQuery[Any, Nothing, ResponseValue], FieldInfo) => ZQuery[R, CalibanError, ResponseValue],
+    wrapPureValues: Boolean = false
+  ) extends Wrapper[R]
+
+  private[caliban] def wrap[R, E, A, Info](
+    zio: IO[E, A]
+  )(wrappers: List[WrappingFunction[R, E, A, Info]], info: Info): ZIO[R, E, A] = {
+    def loop(zio: IO[E, A], wrappers: List[WrappingFunction[R, E, A, Info]]): ZIO[R, E, A] =
+      wrappers match {
+        case Nil => zio
+        case wrapper :: tail =>
+          ZIO.environment[R].flatMap(env => loop(wrapper(zio, info).provide(env), tail))
+      }
+    loop(zio, wrappers)
+  }
+
+  private[caliban] def decompose[R](wrappers: List[Wrapper[R]]): (
+    List[WrappingFunction[R, Nothing, GraphQLResponse[CalibanError], String]],
+    List[WrappingFunction[R, ParsingError, Document, String]],
+    List[WrappingFunction[R, ValidationError, Unit, Document]],
+    List[WrappingFunction[R, Nothing, GraphQLResponse[CalibanError], Document]],
+    List[FieldWrapper[R]]
+  ) =
+    wrappers.foldLeft(
+      (
+        List.empty[WrappingFunction[R, Nothing, GraphQLResponse[CalibanError], String]],
+        List.empty[WrappingFunction[R, ParsingError, Document, String]],
+        List.empty[WrappingFunction[R, ValidationError, Unit, Document]],
+        List.empty[WrappingFunction[R, Nothing, GraphQLResponse[CalibanError], Document]],
+        List.empty[FieldWrapper[R]]
+      )
+    ) {
+      case ((o, p, v, e, f), OverallWrapper(wrapper))    => (wrapper :: o, p, v, e, f)
+      case ((o, p, v, e, f), ParsingWrapper(wrapper))    => (o, wrapper :: p, v, e, f)
+      case ((o, p, v, e, f), ValidationWrapper(wrapper)) => (o, p, wrapper :: v, e, f)
+      case ((o, p, v, e, f), ExecutionWrapper(wrapper))  => (o, p, v, wrapper :: e, f)
+      case ((o, p, v, e, f), wrapper: FieldWrapper[_])   => (o, p, v, e, wrapper :: f)
+    }
+
+}

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -1,0 +1,42 @@
+package caliban.wrappers
+
+import caliban.CalibanError.ExecutionError
+import caliban.Value.NullValue
+import caliban.wrappers.Wrapper.OverallWrapper
+import caliban.{ GraphQL, GraphQLResponse }
+import zio.ZIO
+import zio.clock.Clock
+import zio.console.{ putStrLn, Console }
+import zio.duration.Duration
+
+object Wrappers {
+
+  def logSlowQueries[R <: Console with Clock](maxDuration: Duration)(api: GraphQL[R]): GraphQL[R] =
+    api.withWrapper(logSlowQueriesWrapper(maxDuration))
+
+  def logSlowQueriesWrapper(maxDuration: Duration): OverallWrapper[Console with Clock] =
+    OverallWrapper {
+      case (io, query) =>
+        io.timed.flatMap {
+          case (time, res) =>
+            ZIO.when(time > maxDuration)(putStrLn(s"Slow query took ${time.render}:\n$query")).as(res)
+        }
+    }
+
+  def timeout[R <: Clock](maxDuration: Duration)(api: GraphQL[R]): GraphQL[R] =
+    api.withWrapper(timeoutWrapper(maxDuration))
+
+  def timeoutWrapper(maxDuration: Duration): OverallWrapper[Clock] =
+    OverallWrapper {
+      case (io, query) =>
+        io.timeout(maxDuration)
+          .map(
+            _.getOrElse(
+              GraphQLResponse(
+                NullValue,
+                List(ExecutionError(s"Query was interrupted after timeout of ${maxDuration.render}:\n$query"))
+              )
+            )
+          )
+    }
+}

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -11,30 +11,48 @@ import zio.duration.Duration
 
 object Wrappers {
 
-  def logSlowQueries[R <: Console with Clock](maxDuration: Duration)(api: GraphQL[R]): GraphQL[R] =
-    api.withWrapper(logSlowQueriesWrapper(maxDuration))
+  /**
+   * Attaches to the given GraphQL API definition a wrapper that logs slow queries.
+   * @param duration threshold above which queries are considered slow
+   * @param api a GraphQL API definition
+   */
+  def logSlowQueries[R <: Console with Clock](duration: Duration)(api: GraphQL[R]): GraphQL[R] =
+    api.withWrapper(logSlowQueriesWrapper(duration))
 
-  def logSlowQueriesWrapper(maxDuration: Duration): OverallWrapper[Console with Clock] =
+  /**
+   * Returns a wrapper that logs slow queries
+   * @param duration threshold above which queries are considered slow
+   */
+  def logSlowQueriesWrapper(duration: Duration): OverallWrapper[Console with Clock] =
     OverallWrapper {
       case (io, query) =>
         io.timed.flatMap {
           case (time, res) =>
-            ZIO.when(time > maxDuration)(putStrLn(s"Slow query took ${time.render}:\n$query")).as(res)
+            ZIO.when(time > duration)(putStrLn(s"Slow query took ${time.render}:\n$query")).as(res)
         }
     }
 
-  def timeout[R <: Clock](maxDuration: Duration)(api: GraphQL[R]): GraphQL[R] =
-    api.withWrapper(timeoutWrapper(maxDuration))
+  /**
+   * Attaches to the given GraphQL API definition a wrapper that times out queries taking more than a specified time.
+   * @param duration threshold above which queries should be timed out
+   * @param api a GraphQL API definition
+   */
+  def timeout[R <: Clock](duration: Duration)(api: GraphQL[R]): GraphQL[R] =
+    api.withWrapper(timeoutWrapper(duration))
 
-  def timeoutWrapper(maxDuration: Duration): OverallWrapper[Clock] =
+  /**
+   * Returns a wrapper that times out queries taking more than a specified time.
+   * @param duration threshold above which queries should be timed out
+   */
+  def timeoutWrapper(duration: Duration): OverallWrapper[Clock] =
     OverallWrapper {
       case (io, query) =>
-        io.timeout(maxDuration)
+        io.timeout(duration)
           .map(
             _.getOrElse(
               GraphQLResponse(
                 NullValue,
-                List(ExecutionError(s"Query was interrupted after timeout of ${maxDuration.render}:\n$query"))
+                List(ExecutionError(s"Query was interrupted after timeout of ${duration.render}:\n$query"))
               )
             )
           )

--- a/core/src/main/scala/zquery/ZQuery.scala
+++ b/core/src/main/scala/zquery/ZQuery.scala
@@ -287,6 +287,11 @@ object ZQuery {
     foreachPar(as)(identity)
 
   /**
+   * Accesses the whole environment of the query.
+   */
+  def environment[R]: ZQuery[R, Nothing, R] = ZQuery.fromEffect(ZIO.environment[R])
+
+  /**
    * Constructs a query that fails with the specified error.
    */
   def fail[E](error: E): ZQuery[Any, E, Nothing] =

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -1,0 +1,81 @@
+package caliban.wrappers
+
+import scala.language.postfixOps
+import caliban.CalibanError.ExecutionError
+import caliban.GraphQL._
+import caliban.Macros.gqldoc
+import caliban.RootResolver
+import caliban.schema.GenericSchema
+import zio.clock.Clock
+import zio.duration._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestClock
+import zio.{ clock, URIO }
+
+object WrappersSpec
+    extends DefaultRunnableSpec(
+      suite("WrappersSpec")(
+        testM("Timeout") {
+          case class Test(a: URIO[Clock, Int])
+
+          object schema extends GenericSchema[Clock]
+          import schema._
+
+          val interpreter =
+            Wrappers
+              .timeout(1 minute)(
+                graphQL(RootResolver(Test(clock.sleep(2 minutes).as(0))))
+              )
+              .interpreter
+          val query = gqldoc("""
+              {
+                a
+              }""")
+          assertM(
+            TestClock.adjust(1 minute) *> interpreter.execute(query).map(_.errors),
+            equalTo(List(ExecutionError("""Query was interrupted after timeout of 1 m:
+
+              {
+                a
+              }""".stripMargin)))
+          )
+        },
+        testM("Apollo Tracing") {
+          case class Query(hero: Hero)
+          case class Hero(name: String, friends: List[Hero] = Nil)
+
+          object schema extends GenericSchema[Clock]
+          import schema._
+
+          val interpreter =
+            ApolloTracing
+              .apolloTracing(
+                graphQL(
+                  RootResolver(
+                    Query(Hero("R2-D2", List(Hero("Luke Skywalker"), Hero("Han Solo"), Hero("Leia Organa"))))
+                  )
+                )
+              )
+              .map(_.interpreter)
+
+          val query = gqldoc("""
+              {
+                hero {
+                  name
+                  friends {
+                    name
+                  }
+                }
+              }""")
+          assertM(
+            interpreter >>= (_.execute(query).map(_.extensions.map(_.toString))),
+            isSome(
+              equalTo(
+                """{"tracing":{"version":1,"startTime":"1970-01-01T00:00:00.000Z","endTime":"1970-01-01T00:00:00.000Z","duration":0,"parsing":{"startOffset":0,"duration":0},"validation":{"startOffset":0,"duration":0},"execution":{"resolvers":[{"path":["hero"],"parentType":"Query","fieldName":"hero","returnType":"Hero!","startOffset":0,"duration":0},{"path":["hero","friends"],"parentType":"Hero","fieldName":"friends","returnType":"[Hero!]!","startOffset":0,"duration":0},{"path":["hero","friends",2,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":0},{"path":["hero","friends",1,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":0},{"path":["hero","friends",0,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":0},{"path":["hero","name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":0}]}}}"""
+              )
+            )
+          )
+        }
+      )
+    )

--- a/examples/src/main/scala/caliban/http4s/ExampleApp.scala
+++ b/examples/src/main/scala/caliban/http4s/ExampleApp.scala
@@ -43,7 +43,7 @@ object ExampleApp extends CatsApp with GenericSchema[Console with Clock] {
   implicit val charactersArgsSchema = gen[CharactersArgs]
 
   def makeApi(service: ExampleService): UIO[GraphQL[Console with Clock]] =
-    apolloTracing(
+    apolloTracing(                // wrapper for https://github.com/apollographql/apollo-tracing
       logSlowQueries(500 millis)( // wrapper that logs slow queries
         timeout(3 seconds)(       // wrapper that fails slow queries
           maxDepth(30)(           // query analyzer that limit query depth

--- a/examples/src/main/scala/caliban/http4s/ExampleApp.scala
+++ b/examples/src/main/scala/caliban/http4s/ExampleApp.scala
@@ -4,7 +4,7 @@ import scala.language.postfixOps
 import caliban.ExampleData._
 import caliban.GraphQL._
 import caliban.execution.QueryAnalyzer._
-import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLName }
+import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
 import caliban.schema.GenericSchema
 import caliban.wrappers.ApolloTracing.apolloTracing
 import caliban.wrappers.Wrappers._
@@ -30,14 +30,10 @@ object ExampleApp extends CatsApp with GenericSchema[Console with Clock] {
     @GQLDescription("Return all characters from a given origin")
     characters: CharactersArgs => URIO[Console, List[Character]],
     @GQLDeprecated("Use `characters`")
-    character: CharacterArgs => URIO[Console, Option[Character]],
-    test: Foo[Int]
+    character: CharacterArgs => URIO[Console, Option[Character]]
   )
   case class Mutations(deleteCharacter: CharacterArgs => URIO[Console, Boolean])
   case class Subscriptions(characterDeleted: ZStream[Console, Nothing, String])
-
-  @GQLName("FooAnnotated")
-  case class Foo[E](e: E)
 
   type ExampleTask[A] = RIO[Console with Clock, A]
 
@@ -56,8 +52,7 @@ object ExampleApp extends CatsApp with GenericSchema[Console with Clock] {
                 RootResolver(
                   Queries(
                     args => service.getCharacters(args.origin),
-                    args => service.findCharacter(args.name),
-                    Foo(2)
+                    args => service.findCharacter(args.name)
                   ),
                   Mutations(args => service.deleteCharacter(args.name)),
                   Subscriptions(service.deletedEvents)


### PR DESCRIPTION
Fixes #99 
Fixes #133 
Fixes #157 

You can use `GraphQL#withWrapper` to register a function that will wrap the execution of the query processing (or only a part of it).

There are 5 types of wrappers:
 - `OverallWrapper` to wrap the whole query processing
 - `ParsingWrapper` to wrap the query parsing only
 - `ValidationWrapper` to wrap the query validation only
 - `ExecutionWrapper` to wrap the query execution only
 - `FieldWrapper` to wrap each field execution

Each one requires a function that takes an `IO` or `ZQuery` computation together with some contextual information (e.g. the query string) and should return another computation.

Let's see how to implement a wrapper that times out the whole query if its processing takes longer that 1 minute.

```scala
val wrapper = OverallWrapper {
  case (io, query) =>
    io.timeout(1 minute)
      .map(
        _.getOrElse(
          GraphQLResponse(
            NullValue,
            List(ExecutionError(s"Query was interrupted after timeout of ${duration.render}:\n$query"))
          )
        )
      )
}

val api = graphQL(...).withWrapper(wrapper)
```

Caliban comes with a few pre-made wrappers:
- `caliban.wrappers.Wrappers.logSlowQueries` returns a wrapper that logs slow queries
- `caliban.wrappers.Wrappers.timeout` returns a wrapper that fails queries taking more than a specified time
- `caliban.wrappers.ApolloTracing.apolloTracing` returns a wrapper that adds tracing data into the `extensions` field of each response following [Apollo Tracing](https://github.com/apollographql/apollo-tracing) format.

They can be used like this:
```scala
val api =
  apolloTracing( // note: this constructor is effectful
    logSlowQueries(500 millis)(
      timeout(3 seconds)(  
        graphQL(...)
      )
    )
  )
```