### PR TITLE
Add location and path info to error message

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -227,7 +227,7 @@ object Executor {
     cause.failureOrCause match {
       case Left(e) =>
         e match {
-          case e: ExecutionError => Cause.fail(e)
+          case e: ExecutionError => Cause.fail(e.copy(path = path.reverse, locationInfo = locationInfo))
           case other             => Cause.fail(ExecutionError("Effect failure", path.reverse, locationInfo, Some(other)))
         }
       case Right(cause) =>

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -189,7 +189,11 @@ object ExecutionSpec extends DefaultRunnableSpec {
 
         assertM(
           api.interpreter.flatMap(_.execute(query, None, Map("term" -> StringValue("search")))).map(_.asJson.noSpaces)
-        )(equalTo("""{"data":{"getId":null},"errors":[{"message":"Can't build a String from input null"}]}"""))
+        )(
+          equalTo(
+            """{"data":{"getId":null},"errors":[{"message":"Can't build a String from input null","locations":[{"line":1,"column":44}],"path":["getId"]}]}"""
+          )
+        )
       },
       testM("variable in list") {
         val interpreter = graphQL(resolver).interpreter


### PR DESCRIPTION
This adds the location and path info to an `ExecutionError` that is thrown during field resolution. I'm not sure if we want to have some sort of "opt-out" mechanism in case users don't want this behavior, but in general it is the minimum we should have when showing errors, since it allows the client to piece it back together with the original query.