### PR TITLE
Add play-json integration

### DIFF
--- a/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -1,7 +1,7 @@
 package caliban
 
-import caliban.ResponseValue._
-import caliban.Value._
+import caliban.ResponseValue.{ ObjectValue, StreamValue }
+import caliban.Value.NullValue
 import cats.data.{ Kleisli, OptionT }
 import cats.effect.Effect
 import cats.effect.syntax.all._

--- a/build.sbt
+++ b/build.sbt
@@ -74,14 +74,15 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
-      "com.lihaoyi"    %%% "fastparse"    % "2.2.4",
-      "com.propensive" %%% "magnolia"     % "0.12.7",
-      "com.propensive" %%% "mercator"     % "0.2.1",
-      "dev.zio"        %%% "zio"          % zioVersion,
-      "dev.zio"        %%% "zio-streams"  % zioVersion,
-      "dev.zio"        %%% "zio-test"     % zioVersion % "test",
-      "dev.zio"        %%% "zio-test-sbt" % zioVersion % "test",
-      "io.circe"       %%% "circe-core"   % "0.13.0" % Optional,
+      "com.lihaoyi"       %%% "fastparse"    % "2.2.4",
+      "com.propensive"    %%% "magnolia"     % "0.12.7",
+      "com.propensive"    %%% "mercator"     % "0.2.1",
+      "dev.zio"           %%% "zio"          % zioVersion,
+      "dev.zio"           %%% "zio-streams"  % zioVersion,
+      "dev.zio"           %%% "zio-test"     % zioVersion % "test",
+      "dev.zio"           %%% "zio-test-sbt" % zioVersion % "test",
+      "io.circe"          %%% "circe-core"   % "0.13.0" % Optional,
+      "com.typesafe.play" %%% "play-json"    % "2.8.1" % Optional,
       compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
     )
   )

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -117,7 +117,8 @@ private object ErrorPlayJson {
     path: Option[JsArray]
   )
 
-  implicit val locationInfoWrites: Writes[LocationInfo] = Json.writes[LocationInfo].transform((v: JsValue) => Json.arr(v))
+  implicit val locationInfoWrites: Writes[LocationInfo] =
+    Json.writes[LocationInfo].transform((v: JsValue) => Json.arr(v))
 
   private implicit val errorDTOWrites = Json.writes[ErrorDTO]
 

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -117,7 +117,7 @@ private object ErrorPlayJson {
     path: Option[JsArray]
   )
 
-  implicit val locationInfoWrites: Writes[LocationInfo] = Json.writes[LocationInfo].transform(v => JsArray(Seq(v)))
+  implicit val locationInfoWrites: Writes[LocationInfo] = Json.writes[LocationInfo].transform((v: JsValue) => Json.arr(v))
 
   private implicit val errorDTOWrites = Json.writes[ErrorDTO]
 

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -117,7 +117,7 @@ private object ErrorPlayJson {
     path: Option[JsArray]
   )
 
-  implicit val locationInfoWrites: Writes[LocationInfo] = Json.writes[LocationInfo].transform(Json.arr(_))
+  implicit val locationInfoWrites: Writes[LocationInfo] = Json.writes[LocationInfo].transform(v => JsArray(Seq(v)))
 
   private implicit val errorDTOWrites = Json.writes[ErrorDTO]
 

--- a/core/src/main/scala/caliban/GraphQLRequest.scala
+++ b/core/src/main/scala/caliban/GraphQLRequest.scala
@@ -1,6 +1,7 @@
 package caliban
 
 import caliban.interop.circe._
