### PR TITLE
Performance improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -294,8 +294,8 @@ lazy val benchmarks = project
   .enablePlugins(JmhPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "org.sangria-graphql" %% "sangria"       % "1.4.2",
-      "org.sangria-graphql" %% "sangria-circe" % "1.2.1"
+      "org.sangria-graphql" %% "sangria"       % "2.0.0",
+      "org.sangria-graphql" %% "sangria-circe" % "1.3.0"
     )
   )
 

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -201,10 +201,10 @@ object GraphQL {
     subscriptionSchema: Schema[R, S]
   ): GraphQL[R] = new GraphQL[R] {
     val schemaBuilder: RootSchemaBuilder[R] = RootSchemaBuilder(
-      resolver.queryResolver.map(r => Operation(querySchema.toType(), querySchema.resolve(r))),
-      resolver.mutationResolver.map(r => Operation(mutationSchema.toType(), mutationSchema.resolve(r))),
+      resolver.queryResolver.map(r => Operation(querySchema.asType(), querySchema.resolve(r))),
+      resolver.mutationResolver.map(r => Operation(mutationSchema.asType(), mutationSchema.resolve(r))),
       resolver.subscriptionResolver.map(r =>
-        Operation(subscriptionSchema.toType(isSubscription = true), subscriptionSchema.resolve(r))
+        Operation(subscriptionSchema.asType(isSubscription = true), subscriptionSchema.resolve(r))
       )
     )
     val wrappers: List[Wrapper[R]]              = Nil

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -201,10 +201,10 @@ object GraphQL {
     subscriptionSchema: Schema[R, S]
   ): GraphQL[R] = new GraphQL[R] {
     val schemaBuilder: RootSchemaBuilder[R] = RootSchemaBuilder(
-      resolver.queryResolver.map(r => Operation(querySchema.asType(), querySchema.resolve(r))),
-      resolver.mutationResolver.map(r => Operation(mutationSchema.asType(), mutationSchema.resolve(r))),
+      resolver.queryResolver.map(r => Operation(querySchema.toType_(), querySchema.resolve(r))),
+      resolver.mutationResolver.map(r => Operation(mutationSchema.toType_(), mutationSchema.resolve(r))),
       resolver.subscriptionResolver.map(r =>
-        Operation(subscriptionSchema.asType(isSubscription = true), subscriptionSchema.resolve(r))
+        Operation(subscriptionSchema.toType_(isSubscription = true), subscriptionSchema.resolve(r))
       )
     )
     val wrappers: List[Wrapper[R]]              = Nil

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -183,8 +183,6 @@ object Executor {
     val array = ArrayBuffer.empty[Field]
     val map   = collection.mutable.Map.empty[String, Int]
 
-    val reusedFieldBuilder: ArrayBuffer[Field] = ArrayBuffer.empty[Field]
-
     field.fields.foreach { field =>
       if (field.condition.forall(_ == typeName)) {
         val name = field.alias.getOrElse(field.name)
@@ -195,10 +193,7 @@ object Executor {
           case Some(index) =>
             // field already existed, merge it
             val f = array(index)
-            reusedFieldBuilder ++= f.fields
-            reusedFieldBuilder ++= field.fields
-            array(index) = f.copy(fields = reusedFieldBuilder.toList)
-            reusedFieldBuilder.clear()
+            array(index) = f.copy(fields = f.fields ::: field.fields)
         }
       }
     }

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -17,9 +17,11 @@ case class Field(
   fields: List[Field] = Nil,
   conditionalFields: Map[String, List[Field]] = Map(),
   arguments: Map[String, InputValue] = Map(),
-  locationInfo: LocationInfo = LocationInfo.origin,
+  _locationInfo: () => LocationInfo = () => LocationInfo.origin,
   directives: List[Directive] = List.empty
-)
+) {
+  lazy val locationInfo: LocationInfo = _locationInfo()
+}
 
 object Field {
   def apply(
@@ -56,7 +58,7 @@ object Field {
                 field.fields,
                 field.conditionalFields,
                 arguments,
-                sourceMapper.getLocation(index),
+                () => sourceMapper.getLocation(index),
                 directives ++ schemaDirectives
               )
             ),

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -15,7 +15,7 @@ case class Field(
   parentType: Option[__Type],
   alias: Option[String] = None,
   fields: List[Field] = Nil,
-  conditionalFields: Map[String, List[Field]] = Map(),
+  condition: Option[String] = None,
   arguments: Map[String, InputValue] = Map(),
   _locationInfo: () => LocationInfo = () => LocationInfo.origin,
   directives: List[Directive] = List.empty
@@ -34,8 +34,9 @@ object Field {
   ): Field = {
 
     def loop(selectionSet: List[Selection], fieldType: __Type): Field = {
+      val fieldList = List.newBuilder[Field]
       val innerType = Types.innerType(fieldType)
-      val (fields, cFields) = selectionSet.map {
+      selectionSet.foreach {
         case F(alias, name, arguments, directives, selectionSet, index)
             if checkDirectives(directives, variableValues) =>
           val selected = innerType
@@ -44,35 +45,28 @@ object Field {
 
           val schemaDirectives = selected.flatMap(_.directives).getOrElse(Nil)
 
-          val t = selected
-            .fold(Types.string)(_.`type`()) // default only case where it's not found is __typename
+          val t = selected.fold(Types.string)(_.`type`()) // default only case where it's not found is __typename
 
           val field = loop(selectionSet, t)
-          (
-            List(
-              Field(
-                name,
-                t,
-                Some(innerType),
-                alias,
-                field.fields,
-                field.conditionalFields,
-                arguments,
-                () => sourceMapper.getLocation(index),
-                directives ++ schemaDirectives
-              )
-            ),
-            Map.empty[String, List[Field]]
-          )
+          fieldList +=
+            Field(
+              name,
+              t,
+              Some(innerType),
+              alias,
+              field.fields,
+              None,
+              arguments,
+              () => sourceMapper.getLocation(index),
+              directives ++ schemaDirectives
+            )
         case FragmentSpread(name, directives) if checkDirectives(directives, variableValues) =>
-          lazy val default = (Nil, Map.empty[String, List[Field]])
           fragments
             .get(name)
-            .fold(default) { f =>
+            .foreach { f =>
               val t =
                 innerType.possibleTypes.flatMap(_.find(_.name.contains(f.typeCondition.name))).getOrElse(fieldType)
-              val field = loop(f.selectionSet, t)
-              (Nil, combineMaps(List(field.conditionalFields, Map(f.typeCondition.name -> field.fields))))
+              fieldList ++= loop(f.selectionSet, t).fields.map(_.copy(condition = Some(f.typeCondition.name)))
             }
         case InlineFragment(typeCondition, directives, selectionSet) if checkDirectives(directives, variableValues) =>
           val t = innerType.possibleTypes
@@ -80,22 +74,16 @@ object Field {
             .getOrElse(fieldType)
           val field = loop(selectionSet, t)
           typeCondition match {
-            case None           => (field.fields, field.conditionalFields)
-            case Some(typeName) => (Nil, combineMaps(List(field.conditionalFields, Map(typeName.name -> field.fields))))
+            case None           => fieldList ++= field.fields
+            case Some(typeName) => fieldList ++= field.fields.map(_.copy(condition = Some(typeName.name)))
           }
-        case _ => (Nil, Map.empty[String, List[Field]])
-      }.unzip
-      Field("", fieldType, None, fields = fields.flatten, conditionalFields = combineMaps(cFields))
+        case _ =>
+      }
+      Field("", fieldType, None, fields = fieldList.result())
     }
 
     loop(selectionSet, fieldType)
   }
-
-  private def combineMaps[A, B](maps: List[Map[A, List[B]]]): Map[A, List[B]] =
-    maps.foldLeft(Map.empty[A, List[B]]) {
-      case (result, map) =>
-        map.foldLeft(result) { case (result, (k, v)) => result.updated(k, result.getOrElse(k, Nil) ++ v) }
-    }
 
   private def checkDirectives(directives: List[Directive], variableValues: Map[String, InputValue]): Boolean =
     !checkDirective("skip", default = false, directives, variableValues) &&

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -45,7 +45,7 @@ object Introspector {
       args => types.find(_.name.contains(args.name)).get
     )
     val introspectionSchema = Schema.gen[__Introspection]
-    RootSchema(Operation(introspectionSchema.toType(), introspectionSchema.resolve(resolver)), None, None)
+    RootSchema(Operation(introspectionSchema.asType(), introspectionSchema.resolve(resolver)), None, None)
   }
 
   private[caliban] def isIntrospection(document: Document): Boolean =

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -45,7 +45,7 @@ object Introspector {
       args => types.find(_.name.contains(args.name)).get
     )
     val introspectionSchema = Schema.gen[__Introspection]
-    RootSchema(Operation(introspectionSchema.asType(), introspectionSchema.resolve(resolver)), None, None)
+    RootSchema(Operation(introspectionSchema.toType_(), introspectionSchema.resolve(resolver)), None, None)
   }
 
   private[caliban] def isIntrospection(document: Document): Boolean =

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -39,14 +39,23 @@ trait Schema[-R, T] { self =>
   private lazy val asInputType: __Type        = toType(isInput = true)
   private lazy val asSubscriptionType: __Type = toType(isSubscription = true)
 
-  def asType(isInput: Boolean = false, isSubscription: Boolean = false): __Type =
+  /**
+   * Generates a GraphQL type object from `T`.
+   * Unlike `toType`, this function is optimized and will not re-generate the type at each call.
+   * @param isInput indicates if the type is passed as an argument. This is needed because GraphQL differentiates `InputType` from `ObjectType`.
+   * @param isSubscription indicates if the type is used in a subscription operation.
+   *                       For example, ZStream gives a different GraphQL type depending whether it is used in a subscription or elsewhere.
+   */
+  final def toType_(isInput: Boolean = false, isSubscription: Boolean = false): __Type =
     if (isInput) asInputType else if (isSubscription) asSubscriptionType else asType
 
   /**
    * Generates a GraphQL type object from `T`.
    * @param isInput indicates if the type is passed as an argument. This is needed because GraphQL differentiates `InputType` from `ObjectType`.
+   * @param isSubscription indicates if the type is used in a subscription operation.
+   *                       For example, ZStream gives a different GraphQL type depending whether it is used in a subscription or elsewhere.
    */
-  def toType(isInput: Boolean = false, isSubscription: Boolean = false): __Type
+  protected[this] def toType(isInput: Boolean = false, isSubscription: Boolean = false): __Type
 
   /**
    * Resolves `T` by turning a value of type `T` into an execution step that describes how to resolve the value.
@@ -71,7 +80,7 @@ trait Schema[-R, T] { self =>
   def contramap[A](f: A => T): Schema[R, A] = new Schema[R, A] {
     override def optional: Boolean                                         = self.optional
     override def arguments: List[__InputValue]                             = self.arguments
-    override def toType(isInput: Boolean, isSubscription: Boolean): __Type = self.asType(isInput, isSubscription)
+    override def toType(isInput: Boolean, isSubscription: Boolean): __Type = self.toType_(isInput, isSubscription)
     override def resolve(value: A): Step[R]                                = self.resolve(f(value))
   }
 }
@@ -130,7 +139,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
 
   implicit def optionSchema[A](implicit ev: Schema[R, A]): Schema[R, Option[A]] = new Schema[R, Option[A]] {
     override def optional: Boolean                                         = true
-    override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.asType(isInput, isSubscription)
+    override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
 
     override def resolve(value: Option[A]): Step[R] =
       value match {
@@ -140,7 +149,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   }
   implicit def listSchema[A](implicit ev: Schema[R, A]): Schema[R, List[A]] = new Schema[R, List[A]] {
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
-      val t = ev.asType(isInput, isSubscription)
+      val t = ev.toType_(isInput, isSubscription)
       makeList(if (ev.optional) t else makeNonNull(t))
     }
 
@@ -153,7 +162,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   implicit def functionUnitSchema[A](implicit ev: Schema[R, A]): Schema[R, () => A] =
     new Schema[R, () => A] {
       override def optional: Boolean                                         = ev.optional
-      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.asType(isInput, isSubscription)
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: () => A): Step[R]                          = FunctionStep(_ => ev.resolve(value()))
     }
 
@@ -161,8 +170,8 @@ trait GenericSchema[R] extends DerivationSchema[R] {
     implicit evA: Schema[RA, A],
     evB: Schema[RB, B]
   ): Schema[RA with RB, Either[A, B]] = {
-    lazy val typeAName: String   = Types.name(evA.asType())
-    lazy val typeBName: String   = Types.name(evB.asType())
+    lazy val typeAName: String   = Types.name(evA.toType_())
+    lazy val typeBName: String   = Types.name(evB.toType_())
     lazy val name: String        = s"Either${typeAName}Or$typeBName"
     lazy val description: String = s"Either $typeAName or $typeBName"
 
@@ -171,11 +180,11 @@ trait GenericSchema[R] extends DerivationSchema[R] {
       Some(description),
       (isInput, isSubscription) =>
         List(
-          __Field("left", Some("Left element of the Either"), Nil, () => evA.asType(isInput, isSubscription)) -> {
+          __Field("left", Some("Left element of the Either"), Nil, () => evA.toType_(isInput, isSubscription)) -> {
             case Left(value) => evA.resolve(value)
             case Right(_)    => NullStep
           },
-          __Field("right", Some("Right element of the Either"), Nil, () => evB.asType(isInput, isSubscription)) -> {
+          __Field("right", Some("Right element of the Either"), Nil, () => evB.toType_(isInput, isSubscription)) -> {
             case Left(_)      => NullStep
             case Right(value) => evB.resolve(value)
           }
@@ -186,8 +195,8 @@ trait GenericSchema[R] extends DerivationSchema[R] {
     implicit evA: Schema[RA, A],
     evB: Schema[RB, B]
   ): Schema[RA with RB, (A, B)] = {
-    lazy val typeAName: String = Types.name(evA.asType())
-    lazy val typeBName: String = Types.name(evB.asType())
+    lazy val typeAName: String = Types.name(evA.toType_())
+    lazy val typeBName: String = Types.name(evB.toType_())
 
     objectSchema(
       s"Tuple${typeAName}And$typeBName",
@@ -199,8 +208,8 @@ trait GenericSchema[R] extends DerivationSchema[R] {
             Some("First element of the tuple"),
             Nil,
             () =>
-              if (evA.optional) evA.asType(isInput, isSubscription)
-              else makeNonNull(evA.asType(isInput, isSubscription))
+              if (evA.optional) evA.toType_(isInput, isSubscription)
+              else makeNonNull(evA.toType_(isInput, isSubscription))
           ) ->
             ((tuple: (A, B)) => evA.resolve(tuple._1)),
           __Field(
@@ -208,8 +217,8 @@ trait GenericSchema[R] extends DerivationSchema[R] {
             Some("Second element of the tuple"),
             Nil,
             () =>
-              if (evB.optional) evB.asType(isInput, isSubscription)
-              else makeNonNull(evB.asType(isInput, isSubscription))
+              if (evB.optional) evB.toType_(isInput, isSubscription)
+              else makeNonNull(evB.toType_(isInput, isSubscription))
           ) ->
             ((tuple: (A, B)) => evB.resolve(tuple._2))
         )
@@ -217,8 +226,8 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   }
   implicit def mapSchema[RA, RB, A, B](implicit evA: Schema[RA, A], evB: Schema[RB, B]): Schema[RA with RB, Map[A, B]] =
     new Schema[RA with RB, Map[A, B]] {
-      lazy val typeAName: String   = Types.name(evA.asType())
-      lazy val typeBName: String   = Types.name(evB.asType())
+      lazy val typeAName: String   = Types.name(evA.toType_())
+      lazy val typeBName: String   = Types.name(evB.toType_())
       lazy val name: String        = s"KV$typeAName$typeBName"
       lazy val description: String = s"A key-value pair of $typeAName and $typeBName"
 
@@ -232,8 +241,8 @@ trait GenericSchema[R] extends DerivationSchema[R] {
               Some("Key"),
               Nil,
               () =>
-                if (evA.optional) evA.asType(isInput, isSubscription)
-                else makeNonNull(evA.asType(isInput, isSubscription))
+                if (evA.optional) evA.toType_(isInput, isSubscription)
+                else makeNonNull(evA.toType_(isInput, isSubscription))
             )
               -> ((kv: (A, B)) => evA.resolve(kv._1)),
             __Field(
@@ -241,15 +250,15 @@ trait GenericSchema[R] extends DerivationSchema[R] {
               Some("Value"),
               Nil,
               () =>
-                if (evB.optional) evB.asType(isInput, isSubscription)
-                else makeNonNull(evB.asType(isInput, isSubscription))
+                if (evB.optional) evB.toType_(isInput, isSubscription)
+                else makeNonNull(evB.toType_(isInput, isSubscription))
             )
               -> ((kv: (A, B)) => evB.resolve(kv._2))
           )
       )
 
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
-        makeList(makeNonNull(kvSchema.asType(isInput, isSubscription)))
+        makeList(makeNonNull(kvSchema.toType_(isInput, isSubscription)))
 
       override def resolve(value: Map[A, B]): Step[RA with RB] = ListStep(value.toList.map(kvSchema.resolve))
     }
@@ -260,7 +269,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   ): Schema[RA with RB, A => B] =
     new Schema[RA with RB, A => B] {
       override def arguments: List[__InputValue] = {
-        val t = ev1.asType(true)
+        val t = ev1.toType_(true)
         t.inputFields.getOrElse(t.kind match {
           case __TypeKind.SCALAR | __TypeKind.ENUM | __TypeKind.LIST =>
             // argument was not wrapped in a case class, give it an arbitrary name
@@ -269,7 +278,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
         })
       }
       override def optional: Boolean                                         = ev2.optional
-      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev2.asType(isInput, isSubscription)
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev2.toType_(isInput, isSubscription)
 
       override def resolve(f: A => B): Step[RA with RB] =
         FunctionStep(args =>
@@ -284,13 +293,13 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   implicit def infallibleEffectSchema[R1 >: R, R2 >: R, A](implicit ev: Schema[R2, A]): Schema[R, URIO[R1, A]] =
     new Schema[R, URIO[R1, A]] {
       override def optional: Boolean                                         = ev.optional
-      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.asType(isInput, isSubscription)
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: URIO[R1, A]): Step[R]                      = QueryStep(ZQuery.fromEffect(value.map(ev.resolve)))
     }
   implicit def effectSchema[R1 >: R, R2 >: R, E <: Throwable, A](implicit ev: Schema[R2, A]): Schema[R, ZIO[R1, E, A]] =
     new Schema[R, ZIO[R1, E, A]] {
       override def optional: Boolean                                         = true
-      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.asType(isInput, isSubscription)
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: ZIO[R1, E, A]): Step[R]                    = QueryStep(ZQuery.fromEffect(value.map(ev.resolve)))
     }
   implicit def infallibleQuerySchema[R1 >: R, R2 >: R, A](
@@ -298,7 +307,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   ): Schema[R, ZQuery[R1, Nothing, A]] =
     new Schema[R, ZQuery[R1, Nothing, A]] {
       override def optional: Boolean                                         = ev.optional
-      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.asType(isInput, isSubscription)
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: ZQuery[R1, Nothing, A]): Step[R]           = QueryStep(value.map(ev.resolve))
     }
   implicit def querySchema[R1 >: R, R2 >: R, E <: Throwable, A](
@@ -306,7 +315,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
   ): Schema[R, ZQuery[R1, E, A]] =
     new Schema[R, ZQuery[R1, E, A]] {
       override def optional: Boolean                                         = true
-      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.asType(isInput, isSubscription)
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: ZQuery[R1, E, A]): Step[R]                 = QueryStep(value.map(ev.resolve))
     }
   implicit def infallibleStreamSchema[R1 >: R, R2 >: R, A](
@@ -315,7 +324,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
     new Schema[R, ZStream[R1, Nothing, A]] {
       override def optional: Boolean = false
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
-        val t = ev.asType(isInput, isSubscription)
+        val t = ev.toType_(isInput, isSubscription)
         if (isSubscription) t else makeList(if (ev.optional) t else makeNonNull(t))
       }
       override def resolve(value: ZStream[R1, Nothing, A]): Step[R] = StreamStep(value.map(ev.resolve))
@@ -326,7 +335,7 @@ trait GenericSchema[R] extends DerivationSchema[R] {
     new Schema[R, ZStream[R1, E, A]] {
       override def optional: Boolean = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
-        val t = ev.asType(isInput, isSubscription)
+        val t = ev.toType_(isInput, isSubscription)
         if (isSubscription) t else makeList(if (ev.optional) t else makeNonNull(t))
       }
       override def resolve(value: ZStream[R1, E, A]): Step[R] = StreamStep(value.map(ev.resolve))
@@ -348,7 +357,7 @@ trait DerivationSchema[R] {
 
   def combine[T](ctx: ReadOnlyCaseClass[Typeclass, T]): Typeclass[T] = new Typeclass[T] {
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
-      if (ctx.isValueClass && ctx.parameters.nonEmpty) ctx.parameters.head.typeclass.asType(isInput, isSubscription)
+      if (ctx.isValueClass && ctx.parameters.nonEmpty) ctx.parameters.head.typeclass.toType_(isInput, isSubscription)
       else if (isInput)
         makeInputObject(
           Some(ctx.annotations.collectFirst { case GQLInputName(suffix) => suffix }
@@ -360,8 +369,8 @@ trait DerivationSchema[R] {
                 p.label,
                 getDescription(p),
                 () =>
-                  if (p.typeclass.optional) p.typeclass.asType(isInput, isSubscription)
-                  else makeNonNull(p.typeclass.asType(isInput, isSubscription)),
+                  if (p.typeclass.optional) p.typeclass.toType_(isInput, isSubscription)
+                  else makeNonNull(p.typeclass.toType_(isInput, isSubscription)),
                 None,
                 Some(p.annotations.collect { case GQLDirective(dir) => dir }.toList).filter(_.nonEmpty)
               )
@@ -380,8 +389,8 @@ trait DerivationSchema[R] {
                 getDescription(p),
                 p.typeclass.arguments,
                 () =>
-                  if (p.typeclass.optional) p.typeclass.asType(isInput, isSubscription)
-                  else makeNonNull(p.typeclass.asType(isInput, isSubscription)),
+                  if (p.typeclass.optional) p.typeclass.toType_(isInput, isSubscription)
+                  else makeNonNull(p.typeclass.toType_(isInput, isSubscription)),
                 p.annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
                 p.annotations.collectFirst { case GQLDeprecated(reason) => reason },
                 Option(p.annotations.collect { case GQLDirective(dir) => dir }.toList).filter(_.nonEmpty)
@@ -408,7 +417,7 @@ trait DerivationSchema[R] {
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
       val subtypes =
         ctx.subtypes
-          .map(s => s.typeclass.asType(isInput = false, isSubscription = false) -> s.annotations)
+          .map(s => s.typeclass.toType_(isInput = false, isSubscription = false) -> s.annotations)
           .toList
           .sortBy {
             case (tpe, _) => tpe.name.getOrElse("")

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -397,8 +397,11 @@ trait DerivationSchema[R] {
       else if (ctx.isValueClass && ctx.parameters.nonEmpty) {
         val head = ctx.parameters.head
         head.typeclass.resolve(head.dereference(value))
-      } else
-        ObjectStep(getName(ctx), ctx.parameters.map(p => p.label -> p.typeclass.resolve(p.dereference(value))).toMap)
+      } else {
+        val fields = Map.newBuilder[String, Step[R]]
+        ctx.parameters.foreach(p => fields += p.label -> p.typeclass.resolve(p.dereference(value)))
+        ObjectStep(getName(ctx), fields.result())
+      }
   }
 
   def dispatch[T](ctx: SealedTrait[Typeclass, T]): Typeclass[T] = new Typeclass[T] {

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -34,7 +34,8 @@ object Types {
       __TypeKind.ENUM,
       name,
       description,
-      enumValues = args => Some(values.filter(v => args.includeDeprecated.getOrElse(false) || !v.isDeprecated)),
+      enumValues =
+        args => if (args.includeDeprecated.getOrElse(false)) Some(values) else Some(values.filter(!_.isDeprecated)),
       origin = origin
     )
 
@@ -49,7 +50,8 @@ object Types {
       __TypeKind.OBJECT,
       name,
       description,
-      fields = args => Some(fields.filter(v => args.includeDeprecated.getOrElse(false) || !v.isDeprecated)),
+      fields =
+        args => if (args.includeDeprecated.getOrElse(false)) Some(fields) else Some(fields.filter(!_.isDeprecated)),
       interfaces = () => Some(Nil),
       directives = Some(directives),
       origin = origin
@@ -82,7 +84,8 @@ object Types {
       __TypeKind.INTERFACE,
       name,
       description,
-      fields = args => Some(fields.filter(v => args.includeDeprecated.getOrElse(false) || !v.isDeprecated)),
+      fields =
+        args => if (args.includeDeprecated.getOrElse(false)) Some(fields) else Some(fields.filter(!_.isDeprecated)),
       possibleTypes = Some(subTypes),
       origin = origin
     )

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -144,19 +144,29 @@ object Validator {
     }
 
   private def collectVariablesUsed(context: Context, selectionSet: List[Selection]): Set[String] = {
-    def collectValues(selectionSet: List[Selection]): List[InputValue] =
-      selectionSet.flatMap {
+    def collectValues(selectionSet: List[Selection]): List[InputValue] = {
+      // ugly mutable code but it's worth it for the speed ;)
+      val inputValues = List.newBuilder[InputValue]
+      selectionSet.foreach {
         case FragmentSpread(name, directives) =>
-          directives.flatMap(_.arguments.values) ++ context.fragments
+          directives.foreach(inputValues ++= _.arguments.values)
+          context.fragments
             .get(name)
-            .fold(List.empty[InputValue])(f =>
-              f.directives.flatMap(_.arguments.values) ++ collectValues(f.selectionSet)
-            )
+            .foreach { f =>
+              f.directives.foreach(inputValues ++= _.arguments.values)
+              inputValues ++= collectValues(f.selectionSet)
+            }
         case Field(_, _, arguments, directives, selectionSet, _) =>
-          arguments.values ++ directives.flatMap(_.arguments.values) ++ collectValues(selectionSet)
+          inputValues ++= arguments.values
+          directives.foreach(inputValues ++= _.arguments.values)
+          inputValues ++= collectValues(selectionSet)
         case InlineFragment(_, directives, selectionSet) =>
-          directives.flatMap(_.arguments.values) ++ collectValues(selectionSet)
+          directives.foreach(inputValues ++= _.arguments.values)
+          inputValues ++= collectValues(selectionSet)
       }
+      inputValues.result()
+    }
+
     def collectVariableValues(values: List[InputValue]): List[VariableValue] =
       values.flatMap({
         case InputValue.ListValue(values)   => collectVariableValues(values)

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -71,7 +71,7 @@ object Wrappers {
 
   private def calculateDepth(field: Field): UIO[Int] = {
     val self     = if (field.name.nonEmpty) 1 else 0
-    val children = field.fields ++ field.conditionalFields.values.flatten
+    val children = field.fields
     ZIO
       .foreach(children)(calculateDepth)
       .map {
@@ -96,13 +96,7 @@ object Wrappers {
     }
 
   private def countFields(field: Field): UIO[Int] =
-    for {
-      inner <- innerFields(field.fields)
-      conditional <- IO.foreach(field.conditionalFields.values)(innerFields).map {
-                      case Nil  => 0
-                      case list => list.max
-                    }
-    } yield inner + conditional
+    innerFields(field.fields)
 
   private def innerFields(fields: List[Field]): UIO[Int] =
     IO.foreach(fields)(countFields).map(_.sum + fields.length)

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -108,6 +108,6 @@ object SchemaSpec extends DefaultRunnableSpec {
     case class B(common: Int, different: Boolean) extends MyInterface
   }
 
-  def introspect[Q](implicit schema: Schema[Any, Q]): __Type             = schema.toType()
-  def introspectSubscription[Q](implicit schema: Schema[Any, Q]): __Type = schema.toType(isSubscription = true)
+  def introspect[Q](implicit schema: Schema[Any, Q]): __Type             = schema.toType_()
+  def introspectSubscription[Q](implicit schema: Schema[Any, Q]): __Type = schema.toType_(isSubscription = true)
 }

--- a/federation/src/main/scala/caliban/federation/EntityResolver.scala
+++ b/federation/src/main/scala/caliban/federation/EntityResolver.scala
@@ -24,7 +24,7 @@ object EntityResolver {
           resolver(arg).map(_.fold[Step[R]](Step.NullStep)(schema.resolve))
         }
 
-      override def toType: __Type = schema.toType()
+      override def toType: __Type = schema.asType()
     }
 
   def from[A]: EntityResolverPartiallyApplied[A] =

--- a/federation/src/main/scala/caliban/federation/EntityResolver.scala
+++ b/federation/src/main/scala/caliban/federation/EntityResolver.scala
@@ -24,7 +24,7 @@ object EntityResolver {
           resolver(arg).map(_.fold[Step[R]](Step.NullStep)(schema.resolve))
         }
 
-      override def toType: __Type = schema.asType()
+      override def toType: __Type = schema.toType_()
     }
 
   def from[A]: EntityResolverPartiallyApplied[A] =

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -46,7 +46,7 @@ object CatsInterop {
   def schema[F[_]: Effect, R, A](implicit ev: Schema[R, A]): Schema[R, F[A]] =
     new Schema[R, F[A]] {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
-        ev.toType(isInput, isSubscription)
+        ev.asType(isInput, isSubscription)
 
       override def optional: Boolean =
         ev.optional

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -46,7 +46,7 @@ object CatsInterop {
   def schema[F[_]: Effect, R, A](implicit ev: Schema[R, A]): Schema[R, F[A]] =
     new Schema[R, F[A]] {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
-        ev.asType(isInput, isSubscription)
+        ev.toType_(isInput, isSubscription)
 
       override def optional: Boolean =
         ev.optional

--- a/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
+++ b/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
@@ -45,7 +45,7 @@ object MonixInterop {
 
   def taskSchema[R, A](implicit ev: Schema[R, A], ev2: ConcurrentEffect[MonixTask]): Schema[R, MonixTask[A]] =
     new Schema[R, MonixTask[A]] {
-      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.asType(isInput, isSubscription)
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def optional: Boolean                                         = ev.optional
       override def resolve(value: MonixTask[A]): Step[R] =
         QueryStep(ZQuery.fromEffect(value.to[Task].map(ev.resolve)))
@@ -57,7 +57,7 @@ object MonixInterop {
     new Schema[R, Observable[A]] {
       override def optional: Boolean = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
-        val t = ev.asType(isInput, isSubscription)
+        val t = ev.toType_(isInput, isSubscription)
         if (isSubscription) t else Types.makeList(if (ev.optional) t else Types.makeNonNull(t))
       }
       override def resolve(value: Observable[A]): Step[R] =

--- a/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
+++ b/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
@@ -45,7 +45,7 @@ object MonixInterop {
 
   def taskSchema[R, A](implicit ev: Schema[R, A], ev2: ConcurrentEffect[MonixTask]): Schema[R, MonixTask[A]] =
     new Schema[R, MonixTask[A]] {
-      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType(isInput, isSubscription)
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.asType(isInput, isSubscription)
       override def optional: Boolean                                         = ev.optional
       override def resolve(value: MonixTask[A]): Step[R] =
         QueryStep(ZQuery.fromEffect(value.to[Task].map(ev.resolve)))
@@ -57,7 +57,7 @@ object MonixInterop {
     new Schema[R, Observable[A]] {
       override def optional: Boolean = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
-        val t = ev.toType(isInput, isSubscription)
+        val t = ev.asType(isInput, isSubscription)
         if (isSubscription) t else Types.makeList(if (ev.optional) t else Types.makeNonNull(t))
       }
       override def resolve(value: Observable[A]): Step[R] =

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -105,11 +105,11 @@ package object tapir {
             __Field(
               extractPath(serverEndpoint.endpoint.info.name, serverEndpoint.endpoint.input),
               serverEndpoint.endpoint.info.description,
-              getArgs(inputSchema.toType(true), inputSchema.optional),
+              getArgs(inputSchema.toType_(isInput = true), inputSchema.optional),
               () =>
                 if (serverEndpoint.endpoint.errorOutput == EndpointOutput.Void())
-                  Types.makeNonNull(outputSchema.toType())
-                else outputSchema.toType(),
+                  Types.makeNonNull(outputSchema.toType_())
+                else outputSchema.toType_(),
               serverEndpoint.endpoint.info.deprecated
             )
           ),

--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -167,7 +167,7 @@ object SchemaWriter {
   }
 
   def escapeDoubleQuotes(input: String): String =
-    input.replaceAllLiterally("\"", "\\\"")
+    input.replace("\"", "\\\"")
 
   def writeDescription(description: Option[String]): String =
     description.fold("") {


### PR DESCRIPTION
Includes the following improvements:
- Avoid re-generating `__Type` objects all the time
- Make calls to `sourceMapper.getLocation` lazy since it's only needed in case of error
- Use mutable data structures in internal code that's on the hot path
- Optimize the whitespace parsing by fastparse by @yoohaemin 

Benchmarks show that the introspection query is executed 4x faster.

Before:
```
[info] Benchmark                             Mode  Cnt      Score     Error  Units
[info] GraphQLBenchmarks.introspectCaliban  thrpt    5    565.365 ±  27.284  ops/s
[info] GraphQLBenchmarks.introspectSangria  thrpt    5    485.646 ±   7.157  ops/s
[info] GraphQLBenchmarks.simpleCaliban      thrpt    5  15850.452 ± 554.077  ops/s
[info] GraphQLBenchmarks.simpleSangria      thrpt    5   7710.546 ± 140.220  ops/s
```
After:
```
[info] Benchmark                             Mode  Cnt      Score     Error  Units
[info] GraphQLBenchmarks.introspectCaliban  thrpt    5   2249.019 ±  30.014  ops/s
[info] GraphQLBenchmarks.introspectSangria  thrpt    5    495.380 ±  14.566  ops/s
[info] GraphQLBenchmarks.simpleCaliban      thrpt    5  20622.959 ± 774.391  ops/s
[info] GraphQLBenchmarks.simpleSangria      thrpt    5   7939.774 ±  43.622  ops/s
```