### PR TITLE
Fix Akka HTTP example

### DIFF
--- a/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -44,11 +44,6 @@ object AkkaHttpAdapter extends FailFastCirceSupport {
         .future
     )
 
-  def makeHttpServiceM[R, E](
-    interpreter: URIO[R, GraphQLInterpreter[R, E]]
-  )(implicit ec: ExecutionContext, runtime: Runtime[R]): Route =
-    makeHttpService(runtime.unsafeRun(interpreter))
-
   def makeHttpService[R, E](
     interpreter: GraphQLInterpreter[R, E]
   )(implicit ec: ExecutionContext, runtime: Runtime[R]): Route = {


### PR DESCRIPTION
The interpreter (and the service) were recreated at every API call.