### PR TITLE
fix link of caliban-http4s on Getting Started(vuepress document).

### DIFF
--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -119,7 +119,7 @@ A `CalibanError` can be:
 - a `ValidationError`: the query was parsed but does not match the schema
 - an `ExecutionError`: an error happened while executing the query
 
-Caliban itself is not tied to any web framework, you are free to expose this function using the protocol and library of your choice. The [caliban-http4s](https://github.com/ghostdogpr/caliban/tree/master/http4s) module provides an `Http4sAdapter` that exposes an interpreter over HTTP and WebSocket using http4s. There are also similar adapters for Akka HTTP, Play, Finch and uzhttp.
+Caliban itself is not tied to any web framework, you are free to expose this function using the protocol and library of your choice. The [caliban-http4s](https://github.com/ghostdogpr/caliban/tree/master/adapters/http4s) module provides an `Http4sAdapter` that exposes an interpreter over HTTP and WebSocket using http4s. There are also similar adapters for Akka HTTP, Play, Finch and uzhttp.
 
 ::: tip Combining GraphQL APIs
 You don't have to define all your root fields into a single case class: you can use smaller case classes and combine `GraphQL` objects using the `|+|` operator.


### PR DESCRIPTION
Thank you for creating and enhancing caliban, which is great library.
I become a fan of this.

I  read the `Documentation`, then I found a link of  caliban-http4s.
The file path was changed by 049d024.
