### PR TITLE
ZQuery Improvements

### DIFF
--- a/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
@@ -159,10 +159,11 @@ object ApolloTracing {
       {
         case (query, fieldInfo) =>
           for {
-            start    <- ZQuery.fromEffect(clock.nanoTime)
-            result   <- query
-            end      <- ZQuery.fromEffect(clock.nanoTime)
-            duration = Duration.fromNanos(end - start)
+            summarized <- query.summarized { (start: Long, end: Long) =>
+                           (start, end)
+                         }(clock.nanoTime)
+            ((start, end), result) = summarized
+            duration               = Duration.fromNanos(end - start)
             _ <- ZQuery.fromEffect(
                   ref
                     .update(

--- a/core/src/main/scala/zquery/Cache.scala
+++ b/core/src/main/scala/zquery/Cache.scala
@@ -21,7 +21,7 @@ final class Cache private (private val state: Ref[Map[Any, Any]]) {
    * Looks up a request in the cache, failing with the unit value if the
    * request is not in the cache, succeeding with `Ref(None)` if the request is
    * in the cache but has not been executed yet, or `Ref(Some(value))` if the
-   * request has been xecuted.
+   * request has been executed.
    */
   def lookup[E, A](request: Request[E, A]): IO[Unit, Ref[Option[Either[E, A]]]] =
     state.get.map(_.get(request).asInstanceOf[Option[Ref[Option[Either[E, A]]]]]).get

--- a/core/src/main/scala/zquery/Cache.scala
+++ b/core/src/main/scala/zquery/Cache.scala
@@ -18,10 +18,10 @@ final class Cache private (private val state: Ref[Map[Any, Any]]) {
     state.update(_ + (request -> result)).unit
 
   /**
-   * Looks up a request in the cache, returning `None` if the request is not in
-   * the cache, `Some(Ref(None))` if the request is in the cache but has not
-   * been executed yet, or `Some(Ref(Some(value)))` if the request has been
-   * executed.
+   * Looks up a request in the cache, failing with the unit value if the
+   * request is not in the cache, succeeding with `Ref(None)` if the request is
+   * in the cache but has not been executed yet, or `Ref(Some(value))` if the
+   * request has been xecuted.
    */
   def lookup[E, A](request: Request[E, A]): IO[Unit, Ref[Option[Either[E, A]]]] =
     state.get.map(_.get(request).asInstanceOf[Option[Ref[Option[Either[E, A]]]]]).get

--- a/core/src/main/scala/zquery/CompletedRequestMap.scala
+++ b/core/src/main/scala/zquery/CompletedRequestMap.scala
@@ -21,6 +21,16 @@ final class CompletedRequestMap private (private val map: Map[Any, Either[Any, A
     new CompletedRequestMap(self.map + (request -> result))
 
   /**
+   * Appends the specified optional result to the completed request map.
+   */
+  def insertOption[E, A](request: Request[E, A])(result: Either[E, Option[A]]): CompletedRequestMap =
+    result match {
+      case Left(e)        => insert(request)(Left(e))
+      case Right(Some(a)) => insert(request)(Right(a))
+      case Right(None)    => self
+    }
+
+  /**
    * Retrieves the result of the specified request if it exists.
    */
   def lookup[E, A](request: Request[E, A]): Option[Either[E, A]] =

--- a/core/src/main/scala/zquery/Result.scala
+++ b/core/src/main/scala/zquery/Result.scala
@@ -80,6 +80,16 @@ private[zquery] object Result {
   def fromEither[E, A](either: Either[E, A]): Result[Any, E, A] =
     either.fold(e => Result.fail(Cause.fail(e)), a => Result.done(a))
 
+  /**
+   * Lifts an `Option[Either[E, A]]` into a result.
+   */
+  def fromOptionEither[E, A](oeea: Option[Either[E, A]]): Result[Any, E, Option[A]] =
+    oeea match {
+      case None           => Result.done(None)
+      case Some(Left(e))  => Result.fail(Cause.fail(e))
+      case Some(Right(a)) => Result.done(Some(a))
+    }
+
   final case class Blocked[-R, +E, +A](blockedRequests: BlockedRequestMap[R], continue: ZQuery[R, E, A])
       extends Result[R, E, A]
 

--- a/core/src/test/scala/zquery/ZQuerySpec.scala
+++ b/core/src/test/scala/zquery/ZQuerySpec.scala
@@ -36,6 +36,14 @@ object ZQuerySpec
             failure.getMessage,
             equalTo("Data source UserRequestDataSource did not complete request GetNameById(27).")
           )
+        },
+        testM("timed does not prevent batching") {
+          val a = getUserNameById(1).zip(getUserNameById(2)).timed
+          val b = getUserNameById(3).zip(getUserNameById(4))
+          for {
+            result <- ZQuery.collectAllPar(List(a, b)).run
+            log    <- TestConsole.output
+          } yield assert(log, hasSize(equalTo(2)))
         }
       )
     )


### PR DESCRIPTION
Improvements to ZQuery based on recent suggestions:

- Query metrics - implements `summarized` and `timed` methods on ZQuery analogous to existing methods on ZIO. These do not interfere with query batching. 
- Optional data sources - implements `fromRequestOption` constructor on ZQuery to construct queries that return `None` instead of failing with a `QueryFailure` if a data source does not return a result for a request. Implements `fromFunctionOption`, `fromFunctionOptionM`, `fromFunctionBatchedOption`, and `fromFunctionBatchedOptionM` to create data sources that may not return a result for a request.
- More support for data sources that can fail - `fromFunctionBatchedWithM` now also allows you to use an effect that can fail. If the effect fails the failure will be returned for all requests.