### PR TITLE
Add --effect option to codegen

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CodegenPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CodegenPlugin.scala
@@ -11,7 +11,7 @@ object CodegenPlugin extends AutoPlugin {
   lazy val genSchemaCommand         = genCommand("calibanGenSchema", genSchemaHelpMsg, SchemaWriter.write)
   lazy val genClientCommand         = genCommand("calibanGenClient", genClientHelpMsg, ClientWriter.write)
 
-  def genCommand(name: String, helpMsg: String, writer: (Document, String, Option[String]) => String): Command =
+  def genCommand(name: String, helpMsg: String, writer: (Document, String, Option[String], String) => String): Command =
     Command.args(name, helpMsg) { (state: State, args: Seq[String]) =>
       Runtime.default.unsafeRun(
         execGenCommand(helpMsg, args.toList, writer)
@@ -59,7 +59,7 @@ object CodegenPlugin extends AutoPlugin {
   def execGenCommand(
     helpMsg: String,
     args: List[String],
-    writer: (Document, String, Option[String]) => String
+    writer: (Document, String, Option[String], String) => String
   ): RIO[Console, Unit] =
     Options.fromArgs(args) match {
       case Some(arguments) =>

--- a/codegen/src/main/scala/caliban/codegen/ClientWriter.scala
+++ b/codegen/src/main/scala/caliban/codegen/ClientWriter.scala
@@ -9,7 +9,12 @@ import caliban.parsing.adt.{ Document, Type }
 
 object ClientWriter {
 
-  def write(schema: Document, objectName: String = "Client", packageName: Option[String] = None): String = {
+  def write(
+    schema: Document,
+    objectName: String = "Client",
+    packageName: Option[String] = None,
+    effect: String = "zio.UIO"
+  ): String = {
     val schemaDef = Document.schemaDefinitions(schema).headOption
 
     val typesMap: Map[String, TypeDefinition] = schema.definitions.collect {

--- a/codegen/src/main/scala/caliban/codegen/Codegen.scala
+++ b/codegen/src/main/scala/caliban/codegen/Codegen.scala
@@ -8,14 +8,15 @@ import caliban.parsing.Parser
 object Codegen {
   def generate(
     arguments: Options,
-    writer: (Document, String, Option[String]) => String
+    writer: (Document, String, Option[String], String) => String
   ): Task[Unit] = {
     val s           = ".*/scala/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
     val packageName = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
     val objectName  = s.map(_.group(2)).getOrElse("Client")
+    val effect      = arguments.effect.getOrElse("zio.UIO")
     for {
       schema    <- getSchema(arguments.schemaPath, arguments.headers)
-      code      = writer(schema, objectName, packageName)
+      code      = writer(schema, objectName, packageName, effect)
       formatted <- Formatter.format(code, arguments.fmtPath)
       _ <- Task(new PrintWriter(new File(arguments.toPath)))
             .bracket(q => UIO(q.close()), pw => Task(pw.println(formatted)))

--- a/codegen/src/main/scala/caliban/codegen/Options.scala
+++ b/codegen/src/main/scala/caliban/codegen/Options.scala
@@ -8,12 +8,18 @@ final case class Options(
   toPath: String,
   fmtPath: Option[String],
   headers: Option[List[Options.Header]],
-  packageName: Option[String]
+  packageName: Option[String],
+  effect: Option[String]
 )
 
 object Options {
   final case class Header(name: String, value: String)
-  final case class RawOptions(scalafmtPath: Option[String], headers: Option[List[String]], packageName: Option[String])
+  final case class RawOptions(
+    scalafmtPath: Option[String],
+    headers: Option[List[String]],
+    packageName: Option[String],
+    effect: Option[String]
+  )
 
   def fromArgs(args: List[String]): Option[Options] =
     args match {
@@ -39,7 +45,8 @@ object Options {
                 }
               }
             },
-            rawOpts.packageName
+            rawOpts.packageName,
+            rawOpts.effect
           )
         }
       case _ => None

--- a/codegen/src/test/scala/caliban/codegen/OptionsSpec.scala
+++ b/codegen/src/test/scala/caliban/codegen/OptionsSpec.scala
@@ -19,6 +19,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 "output",
                 Some("fmtPath"),
                 Some(List(Header("header1", "value1"), Header("header2", "value2"))),
+                None,
                 None
               )
             )
@@ -36,6 +37,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 "output",
                 Some("fmtPath"),
                 Some(List(Header("header1", "value1"), Header("header2", "value2"))),
+                None,
                 None
               )
             )
@@ -48,7 +50,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         assert(result)(
           equalTo(
             Some(
-              Options("schema", "output", None, None, None)
+              Options("schema", "output", None, None, None, None)
             )
           )
         )
@@ -78,7 +80,26 @@ object OptionsSpec extends DefaultRunnableSpec {
                 "output",
                 None,
                 None,
-                Some("com.github.ghostdogpr")
+                Some("com.github.ghostdogpr"),
+                None
+              )
+            )
+          )
+        )
+      },
+      test("provide effect") {
+        val input  = List("schema", "output", "--effect", "cats.effect.IO")
+        val result = Options.fromArgs(input)
+        assert(result)(
+          equalTo(
+            Some(
+              Options(
+                "schema",
+                "output",
+                None,
+                None,
+                None,
+                Some("cats.effect.IO")
               )
             )
           )

--- a/codegen/src/test/scala/caliban/codegen/SchemaWriterSpec.scala
+++ b/codegen/src/test/scala/caliban/codegen/SchemaWriterSpec.scala
@@ -68,7 +68,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
           .map { doc =>
             Document
               .objectTypeDefinition(doc, "Query")
-              .map(SchemaWriter.writeRootQueryOrMutationDef)
+              .map(SchemaWriter.writeRootQueryOrMutationDef(_, "zio.UIO"))
               .mkString("\n")
           }
 
@@ -76,8 +76,8 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
           equalTo(
             """
 case class Query(
-user: UserArgs => Option[User],
-userList: () => List[Option[User]]
+user: UserArgs => zio.UIO[Option[User]],
+userList: zio.UIO[List[Option[User]]]
 )""".stripMargin
           )
         )
@@ -94,7 +94,7 @@ userList: () => List[Option[User]]
           .map { doc =>
             Document
               .objectTypeDefinition(doc, "Mutation")
-              .map(SchemaWriter.writeRootQueryOrMutationDef)
+              .map(SchemaWriter.writeRootQueryOrMutationDef(_, "zio.UIO"))
               .mkString("\n")
           }
 
@@ -102,7 +102,7 @@ userList: () => List[Option[User]]
           equalTo(
             """
               |case class Mutation(
-              |setMessage: SetMessageArgs => Option[String]
+              |setMessage: SetMessageArgs => zio.UIO[Option[String]]
               |)""".stripMargin
           )
         )
@@ -166,15 +166,15 @@ userList: () => List[Option[User]]
               |object Operations {
               |
               |  case class Query(
-              |    posts: () => Option[List[Option[Post]]]
+              |    posts: zio.UIO[Option[List[Option[Post]]]]
               |  )
               |
               |  case class Mutation(
-              |    addPost: AddPostArgs => Option[Post]
+              |    addPost: AddPostArgs => zio.UIO[Option[Post]]
               |  )
               |
               |  case class Subscription(
-              |    postAdded: () => ZStream[Any, Nothing, Option[Post]]
+              |    postAdded: ZStream[Any, Nothing, Option[Post]]
               |  )
               |
               |}
@@ -266,7 +266,7 @@ object Types {
             """object Operations {
 
   case class Queries(
-    characters: () => Int
+    characters: zio.UIO[Int]
   )
 
 }

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -205,7 +205,7 @@ enablePlugins(CodegenPlugin)
 ```
 Then call the `calibanGenSchema` sbt command.
 ```scala
-calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2]
+calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect]
 
 calibanGenSchema project/schema.graphql src/main/MyAPI.scala
 ```
@@ -215,7 +215,8 @@ The generated code will be formatted with Scalafmt using the configuration defin
 If you provide a URL for `schemaPath`, you can provide request headers with `--headers` option.
 The package of the generated code is derived from the folder of `outputPath`.
 This can be overridden by providing an alternative package with the `--packageName`
-option.
+option. By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. 
+This can be overridden by providing an alternative effect with the `--effect` option.
 
 ::: warning Unsupported features
 Some features are not supported by Caliban and will cause an error during code generation:


### PR DESCRIPTION
In order not to rely only on synchronous code execution, it can be useful to inject a specific effect type in order to integrate well with existing codebase