### PR TITLE
Add spray-json support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     fork in Test := true,
     fork in run := true
   )
-lazy val coreJVM = core.jvm
+lazy val coreJVM = core.jvm.settings(
+  libraryDependencies += "io.spray" %% "spray-json" % "1.3.5" % Optional
+)
 lazy val coreJS = core.js.settings(
   libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC5" % Test
 )

--- a/core/.js/src/main/scala/caliban/CalibanErrorPlatformSpecific.scala
+++ b/core/.js/src/main/scala/caliban/CalibanErrorPlatformSpecific.scala
@@ -1,0 +1,3 @@
+package caliban
+
+private[caliban] trait CalibanErrorPlatformSpecific {}

--- a/core/.js/src/main/scala/caliban/GraphQLRequestPlatformSpecific.scala
+++ b/core/.js/src/main/scala/caliban/GraphQLRequestPlatformSpecific.scala
@@ -1,0 +1,3 @@
+package caliban
+
+private[caliban] trait GraphQLRequestPlatformSpecific {}

--- a/core/.js/src/main/scala/caliban/GraphQLResponsePlatformSpecific.scala
+++ b/core/.js/src/main/scala/caliban/GraphQLResponsePlatformSpecific.scala
@@ -1,0 +1,2 @@
+package caliban
+private[caliban] trait GraphQLResponsePlatformSpecific {}

--- a/core/.js/src/main/scala/caliban/InputValuePlatformSpecific.scala
+++ b/core/.js/src/main/scala/caliban/InputValuePlatformSpecific.scala
@@ -1,0 +1,3 @@
+package caliban
+
+private[caliban] trait InputValuePlatformSpecific {}

--- a/core/.js/src/main/scala/caliban/ResponseValuePlatformSpecific.scala
+++ b/core/.js/src/main/scala/caliban/ResponseValuePlatformSpecific.scala
@@ -1,0 +1,3 @@
+package caliban
+
+private[caliban] trait ResponseValuePlatformSpecific {}

--- a/core/.jvm/src/main/scala/caliban/CalibanErrorPlatformSpecific.scala
+++ b/core/.jvm/src/main/scala/caliban/CalibanErrorPlatformSpecific.scala
@@ -1,0 +1,59 @@
+package caliban
+
+import caliban.ValueSprayJson.responseValueFormat
+import caliban.interop.spray.IsSprayJsonWriter
+import caliban.parsing.adt.LocationInfo
+import spray.json.{ DefaultJsonProtocol, JsArray, JsNumber, JsObject, JsString, JsValue, JsonWriter }
+
+private[caliban] trait CalibanErrorPlatformSpecific {
+  implicit def sprayJsonWriter[F[_]: IsSprayJsonWriter]: F[CalibanError] =
+    CalibanErrorSprayJson.calibanErrorJsonWriter.asInstanceOf[F[CalibanError]]
+}
+
+private[caliban] object CalibanErrorSprayJson extends DefaultJsonProtocol {
+
+  val calibanErrorJsonWriter: JsonWriter[CalibanError] = new JsonWriter[CalibanError] {
+    def write(obj: CalibanError): JsValue = obj match {
+      case CalibanError.ParsingError(msg, locationInfo, _, extensions) =>
+        val strictFields = Map(
+          "message"    -> JsString(s"Parsing Error: $msg"),
+          "extensions" -> implicitly[JsonWriter[Option[ResponseValue]]].write(extensions)
+        )
+        // excluding to avoid nulls
+        val optionalFields = locationToJson(locationInfo)
+
+        JsObject(strictFields ++ optionalFields)
+      case CalibanError.ValidationError(msg, _, locationInfo, extensions) =>
+        val strictFields = Map(
+          "message"    -> JsString(msg),
+          "extensions" -> implicitly[JsonWriter[Option[ResponseValue]]].write(extensions)
+        )
+        // excluding to avoid nulls
+        val optionalFields = locationToJson(locationInfo)
+
+        JsObject(strictFields ++ optionalFields)
+      case CalibanError.ExecutionError(msg, path, locationInfo, _, extensions) =>
+        val strictFields = Map(
+          "message"    -> JsString(msg),
+          "extensions" -> implicitly[JsonWriter[Option[ResponseValue]]].write(extensions)
+        )
+        // excluding to avoid nulls
+        val optionalFields = locationToJson(locationInfo) ++
+          Some(path).collect {
+            case p if p.nonEmpty =>
+              JsArray(p.map {
+                case Left(value)  => JsString(value)
+                case Right(value) => JsNumber(value)
+              }: _*)
+          }.fold(Map.empty[String, JsValue])(v => Map("path" -> v))
+
+        JsObject(strictFields ++ optionalFields)
+    }
+  }
+
+  private def locationToJson(locInfo: Option[LocationInfo]): Map[String, JsValue] =
+    Some(locInfo).collect {
+      case Some(li) => JsArray(JsObject("line" -> JsNumber(li.line), "column" -> JsNumber(li.column)))
+    }.fold(Map.empty[String, JsValue])(v => Map("locations" -> v))
+
+}

