### PR TITLE
Make the schema type of a ZStream a List

### DIFF
--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -297,7 +297,10 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   ): Schema[R, ZStream[R1, E, A]] =
     new Schema[R, ZStream[R1, E, A]] {
       override def optional: Boolean                          = ev.optional
-      override def toType(isInput: Boolean = false): __Type   = ev.toType(isInput)
+      override def toType(isInput: Boolean = false): __Type   = {
+        val t = ev.toType(isInput)
+        makeList(if (ev.optional) t else makeNonNull(t))
+      }
       override def resolve(value: ZStream[R1, E, A]): Step[R] = StreamStep(value.map(ev.resolve))
     }
 


### PR DESCRIPTION
Hi.

Given this Queries object:
```scala
case class Queries(
      @GQLDescription("return all images")
      images: ImagesArgs => ZStream[ExampleService, Throwable, Image]
  )
```
The introspection would return this piece of information:
```json
{
            "name": "images",
            "description": "return all images",
            "args": [
               ...
            ],
            "type": {
              "kind": "NON_NULL",
              "name": null,
              "ofType": { "kind": "OBJECT", "name": "Image", "ofType": null }
            },
            "isDeprecated": false,
            "deprecationReason": null
          }
```
which, AFAIU, means that it returns a single `Image`, but the stream emits multiple images of course.