### PR TITLE
Handle queue interruption properly in examples

### DIFF
--- a/examples/src/main/scala/caliban/ExampleService.scala
+++ b/examples/src/main/scala/caliban/ExampleService.scala
@@ -56,7 +56,7 @@ object ExampleService {
                     .offer(name)
                     .catchSomeCause {
                       case cause if cause.interrupted =>
-                        subscribers.update(_.filterNot(_ == queue)) *> UIO.succeed(false)
+                        subscribers.update(_.filterNot(_ == queue)).as(false)
                     } // if queue was shutdown, remove from subscribers
                 )
               )

--- a/examples/src/main/scala/caliban/ExampleService.scala
+++ b/examples/src/main/scala/caliban/ExampleService.scala
@@ -54,13 +54,15 @@ object ExampleService {
                 UIO.foreach(_)(queue =>
                   queue
                     .offer(name)
-                    .onInterrupt(
-                      subscribers.update(_.filterNot(_ == queue))
-                    ) // if queue was shutdown, remove from subscribers
+                    .catchSomeCause {
+                      case cause if cause.interrupted =>
+                        subscribers.update(_.filterNot(_ == queue)) *> UIO.succeed(false)
+                    } // if queue was shutdown, remove from subscribers
                 )
               )
             )
           )
+
       def deletedEvents: ZStream[Any, Nothing, String] = ZStream.unwrap {
         for {
           queue <- Queue.unbounded[String]

--- a/examples/src/main/scala/caliban/federation/CharacterService.scala
+++ b/examples/src/main/scala/caliban/federation/CharacterService.scala
@@ -61,7 +61,7 @@ object CharacterService {
                     .offer(name)
                     .catchSomeCause {
                       case cause if cause.interrupted =>
-                        subscribers.update(_.filterNot(_ == queue)) *> UIO.succeed(false)
+                        subscribers.update(_.filterNot(_ == queue)).as(false)
                     } // if queue was shutdown, remove from subscribers
                 )
               )


### PR DESCRIPTION
Hi! 
Current logic no propagate updates to subscribers in examples is 
```scala 
subscribers.get.flatMap(
    // add item to all subscribers
    UIO.foreach(_)(queue =>
        queue
            .offer(name)
            .onInterrupt(
                subscribers.update(_.filterNot(_ == queue))
             ) // if queue was shutdown, remove from subscribers
         )
    )
```
But when some queue is shutdown `foreach` gets interrupted and other subscribers don't receive an update.

I propose to use `catchSomeCause` to fallback on interruption and continue with `foreach` loop. 