### PR TITLE
akka-http: access http request inside effect world

### DIFF
--- a/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.model.ws.{ Message, TextMessage }
 import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives.{ complete, extractRequestContext }
-import akka.http.scaladsl.server.{ RequestContext, Route, StandardRoute }
+import akka.http.scaladsl.server.{ RequestContext, Route }
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import akka.stream.scaladsl.{ Flow, Sink, Source, SourceQueueWithComplete }
 import akka.stream.{ Materializer, OverflowStrategy, QueueOfferResult }

--- a/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -62,7 +62,8 @@ trait AkkaHttpAdapter {
     interpreter: GraphQLInterpreter[R, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
-    around: RequestContext => URIO[R, HttpResponse] => URIO[R, HttpResponse] = _ => identity
+    around: RequestContext => URIO[R, HttpResponse] => URIO[R, HttpResponse] = (_: RequestContext) =>
+      (e: URIO[R, HttpResponse]) => e
   )(request: GraphQLRequest)(implicit ec: ExecutionContext, runtime: Runtime[R]): Route =
     extractRequestContext { ctx =>
       complete(
@@ -85,7 +86,8 @@ trait AkkaHttpAdapter {
     interpreter: GraphQLInterpreter[R, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
-    around: RequestContext => URIO[R, HttpResponse] => URIO[R, HttpResponse] = _ => identity
+    around: RequestContext => URIO[R, HttpResponse] => URIO[R, HttpResponse] = (_: RequestContext) =>
+      (e: URIO[R, HttpResponse]) => e
   )(implicit ec: ExecutionContext, runtime: Runtime[R]): Route = {
     import akka.http.scaladsl.server.Directives._
 


### PR DESCRIPTION
My main use-case is parsing opentracing's span from request and bypass is up to datasource (via FiberRef).

Another use-case is user authentication.