--- a/core/.jvm/src/main/scala/caliban/GraphQLRequestPlatformSpecific.scala
+++ b/core/.jvm/src/main/scala/caliban/GraphQLRequestPlatformSpecific.scala
@@ -1,0 +1,25 @@
+package caliban
+
+import caliban.interop.spray.IsSprayJsonReader
+import spray.json.{ DefaultJsonProtocol, JsValue, JsonReader }
+import ValueSprayJson.inputValueFormat
+
+private[caliban] trait GraphQLRequestPlatformSpecific {
+  implicit def sprayJsonReader[F[_]: IsSprayJsonReader]: F[GraphQLRequest] =
+    GraphQLRequestSprayJson.graphQLRequestJsonReader.asInstanceOf[F[GraphQLRequest]]
+}
+
+private[caliban] object GraphQLRequestSprayJson extends DefaultJsonProtocol {
+
+  val graphQLRequestJsonReader: JsonReader[GraphQLRequest] = new JsonReader[GraphQLRequest] {
+    def read(json: JsValue): GraphQLRequest = {
+      val obj = json.asJsObject
+      GraphQLRequest(
+        obj.fields("query").convertTo[String],
+        obj.fields("operationName").convertTo[Option[String]],
+        obj.fields("variables").convertTo[Option[Map[String, InputValue]]]
+      )
+    }
+  }
+
+}

--- a/core/.jvm/src/main/scala/caliban/GraphQLResponsePlatformSpecific.scala
+++ b/core/.jvm/src/main/scala/caliban/GraphQLResponsePlatformSpecific.scala
@@ -1,0 +1,40 @@
+package caliban
+
+import caliban.interop.spray.IsSprayJsonWriter
+import spray.json.{ DefaultJsonProtocol, JsArray, JsObject, JsString, JsValue, JsonWriter }
+
+private[caliban] trait GraphQLResponsePlatformSpecific {
+  implicit def sprayJsonWriter[F[_]: IsSprayJsonWriter, E]: F[GraphQLResponse[E]] =
+    GraphQLResponseSprayJson.graphQLResponseJsonWriter.asInstanceOf[F[GraphQLResponse[E]]]
+}
+
+private[caliban] object GraphQLResponseSprayJson extends DefaultJsonProtocol {
+
+  def asJson(r: ResponseValue): JsValue = ValueSprayJson.responseValueWriter.write(r)
+  val graphQLResponseJsonWriter: JsonWriter[GraphQLResponse[Any]] = new JsonWriter[GraphQLResponse[Any]] {
+    def write(obj: GraphQLResponse[Any]): JsValue = obj match {
+      case GraphQLResponse(data, Nil, None) => JsObject("data" -> ValueSprayJson.responseValueWriter.write(data))
+      case GraphQLResponse(data, Nil, Some(extensions)) =>
+        JsObject(
+          "data" -> asJson(data),
+          "extensions" ->
+            asJson(extensions.asInstanceOf[ResponseValue])
+        )
+      case GraphQLResponse(data, errors, None) =>
+        JsObject("data" -> asJson(data), "errors" -> JsArray(errors.map(handleError): _*))
+      case GraphQLResponse(data, errors, Some(extensions)) =>
+        JsObject(
+          "data"       -> asJson(data),
+          "errors"     -> JsArray(errors.map(handleError): _*),
+          "extensions" -> asJson(extensions.asInstanceOf[ResponseValue])
+        )
+    }
+
+    private def handleError(err: Any): JsValue =
+      err match {
+        case ce: CalibanError => CalibanErrorSprayJson.calibanErrorJsonWriter.write(ce)
+        case _                => JsObject("message" -> JsString(err.toString))
+      }
+  }
+
+}

