### PR TITLE
add function to support query string parameter in finch.

### DIFF
--- a/adapters/finch/src/main/scala/caliban/FinchAdapter.scala
+++ b/adapters/finch/src/main/scala/caliban/FinchAdapter.scala
@@ -80,23 +80,24 @@ object FinchAdapter extends Endpoint.Module[Task] {
   )(implicit runtime: Runtime[R]): Endpoint[Task, Json :+: Json :+: CNil] =
     post(queryParams :: stringBodyOption :: header("content-type")) {
       (queryRequest: GraphQLRequest, body: Option[String], contentType: String) =>
-        val request: GraphQLRequest = (queryRequest, body, contentType) match {
+        val queryTask = (queryRequest, body, contentType) match {
           case (_, Some(bodyValue), "application/json") =>
-            parse(bodyValue).flatMap(_.as[GraphQLRequest]).getOrElse(GraphQLRequest())
+            Task.fromEither(parse(bodyValue).flatMap(_.as[GraphQLRequest]))
           case (_, Some(_), "application/graphql") =>
-            GraphQLRequest(body)
+            Task(GraphQLRequest(body))
           case (queryRequest, _, _) if queryRequest.query.isDefined =>
-            queryRequest
+            Task(queryRequest)
           // treat unmatched content-type as same as None of body.
           case _ =>
-            GraphQLRequest()
+            Task.fail(new Exception("Query was not found"))
         }
-        executeRequest(
-          request,
-          interpreter,
-          skipValidation = skipValidation,
-          enableIntrospection = enableIntrospection
-        )
+        runtime
+          .unsafeRunToFuture(
+            queryTask
+              .flatMap(createRequest(_, interpreter, skipValidation, enableIntrospection))
+              .catchAll(error => Task(Ok(GraphQLResponse(NullValue, List(error.getMessage)).asJson)))
+          )
+          .future
     } :+: get(queryParams) { request: GraphQLRequest =>
       executeRequest(request, interpreter, skipValidation = skipValidation, enableIntrospection = enableIntrospection)
     }


### PR DESCRIPTION
I Implemented function (suport "query" query string as GET)
in the case of finch as details in #421 

Paste the result of Test below.
* `curl GET query`
<details>
<p>

```sh
$ curl  -X GET "http://localhost:8088/api/graphql?query=\{characters\{name\}\}" \
>   -H 'Host: localhost:8088' \
>   | jq
{
  "data": {
    "characters": [
      {
        "name": "James Holden"
      },
      {
        "name": "Naomi Nagata"
      },
      {
        "name": "Amos Burton"
      },
      {
        "name": "Alex Kamal"
      },
      {
        "name": "Chrisjen Avasarala"
      },
      {
        "name": "Josephus Miller"
      },
      {
        "name": "Roberta Draper"
      }
    ]
  },
  "extensions": {
<-- snip apolo tracing -->
  }
}
```

</p>
</details>

* `curl POST query`
<details>
<p>

```sh
$ curl -X POST \
>  http://localhost:8088/api/graphql \
>   -H 'Host: localhost:8088' \
>   -H 'Content-Type: application/x-www-form-urlencoded' \
>   -d 'query={characters { name }}' \
>   | jq

{
  "data": {
    "characters": [
      {
        "name": "James Holden"
      },
      {
        "name": "Naomi Nagata"
      },
      {
        "name": "Amos Burton"
      },
      {
        "name": "Alex Kamal"
      },
      {
        "name": "Chrisjen Avasarala"
      },
      {
        "name": "Josephus Miller"
      },
      {
        "name": "Roberta Draper"
      }
    ]
  },
  "extensions": {
<-- snip apolo tracing -->
  }
}
```
</p>
</details>