### PR TITLE
Type name validation

### DIFF
--- a/core/src/main/scala/caliban/RootResolver.scala
+++ b/core/src/main/scala/caliban/RootResolver.scala
@@ -4,11 +4,9 @@ package caliban
  * A `root resolver` contains resolvers for the 3 types of operations allowed in GraphQL: queries, mutations and subscriptions.
  *
  * A `resolver` is a simple value of the case class describing the API.
- *
- * It's mandatory to have a query resolver, the 2 others are optional.
  */
 case class RootResolver[+Query, +Mutation, +Subscription](
-  queryResolver: Query,
+  queryResolver: Option[Query],
   mutationResolver: Option[Mutation],
   subscriptionResolver: Option[Subscription]
 )
@@ -19,13 +17,13 @@ object RootResolver {
    * Constructs a [[RootResolver]] with only a query resolver.
    */
   def apply[Query](queryResolver: Query): RootResolver[Query, Unit, Unit] =
-    RootResolver(queryResolver, Option.empty[Unit], Option.empty[Unit])
+    RootResolver(Some(queryResolver), Option.empty[Unit], Option.empty[Unit])
 
   /**
    * Constructs a [[RootResolver]] with a query resolver and a mutation resolver.
    */
   def apply[Query, Mutation](queryResolver: Query, mutationResolver: Mutation): RootResolver[Query, Mutation, Unit] =
-    RootResolver(queryResolver, Some(mutationResolver), Option.empty[Unit])
+    RootResolver(Some(queryResolver), Some(mutationResolver), Option.empty[Unit])
 
   /**
    * Constructs a [[RootResolver]] with a query resolver, a mutation resolver and a subscription resolver.
@@ -35,5 +33,5 @@ object RootResolver {
     mutationResolver: Mutation,
     subscriptionResolver: Subscription
   ): RootResolver[Query, Mutation, Subscription] =
-    RootResolver(queryResolver, Some(mutationResolver), Some(subscriptionResolver))
+    RootResolver(Some(queryResolver), Some(mutationResolver), Some(subscriptionResolver))
 }

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -4,8 +4,7 @@ import caliban.introspection.adt._
 import caliban.parsing.adt.Definition.ExecutableDefinition.OperationDefinition
 import caliban.parsing.adt.Document
 import caliban.parsing.adt.Selection.Field
-import caliban.schema.RootSchema.Operation
-import caliban.schema.{ RootSchema, RootType, Schema, Types }
+import caliban.schema.{ Operation, RootSchema, RootType, Schema, Types }
 
 object Introspector {
 

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -12,21 +12,20 @@ case class __Type(
   enumValues: __DeprecatedArgs => Option[List[__EnumValue]] = _ => None,
   inputFields: Option[List[__InputValue]] = None,
   ofType: Option[__Type] = None,
-  directives: Option[List[Directive]] = None
+  directives: Option[List[Directive]] = None,
+  origin: Option[String] = None
 ) {
   def |+|(that: __Type): __Type = __Type(
     kind,
     (name ++ that.name).reduceOption((_, b) => b),
     (description ++ that.description).reduceOption((_, b) => b),
-    args =>
-      (fields(args) ++ that.fields(args)).reduceOption((a, b) => a.filterNot(f => b.exists(_.name == f.name)) ++ b),
-    () => (interfaces() ++ that.interfaces()).reduceOption((a, b) => a.filterNot(t => b.exists(_.name == t.name)) ++ b),
-    (possibleTypes ++ that.possibleTypes).reduceOption((a, b) => a.filterNot(t => b.exists(_.name == t.name)) ++ b),
-    args =>
-      (enumValues(args) ++ that.enumValues(args))
-        .reduceOption((a, b) => a.filterNot(v => b.exists(_.name == v.name)) ++ b),
-    (inputFields ++ that.inputFields).reduceOption((a, b) => a.filterNot(t => b.exists(_.name == t.name)) ++ b),
+    args => (fields(args) ++ that.fields(args)).reduceOption(_ ++ _),
+    () => (interfaces() ++ that.interfaces()).reduceOption(_ ++ _),
+    (possibleTypes ++ that.possibleTypes).reduceOption(_ ++ _),
+    args => (enumValues(args) ++ that.enumValues(args)).reduceOption(_ ++ _),
+    (inputFields ++ that.inputFields).reduceOption(_ ++ _),
     (ofType ++ that.ofType).reduceOption(_ |+| _),
-    (directives ++ that.directives).reduceOption(_ ++ _)
+    (directives ++ that.directives).reduceOption(_ ++ _),
+    (origin ++ that.origin).reduceOption((_, b) => b)
   )
 }

--- a/core/src/main/scala/caliban/schema/Operation.scala
+++ b/core/src/main/scala/caliban/schema/Operation.scala
@@ -1,0 +1,8 @@
+package caliban.schema
+
+import caliban.introspection.adt.__Type
+
+case class Operation[-R](opType: __Type, plan: Step[R]) {
+  def |+|[R1 <: R](that: Operation[R1]): Operation[R1] =
+    Operation(opType |+| that.opType, Step.mergeRootSteps(plan, that.plan))
+}

--- a/core/src/main/scala/caliban/schema/RootSchema.scala
+++ b/core/src/main/scala/caliban/schema/RootSchema.scala
@@ -1,26 +1,3 @@
 package caliban.schema
 
-import caliban.introspection.adt.__Type
-import caliban.schema.RootSchema.Operation
-
-case class RootSchema[-R](
-  query: Operation[R],
-  mutation: Option[Operation[R]],
-  subscription: Option[Operation[R]]
-) {
-  def |+|[R1 <: R](that: RootSchema[R1]): RootSchema[R1] =
-    RootSchema(
-      query |+| that.query,
-      (mutation ++ that.mutation).reduceOption(_ |+| _),
-      (subscription ++ that.subscription).reduceOption(_ |+| _)
-    )
-}
-
-object RootSchema {
-
-  case class Operation[-R](opType: __Type, plan: Step[R]) {
-    def |+|[R1 <: R](that: Operation[R1]): Operation[R1] =
-      Operation(opType |+| that.opType, Step.mergeRootSteps(plan, that.plan))
-  }
-
-}
+case class RootSchema[-R](query: Operation[R], mutation: Option[Operation[R]], subscription: Option[Operation[R]])

--- a/core/src/main/scala/caliban/schema/RootSchemaBuilder.scala
+++ b/core/src/main/scala/caliban/schema/RootSchemaBuilder.scala
@@ -1,0 +1,27 @@
+package caliban.schema
+
+import caliban.introspection.adt.__Type
+import caliban.schema.Types.collectTypes
+
+case class RootSchemaBuilder[-R](
+  query: Option[Operation[R]],
+  mutation: Option[Operation[R]],
+  subscription: Option[Operation[R]]
+) {
+  def |+|[R1 <: R](that: RootSchemaBuilder[R1]): RootSchemaBuilder[R1] =
+    RootSchemaBuilder(
+      (query ++ that.query).reduceOption(_ |+| _),
+      (mutation ++ that.mutation).reduceOption(_ |+| _),
+      (subscription ++ that.subscription).reduceOption(_ |+| _)
+    )
+
+  def types: List[__Type] = {
+    val empty = List.empty[__Type]
+    (query.map(_.opType).fold(empty)(collectTypes(_)) ++
+      mutation.map(_.opType).fold(empty)(collectTypes(_)) ++
+      subscription.map(_.opType).fold(empty)(collectTypes(_)))
+      .groupBy(t => (t.name, t.kind, t.origin))
+      .flatMap(_._2.headOption)
+      .toList
+  }
+}

--- a/core/src/main/scala/caliban/schema/RootType.scala
+++ b/core/src/main/scala/caliban/schema/RootType.scala
@@ -9,9 +9,9 @@ case class RootType(
   subscriptionType: Option[__Type],
   additionalDirectives: List[__Directive] = List.empty
 ) {
-  val empty = Map.empty[String, __Type]
+  val empty = List.empty[__Type]
   val types: Map[String, __Type] =
-    collectTypes(queryType) ++
+    (collectTypes(queryType) ++
       mutationType.fold(empty)(collectTypes(_)) ++
-      subscriptionType.fold(empty)(collectTypes(_))
+      subscriptionType.fold(empty)(collectTypes(_))).map(t => t.name.getOrElse("") -> t).toMap
 }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -299,7 +299,8 @@ trait DerivationSchema[R] {
                 Some(p.annotations.collect { case GQLDirective(dir) => dir }.toList).filter(_.nonEmpty)
               )
             )
-            .toList
+            .toList,
+          Some(ctx.typeName.full)
         )
       else
         makeObject(
@@ -319,7 +320,8 @@ trait DerivationSchema[R] {
               )
             )
             .toList,
-          getDirectives(ctx)
+          getDirectives(ctx),
+          Some(ctx.typeName.full)
         )
 
     override def resolve(value: T): Step[R] =
@@ -348,14 +350,15 @@ trait DerivationSchema[R] {
           Some(getName(ctx)),
           getDescription(ctx),
           subtypes.collect {
-            case (__Type(_, Some(name), description, _, _, _, _, _, _, _), annotations) =>
+            case (__Type(_, Some(name), description, _, _, _, _, _, _, _, _), annotations) =>
               __EnumValue(
                 name,
                 description,
                 annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
                 annotations.collectFirst { case GQLDeprecated(reason) => reason }
               )
-          }
+          },
+          Some(ctx.typeName.full)
         )
       else {
         ctx.annotations.collectFirst {
@@ -364,7 +367,8 @@ trait DerivationSchema[R] {
           makeUnion(
             Some(getName(ctx)),
             getDescription(ctx),
-            subtypes.map { case (t, _) => fixEmptyUnionObject(t) }
+            subtypes.map { case (t, _) => fixEmptyUnionObject(t) },
+            Some(ctx.typeName.full)
           )
         ) { _ =>
           val impl = subtypes.map(_._1.copy(interfaces = () => Some(List(toType(isInput)))))
@@ -379,7 +383,7 @@ trait DerivationSchema[R] {
             }
             .flatten
 
-          makeInterface(Some(getName(ctx)), getDescription(ctx), commonFields.toList, impl)
+          makeInterface(Some(getName(ctx)), getDescription(ctx), commonFields.toList, impl, Some(ctx.typeName.full))
         }
       }
     }

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -187,5 +187,22 @@ object TestUtils {
     val resolverInterfaceWrongArgumentInputType = RootResolver(
       TestWrongArgumentType(InterfaceWrongArgumentInputType.A(_ => UIO.unit))
     )
+
+    case class ClashingObjectArgs(a: ClashingObject)
+    case class ClashingObject(a: String)
+    case class ClashingObjectInput(a: String)
+    case class ClashingQuery(test: ClashingObjectArgs => ClashingObjectInput)
+    val resolverClashingObjects = RootResolver(
+      ClashingQuery(args => ClashingObjectInput(args.a.a))
+    )
+
+    object A {
+      case class C(a: String)
+    }
+    object B {
+      case class C(a: String)
+    }
+    case class ClashingNamesQuery(a: A.C, b: B.C)
+    val resolverClashingNames = RootResolver(ClashingNamesQuery(A.C(""), B.C("")))
   }
 }

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -33,7 +33,9 @@ object SchemaSpec extends DefaultRunnableSpec {
         case class A(b: B)
         case class B(c: C)
         case class C(d: Int)
-        assert(Types.collectTypes(introspect[Queries]).keys)(contains("BInput") && contains("CInput"))
+        assert(Types.collectTypes(introspect[Queries]).map(_.name.getOrElse("")))(
+          contains("BInput") && contains("CInput")
+        )
       },
       test("UUID field should be converted to ID") {
         assert(introspect[IDSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(

--- a/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
@@ -1,7 +1,7 @@
 package caliban.validation
 
 import caliban.CalibanError.ValidationError
-import caliban.GraphQL
+import caliban.{ GraphQL, RootResolver }
 import caliban.GraphQL.graphQL
 import caliban.TestUtils.InvalidSchemas._
 import zio.IO
@@ -53,6 +53,24 @@ object ValidationSchemaSpec extends DefaultRunnableSpec {
           check(
             graphQL(resolverInterfaceWrongArgumentInputType),
             "UnionInput of InputValue 'union' of InputObject 'UnionArgInput' is of kind UNION, must be an InputType"
+          )
+        },
+        testM("clashing input and object types") {
+          check(
+            graphQL(resolverClashingObjects),
+            "Type 'ClashingObjectInput' is defined multiple times (INPUT_OBJECT in caliban.TestUtils.InvalidSchemas.ClashingObject, OBJECT in caliban.TestUtils.InvalidSchemas.ClashingObjectInput)."
+          )
+        },
+        testM("clashing names from different packages") {
+          check(
+            graphQL(resolverClashingNames),
+            "Type 'C' is defined multiple times (OBJECT in caliban.TestUtils.InvalidSchemas.A.C, OBJECT in caliban.TestUtils.InvalidSchemas.B.C)."
+          )
+        },
+        testM("missing root query") {
+          check(
+            graphQL(RootResolver[Unit, Unit, Unit](None, None, None)),
+            "The query root operation is missing."
           )
         }
       )

--- a/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
+++ b/examples/src/main/scala/caliban/interop/cats/ExampleCatsInterop.scala
@@ -34,8 +34,8 @@ object ExampleCatsInterop extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] =
     for {
-      _           <- api.checkAsync[IO](query)
       interpreter <- api.interpreterAsync[IO]
+      _           <- interpreter.checkAsync[IO](query)
       result      <- interpreter.executeAsync[IO](query)
       _           <- IO(println(result.data))
     } yield ExitCode.Success

--- a/examples/src/main/scala/caliban/interop/monix/ExampleMonixInterop.scala
+++ b/examples/src/main/scala/caliban/interop/monix/ExampleMonixInterop.scala
@@ -24,7 +24,7 @@ object ExampleMonixInterop extends TaskApp {
   val queries      = Queries(numbers, randomNumber)
 
   val subscriptions = Subscriptions(Observable.fromIterable(List(1, 2, 3)))
-  val api           = graphQL(RootResolver(queries, Option.empty[Unit], Some(subscriptions)))
+  val api           = graphQL(RootResolver(Some(queries), Option.empty[Unit], Some(subscriptions)))
 
   val query = """
   {

--- a/examples/src/main/scala/caliban/interop/monix/ExampleMonixInterop.scala
+++ b/examples/src/main/scala/caliban/interop/monix/ExampleMonixInterop.scala
@@ -44,12 +44,12 @@ object ExampleMonixInterop extends TaskApp {
 
   override def run(args: List[String]): Task[ExitCode] =
     for {
-      _           <- api.checkAsync(query)
       interpreter <- api.interpreterAsync
+      _           <- interpreter.checkAsync(query)
       result      <- interpreter.executeAsync(query)
       _           <- Task.eval(println(result.data))
 
-      _      <- api.checkAsync(subscription)
+      _      <- interpreter.checkAsync(subscription)
       result <- interpreter.executeAsync(subscription)
       _ <- result.data match {
             case ObjectValue(("numbers", StreamValue(stream)) :: Nil) =>

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -25,7 +25,9 @@ object CatsInterop {
       runtime.unsafeRunAsync(execution)(exit => cb(exit.toEither))
     }
 
-  def checkAsync[F[_]: Async, R](graphQL: GraphQL[R])(query: String)(implicit runtime: Runtime[R]): F[Unit] =
+  def checkAsync[F[_]: Async, R](
+    graphQL: GraphQLInterpreter[R, Any]
+  )(query: String)(implicit runtime: Runtime[R]): F[Unit] =
     Async[F].async(cb => runtime.unsafeRunAsync(graphQL.check(query))(exit => cb(exit.toEither)))
 
   def interpreterAsync[F[_]: Async, R](

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -21,12 +21,12 @@ package object implicits {
         variables,
         skipValidation
       )
-  }
-
-  implicit class CatsEffectGraphQL[R, E](underlying: GraphQL[R]) {
 
     def checkAsync[F[_]: Async](query: String)(implicit runtime: Runtime[R]): F[Unit] =
       CatsInterop.checkAsync(underlying)(query)
+  }
+
+  implicit class CatsEffectGraphQL[R, E](underlying: GraphQL[R]) {
 
     def interpreterAsync[F[_]: Async](implicit runtime: Runtime[R]): F[GraphQLInterpreter[R, CalibanError]] =
       CatsInterop.interpreterAsync(underlying)

--- a/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
+++ b/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
@@ -26,7 +26,7 @@ object MonixInterop {
       runtime.unsafeRunAsync(execution)(exit => cb(exit.toEither))
     }
 
-  def checkAsync[R](graphQL: GraphQL[R])(query: String)(implicit runtime: Runtime[R]): MonixTask[Unit] =
+  def checkAsync[R](graphQL: GraphQLInterpreter[R, Any])(query: String)(implicit runtime: Runtime[R]): MonixTask[Unit] =
     MonixTask.async(cb => runtime.unsafeRunAsync(graphQL.check(query))(exit => cb(exit.toEither)))
 
   def interpreterAsync[R](

--- a/interop/monix/src/main/scala/caliban/interop/monix/implicits/package.scala
+++ b/interop/monix/src/main/scala/caliban/interop/monix/implicits/package.scala
@@ -23,12 +23,12 @@ package object implicits {
         variables,
         skipValidation
       )
-  }
-
-  implicit class MonixGraphQL[R, E](underlying: GraphQL[R]) {
 
     def checkAsync(query: String)(implicit runtime: Runtime[R]): Task[Unit] =
       MonixInterop.checkAsync(underlying)(query)
+  }
+
+  implicit class MonixGraphQL[R, E](underlying: GraphQL[R]) {
 
     def interpreterAsync(implicit runtime: Runtime[R]): Task[GraphQLInterpreter[R, CalibanError]] =
       MonixInterop.interpreterAsync(underlying)

--- a/vuepress/docs/docs/interop.md
+++ b/vuepress/docs/docs/interop.md
@@ -5,7 +5,8 @@ If you prefer using [Cats Effect](https://github.com/typelevel/cats-effect) or [
 ## Cats Effect
 You first need to import `caliban.interop.cats.implicits._` and have an implicit `zio.Runtime` in scope. Then a few helpers are available:
 
-- the GraphQL object is enriched with `interpreterAsync`, `executeAsync` and `checkAsync`, variants of `interpreter`, `execute` and `check` that return an `F[_]: Async` instead of a `ZIO`.
+- the `GraphQL` object is enriched with `interpreterAsync`, a variant of `interpreter` that return an `F[_]: Async` instead of a `ZIO`.
+- the `GraphQLInterpreter` object is enriched with `executeAsync` and `checkAsync`, variants of `execute` and `check` that return an `F[_]: Async` instead of a `ZIO`.
 - the `Http4sAdapter` also has cats-effect variants named `makeRestServiceF` and `makeWebSocketServiceF`.
 
 In addition to that, a `Schema` for any `F[_]: Effect` is provided. That means you can include fields returning Monix Task for Cats IO in your queries, mutations or subscriptions.
@@ -48,7 +49,8 @@ You can find this example within the [examples](https://github.com/ghostdogpr/ca
 ## Monix
 You first need to import `caliban.interop.monix.implicits._` and have an implicit `zio.Runtime` in scope. Then a few helpers are available:
 
-- the GraphQL object is enriched with `interpreterAsync`, `executeAsync` and `checkAsync`, variants of `interpreter`, `execute` and `check` that return a Monix `Task` instead of a `ZIO`.
+- the `GraphQL` object is enriched with `interpreterAsync`, a variant of `interpreter` that return a Monix `Task` instead of a `ZIO`.
+- the `GraphQLInterpreter` object is enriched with `executeAsync` and `checkAsync`, variants of `execute` and `check` that return a Monix `Task` instead of a `ZIO`.
 
 In addition to that, a `Schema` for any Monix `Task` as well as `Observable` is provided.
 


### PR DESCRIPTION
Closes #170 

- Moves `check` to `GraphQLInterpreter`
- Verifies that each type is defined only once (e.g. case classes from different packages or an object used as OBJECT and INPUT_OBJECT at the same time).
- Allows defining an empty root query (useful when you break your API in multiple parts and combine them). Will return an error when calling `interpreter` if there is no root query.