### PR TITLE
Add a helper to make http4s middleware creation easier

### DIFF
--- a/examples/src/main/scala/caliban/http4s/AuthExampleApp.scala
+++ b/examples/src/main/scala/caliban/http4s/AuthExampleApp.scala
@@ -1,0 +1,67 @@
+package caliban.http4s
+
+import caliban.GraphQL._
+import caliban.schema.GenericSchema
+import caliban.{ Http4sAdapter, RootResolver }
+import org.http4s.dsl.Http4sDsl
+import org.http4s.implicits._
+import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.server.{ Router, ServiceErrorHandler }
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.HttpRoutes
+import zio._
+import zio.console.putStrLn
+import zio.interop.catz._
+import zio.interop.catz.implicits._
+
+object AuthExampleApp extends CatsApp {
+
+  // Simple service that returns the token coming from the request
+  type Auth = Has[Auth.Service]
+  object Auth {
+    trait Service {
+      def token: String
+    }
+  }
+  type AuthTask[A] = RIO[Auth, A]
+
+  case class MissingToken() extends Throwable
+
+  // http4s middleware that extracts a token from the request and eliminate the Auth layer dependency
+  object AuthMiddleware {
+    def apply(route: HttpRoutes[AuthTask]): HttpRoutes[Task] =
+      Http4sAdapter.provideLayerFromRequest(
+        route,
+        _.headers.get(CaseInsensitiveString("token")) match {
+          case Some(value) => ZLayer.succeed(new Auth.Service { override def token: String = value.value })
+          case None        => ZLayer.fail(MissingToken())
+        }
+      )
+  }
+
+  // http4s error handler to customize the response for our throwable
+  object dsl extends Http4sDsl[Task]
+  import dsl._
+  val errorHandler: ServiceErrorHandler[Task] = _ => { case MissingToken() => Forbidden() }
+
+  // our GraphQL API
+  val schema: GenericSchema[Auth] = new GenericSchema[Auth] {}
+  import schema._
+  case class Query(token: RIO[Auth, String])
+  private val resolver = RootResolver(Query(ZIO.access[Auth](_.get[Auth.Service].token)))
+  private val api      = graphQL(resolver)
+
+  override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] =
+    (for {
+      interpreter <- api.interpreter
+      route       = AuthMiddleware(Http4sAdapter.makeHttpService(interpreter))
+      _ <- BlazeServerBuilder[Task]
+            .withServiceErrorHandler(errorHandler)
+            .bindHttp(8088, "localhost")
+            .withHttpApp(Router[Task]("/api/graphql" -> route).orNotFound)
+            .resource
+            .toManaged
+            .useForever
+    } yield 0)
+      .catchAll(err => putStrLn(err.toString).as(1))
+}


### PR DESCRIPTION
Closes #309 

Added helper functions and a full example showing how to parse a request to extract a token and provide eliminate an `Auth` dependency.