### PR TITLE
ZQuery: Implement ZQuery#optional

### DIFF
--- a/core/src/main/scala/zquery/DataSource.scala
+++ b/core/src/main/scala/zquery/DataSource.scala
@@ -18,7 +18,9 @@ import zio.{ NeedsEnv, ZIO }
  * the request type to a `Request[A]`. Data sources can then pattern match on
  * the collection of requests to determine the information requested, execute
  * the query, and place the results into the `CompletedRequestsMap` using
- * [[CompletedRequestMap.empty]] and [[CompletedRequestMap.insert]].
+ * [[CompletedRequestMap.empty]] and [[CompletedRequestMap.insert]]. Data
+ * sources must provide results for all requests received. Failure to do so
+ * will cause a query to die with a `QueryFailure` when run.
  */
 trait DataSource[-R, -A] { self =>
 

--- a/core/src/main/scala/zquery/QueryFailure.scala
+++ b/core/src/main/scala/zquery/QueryFailure.scala
@@ -1,5 +1,7 @@
 package zquery
 
+import zio.Cause
+
 /**
  * `QueryFailure` keeps track of details relevant to query failures.
  */
@@ -7,4 +9,35 @@ final case class QueryFailure(dataSource: DataSource[Nothing, Nothing], request:
     extends Throwable(null, null, true, false) {
   override def getMessage: String =
     s"Data source ${dataSource.identifier} did not complete request ${request.toString}."
+}
+
+object QueryFailure {
+
+  /**
+   * Strips all query failures from the specified cause, returning either
+   * `None` is there are no causes other than query failures or a cause known
+   * to contain no query failures.
+   */
+  def strip[E](cause: Cause[E]): Option[Cause[E]] =
+    cause.fold(
+      None,
+      e => Some(Cause.Fail(e)), {
+        case _: QueryFailure => None
+        case t               => Some(Cause.Die(t))
+      },
+      fiberId => Some(Cause.Interrupt(fiberId))
+    )(
+      {
+        case (Some(l), Some(r)) => Some(Cause.Both(l, r))
+        case (Some(l), None)    => Some(l)
+        case (None, Some(r))    => Some(r)
+        case (None, None)       => None
+      }, {
+        case (Some(l), Some(r)) => Some(Cause.Then(l, r))
+        case (Some(l), None)    => Some(l)
+        case (None, Some(r))    => Some(r)
+        case (None, None)       => None
+      },
+      (causeOption, trace) => causeOption.map(Cause.Traced(_, trace))
+    )
 }

--- a/core/src/main/scala/zquery/Result.scala
+++ b/core/src/main/scala/zquery/Result.scala
@@ -80,16 +80,6 @@ private[zquery] object Result {
   def fromEither[E, A](either: Either[E, A]): Result[Any, E, A] =
     either.fold(e => Result.fail(Cause.fail(e)), a => Result.done(a))
 
-  /**
-   * Lifts an `Option[Either[E, A]]` into a result.
-   */
-  def fromOptionEither[E, A](oeea: Option[Either[E, A]]): Result[Any, E, Option[A]] =
-    oeea match {
-      case None           => Result.done(None)
-      case Some(Left(e))  => Result.fail(Cause.fail(e))
-      case Some(Right(a)) => Result.done(Some(a))
-    }
-
   final case class Blocked[-R, +E, +A](blockedRequests: BlockedRequestMap[R], continue: ZQuery[R, E, A])
       extends Result[R, E, A]
 

--- a/core/src/test/scala/zquery/ZQuerySpec.scala
+++ b/core/src/test/scala/zquery/ZQuerySpec.scala
@@ -2,6 +2,7 @@ package zquery
 
 import zio.console.Console
 import zio.test.Assertion._
+import zio.test.TestAspect.silent
 import zio.test._
 import zio.test.environment.{ TestConsole, TestEnvironment }
 import zio.{ console, ZIO }
@@ -43,8 +44,13 @@ object ZQuerySpec extends ZIOBaseSpec {
           _   <- ZQuery.collectAllPar(List(a, b)).run
           log <- TestConsole.output
         } yield assert(log)(hasSize(equalTo(2)))
+      },
+      testM("optional converts a query to one that returns its value optionally") {
+        for {
+          result <- getUserNameById(27).map(identity).optional.run
+        } yield assert(result)(isNone)
       }
-    )
+    ) @@ silent
 
   val userIds: List[Int]          = (1 to 26).toList
   val userNames: Map[Int, String] = userIds.zip(('a' to 'z').map(_.toString)).toMap


### PR DESCRIPTION
The current approach to handling optional values in `ZQuery` is somewhat ad hoc, with users needing to use the `fromRequestOption` constructor to create an optional query. This PR replaces that with a new `optional` combinator that can be called on any query to convert it into one that will return `Some` if data sources return results for all requests received or `None` otherwise. This gives users more flexibility because they can convert a query to an optional one at any point instead of having to specify it at the time of query creation. `fromRequestOption` goes away in favor of `fromRequest.optional`.