### PR TITLE
Add directive support

### DIFF
--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -6,42 +6,61 @@ import caliban.parsing.adt.Directive
 
 object Rendering {
 
+  private implicit val kindOrdering: Ordering[__TypeKind] = Ordering
+    .by[__TypeKind, Int] {
+      case __TypeKind.SCALAR       => 1
+      case __TypeKind.NON_NULL     => 2
+      case __TypeKind.LIST         => 3
+      case __TypeKind.UNION        => 4
+      case __TypeKind.ENUM         => 5
+      case __TypeKind.INPUT_OBJECT => 6
+      case __TypeKind.INTERFACE    => 7
+      case __TypeKind.OBJECT       => 8
+    }
+
+  private implicit val renderOrdering: Ordering[(String, __Type)] = Ordering.by(o => (o._2.kind, o._2.name))
+
   /**
    * Returns a string that renders the provided types into the GraphQL format.
    */
   def renderTypes(types: Map[String, __Type]): String =
-    types.flatMap {
-      case (_, t) =>
-        t.kind match {
-          case __TypeKind.SCALAR   => t.name.flatMap(name => if (isBuiltinScalar(name)) None else Some(s"scalar $name"))
-          case __TypeKind.NON_NULL => None
-          case __TypeKind.LIST     => None
-          case __TypeKind.UNION =>
-            val renderedTypes: String =
-              t.possibleTypes
-                .fold(List.empty[String])(_.flatMap(_.name))
-                .mkString(" | ")
-            Some(s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)} = $renderedTypes""")
-          case _ =>
-            val renderedDirectives: String = renderDirectives(t.directives)
-            val renderedFields: String = t
-              .fields(__DeprecatedArgs())
-              .fold(List.empty[String])(_.map(renderField))
-              .mkString("\n  ")
-            val renderedInputFields: String = t.inputFields
-              .fold(List.empty[String])(_.map(renderInputValue))
-              .mkString("\n  ")
-            val renderedEnumValues = t
-              .enumValues(__DeprecatedArgs())
-              .fold(List.empty[String])(_.map(renderEnumValue))
-              .mkString("\n  ")
-            Some(
-              s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderInterfaces(t)}$renderedDirectives {
-                 |  $renderedFields$renderedInputFields$renderedEnumValues
-                 |}""".stripMargin
-            )
-        }
-    }.mkString("\n\n")
+    types.toList
+      .sorted(renderOrdering)
+      .flatMap {
+        case (_, t) =>
+          t.kind match {
+            case __TypeKind.SCALAR   => t.name.flatMap(name => if (isBuiltinScalar(name)) None else Some(s"scalar $name"))
+            case __TypeKind.NON_NULL => None
+            case __TypeKind.LIST     => None
+            case __TypeKind.UNION =>
+              val renderedTypes: String =
+                t.possibleTypes
+                  .fold(List.empty[String])(_.flatMap(_.name))
+                  .mkString(" | ")
+              Some(
+                s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)} = $renderedTypes"""
+              )
+            case _ =>
+              val renderedDirectives: String = renderDirectives(t.directives)
+              val renderedFields: String = t
+                .fields(__DeprecatedArgs())
+                .fold(List.empty[String])(_.map(renderField))
+                .mkString("\n  ")
+              val renderedInputFields: String = t.inputFields
+                .fold(List.empty[String])(_.map(renderInputValue))
+                .mkString("\n  ")
+              val renderedEnumValues = t
+                .enumValues(__DeprecatedArgs())
+                .fold(List.empty[String])(_.map(renderEnumValue))
+                .mkString("\n  ")
+              Some(
+                s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderInterfaces(t)}$renderedDirectives {
+                   |  $renderedFields$renderedInputFields$renderedEnumValues
+                   |}""".stripMargin
+              )
+          }
+      }
+      .mkString("\n\n")
 
   private def renderInterfaces(t: __Type): String =
     t.interfaces()
@@ -65,24 +84,25 @@ object Rendering {
     case Some(value) => if (value.contains("\n")) s"""\"\"\"\n$value\"\"\"\n""" else s""""$value"\n"""
   }
 