--- a/core/.jvm/src/main/scala/caliban/InputValuePlatformSpecific.scala
+++ b/core/.jvm/src/main/scala/caliban/InputValuePlatformSpecific.scala
@@ -1,0 +1,12 @@
+package caliban
+
+import caliban.interop.spray.{ IsSprayJsonReader, IsSprayJsonWriter }
+
+private[caliban] trait InputValuePlatformSpecific {
+  implicit def sprayJsonWriter[F[_]: IsSprayJsonWriter]: F[InputValue] =
+    ValueSprayJson.inputValueWriter.asInstanceOf[F[InputValue]]
+  implicit def sprayJsonReader[F[_]: IsSprayJsonReader]: F[InputValue] =
+    ValueSprayJson.inputValueReader.asInstanceOf[F[InputValue]]
+}
+
+private[caliban] object InputValuePlatformSpecific extends InputValuePlatformSpecific

--- a/core/.jvm/src/main/scala/caliban/ResponseValuePlatformSpecific.scala
+++ b/core/.jvm/src/main/scala/caliban/ResponseValuePlatformSpecific.scala
@@ -1,0 +1,12 @@
+package caliban
+
+import caliban.interop.spray.{ IsSprayJsonReader, IsSprayJsonWriter }
+
+private[caliban] trait ResponseValuePlatformSpecific {
+  implicit def sprayJsonWriter[F[_]: IsSprayJsonWriter]: F[ResponseValue] =
+    ValueSprayJson.responseValueWriter.asInstanceOf[F[ResponseValue]]
+  implicit def sprayJsonReader[F[_]: IsSprayJsonReader]: F[ResponseValue] =
+    ValueSprayJson.responseValueReader.asInstanceOf[F[ResponseValue]]
+}
+
+private[caliban] object ResponseValuePlatformSpecific extends ResponseValuePlatformSpecific