+import caliban.interop.play.IsPlayJsonReads
 
 /**
  * Represents a GraphQL request, containing a query, an operation name and a map of variables.
@@ -14,6 +15,8 @@ case class GraphQLRequest(
 object GraphQLRequest {
   implicit def circeDecoder[F[_]: IsCirceDecoder]: F[GraphQLRequest] =
     GraphQLRequestCirce.graphQLRequestDecoder.asInstanceOf[F[GraphQLRequest]]
+  implicit def playJsonReads[F[_]: IsPlayJsonReads]: F[GraphQLRequest] =
+    GraphQLRequestPlayJson.graphQLRequestReads.asInstanceOf[F[GraphQLRequest]]
 }
 
 private object GraphQLRequestCirce {
@@ -25,4 +28,17 @@ private object GraphQLRequestCirce {
       variables     <- c.downField("variables").as[Option[Map[String, InputValue]]]
     } yield GraphQLRequest(query, operationName, variables)
 
+}
+
+private object GraphQLRequestPlayJson {
+  import play.api.libs.json._
+  import play.api.libs.json.Reads._
+  import play.api.libs.functional.syntax._
+
+  val graphQLRequestReads: Reads[GraphQLRequest] =
+    (
+      (JsPath \ "query").read[String] and
+        (JsPath \ "operationName").readNullable[String] and
+        (JsPath \ "variables").readNullable[Map[String, InputValue]]
+    )(GraphQLRequest.apply _)
 }

--- a/core/src/main/scala/caliban/GraphQLRequest.scala
+++ b/core/src/main/scala/caliban/GraphQLRequest.scala
@@ -32,13 +32,6 @@ private object GraphQLRequestCirce {
 
 private object GraphQLRequestPlayJson {
   import play.api.libs.json._
-  import play.api.libs.json.Reads._
-  import play.api.libs.functional.syntax._
 
-  val graphQLRequestReads: Reads[GraphQLRequest] =
-    (
-      (JsPath \ "query").read[String] and
-        (JsPath \ "operationName").readNullable[String] and
-        (JsPath \ "variables").readNullable[Map[String, InputValue]]
-    )(GraphQLRequest.apply _)
+  val graphQLRequestReads: Reads[GraphQLRequest] = Json.reads[GraphQLRequest]
 }

--- a/core/src/main/scala/caliban/GraphQLResponse.scala
+++ b/core/src/main/scala/caliban/GraphQLResponse.scala
@@ -47,23 +47,23 @@ private object GraphQLResponsePlayJson {
   import play.api.libs.json.Json.toJson
 
   val graphQLResponseWrites: Writes[GraphQLResponse[Any]] = Writes {
-    case GraphQLResponse(data, Nil, None) => Json.obj("data" -> toJson(data))
+    case GraphQLResponse(data, Nil, None) => Json.obj("data" -> data)
     case GraphQLResponse(data, Nil, Some(extensions)) =>
-      Json.obj("data" -> toJson(data), "extensions" -> toJson(extensions.asInstanceOf[ResponseValue]))
+      Json.obj("data" -> data, "extensions" -> extensions.asInstanceOf[ResponseValue])
     case GraphQLResponse(data, errors, None) =>
-      Json.obj("data" -> toJson(data), "errors" -> JsArray(errors.map(handleError)))
+      Json.obj("data" -> data, "errors" -> JsArray(errors.map(handleError)))
     case GraphQLResponse(data, errors, Some(extensions)) =>
       Json.obj(
-        "data"       -> toJson(data),
+        "data"       -> data,
         "errors"     -> JsArray(errors.map(handleError)),
-        "extensions" -> toJson(extensions.asInstanceOf[ResponseValue])
+        "extensions" -> extensions.asInstanceOf[ResponseValue]
       )
   }
 
   private def handleError(err: Any): JsValue =
     err match {
       case ce: CalibanError => toJson(ce)
-      case _                => Json.obj("message" -> JsString(err.toString))
+      case _                => Json.obj("message" -> err.toString)
     }
 
 }

--- a/core/src/main/scala/caliban/interop/play/play.scala
+++ b/core/src/main/scala/caliban/interop/play/play.scala
@@ -5,7 +5,7 @@ import caliban.schema.Step.QueryStep
 import caliban.schema.Types.makeScalar
 import caliban.schema.{ ArgBuilder, PureStep, Schema, Step }
 import caliban.{ InputValue, ResponseValue }
-import play.api.libs.json.{ JsValue, Reads, Writes }
+import play.api.libs.json.{ JsValue, Json, Reads, Writes }
 import zio.ZIO
 import zquery.ZQuery
 
@@ -41,5 +41,5 @@ object json {
       QueryStep(ZQuery.fromEffect(ZIO.fromEither(parse(value))).map(PureStep))
   }
   implicit val jsonArgBuilder: ArgBuilder[JsValue] = (input: InputValue) =>
-    Right(implicitly[Writes[InputValue]].writes(input))
+    Right(Json.toJson(input))
 }

--- a/core/src/main/scala/caliban/interop/play/play.scala
+++ b/core/src/main/scala/caliban/interop/play/play.scala
@@ -40,6 +40,5 @@ object json {
     override def resolve(value: JsValue): Step[Any] =
       QueryStep(ZQuery.fromEffect(ZIO.fromEither(parse(value))).map(PureStep))
   }
-  implicit val jsonArgBuilder: ArgBuilder[JsValue] = (input: InputValue) =>
-    Right(Json.toJson(input))
+  implicit val jsonArgBuilder: ArgBuilder[JsValue] = (input: InputValue) => Right(Json.toJson(input))
 }

--- a/core/src/main/scala/caliban/interop/play/play.scala
+++ b/core/src/main/scala/caliban/interop/play/play.scala
@@ -40,5 +40,6 @@ object json {
     override def resolve(value: JsValue): Step[Any] =
       QueryStep(ZQuery.fromEffect(ZIO.fromEither(parse(value))).map(PureStep))
   }
-  implicit val jsonArgBuilder: ArgBuilder[JsValue] = (input: InputValue) => Right(implicitly[Writes[InputValue]].writes(input))
+  implicit val jsonArgBuilder: ArgBuilder[JsValue] = (input: InputValue) =>
+    Right(implicitly[Writes[InputValue]].writes(input))
 }

--- a/core/src/main/scala/caliban/interop/play/play.scala
+++ b/core/src/main/scala/caliban/interop/play/play.scala
@@ -1,0 +1,44 @@
+package caliban.interop.play
+
+import caliban.introspection.adt.__Type
+import caliban.schema.Step.QueryStep
+import caliban.schema.Types.makeScalar
+import caliban.schema.{ ArgBuilder, PureStep, Schema, Step }
+import caliban.{ InputValue, ResponseValue }
+import play.api.libs.json.{ JsValue, Reads, Writes }
+import zio.ZIO
+import zquery.ZQuery
+
+/**
+ * This class is an implementation of the pattern described in https://blog.7mind.io/no-more-orphans.html
+ * It makes it possible to mark play-json dependency as optional and keep Writes defined in the companion object.
+ */
+private[caliban] trait IsPlayJsonWrites[F[_]]
+private[caliban] object IsPlayJsonWrites {
+  implicit val isPlayJsonWrites: IsPlayJsonWrites[Writes] = null
+}
+
+/**
+ * This class is an implementation of the pattern described in https://blog.7mind.io/no-more-orphans.html
+ * It makes it possible to mark play-json dependency as optional and keep Reads defined in the companion object.
+ */
+private[caliban] trait IsPlayJsonReads[F[_]]
+private[caliban] object IsPlayJsonReads {
+  implicit val isPlayJsonReads: IsPlayJsonReads[Reads] = null
+}
+
+object json {
+  implicit val jsonSchema: Schema[Any, JsValue] = new Schema[Any, JsValue] {
+    private def parse(value: JsValue) =
+      implicitly[Reads[ResponseValue]]
+        .reads(value)
+        .asEither
+        .left
+        .map(errs => new Throwable(s"Couldn't decode json: $errs"))
+
+    override def toType(isInput: Boolean): __Type = makeScalar("Json")
+    override def resolve(value: JsValue): Step[Any] =
+      QueryStep(ZQuery.fromEffect(ZIO.fromEither(parse(value))).map(PureStep))
+  }
+  implicit val jsonArgBuilder: ArgBuilder[JsValue] = (input: InputValue) => Right(implicitly[Writes[InputValue]].writes(input))
+}

