### PR TITLE
Allow errors to send an error code in the response extension

### DIFF
--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -1,5 +1,6 @@
 package caliban
 
+import caliban.ResponseValue.ObjectValue
 import caliban.interop.circe.IsCirceEncoder
 import caliban.parsing.adt.LocationInfo
 
@@ -18,7 +19,8 @@ object CalibanError {
   case class ParsingError(
     msg: String,
     locationInfo: Option[LocationInfo] = None,
-    innerThrowable: Option[Throwable] = None
+    innerThrowable: Option[Throwable] = None,
+    extensions: Option[ObjectValue] = None
   ) extends CalibanError {
     override def toString: String = s"Parsing Error: $msg ${innerThrowable.fold("")(_.toString)}"
   }
@@ -26,8 +28,12 @@ object CalibanError {
   /**
    * Describes an error that happened while validating a query.
    */
-  case class ValidationError(msg: String, explanatoryText: String, locationInfo: Option[LocationInfo] = None)
-      extends CalibanError {
+  case class ValidationError(
+    msg: String,
+    explanatoryText: String,
+    locationInfo: Option[LocationInfo] = None,
+    extensions: Option[ObjectValue] = None
+  ) extends CalibanError {
     override def toString: String = s"ValidationError Error: $msg"
   }
 
@@ -38,7 +44,8 @@ object CalibanError {
     msg: String,
     path: List[Either[String, Int]] = Nil,
     locationInfo: Option[LocationInfo] = None,
-    innerThrowable: Option[Throwable] = None
+    innerThrowable: Option[Throwable] = None,
+    extensions: Option[ObjectValue] = None
   ) extends CalibanError {
     override def toString: String = s"Execution Error: $msg ${innerThrowable.fold("")(_.toString)}"
   }
@@ -55,25 +62,27 @@ private object ErrorCirce {
     Json.obj("line" -> li.line.asJson, "column" -> li.column.asJson)
 
   val errorValueEncoder: Encoder[CalibanError] = Encoder.instance[CalibanError] {
-    case CalibanError.ParsingError(msg, locationInfo, _) =>
+    case CalibanError.ParsingError(msg, locationInfo, _, extensions) =>
       Json
         .obj(
           "message" -> s"Parsing Error: $msg".asJson,
           "locations" -> Some(locationInfo).collect {
             case Some(li) => Json.arr(locationToJson(li))
-          }.asJson
+          }.asJson,
+          "extensions" -> extensions.asInstanceOf[Option[ResponseValue]].asJson.dropNullValues
         )
         .dropNullValues
-    case CalibanError.ValidationError(msg, _, locationInfo) =>
+    case CalibanError.ValidationError(msg, _, locationInfo, extensions) =>
       Json
         .obj(
           "message" -> msg.asJson,
           "locations" -> Some(locationInfo).collect {
             case Some(li) => Json.arr(locationToJson(li))
-          }.asJson
+          }.asJson,
+          "extensions" -> extensions.asInstanceOf[Option[ResponseValue]].asJson.dropNullValues
         )
         .dropNullValues
-    case CalibanError.ExecutionError(msg, path, locationInfo, _) =>
+    case CalibanError.ExecutionError(msg, path, locationInfo, _, extensions) =>
       Json
         .obj(
           "message" -> msg.asJson,
@@ -86,7 +95,8 @@ private object ErrorCirce {
                 case Left(value)  => value.asJson
                 case Right(value) => value.asJson
               })
-          }.asJson
+          }.asJson,
+          "extensions" -> extensions.asInstanceOf[Option[ResponseValue]].asJson.dropNullValues
         )
         .dropNullValues
   }

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -69,7 +69,7 @@ private object ErrorCirce {
           "locations" -> Some(locationInfo).collect {
             case Some(li) => Json.arr(locationToJson(li))
           }.asJson,
-          "extensions" -> extensions.asInstanceOf[Option[ResponseValue]].asJson.dropNullValues
+          "extensions" -> (extensions: Option[ResponseValue]).asJson.dropNullValues
         )
         .dropNullValues
     case CalibanError.ValidationError(msg, _, locationInfo, extensions) =>
@@ -79,7 +79,7 @@ private object ErrorCirce {
           "locations" -> Some(locationInfo).collect {
             case Some(li) => Json.arr(locationToJson(li))
           }.asJson,
-          "extensions" -> extensions.asInstanceOf[Option[ResponseValue]].asJson.dropNullValues
+          "extensions" -> (extensions: Option[ResponseValue]).asJson.dropNullValues
         )
         .dropNullValues
     case CalibanError.ExecutionError(msg, path, locationInfo, _, extensions) =>
@@ -96,7 +96,7 @@ private object ErrorCirce {
                 case Right(value) => value.asJson
               })
           }.asJson,
-          "extensions" -> extensions.asInstanceOf[Option[ResponseValue]].asJson.dropNullValues
+          "extensions" -> (extensions: Option[ResponseValue]).asJson.dropNullValues
         )
         .dropNullValues
   }

--- a/core/src/test/scala/caliban/GraphQLResponseSpec.scala
+++ b/core/src/test/scala/caliban/GraphQLResponseSpec.scala
@@ -1,6 +1,7 @@
 package caliban
 
 import caliban.CalibanError.ExecutionError