--- a/core/.jvm/src/main/scala/caliban/ValueSprayJson.scala
+++ b/core/.jvm/src/main/scala/caliban/ValueSprayJson.scala
@@ -43,7 +43,7 @@ private[caliban] object ValueSprayJson extends DefaultJsonProtocol {
 
   private def jsonToInputValue(json: JsValue): InputValue =
     json match {
-      case JsObject(fields)  => InputValue.ObjectValue(fields.mapValues(jsonToInputValue))
+      case JsObject(fields)  => InputValue.ObjectValue(fields.map { case (k, v) => k -> jsonToInputValue(v) })
       case JsArray(elements) => InputValue.ListValue(elements.toList.map(jsonToInputValue))
       case JsString(value)   => StringValue(value)
       case JsNumber(value) =>
@@ -63,7 +63,7 @@ private[caliban] object ValueSprayJson extends DefaultJsonProtocol {
       case value: Value                 => valueWriter.write(value)
       case InputValue.ListValue(values) => JsArray(values.map(inputValueWriter.write): _*)
       case InputValue.ObjectValue(fields) =>
-        JsObject(fields.mapValues(inputValueWriter.write).toList: _*)
+        JsObject(fields.map { case (k, v) => k -> inputValueWriter.write(v) }.toList: _*)
       case InputValue.VariableValue(name) => JsString(name)
     }
   }
@@ -75,7 +75,8 @@ private[caliban] object ValueSprayJson extends DefaultJsonProtocol {
 
   private def jsonToResponseValue(json: JsValue): ResponseValue =
     json match {
-      case JsObject(fields)  => ResponseValue.ObjectValue(fields.mapValues(jsonToResponseValue).toList)
+      case JsObject(fields) =>
+        ResponseValue.ObjectValue(fields.map { case (k, v) => k -> jsonToResponseValue(v) }.toList)
       case JsArray(elements) => ResponseValue.ListValue(elements.toList.map(jsonToResponseValue))
       case JsString(value)   => StringValue(value)
       case JsNumber(value) =>

--- a/core/.jvm/src/main/scala/caliban/ValueSprayJson.scala
+++ b/core/.jvm/src/main/scala/caliban/ValueSprayJson.scala
@@ -1,0 +1,110 @@
+package caliban
+
+import spray.json.{
+  DefaultJsonProtocol,
+  JsArray,
+  JsBoolean,
+  JsNull,
+  JsNumber,
+  JsObject,
+  JsString,
+  JsValue,
+  JsonFormat,
+  JsonReader,
+  JsonWriter
+}
+import Value._
+
+import scala.util.Try
+
+private[caliban] object ValueSprayJson extends DefaultJsonProtocol {
+
+  val valueWriter: JsonWriter[Value] = new JsonWriter[Value] {
+    def write(obj: Value): JsValue = obj match {
+      case NullValue => JsNull
+      case v: IntValue =>
+        v match {
+          case IntValue.IntNumber(value)    => JsNumber(BigDecimal(value))
+          case IntValue.LongNumber(value)   => JsNumber(BigDecimal(value))
+          case IntValue.BigIntNumber(value) => JsNumber(BigDecimal(value))
+        }
+      case v: FloatValue =>
+        v match {
+          case FloatValue.FloatNumber(value)      => JsNumber(BigDecimal(value.toDouble))
+          case FloatValue.DoubleNumber(value)     => JsNumber(BigDecimal(value))
+          case FloatValue.BigDecimalNumber(value) => JsNumber(value)
+        }
+      case StringValue(value)  => JsString(value)
+      case BooleanValue(value) => JsBoolean(value)
+      case EnumValue(value)    => JsString(value)
+    }
+
+  }
+
+  private def jsonToInputValue(json: JsValue): InputValue =
+    json match {
+      case JsObject(fields)  => InputValue.ObjectValue(fields.mapValues(jsonToInputValue))
+      case JsArray(elements) => InputValue.ListValue(elements.toList.map(jsonToInputValue))
+      case JsString(value)   => StringValue(value)
+      case JsNumber(value) =>
+        Try(value.toIntExact)
+          .map(IntValue.apply)
+          .getOrElse(FloatValue(value))
+
+      case b: JsBoolean => BooleanValue(b.value)
+      case JsNull       => NullValue
+    }
+
+  val inputValueReader: JsonReader[InputValue] = new JsonReader[InputValue] {
+    def read(json: JsValue): InputValue = jsonToInputValue(json)
+  }
+  val inputValueWriter: JsonWriter[InputValue] = new JsonWriter[InputValue] {
+    def write(obj: InputValue): JsValue = obj match {
+      case value: Value                 => valueWriter.write(value)
+      case InputValue.ListValue(values) => JsArray(values.map(inputValueWriter.write): _*)
+      case InputValue.ObjectValue(fields) =>
+        JsObject(fields.mapValues(inputValueWriter.write).toList: _*)
+      case InputValue.VariableValue(name) => JsString(name)
+    }
+  }
+
+  implicit val inputValueFormat = new JsonFormat[InputValue] {
+    def write(obj: InputValue): JsValue = inputValueWriter.write(obj)
+    def read(json: JsValue): InputValue = inputValueReader.read(json)
+  }
+
+  private def jsonToResponseValue(json: JsValue): ResponseValue =
+    json match {
+      case JsObject(fields)  => ResponseValue.ObjectValue(fields.mapValues(jsonToResponseValue).toList)
+      case JsArray(elements) => ResponseValue.ListValue(elements.toList.map(jsonToResponseValue))
+      case JsString(value)   => StringValue(value)
+      case JsNumber(value) =>
+        Try(value.toIntExact)
+          .map(IntValue.apply)
+          .getOrElse(FloatValue(value))
+
+      case b: JsBoolean => BooleanValue(b.value)
+      case JsNull       => NullValue
+    }
+
+  val responseValueReader: JsonReader[ResponseValue] =
+    new JsonReader[ResponseValue] {
+      def read(json: JsValue): ResponseValue = jsonToResponseValue(json)
+    }
+
+  val responseValueWriter: JsonWriter[ResponseValue] = new JsonWriter[ResponseValue] {
+    def write(obj: ResponseValue): JsValue = obj match {
+      case value: Value                    => valueWriter.write(value)
+      case ResponseValue.ListValue(values) => JsArray(values.map(responseValueWriter.write): _*)
+      case ResponseValue.ObjectValue(fields) =>
+        JsObject(fields.map { case (k, v) => k -> responseValueWriter.write(v) }: _*)
+      case s: ResponseValue.StreamValue => JsString(s.toString)
+    }
+  }
+
+  implicit val responseValueFormat = new JsonFormat[ResponseValue] {
+    def write(obj: ResponseValue): JsValue = responseValueWriter.write(obj)
+    def read(json: JsValue): ResponseValue = responseValueReader.read(json)
+  }
+
+}

--- a/core/.jvm/src/main/scala/caliban/interop/spray/spray.scala
+++ b/core/.jvm/src/main/scala/caliban/interop/spray/spray.scala
@@ -1,0 +1,38 @@
+package caliban.interop.spray
+
+import caliban.introspection.adt.__Type
+import caliban.schema.Step.QueryStep
+import caliban.schema.Types.makeScalar
+import caliban.schema.{ ArgBuilder, PureStep, Schema, Step }
+import caliban.{ InputValue, ResponseValue }
+import spray.json.{ JsValue, JsonReader, JsonWriter }
+import zio.ZIO
+import zquery.ZQuery
+
+/**
+ * This class is an implementation of the pattern described in https://blog.7mind.io/no-more-orphans.html
+ * It makes it possible to mark spray-json dependency as optional and keep Readers defined in the companion object.
+ */
+private[caliban] trait IsSprayJsonReader[F[_]]
+private[caliban] object IsSprayJsonReader {
+  implicit val isSprayJsonReader: IsSprayJsonReader[JsonReader] = null
+}
+
+/**
+ * This class is an implementation of the pattern described in https://blog.7mind.io/no-more-orphans.html
+ * It makes it possible to mark spray-json dependency as optional and keep Writers defined in the companion object.
+ */
+private[caliban] trait IsSprayJsonWriter[F[_]]
+private[caliban] object IsSprayJsonWriter {
+  implicit val isSprayJsonWriter: IsSprayJsonWriter[JsonWriter] = null
+}
+
+object json {
+  implicit val jsonSchema: Schema[Any, JsValue] = new Schema[Any, JsValue] {
+    override def toType(isInput: Boolean): __Type = makeScalar("Json")
+    override def resolve(value: JsValue): Step[Any] =
+      QueryStep(ZQuery.fromEffect(ZIO.effect(implicitly[JsonReader[ResponseValue]].read(value))).map(PureStep))
+  }
+  implicit val jsonArgBuilder: ArgBuilder[JsValue] = (input: InputValue) =>
+    Right(implicitly[JsonWriter[InputValue]].write(input))
+}

--- a/core/.jvm/src/test/scala/caliban/JVMGraphQLRequestSpec.scala
+++ b/core/.jvm/src/test/scala/caliban/JVMGraphQLRequestSpec.scala
@@ -12,7 +12,7 @@ object JVMGraphQLRequestSpec extends DefaultRunnableSpec {
       test("can be parsed from JSON (spray)") {
         val request = JsObject("query" -> JsString("{}"), "operationName" -> JsString("op"), "variables" -> JsObject())
         assert(request.convertTo[GraphQLRequest])(
-            equalTo(GraphQLRequest(query = "{}", operationName = Some("op"), variables = Some(Map.empty)))
+          equalTo(GraphQLRequest(query = "{}", operationName = Some("op"), variables = Some(Map.empty)))
         )
       }
     )

--- a/core/.jvm/src/test/scala/caliban/JVMGraphQLRequestSpec.scala
+++ b/core/.jvm/src/test/scala/caliban/JVMGraphQLRequestSpec.scala
@@ -1,0 +1,19 @@
+package caliban
+
+import spray.json.{ JsObject, JsString }
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+object JVMGraphQLRequestSpec extends DefaultRunnableSpec {
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("JVMGraphQLRequestSpec")(
+      test("can be parsed from JSON (spray)") {
+        val request = JsObject("query" -> JsString("{}"), "operationName" -> JsString("op"), "variables" -> JsObject())
+        assert(request.convertTo[GraphQLRequest])(
+            equalTo(GraphQLRequest(query = "{}", operationName = Some("op"), variables = Some(Map.empty)))
+        )
+      }
+    )
+}

--- a/core/.jvm/src/test/scala/caliban/JVMGraphQLResponseSpec.scala
+++ b/core/.jvm/src/test/scala/caliban/JVMGraphQLResponseSpec.scala
@@ -1,0 +1,69 @@
+package caliban
+
+import caliban.CalibanError.ExecutionError
+import caliban.ResponseValue.ObjectValue
+import caliban.Value._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+import spray.json.{ JsArray, JsObject, JsString, JsonWriter }
+
+object JVMGraphQLResponseSpec extends DefaultRunnableSpec {
+
+  val writer = implicitly[JsonWriter[GraphQLResponse[Any]]]
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("JVMGraphQLResponseSpec")(
+      test("can be converted to JSON (spray)") {
+        val response = GraphQLResponse(StringValue("data"), Nil)
+        assert(writer.write(response))(
+          equalTo(JsObject("data" -> JsString("data")))
+        )
+      },
+      test("should include error objects for every error, including extensions (spray)") {
+
+        val errorExtensions = List(
+          ("errorCode", StringValue("TEST_ERROR")),
+          ("myCustomKey", StringValue("my-value"))
+        )
+
+        val response = GraphQLResponse(
+          StringValue("data"),
+          List(
+            ExecutionError(
+              "Resolution failed",
+              extensions = Some(ObjectValue(errorExtensions))
+            )
+          )
+        )
+
+        assert(writer.write(response))(
+          equalTo(
+            JsObject(
+              "data" -> JsString("data"),
+              "errors" -> JsArray(
+                JsObject(
+                  "message"    -> JsString("Resolution failed"),
+                  "extensions" -> JsObject("errorCode" -> JsString("TEST_ERROR"), "myCustomKey" -> JsString("my-value"))
+                )
+              )
+            )
+          )
+        )
+      },
+      test("should not include errors element when there are none (spray)") {
+        val response = GraphQLResponse(
+          StringValue("data"),
+          List.empty
+        )
+
+        assert(writer.write(response))(
+          equalTo(
+            JsObject(
+              "data" -> JsString("data")
+            )
+          )
+        )
+      }
+    )
+}

--- a/core/.jvm/src/test/scala/caliban/execution/JVMExecutionSpec.scala
+++ b/core/.jvm/src/test/scala/caliban/execution/JVMExecutionSpec.scala
@@ -8,7 +8,6 @@ import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestEnvironment
 
-
 object JVMExecutionSpec extends DefaultRunnableSpec {
 
   override def spec: ZSpec[TestEnvironment, Any] =

--- a/core/.jvm/src/test/scala/caliban/execution/JVMExecutionSpec.scala
+++ b/core/.jvm/src/test/scala/caliban/execution/JVMExecutionSpec.scala
@@ -1,0 +1,29 @@
+package caliban.execution
+
+import caliban.GraphQL._
+import caliban.Macros.gqldoc
+import caliban.RootResolver
+import spray.json.{ JsNumber, JsObject, JsValue }
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+
+object JVMExecutionSpec extends DefaultRunnableSpec {
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("JVMExecutionSpec")(
+      testM("Spray json scalar") {
+        import caliban.interop.spray.json._
+        case class Queries(test: JsValue)
+
+        val interpreter = graphQL(RootResolver(Queries(JsObject(("a", JsNumber(333)))))).interpreter
+        val query       = gqldoc("""
+             {
+               test
+             }""")
+
+        assertM(interpreter.flatMap(_.execute(query)).map(_.data.toString))(equalTo("""{"test":{"a":333}}"""))
+      }
+    )
+}

--- a/core/.jvm/src/test/scala/caliban/schema/JVMSchemaSpec.scala
+++ b/core/.jvm/src/test/scala/caliban/schema/JVMSchemaSpec.scala
@@ -1,0 +1,25 @@
+package caliban.schema
+
+import caliban.introspection.adt.{ __DeprecatedArgs, __Type }
+import spray.json.JsValue
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+object JVMSchemaSpec extends DefaultRunnableSpec {
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("SchemaSpec")(
+      test("field with Json object") {
+        import caliban.interop.spray.json._
+
+        case class Queries(to: JsValue, from: JsValue => Unit)
+
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+          isSome(hasField[__Type, String]("to", _.ofType.flatMap(_.name).get, equalTo("Json")))
+        )
+      }
+    )
+
+  def introspect[Q](implicit schema: Schema[Any, Q]): __Type = schema.toType()
+}

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -11,7 +11,7 @@ sealed trait CalibanError extends Throwable with Product with Serializable {
   def msg: String
 }
 
-object CalibanError {
+object CalibanError extends CalibanErrorPlatformSpecific {
 
   /**
    * Describes an error that happened while parsing a query.

--- a/core/src/main/scala/caliban/GraphQLRequest.scala
+++ b/core/src/main/scala/caliban/GraphQLRequest.scala
@@ -11,7 +11,7 @@ case class GraphQLRequest(
   variables: Option[Map[String, InputValue]]
 )
 
-object GraphQLRequest {
+object GraphQLRequest extends GraphQLRequestPlatformSpecific {
   implicit def circeDecoder[F[_]: IsCirceDecoder]: F[GraphQLRequest] =
     GraphQLRequestCirce.graphQLRequestDecoder.asInstanceOf[F[GraphQLRequest]]
 }

--- a/core/src/main/scala/caliban/GraphQLResponse.scala
+++ b/core/src/main/scala/caliban/GraphQLResponse.scala
@@ -8,7 +8,7 @@ import caliban.interop.circe._
  */
 case class GraphQLResponse[+E](data: ResponseValue, errors: List[E], extensions: Option[ObjectValue] = None)
 
-object GraphQLResponse {
+object GraphQLResponse extends GraphQLResponsePlatformSpecific {
   implicit def circeEncoder[F[_]: IsCirceEncoder, E]: F[GraphQLResponse[E]] =
     GraphQLResponseCirce.graphQLResponseEncoder.asInstanceOf[F[GraphQLResponse[E]]]
 }

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -7,7 +7,7 @@ import caliban.interop.circe._
 import zio.stream.Stream
 
 sealed trait InputValue
-object InputValue {
+object InputValue extends InputValuePlatformSpecific {
   case class ListValue(values: List[InputValue])          extends InputValue
   case class ObjectValue(fields: Map[String, InputValue]) extends InputValue
   case class VariableValue(name: String)                  extends InputValue
@@ -19,7 +19,7 @@ object InputValue {
 }
 
 sealed trait ResponseValue
-object ResponseValue {
+object ResponseValue extends ResponseValuePlatformSpecific {
   case class ListValue(values: List[ResponseValue]) extends ResponseValue {
     override def toString: String = values.mkString("[", ",", "]")
   }


### PR DESCRIPTION
Adds support for spray-json, the same way it's done for circe. My ultimate goal here is to make specific http modules (namely akka-http) to have pluggable json backends.

The only problem ATM is that spray-json is not published for ScalaJS yet. So there're some hoops to jump to make it work with fully cross-built caliban.
Support for ScalaJS in spray is actually already implemented and merged, we just lack a release (https://github.com/spray/spray-json/issues/327). So I think we can wait until it's released to make this PR prettier.