### PR TITLE
Improve API combine logic

### DIFF
--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -29,7 +29,8 @@ object Step {
   def mergeRootSteps[R](step1: Step[R], step2: Step[R]): Step[R] = (step1, step2) match {
     case (ObjectStep(name, fields1), ObjectStep(_, fields2)) =>
       ObjectStep(name, fields1 ++ fields2) // fields2 override fields1 in case of conflict
-    case _ => step2
+    case (ObjectStep(_, _), _) => step1 // if only step1 is an object, keep it
+    case _                     => step2 // otherwise keep step2
   }
 }
 


### PR DESCRIPTION
When 2 API are combined, we expect both root types to be GraphQL objects. If one of them is not, discard it and keep only the other one (instead of the 2nd one as it was the case)