+import caliban.ResponseValue.ObjectValue
 import caliban.Value._
 import io.circe._
 import io.circe.syntax._
@@ -14,16 +15,51 @@ object GraphQLResponseSpec extends DefaultRunnableSpec {
     suite("GraphQLResponseSpec")(
       test("can be converted to JSON") {
         val response = GraphQLResponse(StringValue("data"), Nil)
-        assert(response.asJson)(equalTo(Json.obj("data" -> Json.fromString("data"))))
+        assert(response.asJson)(
+          equalTo(Json.obj("data" -> Json.fromString("data")))
+        )
       },
-      test("should include error only if non-empty") {
-        val response = GraphQLResponse(StringValue("data"), List(ExecutionError("Resolution failed")))
+      test("should include error objects for every error, including extensions") {
+
+        val errorExtensions = List(
+          ("errorCode", StringValue("TEST_ERROR")),
+          ("myCustomKey", StringValue("my-value"))
+        )
+
+        val response = GraphQLResponse(
+          StringValue("data"),
+          List(
+            ExecutionError(
+              "Resolution failed",
+              extensions = Some(ObjectValue(errorExtensions))
+            )
+          )
+        )
 
         assert(response.asJson)(
           equalTo(
             Json.obj(
-              "data"   -> Json.fromString("data"),
-              "errors" -> Json.arr(Json.obj("message" -> Json.fromString("Resolution failed")))
+              "data" -> Json.fromString("data"),
+              "errors" -> Json.arr(
+                Json.obj(
+                  "message"    -> Json.fromString("Resolution failed"),
+                  "extensions" -> Json.obj("errorCode" -> "TEST_ERROR".asJson, "myCustomKey" -> "my-value".asJson)
+                )
+              )
+            )
+          )
+        )
+      },
+      test("should not include errors element when there are none") {
+        val response = GraphQLResponse(
+          StringValue("data"),
+          List.empty
+        )
+
+        assert(response.asJson)(
+          equalTo(
+            Json.obj(
+              "data" -> Json.fromString("data")
             )
           )
         )

--- a/examples/src/main/scala/caliban/client/Client.scala
+++ b/examples/src/main/scala/caliban/client/Client.scala
@@ -95,4 +95,3 @@ object Client {
   }
 
 }
-

--- a/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
+++ b/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
@@ -69,9 +69,7 @@ object OptimizedTest extends App with GenericSchema[Console] {
 
   case class GetEvent(id: Int) extends Request[Nothing, Event]
   val EventDataSource: DataSource[Console, GetEvent] =
-    fromFunctionBatchedM("EventDataSource") { requests =>
-      putStrLn("getEvents").as(requests.map(r => fakeEvent(r.id)))
-    }
+    fromFunctionBatchedM("EventDataSource")(requests => putStrLn("getEvents").as(requests.map(r => fakeEvent(r.id))))
 
   case class GetViewerMetadataForEvents(id: Int) extends Request[Nothing, ViewerMetadata]
   val ViewerMetadataDataSource: DataSource[Console, GetViewerMetadataForEvents] =
@@ -81,9 +79,7 @@ object OptimizedTest extends App with GenericSchema[Console] {
 
   case class GetVenue(id: Int) extends Request[Nothing, Venue]
   val VenueDataSource: DataSource[Console, GetVenue] =
-    fromFunctionBatchedM("VenueDataSource") { requests =>
-      putStrLn("getVenues").as(requests.map(_ => Venue("venue")))
-    }
+    fromFunctionBatchedM("VenueDataSource")(requests => putStrLn("getVenues").as(requests.map(_ => Venue("venue"))))
 
   case class GetTags(ids: List[Int]) extends Request[Nothing, List[Tag]]
   val TagsDataSource: DataSource[Console, GetTags] =

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -96,7 +96,7 @@ val i4: GraphQLInterpreter[MyEnv with Clock, CalibanError] =
 
 ## Customizing error responses
 
-During various phases of executing a query, an error may occur. Caliban renders the different instances of `CalibanError` to a GraphQL spec compliant response. As a user, you will most likely encounter `ExecutionError` at some point because this will encapsulate the errors in the error channel of your effects. For Caliban to be able to render some basic message about the error that occured during query execution, it is important that your errror extends `Throwable`.
+During various phases of executing a query, an error may occur. Caliban renders the different instances of `CalibanError` to a GraphQL spec compliant response. As a user, you will most likely encounter `ExecutionError` at some point because this will encapsulate the errors in the error channel of your effects. For Caliban to be able to render some basic message about the error that occured during query execution, it is important that your error extends `Throwable`.
 
 For more meaningful error handling, GraphQL spec allows for an [`extension`](http://spec.graphql.org/June2018/#example-fce18) object in the error response. This object may include, for instance, `code` information to model enum-like error codes that can be handled by a front-end. In order to generate this information, one can use the `mapError` function on a `GraphQLInterpreter`. An example is provided below in which we map a custom domain error within an `ExecutionError` to a meaningful error code.
 


### PR DESCRIPTION
A first attempt to allow errors to define an error code which is renderd in the `extensions` section of error elements. Closely related to #158 

I have no idea whether this is solution is on the right track. If not, no hard feelings on rejections :). If it is on the right track, I can put in a little more effort to include more error information as mentioned in #158

Closes #158