-  private def renderDirectiveArgument(value: InputValue): String = value match {
+  private def renderDirectiveArgument(value: InputValue): Option[String] = value match {
     case InputValue.ListValue(values) =>
-      values.map(renderDirectiveArgument).mkString("[", ",", "]")
+      Some(values.flatMap(renderDirectiveArgument).mkString("[", ",", "]"))
     case InputValue.ObjectValue(fields) =>
-      fields.map { case (key, value) => s"$key: ${renderDirectiveArgument(value)}" }.mkString("{", ",", "}")
-    case InputValue.VariableValue(_) =>
-      throw new Exception("Variable values are not allowed in a directive declaration")
-    case NullValue           => "null"
-    case StringValue(value)  => "\"" + value + "\""
-    case i: IntValue         => i.toInt.toString
-    case f: FloatValue       => f.toFloat.toString
-    case BooleanValue(value) => value.toString
-    case EnumValue(value)    => value
+      Some(
+        fields.map { case (key, value) => renderDirectiveArgument(value).map(v => s"$key: $v") }.mkString("{", ",", "}")
+      )
+    case NullValue                   => Some("null")
+    case StringValue(value)          => Some("\"" + value + "\"")
+    case i: IntValue                 => Some(i.toInt.toString)
+    case f: FloatValue               => Some(f.toFloat.toString)
+    case BooleanValue(value)         => Some(value.toString)
+    case EnumValue(value)            => Some(value)
+    case InputValue.VariableValue(_) => None
   }
 
   private def renderDirective(directive: Directive) =
-    s"@${directive.name}${if (directive.arguments.nonEmpty) s"""(${directive.arguments.map {
-      case (key, value) => s"$key: ${renderDirectiveArgument(value)}"
+    s"@${directive.name}${if (directive.arguments.nonEmpty) s"""(${directive.arguments.flatMap {
+      case (key, value) => renderDirectiveArgument(value).map(v => s"$key: $v")
     }.mkString("{", ",", "}")})"""
     else ""}"
 

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -36,7 +36,7 @@ object Rendering {
               .fold(List.empty[String])(_.map(renderEnumValue))
               .mkString("\n  ")
             Some(
-              s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderInterfaces(t)} $renderedDirectives {
+              s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderInterfaces(t)}$renderedDirectives {
                  |  $renderedFields$renderedInputFields$renderedEnumValues
                  |}""".stripMargin
             )
@@ -87,7 +87,10 @@ object Rendering {
     else ""}"
 
   private def renderDirectives(directives: Option[List[Directive]]) =
-    directives.fold("")(_.map(renderDirective).mkString(" ", " ", ""))
+    directives.fold("") {
+      case Nil => ""
+      case d   => d.map(renderDirective).mkString(" ", " ", "")
+    }
 
   private def renderField(field: __Field): String =
     s"${field.name}${renderArguments(field.args)}: ${renderTypeName(field.`type`())}${if (field.isDeprecated)

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -23,7 +23,7 @@ object Rendering {
                 .mkString(" | ")
             Some(s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)} = $renderedTypes""")
           case _ =>
-            val renderedDirectives: String = t.directives.fold("")(_.map(renderDirective).mkString(" "))
+            val renderedDirectives: String = renderDirectives(t.directives)
             val renderedFields: String = t
               .fields(__DeprecatedArgs())
               .fold(List.empty[String])(_.map(renderField))
@@ -86,13 +86,16 @@ object Rendering {
     }.mkString("{", ",", "}")})"""
     else ""}"
 
+  private def renderDirectives(directives: Option[List[Directive]]) =
+    directives.fold("")(_.map(renderDirective).mkString(" ", " ", ""))
+
   private def renderField(field: __Field): String =
     s"${field.name}${renderArguments(field.args)}: ${renderTypeName(field.`type`())}${if (field.isDeprecated)
       s" @deprecated${field.deprecationReason.fold("")(reason => s"""(reason: "$reason")""")}"
-    else ""}"
+    else ""}${renderDirectives(field.directives)}"
 
   private def renderInputValue(inputValue: __InputValue): String =
-    s"${inputValue.name}: ${renderTypeName(inputValue.`type`())}${inputValue.defaultValue.fold("")(d => s" = $d")}"
+    s"${inputValue.name}: ${renderTypeName(inputValue.`type`())}${inputValue.defaultValue.fold("")(d => s" = $d")}${renderDirectives(inputValue.directives)}"
 
   private def renderEnumValue(v: __EnumValue): String =
     s"${renderDescription(v.description)}${v.name}${if (v.isDeprecated)

--- a/core/src/main/scala/caliban/execution/FieldInfo.scala
+++ b/core/src/main/scala/caliban/execution/FieldInfo.scala
@@ -1,5 +1,10 @@
 package caliban.execution
 
 import caliban.introspection.adt.__Type
+import caliban.parsing.adt.Directive
 
-case class FieldInfo(fieldName: String, path: List[Either[String, Int]], parentType: Option[__Type], returnType: __Type)
+case class FieldInfo(fieldName: String,
+                     path: List[Either[String, Int]],
+                     parentType: Option[__Type],
+                     returnType: __Type,
+                     directives: List[Directive] = Nil)

--- a/core/src/main/scala/caliban/execution/FieldInfo.scala
+++ b/core/src/main/scala/caliban/execution/FieldInfo.scala
@@ -3,8 +3,10 @@ package caliban.execution
 import caliban.introspection.adt.__Type
 import caliban.parsing.adt.Directive
 
-case class FieldInfo(fieldName: String,
-                     path: List[Either[String, Int]],
-                     parentType: Option[__Type],
-                     returnType: __Type,
-                     directives: List[Directive] = Nil)
+case class FieldInfo(
+  fieldName: String,
+  path: List[Either[String, Int]],
+  parentType: Option[__Type],
+  returnType: __Type,
+  directives: List[Directive] = Nil
+)

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -36,11 +36,13 @@ object Introspector {
   def introspect(rootType: RootType): RootSchema[Any] = {
     val types = rootType.types.updated("Boolean", Types.boolean).values.toList.sortBy(_.name.getOrElse(""))
     val resolver = __Introspection(
-      __Schema(rootType.queryType,
-               rootType.mutationType,
-               rootType.subscriptionType,
-               types,
-               directives ++ rootType.additionalDirectives),
+      __Schema(
+        rootType.queryType,
+        rootType.mutationType,
+        rootType.subscriptionType,
+        types,
+        directives ++ rootType.additionalDirectives
+      ),
       args => types.find(_.name.contains(args.name)).get
     )
     val introspectionSchema = Schema.gen[__Introspection]

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -36,7 +36,11 @@ object Introspector {
   def introspect(rootType: RootType): RootSchema[Any] = {
     val types = rootType.types.updated("Boolean", Types.boolean).values.toList.sortBy(_.name.getOrElse(""))
     val resolver = __Introspection(
-      __Schema(rootType.queryType, rootType.mutationType, rootType.subscriptionType, types, directives),
+      __Schema(rootType.queryType,
+               rootType.mutationType,
+               rootType.subscriptionType,
+               types,
+               directives ++ rootType.additionalDirectives),
       args => types.find(_.name.contains(args.name)).get
     )
     val introspectionSchema = Schema.gen[__Introspection]

--- a/core/src/main/scala/caliban/introspection/adt/__Field.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Field.scala
@@ -1,10 +1,13 @@
 package caliban.introspection.adt
 
+import caliban.parsing.adt.Directive
+
 case class __Field(
   name: String,
   description: Option[String],
   args: List[__InputValue],
   `type`: () => __Type,
   isDeprecated: Boolean = false,
-  deprecationReason: Option[String] = None
+  deprecationReason: Option[String] = None,
+  directives: Option[List[Directive]] = None
 )

--- a/core/src/main/scala/caliban/introspection/adt/__InputValue.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__InputValue.scala
@@ -1,3 +1,11 @@
 package caliban.introspection.adt
 
-case class __InputValue(name: String, description: Option[String], `type`: () => __Type, defaultValue: Option[String])
+import caliban.parsing.adt.Directive
+
+case class __InputValue(
+  name: String,
+  description: Option[String],
+  `type`: () => __Type,
+  defaultValue: Option[String],
+  directives: Option[List[Directive]] = None
+)

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -1,5 +1,7 @@
 package caliban.introspection.adt
 
+import caliban.parsing.adt.Directive
+
 case class __Type(
   kind: __TypeKind,
   name: Option[String] = None,
@@ -9,7 +11,8 @@ case class __Type(
   possibleTypes: Option[List[__Type]] = None,
   enumValues: __DeprecatedArgs => Option[List[__EnumValue]] = _ => None,
   inputFields: Option[List[__InputValue]] = None,
-  ofType: Option[__Type] = None
+  ofType: Option[__Type] = None,
+  directives: Option[List[Directive]] = None
 ) {
   def |+|(that: __Type): __Type = __Type(
     kind,
@@ -23,6 +26,7 @@ case class __Type(
       (enumValues(args) ++ that.enumValues(args))
         .reduceOption((a, b) => a.filterNot(v => b.exists(_.name == v.name)) ++ b),
     (inputFields ++ that.inputFields).reduceOption((a, b) => a.filterNot(t => b.exists(_.name == t.name)) ++ b),
-    (ofType ++ that.ofType).reduceOption(_ |+| _)
+    (ofType ++ that.ofType).reduceOption(_ |+| _),
+    (directives ++ that.directives).reduceOption(_ ++ _)
   )
 }

--- a/core/src/main/scala/caliban/parsing/adt/Directive.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Directive.scala
@@ -2,4 +2,4 @@ package caliban.parsing.adt
 
 import caliban.InputValue
 
-case class Directive(name: String, arguments: Map[String, InputValue], index: Int)
+case class Directive(name: String, arguments: Map[String, InputValue] = Map.empty, index: Int = 0)

--- a/core/src/main/scala/caliban/schema/Annotations.scala
+++ b/core/src/main/scala/caliban/schema/Annotations.scala
@@ -1,5 +1,7 @@
 package caliban.schema
 
+import caliban.parsing.adt.Directive
+
 import scala.annotation.StaticAnnotation
 
 object Annotations {
@@ -24,6 +26,11 @@ object Annotations {
    * Annotation used to provide an alternative name to a field or a type.
    */
   case class GQLName(value: String) extends StaticAnnotation
+
+  /**
+   * Annotation used to provide directives to a schema type
+   */
+  case class GQLDirective(directive: Directive) extends StaticAnnotation
 
   /**
    * Annotation to make a sealed trait an interface instead of a union type

--- a/core/src/main/scala/caliban/schema/RootType.scala
+++ b/core/src/main/scala/caliban/schema/RootType.scala
@@ -1,9 +1,12 @@
 package caliban.schema
 
-import caliban.introspection.adt.__Type
+import caliban.introspection.adt.{ __Directive, __Type }
 import caliban.schema.Types.collectTypes
 
-case class RootType(queryType: __Type, mutationType: Option[__Type], subscriptionType: Option[__Type]) {
+case class RootType(queryType: __Type,
+                    mutationType: Option[__Type],
+                    subscriptionType: Option[__Type],
+                    additionalDirectives: List[__Directive] = List.empty) {
   val empty = Map.empty[String, __Type]
   val types: Map[String, __Type] =
     collectTypes(queryType) ++

--- a/core/src/main/scala/caliban/schema/RootType.scala
+++ b/core/src/main/scala/caliban/schema/RootType.scala
@@ -3,10 +3,12 @@ package caliban.schema
 import caliban.introspection.adt.{ __Directive, __Type }
 import caliban.schema.Types.collectTypes
 
-case class RootType(queryType: __Type,
-                    mutationType: Option[__Type],
-                    subscriptionType: Option[__Type],
-                    additionalDirectives: List[__Directive] = List.empty) {
+case class RootType(
+  queryType: __Type,
+  mutationType: Option[__Type],
+  subscriptionType: Option[__Type],
+  additionalDirectives: List[__Directive] = List.empty
+) {
   val empty = Map.empty[String, __Type]
   val types: Map[String, __Type] =
     collectTypes(queryType) ++

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -7,7 +7,8 @@ import scala.language.experimental.macros
 import caliban.ResponseValue._
 import caliban.Value._
 import caliban.introspection.adt._
-import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLInputName, GQLInterface, GQLName }
+import caliban.parsing.adt.Directive
+import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLDirective, GQLInputName, GQLInterface, GQLName }
 import caliban.schema.Step._
 import caliban.schema.Types._
 import caliban.{ InputValue, ResponseValue }
@@ -89,7 +90,8 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   def objectSchema[R1, A](
     name: String,
     description: Option[String],
-    fields: List[(__Field, A => Step[R1])]
+    fields: List[(__Field, A => Step[R1])],
+    directives: List[Directive] = List.empty
   ): Schema[R1, A] =
     new Schema[R1, A] {
 
@@ -98,7 +100,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
           makeInputObject(Some(customizeInputTypeName(name)), description, fields.map {
             case (f, _) => __InputValue(f.name, f.description, f.`type`, None)
           })
-        } else makeObject(Some(name), description, fields.map(_._1))
+        } else makeObject(Some(name), description, fields.map(_._1), directives)
 
       override def resolve(value: A): Step[R1] =
         ObjectStep(name, fields.map { case (f, plan) => f.name -> plan(value) }.toMap)
@@ -226,7 +228,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
             arg1.build(InputValue.ObjectValue(args)) match {
               case Left(error)  => QueryStep(ZQuery.fail(error))
               case Right(value) => ev2.resolve(f(value))
-            }
+          }
         )
     }
   implicit def futureSchema[A](implicit ev: Schema[R, A]): Schema[R, Future[A]] =
@@ -296,7 +298,7 @@ trait DerivationSchema[R] {
                   () =>
                     if (p.typeclass.optional) p.typeclass.toType(isInput) else makeNonNull(p.typeclass.toType(isInput)),
                   None
-                )
+              )
             )
             .toList
         )
@@ -315,9 +317,10 @@ trait DerivationSchema[R] {
                     if (p.typeclass.optional) p.typeclass.toType(isInput) else makeNonNull(p.typeclass.toType(isInput)),
                   p.annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
                   p.annotations.collectFirst { case GQLDeprecated(reason) => reason }
-                )
+              )
             )
-            .toList
+            .toList,
+          getDirectives(ctx)
         )
 
     override def resolve(value: T): Step[R] =
@@ -346,7 +349,7 @@ trait DerivationSchema[R] {
           Some(getName(ctx)),
           getDescription(ctx),
           subtypes.collect {
-            case (__Type(_, Some(name), description, _, _, _, _, _, _), annotations) =>
+            case (__Type(_, Some(name), description, _, _, _, _, _, _, _), annotations) =>
               __EnumValue(
                 name,
                 description,
@@ -399,7 +402,7 @@ trait DerivationSchema[R] {
                     () => makeScalar("Boolean")
                   )
                 )
-              )
+            )
           )
         case _ => t
       }
@@ -407,6 +410,12 @@ trait DerivationSchema[R] {
     override def resolve(value: T): Step[R] =
       ctx.dispatch(value)(subType => subType.typeclass.resolve(subType.cast(value)))
   }
+
+  private def getDirectives(annotations: Seq[Any]): List[Directive] =
+    annotations.collect { case GQLDirective(dir) => dir }.toList
+
+  private def getDirectives[Typeclass[_], Type](ctx: CaseClass[Typeclass, Type]): List[Directive] =
+    getDirectives(ctx.annotations)
 
   private def getName(annotations: Seq[Any], typeName: TypeName): String =
     annotations.collectFirst { case GQLName(name) => name }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -228,7 +228,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
             arg1.build(InputValue.ObjectValue(args)) match {
               case Left(error)  => QueryStep(ZQuery.fail(error))
               case Right(value) => ev2.resolve(f(value))
-          }
+            }
         )
     }
   implicit def futureSchema[A](implicit ev: Schema[R, A]): Schema[R, Future[A]] =
@@ -297,8 +297,9 @@ trait DerivationSchema[R] {
                   getDescription(p),
                   () =>
                     if (p.typeclass.optional) p.typeclass.toType(isInput) else makeNonNull(p.typeclass.toType(isInput)),
-                  None
-              )
+                  None,
+                  Some(p.annotations.collect { case GQLDirective(dir) => dir }.toList).filter(_.nonEmpty)
+                )
             )
             .toList
         )
@@ -316,8 +317,9 @@ trait DerivationSchema[R] {
                   () =>
                     if (p.typeclass.optional) p.typeclass.toType(isInput) else makeNonNull(p.typeclass.toType(isInput)),
                   p.annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
-                  p.annotations.collectFirst { case GQLDeprecated(reason) => reason }
-              )
+                  p.annotations.collectFirst { case GQLDeprecated(reason) => reason },
+                  Option(p.annotations.collect { case GQLDirective(dir) => dir }.toList).filter(_.nonEmpty)
+                )
             )
             .toList,
           getDirectives(ctx)
@@ -402,7 +404,7 @@ trait DerivationSchema[R] {
                     () => makeScalar("Boolean")
                   )
                 )
-            )
+              )
           )
         case _ => t
       }

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -1,6 +1,7 @@
 package caliban.schema
 
 import caliban.introspection.adt._
+import caliban.parsing.adt.Directive
 
 object Types {
 
@@ -29,13 +30,19 @@ object Types {
       enumValues = args => Some(values.filter(v => args.includeDeprecated.getOrElse(false) || !v.isDeprecated))
     )
 
-  def makeObject(name: Option[String], description: Option[String], fields: List[__Field]): __Type =
+  def makeObject(
+    name: Option[String],
+    description: Option[String],
+    fields: List[__Field],
+    directives: List[Directive]
+  ): __Type =
     __Type(
       __TypeKind.OBJECT,
       name,
       description,
       fields = args => Some(fields.filter(v => args.includeDeprecated.getOrElse(false) || !v.isDeprecated)),
-      interfaces = () => Some(Nil)
+      interfaces = () => Some(Nil),
+      directives = Some(directives)
     )
 
   def makeInputObject(name: Option[String], description: Option[String], fields: List[__InputValue]): __Type =

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -73,7 +73,7 @@ object Validator {
           }).map(
             operation =>
               ExecutionRequest(
-                F(op.selectionSet, fragments, variables, operation.opType, document.sourceMapper),
+                F(op.selectionSet, fragments, variables, operation.opType, document.sourceMapper, Nil),
                 op.operationType,
                 op.variableDefinitions
               )
@@ -524,7 +524,7 @@ object Validator {
                  .filter(_.operationType == OperationType.Subscription)
                  .find(
                    op =>
-                     F(op.selectionSet, context.fragments, Map.empty[String, InputValue], t, SourceMapper.empty).fields.length > 1
+                     F(op.selectionSet, context.fragments, Map.empty[String, InputValue], t, SourceMapper.empty, Nil).fields.length > 1
                  )
         } yield op
       )

--- a/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
@@ -11,25 +11,25 @@ import zio.Ref
 import zio.duration.Duration
 import zquery.ZQuery
 
-object CacheControl {
-
-  def apply(scope: ApolloCaching.CacheScope): Directive =
-    Directive("cacheControl", Map("scope" -> EnumValue(scope.toString)))
-
-  def apply(maxAge: Duration): Directive =
-    Directive("cacheControl", Map("maxAge" -> IntValue(maxAge.toMillis / 1000)))
-
-  def apply(maxAge: Duration, scope: ApolloCaching.CacheScope): Directive =
-    Directive("cacheControl", Map("maxAge" -> IntValue(maxAge.toMillis / 1000), "scope" -> EnumValue(scope.toString)))
-
-}
-
 /**
  * Returns a wrapper which applies apollo caching response extensions
  */
 object ApolloCaching {
 
   private val directiveName = "cacheControl"
+
+  object CacheControl {
+
+    def apply(scope: ApolloCaching.CacheScope): Directive =
+      Directive(directiveName, Map("scope" -> EnumValue(scope.toString)))
+
+    def apply(maxAge: Duration): Directive =
+      Directive(directiveName, Map("maxAge" -> IntValue(maxAge.toMillis / 1000)))
+
+    def apply(maxAge: Duration, scope: ApolloCaching.CacheScope): Directive =
+      Directive(directiveName, Map("maxAge" -> IntValue(maxAge.toMillis / 1000), "scope" -> EnumValue(scope.toString)))
+
+  }
 
   val apolloCaching: EffectfulWrapper[Any] =
     EffectfulWrapper(

--- a/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
@@ -1,0 +1,146 @@
+package caliban.wrappers
+
+import java.util.concurrent.TimeUnit
+
+import caliban.ResponseValue
+import caliban.ResponseValue.{ ListValue, ObjectValue }
+import caliban.Value.{ EnumValue, IntValue, StringValue }
+import caliban.parsing.adt.Directive
+import caliban.wrappers.Wrapper.{ EffectfulWrapper, FieldWrapper, OverallWrapper }
+import zio.Ref
+import zio.duration.Duration
+import zquery.ZQuery
+
+object CacheControl {
+
+  def apply(scope: ApolloCaching.CacheScope): Directive =
+    Directive("cacheControl", Map("scope" -> EnumValue(scope.toString)))
+
+  def apply(maxAge: Duration): Directive =
+    Directive("cacheControl", Map("maxAge" -> IntValue(maxAge.toMillis / 1000)))
+
+  def apply(maxAge: Duration, scope: ApolloCaching.CacheScope): Directive =
+    Directive("cacheControl", Map("maxAge" -> IntValue(maxAge.toMillis / 1000), "scope" -> EnumValue(scope.toString)))
+
+}
+
+/**
+ * Returns a wrapper which applies apollo caching response extensions
+ */
+object ApolloCaching {
+
+  private val directiveName = "cacheControl"
+
+  val apolloCaching: EffectfulWrapper[Any] =
+    EffectfulWrapper(
+      Ref.make(Caching()).map(ref => apolloCachingOverall(ref) |+| apolloCachingField(ref))
+    )
+
+  sealed trait CacheScope
+
+  object CacheScope {
+
+    case object Private extends CacheScope {
+      override def toString: String = "PRIVATE"
+    }
+
+    case object Public extends CacheScope {
+      override def toString: String = "PUBLIC"
+    }
+
+  }
+
+  case class CacheHint(
+    fieldName: String = "",
+    path: List[Either[String, Int]] = Nil,
+    maxAge: Duration,
+    scope: CacheScope
+  ) {
+
+    def toResponseValue: ResponseValue =
+      ObjectValue(
+        List(
+          "path"   -> ListValue((Left(fieldName) :: path).reverse.map(_.fold(StringValue, IntValue(_)))),
+          "maxAge" -> IntValue(maxAge.toMillis / 1000),
+          "scope" -> StringValue(scope match {
+            case CacheScope.Private => "PRIVATE"
+            case CacheScope.Public  => "PUBLIC"
+          })
+        )
+      )
+
+  }
+
+  case class Caching(
+    version: Int = 1,
+    hints: List[CacheHint] = List.empty
+  ) {
+
+    def toResponseValue: ResponseValue =
+      ObjectValue(List("version" -> IntValue(version), "hints" -> ListValue(hints.map(_.toResponseValue))))
+  }
+
+  case class CacheDirective(scope: Option[CacheScope] = None, maxAge: Option[Duration] = None)
+
+  private def extractCacheDirective(directives: List[Directive]): Option[CacheDirective] =
+    directives.collectFirst {
+      case d if d.name == directiveName =>
+        val scope = d.arguments.get("scope").collectFirst {
+          case StringValue("PRIVATE") | EnumValue("PRIVATE") => CacheScope.Private
+          case StringValue("PUBLIC") | EnumValue("PUBLIC")   => CacheScope.Public
+        }
+
+        val maxAge = d.arguments.get("maxAge").collectFirst {
+          case i: IntValue => Duration(i.toLong, TimeUnit.SECONDS)
+        }
+
+        CacheDirective(scope, maxAge)
+    }
+
+  private def apolloCachingOverall(ref: Ref[Caching]): OverallWrapper[Any] =
+    OverallWrapper {
+      case (io, _) =>
+        for {
+          result <- io
+          cache  <- ref.get
+        } yield
+          result.copy(
+            extensions = Some(
+              ObjectValue(
+                ("cacheControl" -> cache.toResponseValue) :: result.extensions.fold(
+                  List.empty[(String, ResponseValue)]
+                )(_.fields)
+              )
+            )
+          )
+    }
+
+  private def apolloCachingField(ref: Ref[Caching]): FieldWrapper[Any] =
+    FieldWrapper(
+      {
+        case (query, fieldInfo) =>
+          val cacheDirectives = extractCacheDirective(
+            fieldInfo.directives ++ fieldInfo.returnType.ofType.flatMap(_.directives).getOrElse(Nil)
+          )
+
+          cacheDirectives.foldLeft(query) {
+            case (q, cacheDirective) =>
+              q <* ZQuery.fromEffect(
+                ref.update(
+                  state =>
+                    state.copy(
+                      hints = CacheHint(
+                        path = fieldInfo.path,
+                        fieldName = fieldInfo.fieldName,
+                        maxAge = cacheDirective.maxAge getOrElse Duration.Zero,
+                        scope = cacheDirective.scope getOrElse CacheScope.Private
+                      ) :: state.hints
+                  )
+                )
+              )
+          }
+      },
+      wrapPureValues = true
+    )
+
+}

--- a/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
@@ -103,16 +103,15 @@ object ApolloCaching {
         for {
           result <- io
           cache  <- ref.get
-        } yield
-          result.copy(
-            extensions = Some(
-              ObjectValue(
-                ("cacheControl" -> cache.toResponseValue) :: result.extensions.fold(
-                  List.empty[(String, ResponseValue)]
-                )(_.fields)
-              )
+        } yield result.copy(
+          extensions = Some(
+            ObjectValue(
+              ("cacheControl" -> cache.toResponseValue) :: result.extensions.fold(
+                List.empty[(String, ResponseValue)]
+              )(_.fields)
             )
           )
+        )
     }
 
   private def apolloCachingField(ref: Ref[Caching]): FieldWrapper[Any] =
@@ -135,7 +134,7 @@ object ApolloCaching {
                         maxAge = cacheDirective.maxAge getOrElse Duration.Zero,
                         scope = cacheDirective.scope getOrElse CacheScope.Private
                       ) :: state.hints
-                  )
+                    )
                 )
               )
           }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -11,11 +11,12 @@ object RenderingSpec
         test("it should render directives") {
           assert(
             graphQL(resolver).render.trim,
-            equalTo("""
-                      |union Role = Captain | Engineer | Mechanic | Pilot
+            equalTo("""union Role = Captain | Engineer | Mechanic | Pilot
                       |
-                      |type Engineer {
-                      |  shipName: String!
+                      |enum Origin {
+                      |  BELT
+                      |  EARTH
+                      |  MARS
                       |}
                       |
                       |input CharacterInput {
@@ -25,17 +26,8 @@ object RenderingSpec
                       |  role: Role
                       |}
                       |
-                      |enum Origin {
-                      |  BELT
-                      |  EARTH
-                      |  MARS
-                      |}
-                      |
-                      |"Queries"
-                      |type Query {
-                      |  characters(origin: Origin): [Character!]!
-                      |  charactersIn(names: [String!]!): [Character!]!
-                      |  exists(character: CharacterInput!): Boolean!
+                      |type Captain {
+                      |  shipName: String!
                       |}
                       |
                       |type Character @key({name: "name"}) {
@@ -45,7 +37,7 @@ object RenderingSpec
                       |  role: Role
                       |}
                       |
-                      |type Pilot {
+                      |type Engineer {
                       |  shipName: String!
                       |}
                       |
@@ -53,8 +45,15 @@ object RenderingSpec
                       |  shipName: String!
                       |}
                       |
-                      |type Captain {
+                      |type Pilot {
                       |  shipName: String!
+                      |}
+                      |
+                      |"Queries"
+                      |type Query {
+                      |  characters(origin: Origin): [Character!]!
+                      |  charactersIn(names: [String!]!): [Character!]!
+                      |  exists(character: CharacterInput!): Boolean!
                       |}""".stripMargin.trim)
           )
         }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -14,47 +14,47 @@ object RenderingSpec
             equalTo("""
                       |union Role = Captain | Engineer | Mechanic | Pilot
                       |
-                      |type Engineer  {
-                      |  shipName: String! 
+                      |type Engineer {
+                      |  shipName: String!
                       |}
                       |
-                      |input CharacterInput  {
-                      |  name: String!
-                      |  nicknames: [String!]!
+                      |input CharacterInput {
+                      |  name: String! @external
+                      |  nicknames: [String!]! @required
                       |  origin: Origin!
                       |  role: Role
                       |}
                       |
-                      |enum Origin  {
+                      |enum Origin {
                       |  BELT
                       |  EARTH
                       |  MARS
                       |}
                       |
                       |"Queries"
-                      |type Query  {
-                      |  characters(origin: Origin): [Character!]! 
-                      |  charactersIn(names: [String!]!): [Character!]! 
-                      |  exists(character: CharacterInput!): Boolean! 
+                      |type Query {
+                      |  characters(origin: Origin): [Character!]!
+                      |  charactersIn(names: [String!]!): [Character!]!
+                      |  exists(character: CharacterInput!): Boolean!
                       |}
                       |
                       |type Character @key({name: "name"}) {
                       |  name: String! @external
                       |  nicknames: [String!]! @required
-                      |  origin: Origin! 
-                      |  role: Role 
+                      |  origin: Origin!
+                      |  role: Role
                       |}
                       |
-                      |type Pilot  {
-                      |  shipName: String! 
+                      |type Pilot {
+                      |  shipName: String!
                       |}
                       |
-                      |type Mechanic  {
-                      |  shipName: String! 
+                      |type Mechanic {
+                      |  shipName: String!
                       |}
                       |
-                      |type Captain  {
-                      |  shipName: String! 
+                      |type Captain {
+                      |  shipName: String!
                       |}""".stripMargin.trim)
           )
         }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -9,9 +9,54 @@ object RenderingSpec
     extends DefaultRunnableSpec(
       suite("rendering")(
         test("it should render directives") {
-
-          assert(graphQL(resolver).render, equalTo("bob"))
-
+          assert(
+            graphQL(resolver).render.trim,
+            equalTo("""
+                      |union Role = Captain | Engineer | Mechanic | Pilot
+                      |
+                      |type Engineer  {
+                      |  shipName: String! 
+                      |}
+                      |
+                      |input CharacterInput  {
+                      |  name: String!
+                      |  nicknames: [String!]!
+                      |  origin: Origin!
+                      |  role: Role
+                      |}
+                      |
+                      |enum Origin  {
+                      |  BELT
+                      |  EARTH
+                      |  MARS
+                      |}
+                      |
+                      |"Queries"
+                      |type Query  {
+                      |  characters(origin: Origin): [Character!]! 
+                      |  charactersIn(names: [String!]!): [Character!]! 
+                      |  exists(character: CharacterInput!): Boolean! 
+                      |}
+                      |
+                      |type Character @key({name: "name"}) {
+                      |  name: String! @external
+                      |  nicknames: [String!]! @required
+                      |  origin: Origin! 
+                      |  role: Role 
+                      |}
+                      |
+                      |type Pilot  {
+                      |  shipName: String! 
+                      |}
+                      |
+                      |type Mechanic  {
+                      |  shipName: String! 
+                      |}
+                      |
+                      |type Captain  {
+                      |  shipName: String! 
+                      |}""".stripMargin.trim)
+          )
         }
       )
     )

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -1,0 +1,17 @@
+package caliban
+
+import zio.test._
+import Assertion._
+import TestUtils._
+import caliban.GraphQL._
+
+object RenderingSpec
+    extends DefaultRunnableSpec(
+      suite("rendering")(
+        test("it should render directives") {
+
+          assert(graphQL(resolver).render, equalTo("bob"))
+
+        }
+      )
+    )

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -2,7 +2,9 @@ package caliban
 
 import caliban.TestUtils.Origin._
 import caliban.TestUtils.Role._
