### PR TITLE
move codegen console output into sbt module

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CodegenPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CodegenPlugin.scala
@@ -62,7 +62,12 @@ object CodegenPlugin extends AutoPlugin {
     writer: (Document, String, Option[String]) => String
   ): RIO[Console, Unit] =
     Options.fromArgs(args) match {
-      case Some(arguments) => Codegen.generate(arguments, writer)
-      case None            => putStrLn(helpMsg)
+      case Some(arguments) =>
+        for {
+          _ <- putStrLn(s"Generating code for ${arguments.schemaPath}")
+          _ <- Codegen.generate(arguments, writer)
+          _ <- putStrLn(s"Code generation done")
+        } yield ()
+      case None => putStrLn(helpMsg)
     }
 }

--- a/codegen/src/main/scala/caliban/codegen/Codegen.scala
+++ b/codegen/src/main/scala/caliban/codegen/Codegen.scala
@@ -1,7 +1,7 @@
 package caliban.codegen
 
 import java.io.{ File, PrintWriter }
-import zio.{ RIO, Task, UIO }
+import zio.{ Task, UIO }
 import caliban.parsing.adt.Document
 import caliban.parsing.Parser
 
@@ -9,7 +9,7 @@ object Codegen {
   def generate(
     arguments: Options,
     writer: (Document, String, Option[String]) => String
-  ): RIO[Any, Unit] = {
+  ): Task[Unit] = {
     val s           = ".*/scala/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
     val packageName = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
     val objectName  = s.map(_.group(2)).getOrElse("Client")

--- a/codegen/src/main/scala/caliban/codegen/Codegen.scala
+++ b/codegen/src/main/scala/caliban/codegen/Codegen.scala
@@ -2,7 +2,6 @@ package caliban.codegen
 
 import java.io.{ File, PrintWriter }
 import zio.{ RIO, Task, UIO }
-import zio.console.{ putStrLn, Console }
 import caliban.parsing.adt.Document
 import caliban.parsing.Parser
 
@@ -10,19 +9,18 @@ object Codegen {
   def generate(
     arguments: Options,
     writer: (Document, String, Option[String]) => String
-  ): RIO[Console, Unit] =
+  ): RIO[Any, Unit] = {
+    val s           = ".*/scala/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
+    val packageName = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
+    val objectName  = s.map(_.group(2)).getOrElse("Client")
     for {
-      _           <- putStrLn(s"Generating code for ${arguments.schemaPath}")
-      s           = ".*/scala/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
-      packageName = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
-      objectName  = s.map(_.group(2)).getOrElse("Client")
-      schema      <- getSchema(arguments.schemaPath, arguments.headers)
-      code        = writer(schema, objectName, packageName)
-      formatted   <- Formatter.format(code, arguments.fmtPath)
+      schema    <- getSchema(arguments.schemaPath, arguments.headers)
+      code      = writer(schema, objectName, packageName)
+      formatted <- Formatter.format(code, arguments.fmtPath)
       _ <- Task(new PrintWriter(new File(arguments.toPath)))
             .bracket(q => UIO(q.close()), pw => Task(pw.println(formatted)))
-      _ <- putStrLn(s"Code generation done")
     } yield ()
+  }
 
   private def getSchema(path: String, schemaPathHeaders: Option[List[Options.Header]]): Task[Document] =
     if (path.startsWith("http")) {


### PR DESCRIPTION
This moves the output that the codegen process writes to stdout into the sbt plugin, in order to let other build tools consuming the core codegen module to decide control what and whether output is printed.