### PR TITLE
handle missing nullable variables

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -160,7 +160,7 @@ object Executor {
           lazy val defaultInputValue = (for {
             definition <- variableDefinitions.find(_.name == name)
             inputValue <- definition.defaultValue
-          } yield inputValue) getOrElse value
+          } yield inputValue) getOrElse NullValue
           variableValues.getOrElse(name, defaultInputValue)
         case value: Value => value
       }


### PR DESCRIPTION
Clients are currently required to pass an explicit "null" value for optional variables, and the error that is received when they don't is a bit leaky, mentioning an internal variable wrapper type: `Can't build a String from input VariableValue`. This falls back to a NullValue instead, which allows not sending null variables to the server, and results in the slightly improved error message of `Can't build a String from input null` for missing required variables. Perhaps that can also be improved to include the missing variable name.