-import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLInterface }
+import caliban.Value.StringValue
+import caliban.parsing.adt.Directive
+import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLDirective, GQLInterface }
 import caliban.schema.Schema
 import zio.UIO
 import zio.stream.ZStream
@@ -34,6 +36,7 @@ object TestUtils {
     case class Mechanic(shipName: String) extends Role
   }
 
+  @GQLDirective(Directive("key", Map("name" -> StringValue("name")), 0))
   case class Character(name: String, nicknames: List[String], origin: Origin, role: Option[Role])
 
   object Character {

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -36,8 +36,13 @@ object TestUtils {
     case class Mechanic(shipName: String) extends Role
   }
 
-  @GQLDirective(Directive("key", Map("name" -> StringValue("name")), 0))
-  case class Character(name: String, nicknames: List[String], origin: Origin, role: Option[Role])
+  @GQLDirective(Directive("key", Map("name" -> StringValue("name"))))
+  case class Character(
+    @GQLDirective(Directive("external")) name: String,
+    @GQLDirective(Directive("required")) nicknames: List[String],
+    origin: Origin,
+    role: Option[Role]
+  )
 
   object Character {
     implicit val schema: Schema[Any, Character] = Schema.gen[Character]
@@ -55,7 +60,7 @@ object TestUtils {
 
   case class CharactersArgs(origin: Option[Origin])
   case class CharacterArgs(name: String)
-  case class CharacterInArgs(names: List[String])
+  case class CharacterInArgs(@GQLDirective(Directive("lowercase")) names: List[String])
   case class CharacterObjectArgs(character: Character)
 
   @GQLDescription("Queries")

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -5,6 +5,7 @@ import scala.language.postfixOps
 import caliban.CalibanError.{ ExecutionError, ValidationError }
 import caliban.GraphQL._
 import caliban.Macros.gqldoc
+import caliban.schema.Annotations.GQLDirective
 import caliban.schema.GenericSchema
 import caliban.wrappers.Wrappers._
 import caliban.{ CalibanError, GraphQLInterpreter, RootResolver }
@@ -14,6 +15,8 @@ import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestClock
 import zio.{ clock, Promise, URIO, ZIO }
+
+import scala.language.postfixOps
 
 object WrappersSpec
     extends DefaultRunnableSpec(
@@ -141,6 +144,51 @@ object WrappersSpec
             isSome(
               equalTo(
                 """{"tracing":{"version":1,"startTime":"1970-01-01T00:00:00.000Z","endTime":"1970-01-01T00:00:01.000Z","duration":1000000000,"parsing":{"startOffset":0,"duration":0},"validation":{"startOffset":0,"duration":0},"execution":{"resolvers":[{"path":["hero"],"parentType":"Query","fieldName":"hero","returnType":"Hero!","startOffset":0,"duration":1000000000},{"path":["hero","name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":1000000000},{"path":["hero","friends"],"parentType":"Hero","fieldName":"friends","returnType":"[Hero!]!","startOffset":1000000000,"duration":0},{"path":["hero","friends",2,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":1000000000,"duration":0},{"path":["hero","friends",1,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":1000000000,"duration":0},{"path":["hero","friends",0,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":1000000000,"duration":0}]}}}"""
+              )
+            )
+          )
+        },
+        testM("Apollo Caching") {
+          case class Query(@GQLDirective(CacheControl(10.seconds)) hero: Hero)
+
+          @GQLDirective(CacheControl(2.seconds))
+          case class Hero(name: URIO[Clock, String], friends: List[Hero] = Nil)
+
+          object schema extends GenericSchema[Clock]
+          import schema._
+
+          def interpreter: GraphQLInterpreter[Clock, CalibanError] =
+            (graphQL(
+              RootResolver(
+                Query(
+                  Hero(
+                    ZIO.succeed("R2-D2"),
+                    List(
+                      Hero(ZIO.succeed("Luke Skywalker")),
+                      Hero(ZIO.succeed("Han Solo")),
+                      Hero(ZIO.succeed("Leia Organa"))
+                    )
+                  )
+                )
+              )
+            ) @@ ApolloCaching.apolloCaching).interpreter
+
+          val query = gqldoc("""
+              {
+                hero {
+                  name
+                  friends {
+                    name
+                  }
+                }
+              }""")
+          assertM(
+            for {
+              result <- interpreter.execute(query).map(_.extensions.map(_.toString))
+            } yield result,
+            isSome(
+              equalTo(
+                "{\"cacheControl\":{\"version\":1,\"hints\":[{\"path\":[\"hero\"],\"maxAge\":10,\"scope\":\"PRIVATE\"}]}}"
               )
             )
           )

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -1,12 +1,12 @@
 package caliban.wrappers
 
 import scala.language.postfixOps
-
 import caliban.CalibanError.{ ExecutionError, ValidationError }
 import caliban.GraphQL._
 import caliban.Macros.gqldoc
 import caliban.schema.Annotations.GQLDirective
 import caliban.schema.GenericSchema
+import caliban.wrappers.ApolloCaching.CacheControl
 import caliban.wrappers.Wrappers._
 import caliban.{ CalibanError, GraphQLInterpreter, RootResolver }
 import zio.clock.Clock

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -70,8 +70,6 @@ val api =
     apolloCaching
 ```
 
-As well you can also use 
-
 ## Wrapping the interpreter
 
 All the wrappers mentioned above require that you don't modify the environment `R` and the error type which is always a `CalibanError`. It is also possible to wrap your `GraphQLInterpreter` by calling `wrapExecutionWith` on it. This method takes in a function `f` and returns a new `GraphQLInterpreter` that will wrap the `execute` method with this function `f`.

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -5,7 +5,7 @@ Caliban allows you to perform additional actions at various levels of a query pr
 - modify a query before it's executed
 - add timeouts to queries or fields
 - log each field execution time
-- support [Apollo Tracing](https://github.com/apollographql/apollo-tracing) or anything similar
+- support [Apollo Tracing](https://github.com/apollographql/apollo-tracing), [Apollo Caching](https://github.com/apollographql/apollo-cache-control) or anything similar
 - etc.
 
 ## Wrapper types
@@ -55,7 +55,9 @@ Caliban comes with a few pre-made wrappers in `caliban.wrappers.Wrappers`:
 - `printSlowQueries` returns a wrapper that prints slow queries
 - `onSlowQueries` returns a wrapper that can run a given function on slow queries
 
-In addition to those, `caliban.wrappers.ApolloTracing.apolloTracing` returns a wrapper that adds tracing data into the `extensions` field of each response following [Apollo Tracing](https://github.com/apollographql/apollo-tracing) format.
+In addition to those, Caliban also ships with some non-spec but standard wrappers
+- `caliban.wrappers.ApolloTracing.apolloTracing` returns a wrapper that adds tracing data into the `extensions` field of each response following [Apollo Tracing](https://github.com/apollographql/apollo-tracing) format.
+- `caliban.wrappers.ApolloCaching.apolloCaching` returns a wrapper that adds caching hints to properly annotated fields using the [Apollo Caching](https://github.com/apollographql/apollo-cache-control) format.
 
 They can be used like this:
 ```scala
@@ -64,8 +66,11 @@ val api =
     maxDepth(50) @@
     timeout(3 seconds) @@
     printSlowQueries(500 millis) @@
-    apolloTracing
+    apolloTracing @@
+    apolloCaching
 ```
+
+As well you can also use 
 
 ## Wrapping the interpreter
 

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -156,7 +156,8 @@ Caliban supports a few annotations to enrich data types:
 - `@GQLInputName("name")` allows you to specify a different name for a data type used as an input (by default, the suffix `Input` is appended to the type name).
 - `@GQLDescription("description")` lets you provide a description for a data type or field. This description will be visible when your schema is introspected.
 - `@GQLDeprecated("reason")` allows deprecating a field or an enum value.
-- `@GQLInterface` to force a sealed trait generating an interface instead of a union
+- `@GQLInterface` to force a sealed trait generating an interface instead of a union.
+- `@GQLDirective(directive: Directive)` to add a directive to a field or type.
 
 ## Custom types
 


### PR DESCRIPTION
Revamped version of #192 

This adds schema directives which are needed for such extensions as cache-control and federation. In order to test the behavior I also included an implementation of the cache-control extension using directives and the new wrappers. 