--- a/core/src/test/scala/caliban/interop/circe/GraphQLRequestCirceSpec.scala
+++ b/core/src/test/scala/caliban/interop/circe/GraphQLRequestCirceSpec.scala
@@ -1,15 +1,16 @@
-package caliban
+package caliban.interop.circe
 
+import caliban.GraphQLRequest
 import io.circe._
 import zio.test.Assertion._
 import zio.test.environment.TestEnvironment
-import zio.test._
+import zio.test.{ test, _ }
 
-object GraphQLRequestSpec extends DefaultRunnableSpec {
+object GraphQLRequestCirceSpec extends DefaultRunnableSpec {
 
   override def spec: ZSpec[TestEnvironment, Any] =
-    suite("GraphQLRequestSpec")(
-      test("can be parsed from JSON") {
+    suite("GraphQLRequestCirceSpec")(
+      test("can be parsed from JSON by circe") {
         val request = Json
           .obj("query" -> Json.fromString("{}"), "operationName" -> Json.fromString("op"), "variables" -> Json.obj())
         assert(request.as[GraphQLRequest])(

--- a/core/src/test/scala/caliban/interop/circe/GraphQLResponseCirceSpec.scala
+++ b/core/src/test/scala/caliban/interop/circe/GraphQLResponseCirceSpec.scala
@@ -1,25 +1,26 @@
-package caliban
+package caliban.interop.circe
 
 import caliban.CalibanError.ExecutionError
+import caliban.GraphQLResponse
 import caliban.ResponseValue.ObjectValue
-import caliban.Value._
-import io.circe._
-import io.circe.syntax._
+import caliban.Value.StringValue
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestEnvironment
+import io.circe._
+import io.circe.syntax._
 
-object GraphQLResponseSpec extends DefaultRunnableSpec {
+object GraphQLResponseCirceSpec extends DefaultRunnableSpec {
 
   override def spec: ZSpec[TestEnvironment, Any] =
-    suite("GraphQLResponseSpec")(
-      test("can be converted to JSON") {
+    suite("GraphQLResponseCirceSpec")(
+      test("can be converted to JSON [circe]") {
         val response = GraphQLResponse(StringValue("data"), Nil)
         assert(response.asJson)(
           equalTo(Json.obj("data" -> Json.fromString("data")))
         )
       },
-      test("should include error objects for every error, including extensions") {
+      test("should include error objects for every error, including extensions [circe]") {
 
         val errorExtensions = List(
           ("errorCode", StringValue("TEST_ERROR")),
@@ -50,7 +51,7 @@ object GraphQLResponseSpec extends DefaultRunnableSpec {
           )
         )
       },
-      test("should not include errors element when there are none") {
+      test("should not include errors element when there are none [circe]") {
         val response = GraphQLResponse(
           StringValue("data"),
           List.empty

--- a/core/src/test/scala/caliban/interop/play/GraphQLRequestPlaySpec.scala
+++ b/core/src/test/scala/caliban/interop/play/GraphQLRequestPlaySpec.scala
@@ -1,0 +1,23 @@
+package caliban.interop.play
+
+import caliban.GraphQLRequest
+import zio.test.environment.TestEnvironment
+import zio.test.Assertion.{ equalTo, isRight }
+import zio.test._
+import play.api.libs.json._
+
+object GraphQLRequestPlaySpec extends DefaultRunnableSpec {
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("GraphQLRequestPlaySpec")(
+      test("can be parsed from JSON by play") {
+        val request = Json
+          .obj("query" -> JsString("{}"), "operationName" -> JsString("op"), "variables" -> Json.obj())
+        assert(request.validate[GraphQLRequest].asEither)(
+          isRight(
+            equalTo(GraphQLRequest(query = "{}", operationName = Some("op"), variables = Some(Map.empty)))
+          )
+        )
+      }
+    )
+}

--- a/core/src/test/scala/caliban/interop/play/GraphQLResponsePlaySpec.scala
+++ b/core/src/test/scala/caliban/interop/play/GraphQLResponsePlaySpec.scala
@@ -1,0 +1,69 @@
+package caliban.interop.play
+
+import caliban.CalibanError.ExecutionError
+import caliban.GraphQLResponse
+import caliban.ResponseValue.ObjectValue
+import caliban.Value.StringValue
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+import play.api.libs.json._
+
+object GraphQLResponsePlaySpec extends DefaultRunnableSpec {
+
+  val writer = implicitly[Writes[GraphQLResponse[Any]]]
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("GraphQLResponsePlaySpec")(
+      test("can be converted to JSON [play]") {
+        val response = GraphQLResponse(StringValue("data"), Nil)
+        assert(writer.writes(response))(
+          equalTo(Json.obj("data" -> JsString("data")))
+        )
+      },
+      test("should include error objects for every error, including extensions [play]") {
+        val errorExtensions = List(
+          ("errorCode", StringValue("TEST_ERROR")),
+          ("myCustomKey", StringValue("my-value"))
+        )
+
+        val response = GraphQLResponse(
+          StringValue("data"),
+          List(
+            ExecutionError(
+              "Resolution failed",
+              extensions = Some(ObjectValue(errorExtensions))
+            )
+          )
+        )
+
+        assert(writer.writes(response))(
+          equalTo(
+            Json.obj(
+              "data" -> JsString("data"),
+              "errors" -> Json.arr(
+                Json.obj(
+                  "message"    -> JsString("Resolution failed"),
+                  "extensions" -> Json.obj("errorCode" -> JsString("TEST_ERROR"), "myCustomKey" -> JsString("my-value"))
+                )
+              )
+            )
+          )
+        )
+      },
+      test("should not include errors element when there are none [play]") {
+        val response = GraphQLResponse(
+          StringValue("data"),
+          List.empty
+        )
+
+        assert(writer.writes(response))(
+          equalTo(
+            Json.obj(
+              "data" -> JsString("data")
+            )
+          )
+        )
+      }
+    )
+}

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import scala.concurrent.Future
 import caliban.introspection.adt.{ __DeprecatedArgs, __Type, __TypeKind }
+import play.api.libs.json.JsValue
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestEnvironment
@@ -42,9 +43,17 @@ object SchemaSpec extends DefaultRunnableSpec {
           isSome(hasField[__Type, String]("id", _.ofType.flatMap(_.name).get, equalTo("ID")))
         )
       },
-      test("field with Json object") {
+      test("field with Json object [circe]") {
         import caliban.interop.circe.json._
         case class Queries(to: io.circe.Json, from: io.circe.Json => Unit)
+
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+          isSome(hasField[__Type, String]("to", _.ofType.flatMap(_.name).get, equalTo("Json")))
+        )
+      },
+      test("field with Json object [play]") {
+        import caliban.interop.play.json._
+        case class Queries(to: JsValue, from: JsValue => Unit)
 
         assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
           isSome(hasField[__Type, String]("to", _.ofType.flatMap(_.name).get, equalTo("Json")))

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -29,6 +29,7 @@ The table below shows how common Scala types are converted to GraphQL types.
 | Future[A]                                           | Nullable A                                                       |
 | ZStream[R, E, A]                                    | A (subscription) or List of A (query, mutation)                  |
 | Json (from [Circe](https://github.com/circe/circe)) | Json (custom scalar, need `import caliban.interop.circe.json._`) |
+| Json (from [play-json](https://github.com/playframework/play-json)) | Json (custom scalar, need `import caliban.interop.play.json._`) |
 
 See the [Custom Types](#custom-types) section to find out how to support your own types.
 


### PR DESCRIPTION
This is a part of #143 - only play-json integration. 

It's done in a different way to #234 - there seems to be no objective reason to not be using optional dependency approach (as with circe).

As far as I understand, cross-building to different play versions (as done in #234) also has nothing to do with json - it's related to controllers api changes between play 2.7 and 2.8. Json sould work fine with either.

@yoohaemin, please let me know if you have any concerns with this implementation :)