### PR TITLE
Protect some field names and properties

### DIFF
--- a/codegen/src/main/scala/caliban/codegen/SchemaWriter.scala
+++ b/codegen/src/main/scala/caliban/codegen/SchemaWriter.scala
@@ -84,12 +84,18 @@ object SchemaWriter {
       """
   }
 
+  def protectedReservedName(name: String): String = {
+    val reserved = "package" :: "object" :: "private" :: "type" :: Nil
+    if (reserved.contains(name)) s"`${name}`" else name
+  }
+
   def reservedType(typeDefinition: ObjectTypeDefinition): Boolean =
     typeDefinition.name == "Query" || typeDefinition.name == "Mutation" || typeDefinition.name == "Subscription"
 
   def writeRootField(field: FieldDefinition): String = {
     val argsName = if (field.args.nonEmpty) s"${field.name.capitalize}Args" else "()"
-    s"${field.name}: $argsName => ${writeType(field.ofType)}"
+
+    s"${protectedReservedName(field.name)}: $argsName => ${writeType(field.ofType)}"
   }
 
   def writeRootQueryOrMutationDef(op: ObjectTypeDefinition): String =
@@ -100,7 +106,7 @@ object SchemaWriter {
 
   def writeSubscriptionField(field: FieldDefinition): String =
     "%s: %s => ZStream[Any, Nothing, %s]".format(
-      field.name,
+      protectedReservedName(field.name),
       if (field.args.nonEmpty) s"${field.name.capitalize}Args" else "()",
       writeType(field.ofType)
     )
@@ -126,7 +132,9 @@ object SchemaWriter {
 
           object ${typedef.name} {
             ${typedef.enumValuesDefinition
-      .map(v => s"${writeDescription(v.description)}case object ${v.enumValue} extends ${typedef.name}")
+      .map(v =>
+        s"${writeDescription(v.description)}case object ${protectedReservedName(v.enumValue)} extends ${typedef.name}"
+      )
       .mkString("\n")}
           }
        """
@@ -143,17 +151,17 @@ object SchemaWriter {
 
   def writeField(field: FieldDefinition, of: ObjectTypeDefinition): String =
     if (field.args.nonEmpty) {
-      s"${writeDescription(field.description)}${field.name}: ${of.name.capitalize}${field.name.capitalize}Args => ${writeType(field.ofType)}"
+      s"${writeDescription(field.description)}${protectedReservedName(field.name)}: ${of.name.capitalize}${field.name.capitalize}Args => ${writeType(field.ofType)}"
     } else {
-      s"""${writeDescription(field.description)}${field.name}: ${writeType(field.ofType)}"""
+      s"""${writeDescription(field.description)}${protectedReservedName(field.name)}: ${writeType(field.ofType)}"""
     }
 
   def writeInputValue(value: InputValueDefinition, of: InputObjectTypeDefinition): String =
-    s"""${writeDescription(value.description)}${value.name}: ${writeType(value.ofType)}"""
+    s"""${writeDescription(value.description)}${protectedReservedName(value.name)}: ${writeType(value.ofType)}"""
 
   def writeArguments(field: FieldDefinition): String = {
     def fields(args: List[InputValueDefinition]): String =
-      s"${args.map(arg => s"${arg.name}: ${writeType(arg.ofType)}").mkString(", ")}"
+      s"${args.map(arg => s"${protectedReservedName(arg.name)}: ${writeType(arg.ofType)}").mkString(", ")}"
 
     if (field.args.nonEmpty) {
       s"case class ${field.name.capitalize}Args(${fields(field.args)})"
@@ -163,7 +171,7 @@ object SchemaWriter {
   }
 
   def writeDescription(description: Option[String]): String =
-    description.fold("")(d => s"""@GQLDescription("$d")
+    description.fold("")(d => s"""@GQLDescription(\"\"\"$d\"\"\")
                                  |""".stripMargin)
 
   def writeType(t: Type): String =

--- a/codegen/src/test/scala/caliban/codegen/SchemaWriterSpec.scala
+++ b/codegen/src/test/scala/caliban/codegen/SchemaWriterSpec.scala
@@ -217,11 +217,11 @@ userList: () => List[Option[User]]
           """
              "role"
              union Role = Captain | Pilot
-             
+
              type Captain {
                "ship" shipName: String!
              }
-             
+
              type Pilot {
                shipName: String!
              }
@@ -233,12 +233,12 @@ userList: () => List[Option[User]]
 
 object Types {
 
-  @GQLDescription("role")
+  @GQLDescription(\"\"\"role\"\"\")
   sealed trait Role extends scala.Product with scala.Serializable
 
   object Role {
     case class Captain(
-      @GQLDescription("ship")
+      @GQLDescription(\"\"\"ship\"\"\")
       shipName: String
     ) extends Role
     case class Pilot(shipName: String) extends Role
@@ -292,6 +292,52 @@ object Types {
 
   case class Character(name: String)
   case class CharacterArgs(name: String)
+
+}
+"""
+          )
+        )
+      },
+      testM("schema with multiline comment") {
+        val schema =
+          """
+             input CharacterArgs {
+               \"\"\"
+               Imagine a long comment text
+               that even has multiple lines.
+               \"\"\"
+               name: String!
+             }
+            """.stripMargin
+
+        assertM(gen(schema))(
+          equalTo(
+            """object Types {
+              @GQLDescription(
+                \"\"\"Imagine a long comment text
+                that even has multiple lines.\"\"\"
+              )
+              case class CharacterArgs(name: String)
+            }
+            """
+          )
+        )
+      },
+      testM("scala reserved word used") {
+        val schema =
+          """
+             type Character {
+               private: String!
+               object: String!
+               type: String!
+             }
+            """.stripMargin
+
+        assertM(gen(schema))(
+          equalTo(
+            """object Types {
+
+  case class Character(`private`: String, `object`: String, `type`: String)
 
 }
 """


### PR DESCRIPTION
When trying to generate from github idl some issues
came up:
  * reserved scala keywords are used in multiple places
    which need escaping with ``.
  * multiline strings on the docs, so added the annotations
    to always use the triple quotes """xx"""