### PR TITLE
Add support for context wrapper in subscriptions

### DIFF
--- a/adapters/play/src/main/scala/caliban/PlayAdapter.scala
+++ b/adapters/play/src/main/scala/caliban/PlayAdapter.scala
@@ -17,11 +17,11 @@ import zio.duration.Duration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
-trait PlayAdapter {
+trait PlayAdapter[R] {
 
   def actionBuilder: ActionBuilder[Request, AnyContent]
   def parse: PlayBodyParsers
-  def requestWrapper: RequestWrapper
+  def requestWrapper: RequestWrapper[R, Result]
 
   implicit def writableGraphQLResponse[E](implicit wr: Writes[GraphQLResponse[E]]): Writeable[GraphQLResponse[E]] =
     Writeable.writeableOf_JsValue.map(wr.writes)
@@ -50,7 +50,7 @@ trait PlayAdapter {
       .map(parsingException)
   }
 
-  private def executeRequest[R, E](
+  private def executeRequest[E](
     interpreter: GraphQLInterpreter[R, E],
     request: Request[GraphQLRequest],
     skipValidation: Boolean,
@@ -65,7 +65,7 @@ trait PlayAdapter {
       )
     )
 
-  def makePostAction[R, E](
+  def makePostAction[E](
     interpreter: GraphQLInterpreter[R, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true
@@ -79,7 +79,7 @@ trait PlayAdapter {
       )
     )
 
-  def makeGetAction[R, E](
+  def makeGetAction[E](
     interpreter: GraphQLInterpreter[R, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true
@@ -101,7 +101,7 @@ trait PlayAdapter {
       )
     )
 
-  private def webSocketFlow[R, E](
+  private def webSocketFlow[E](
     interpreter: GraphQLInterpreter[R, E],
     skipValidation: Boolean,
     enableIntrospection: Boolean,
@@ -191,7 +191,7 @@ trait PlayAdapter {
     }
   }
 
-  def makeWebSocket[R, E](
+  def makeWebSocket[E](
     interpreter: GraphQLInterpreter[R, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
@@ -199,7 +199,7 @@ trait PlayAdapter {
   )(implicit ec: ExecutionContext, runtime: Runtime[R], materializer: Materializer): WebSocket =
     WebSocket.accept(_ => webSocketFlow(interpreter, skipValidation, enableIntrospection, keepAliveTime))
 
-  def makeWakeSocketOrResult[R, E](
+  def makeWakeSocketOrResult[E](
     interpreter: GraphQLInterpreter[R, E],
     handleRequestHeader: RequestHeader => Future[Either[Result, Unit]],
     skipValidation: Boolean = false,
@@ -214,29 +214,29 @@ trait PlayAdapter {
 }
 
 object PlayAdapter {
-  def apply(
+  def apply[R](
     playBodyParsers: PlayBodyParsers,
     _actionBuilder: ActionBuilder[Request, AnyContent],
-    wrapper: RequestWrapper = RequestWrapper.empty
-  ): PlayAdapter =
-    new PlayAdapter {
+    wrapper: RequestWrapper[R, Result] = RequestWrapper.empty
+  ): PlayAdapter[R] =
+    new PlayAdapter[R] {
       override def parse: PlayBodyParsers                            = playBodyParsers
       override def actionBuilder: ActionBuilder[Request, AnyContent] = _actionBuilder
-      override def requestWrapper: RequestWrapper                    = wrapper
+      override def requestWrapper: RequestWrapper[R, Result]         = wrapper
     }
 
-  trait RequestWrapper { self =>
-    def apply[R](ctx: RequestHeader)(e: URIO[R, Result]): URIO[R, Result]
+  trait RequestWrapper[-R, +A >: Result] { self =>
+    def apply[R1 <: R, A1 >: A](ctx: RequestHeader)(e: URIO[R1, A1]): URIO[R1, A1]
 
-    def |+|(that: RequestWrapper): RequestWrapper = new RequestWrapper {
-      override def apply[R](ctx: RequestHeader)(e: URIO[R, Result]): URIO[R, Result] =
-        that.apply(ctx)(self.apply(ctx)(e))
+    def |+|[R1 <: R, A1 >: A](that: RequestWrapper[R1, A1]): RequestWrapper[R1, A1] = new RequestWrapper[R1, A1] {
+      override def apply[R2 <: R1, A2 >: A1](ctx: RequestHeader)(e: URIO[R2, A2]): URIO[R2, A2] =
+        that.apply[R2, A2](ctx)(self.apply[R2, A2](ctx)(e))
     }
   }
 
   object RequestWrapper {
-    lazy val empty: RequestWrapper = new RequestWrapper {
-      override def apply[R](ctx: RequestHeader)(effect: URIO[R, Result]): URIO[R, Result] = effect
+    lazy val empty: RequestWrapper[Any, Result] = new RequestWrapper[Any, Result] {
+      override def apply[R, Result](ctx: RequestHeader)(effect: URIO[R, Result]): URIO[R, Result] = effect
     }
   }
 }

--- a/adapters/play/src/main/scala/caliban/PlayRouter.scala
+++ b/adapters/play/src/main/scala/caliban/PlayRouter.scala
@@ -2,7 +2,7 @@ package caliban
 
 import akka.stream.Materializer
 import caliban.PlayAdapter.RequestWrapper
-import play.api.mvc.{ ActionBuilder, AnyContent, ControllerComponents, PlayBodyParsers, Request, Results }
+import play.api.mvc.{ ActionBuilder, AnyContent, ControllerComponents, PlayBodyParsers, Request, Result, Results }
 import play.api.routing.Router.Routes
 import play.api.routing.SimpleRouter
 import play.api.routing.sird._
@@ -20,10 +20,10 @@ case class PlayRouter[R, E](
   skipValidation: Boolean = false,
   enableIntrospection: Boolean = true,
   keepAliveTime: Option[Duration] = None,
-  requestWrapper: RequestWrapper = RequestWrapper.empty
+  requestWrapper: RequestWrapper[R, Result] = RequestWrapper.empty
 )(implicit runtime: Runtime[R], materializer: Materializer)
     extends SimpleRouter
-    with PlayAdapter {
+    with PlayAdapter[R] {
 
   override val actionBuilder: ActionBuilder[Request, AnyContent] = controllerComponents.actionBuilder
   override val parse: PlayBodyParsers                            = controllerComponents.parsers

--- a/adapters/play/src/main/scala/caliban/PlayRouter.scala
+++ b/adapters/play/src/main/scala/caliban/PlayRouter.scala
@@ -2,7 +2,7 @@ package caliban
 
 import akka.stream.Materializer
 import caliban.PlayAdapter.RequestWrapper
-import play.api.mvc.{ ActionBuilder, AnyContent, ControllerComponents, PlayBodyParsers, Request, Result, Results }
+import play.api.mvc.{ ActionBuilder, AnyContent, ControllerComponents, PlayBodyParsers, Request, Results }
 import play.api.routing.Router.Routes
 import play.api.routing.SimpleRouter
 import play.api.routing.sird._
@@ -20,7 +20,7 @@ case class PlayRouter[R, E](
   skipValidation: Boolean = false,
   enableIntrospection: Boolean = true,
   keepAliveTime: Option[Duration] = None,
-  requestWrapper: RequestWrapper[R, Result] = RequestWrapper.empty
+  requestWrapper: RequestWrapper[R] = RequestWrapper.empty
 )(implicit runtime: Runtime[R], materializer: Materializer)
     extends SimpleRouter
     with PlayAdapter[R] {

--- a/examples/src/main/scala/caliban/akkahttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/caliban/akkahttp/AuthExampleApp.scala
@@ -1,0 +1,68 @@
+package caliban.akkahttp
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
+import akka.http.scaladsl.server.Directives.{ getFromResource, path, _ }
+import akka.http.scaladsl.server.RequestContext
+import caliban.AkkaHttpAdapter.ContextWrapper
+import caliban.GraphQL._
+import caliban.RootResolver
+import caliban.interop.circe.AkkaHttpCirceAdapter
+import caliban.schema.GenericSchema
+import zio.internal.Platform
+import zio.{ FiberRef, Has, RIO, Runtime, URIO, ZIO, ZLayer }
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.io.StdIn
+
+object AuthExampleApp extends App with AkkaHttpCirceAdapter {
+
+  case class AuthToken(value: String)
+
+  type Auth = Has[FiberRef[Option[AuthToken]]]
+
+  object AuthWrapper extends ContextWrapper[Auth, HttpResponse] {
+    override def apply[R <: Auth, A >: HttpResponse](
+      ctx: RequestContext
+    )(effect: URIO[R, A]): URIO[R, A] =
+      ctx.request.headers.collectFirst {
+        case header if header.name.toLowerCase == "token" => header.value
+      } match {
+        case Some(token) => ZIO.accessM[Auth](_.get.set(Some(AuthToken(token)))) *> effect
+        case _           => ZIO.succeed(HttpResponse(StatusCodes.Forbidden))
+      }
+  }
+
+  val schema: GenericSchema[Auth] = new GenericSchema[Auth] {}
+  import schema._
+  case class Query(token: RIO[Auth, Option[String]])
+  private val resolver = RootResolver(Query(ZIO.accessM[Auth](_.get.get).map(_.map(_.value))))
+  private val api      = graphQL(resolver)
+
+  implicit val system: ActorSystem                        = ActorSystem()
+  implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+
+  // Note that we must initialize the runtime with any FiberRefs we intend to
+  // pass on so that they are present in the environment for our ContextWrapper(s)
+  // For the auth we wrap in an option, but you could just as well use something
+  // like AuthToken("__INVALID") or a sealed trait hierarchy with an invalid member
+  val initLayer                       = ZLayer.fromEffect(FiberRef.make(Option.empty[AuthToken]))
+  implicit val runtime: Runtime[Auth] = Runtime.unsafeFromLayer(initLayer, Platform.default)
+
+  val interpreter = runtime.unsafeRun(api.interpreter)
+
+  val route =
+    path("api" / "graphql") {
+      adapter.makeHttpService(interpreter, contextWrapper = AuthWrapper)
+    } ~ path("graphiql") {
+      getFromResource("graphiql.html")
+    }
+
+  val bindingFuture = Http().bindAndHandle(route, "localhost", 8088)
+  println(s"Server online at http://localhost:8088/\nPress RETURN to stop...")
+  StdIn.readLine()
+  bindingFuture
+    .flatMap(_.unbind())
+    .onComplete(_ => system.terminate())
+}

--- a/examples/src/main/scala/caliban/play/AuthExampleApp.scala
+++ b/examples/src/main/scala/caliban/play/AuthExampleApp.scala
@@ -1,0 +1,67 @@
+package caliban.play
+
+import caliban.GraphQL.graphQL
+import caliban.PlayAdapter.RequestWrapper
+import caliban.schema.GenericSchema
+import caliban.{ PlayRouter, RootResolver }
+import play.api.Mode
+import play.api.mvc.{ DefaultControllerComponents, RequestHeader, Result, Results }
+import play.core.server.{ AkkaHttpServer, ServerConfig }
+import zio.internal.Platform
+import zio.{ FiberRef, Has, RIO, Runtime, URIO, ZIO, ZLayer }
+
+import scala.io.StdIn.readLine
+
+object AuthExampleApp extends App {
+  case class AuthToken(value: String)
+
+  type Auth = Has[FiberRef[Option[AuthToken]]]
+
+  object AuthWrapper extends RequestWrapper[Auth, Result] {
+    override def apply[R <: Auth, A >: Result](ctx: RequestHeader)(effect: URIO[R, A]): URIO[R, A] =
+      ctx.headers.get("token") match {
+        case Some(token) => ZIO.accessM[Auth](_.get.set(Some(AuthToken(token)))) *> effect
+        case _           => ZIO.succeed(Results.Forbidden)
+      }
+  }
+
+  val schema: GenericSchema[Auth] = new GenericSchema[Auth] {}
+  import schema._
+  case class Query(token: RIO[Auth, Option[String]])
+  private val resolver = RootResolver(Query(ZIO.accessM[Auth](_.get.get).map(_.map(_.value))))
+  private val api      = graphQL(resolver)
+
+  // Note that we must initialize the runtime with any FiberRefs we intend to
+  // pass on so that they are present in the environment for our ContextWrapper(s)
+  // For the auth we wrap in an option, but you could just as well use something
+  // like AuthToken("__INVALID") or a sealed trait hierarchy with an invalid member
+  val initLayer                       = ZLayer.fromEffect(FiberRef.make(Option.empty[AuthToken]))
+  implicit val runtime: Runtime[Auth] = Runtime.unsafeFromLayer(initLayer, Platform.default)
+
+  val interpreter = runtime.unsafeRun(api.interpreter)
+
+  val server = AkkaHttpServer.fromRouterWithComponents(
+    ServerConfig(
+      mode = Mode.Dev,
+      port = Some(8088),
+      address = "127.0.0.1"
+    )
+  ) { components =>
+    PlayRouter(
+      interpreter,
+      DefaultControllerComponents(
+        components.defaultActionBuilder,
+        components.playBodyParsers,
+        components.messagesApi,
+        components.langs,
+        components.fileMimeTypes,
+        components.executionContext
+      ),
+      requestWrapper = AuthWrapper
+    )(runtime, components.materializer).routes
+  }
+
+  println("Server online at http://localhost:8088/\nPress RETURN to stop...")
+  readLine()
+  server.stop()
+}


### PR DESCRIPTION
This pull request is to lift the environment parameter to the trait level, and also parameterize the success type, so that it can be used for more than HttpResponse.  Most notably, this allows us to now wrap executeRequest call in subscriptions.