### PR TITLE
Allow overriding the name of graphql query/operation name

### DIFF
--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -164,7 +164,7 @@ package object tapir {
 
   private def extractPath[I](endpointName: Option[String], input: EndpointInput[I]): String =
     endpointName
-      .flatMap(toCamel)
+      .map(replaceIllegalChars)
       .getOrElse(
         input
           .asVectorOfBasicInputs(includeAuth = false)
@@ -178,14 +178,8 @@ package object tapir {
         }
       )
 
-  private def toCamel(s: String): Option[String] =
-    s.replaceAll("\\W", "_")
-      .split("_")
-      .filterNot(_.isEmpty) match {
-      case Array(head, tail @ _*) =>
-        Some(head ++ tail.map(s => s"${s.head.toUpper}${s.tail.toLowerCase()}").mkString(""))
-      case _ => None
-    }
+  private def replaceIllegalChars(s: String): String =
+    s.replaceAll("\\W+", "_")
 
   private def extractArgNames[I](input: EndpointInput[I]): Map[String, Option[(String, Option[String])]] =
     input.traverseInputs {

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -181,10 +181,10 @@ package object tapir {
   private def toCamel(s: String): Option[String] =
     s.replaceAll("\\W", "_")
       .split("_")
-      .filterNot(_.isEmpty)
-      .map(s => s"${s.head.toUpper}${s.tail.toLowerCase()}") match {
-      case Array(head, tail @ _*) => Some((head.toLowerCase ++ tail).mkString(""))
-      case _                      => None
+      .filterNot(_.isEmpty) match {
+      case Array(head, tail @ _*) =>
+        Some(head ++ tail.map(s => s"${s.head.toUpper}${s.tail.toLowerCase()}").mkString(""))
+      case _ => None
     }
 
   private def extractArgNames[I](input: EndpointInput[I]): Map[String, Option[(String, Option[String])]] =

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -117,7 +117,7 @@ package object tapir {
           None,
           List(
             __Field(
-              extractPath(serverEndpoint.endpoint.input),
+              extractPath(serverEndpoint.endpoint.info.name, serverEndpoint.endpoint.input),
               serverEndpoint.endpoint.info.description,
               getArgs(inputSchema.toType(true), inputSchema.optional),
               () =>
@@ -132,7 +132,7 @@ package object tapir {
         Step.ObjectStep(
           name,
           Map(
-            extractPath(serverEndpoint.endpoint.input) ->
+            extractPath(serverEndpoint.endpoint.info.name, serverEndpoint.endpoint.input) ->
               FunctionStep { args =>
                 val replacedArgs = args.map { case (k, v) => reverseArgNames.getOrElse(k, k) -> v }
                 QueryStep(
@@ -162,17 +162,19 @@ package object tapir {
     override protected val additionalDirectives: List[__Directive] = Nil
   }
 
-  private def extractPath[I](input: EndpointInput[I]): String =
-    input
-      .asVectorOfBasicInputs(includeAuth = false)
-      .collect {
-        case EndpointInput.FixedPath(s, _, _) => s
+  private def extractPath[I](endpointName: Option[String], input: EndpointInput[I]): String =
+    endpointName.getOrElse(
+      input
+        .asVectorOfBasicInputs(includeAuth = false)
+        .collect {
+          case EndpointInput.FixedPath(s, _, _) => s
+        }
+        .toList match {
+        case Nil          => "root"
+        case head :: Nil  => head
+        case head :: tail => head ++ tail.map(_.capitalize).mkString
       }
-      .toList match {
-      case Nil          => "root"
-      case head :: Nil  => head
-      case head :: tail => head ++ tail.map(_.capitalize).mkString
-    }
+    )
 
   private def extractArgNames[I](input: EndpointInput[I]): Map[String, Option[(String, Option[String])]] =
     input.traverseInputs {

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -181,7 +181,8 @@ package object tapir {
   private def toCamel(s: String): Option[String] =
     s.replaceAll("\\W", "_")
       .split("_")
-      .filterNot(_.isEmpty) match {
+      .filterNot(_.isEmpty)
+      .map(s => s"${s.head.toUpper}${s.tail.toLowerCase()}") match {
       case Array(head, tail @ _*) => Some((head.toLowerCase ++ tail).mkString(""))
       case _                      => None
     }

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
@@ -56,11 +56,11 @@ object TapirSpec extends DefaultRunnableSpec {
         val interpreter = api.interpreter
         val query       = gqldoc("""
             query test {
-              overRideWithIllegalChars(title: "Title", X_Auth_Token: "token")
+              overRide_with_IllEgal_ChaRs_(title: "Title", X_Auth_Token: "token")
             }""")
 
         assertM(interpreter.flatMap(_.execute(query)).map(_.data.toString))(
-          equalTo("""{"overRideWithIllegalChars":"Title+token"}""")
+          equalTo("""{"overRide_with_IllEgal_ChaRs_":"Title+token"}""")
         )
       }
     )

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
@@ -48,6 +48,20 @@ object TapirSpec extends DefaultRunnableSpec {
         assertM(interpreter.flatMap(_.execute(query)).map(_.data.toString))(
           equalTo("""{"book":"Title+token"}""")
         )
+      },
+      testM("test override operation name") {
+        val api = getBook
+          .name("override")
+          .toGraphQLQuery({ case (title, token) => ZQuery.succeed(s"$title+$token") })
+        val interpreter = api.interpreter
+        val query       = gqldoc("""
+            query test {
+              override(title: "Title", X_Auth_Token: "token")
+            }""")
+
+        assertM(interpreter.flatMap(_.execute(query)).map(_.data.toString))(
+          equalTo("""{"override":"Title+token"}""")
+        )
       }
     )
 }

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
@@ -51,7 +51,7 @@ object TapirSpec extends DefaultRunnableSpec {
       },
       testM("test override operation name") {
         val api = getBook
-          .name("override")
+          .name("override with IllEgal-ChaRs !@()[]/,>")
           .toGraphQLQuery({ case (title, token) => ZQuery.succeed(s"$title+$token") })
         val interpreter = api.interpreter
         val query       = gqldoc("""
@@ -60,7 +60,7 @@ object TapirSpec extends DefaultRunnableSpec {
             }""")
 
         assertM(interpreter.flatMap(_.execute(query)).map(_.data.toString))(
-          equalTo("""{"override":"Title+token"}""")
+          equalTo("""{"overrideWithIllegalChars":"Title+token"}""")
         )
       }
     )

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
@@ -56,7 +56,7 @@ object TapirSpec extends DefaultRunnableSpec {
         val interpreter = api.interpreter
         val query       = gqldoc("""
             query test {
-              override(title: "Title", X_Auth_Token: "token")
+              overrideWithIllegalChars(title: "Title", X_Auth_Token: "token")
             }""")
 
         assertM(interpreter.flatMap(_.execute(query)).map(_.data.toString))(

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirSpec.scala
@@ -51,16 +51,16 @@ object TapirSpec extends DefaultRunnableSpec {
       },
       testM("test override operation name") {
         val api = getBook
-          .name("override with IllEgal-ChaRs !@()[]/,>")
+          .name("overRide with IllEgal-ChaRs !@()[]/,>")
           .toGraphQLQuery({ case (title, token) => ZQuery.succeed(s"$title+$token") })
         val interpreter = api.interpreter
         val query       = gqldoc("""
             query test {
-              overrideWithIllegalChars(title: "Title", X_Auth_Token: "token")
+              overRideWithIllegalChars(title: "Title", X_Auth_Token: "token")
             }""")
 
         assertM(interpreter.flatMap(_.execute(query)).map(_.data.toString))(
-          equalTo("""{"overrideWithIllegalChars":"Title+token"}""")
+          equalTo("""{"overRideWithIllegalChars":"Title+token"}""")
         )
       }
     )

--- a/vuepress/docs/docs/interop.md
+++ b/vuepress/docs/docs/interop.md
@@ -143,3 +143,14 @@ val api: GraphQL[Any] = addBookEndpoint.toGraphQL
 ```
 
 You can find a [full example](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/caliban/tapir) on github.
+
+### GraphQL restrictions
+
+[GraphQL spec](https://spec.graphql.org/June2018/#sec-Operation-Name-Uniqueness) requires unique naming for all operations.
+
+To customize the [name](https://github.com/softwaremill/tapir/blob/master/core/src/main/scala/sttp/tapir/Endpoint.scala#L287) of an operation use `EndpointInfo.name`
+
+```scala
+endpoint
+  .name("overrideName")
+``` 


### PR DESCRIPTION
by using endpoint.info.name if it exists

Problem: Having more than one operation with the same name
doesn't play well with graphiql and conflicts with caliban execution

#374 
Issue: https://github.com/ghostdogpr/caliban/issues/374