### PR TITLE
send complete message upon completion of a stream

### DIFF
--- a/adapters/akka-http/src/main/scala/caliban/JsonBackend.scala
+++ b/adapters/akka-http/src/main/scala/caliban/JsonBackend.scala
@@ -16,7 +16,7 @@ trait JsonBackend {
 
   def parseWSMessage(text: String): Either[Throwable, WSMessage]
   def encodeWSResponse[E](id: String, data: ResponseValue, errors: List[E]): String
-  def encodeWSError(id: String, error: Throwable): String
+  def encodeWSError(id: String, error: String): String
 
   def reqUnmarshaller: FromEntityUnmarshaller[GraphQLRequest]
 

--- a/adapters/akka-http/src/main/scala/caliban/interop/circe/CirceJsonBackend.scala
+++ b/adapters/akka-http/src/main/scala/caliban/interop/circe/CirceJsonBackend.scala
@@ -52,12 +52,12 @@ final class CirceJsonBackend extends JsonBackend with FailFastCirceSupport {
       )
       .noSpaces
 
-  def encodeWSError(id: String, error: Throwable): String =
+  def encodeWSError(id: String, error: String): String =
     Json
       .obj(
         "id"      -> Json.fromString(id),
-        "type"    -> Json.fromString("complete"),
-        "payload" -> Json.fromString(error.toString)
+        "type"    -> Json.fromString("error"),
+        "payload" -> Json.obj("message" -> Json.fromString(error))
       )
       .noSpaces
 

--- a/adapters/akka-http/src/main/scala/caliban/interop/play/PlayJsonBackend.scala
+++ b/adapters/akka-http/src/main/scala/caliban/interop/play/PlayJsonBackend.scala
@@ -61,13 +61,13 @@ final class PlayJsonBackend extends JsonBackend with PlayJsonSupport {
         )
     )
 
-  def encodeWSError(id: String, error: Throwable): String =
+  def encodeWSError(id: String, error: String): String =
     Json.stringify(
       Json
         .obj(
           "id"      -> id,
-          "type"    -> "complete",
-          "payload" -> error.toString
+          "type"    -> "error",
+          "payload" -> Json.obj("message" -> error)
         )
     )
 

--- a/adapters/uzhttp/src/main/scala/caliban/UzHttpAdapter.scala
+++ b/adapters/uzhttp/src/main/scala/caliban/UzHttpAdapter.scala
@@ -14,6 +14,7 @@ import uzhttp.Status.Ok
 import uzhttp.header.Headers
 import uzhttp.websocket.{ Close, Frame, Text }
 import uzhttp.{ HTTPError, Request, Response }
+import zio.Exit.Failure
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.stream.{ Take, ZStream, ZTransducer }
@@ -120,13 +121,24 @@ object UzHttpAdapter {
                                       stream.foreach { item =>
                                         sendMessage(
                                           sendQueue,
+                                          "data",
                                           id,
-                                          ObjectValue(List(fieldName -> item)),
-                                          result.errors
+                                          GraphQLResponse(ObjectValue(List(fieldName -> item)), result.errors).asJson
                                         )
-                                      }.fork.flatMap(fiber => subscriptions.update(_.updated(id, fiber)))
+                                      }.onExit {
+                                        case Failure(cause) if !cause.interrupted =>
+                                          sendMessage(
+                                            sendQueue,
+                                            "error",
+                                            id,
+                                            Json.obj("message" -> Json.fromString(cause.squash.toString))
+                                          )
+                                        case _ =>
+                                          sendQueue.offer(Take.single(Text(s"""{"type":"complete","id":"$id"}""")))
+                                      }.fork
+                                        .flatMap(fiber => subscriptions.update(_.updated(id, fiber)))
                                     case other =>
-                                      sendMessage(sendQueue, id, other, result.errors) *>
+                                      sendMessage(sendQueue, "data", id, GraphQLResponse(other, result.errors).asJson) *>
                                         sendQueue.offer(
                                           Take.single(Text(s"""{"type":"complete","id":"$id"}"""))
                                         )
@@ -139,11 +151,7 @@ object UzHttpAdapter {
                           .modify(map => (map.get(id), map - id))
                           .flatMap(fiber =>
                             IO.whenCase(fiber) {
-                              case Some(fiber) =>
-                                fiber.interrupt *>
-                                  sendQueue.offer(
-                                    Take.single(Text(s"""{"type":"complete","id":"$id"}"""))
-                                  )
+                              case Some(fiber) => fiber.interrupt
                             }
                           )
                     }
@@ -157,11 +165,11 @@ object UzHttpAdapter {
       } yield ws
   }
 
-  private def sendMessage[E](
+  private def sendMessage(
     sendQueue: Queue[Take[Nothing, Frame]],
+    messageType: String,
     id: String,
-    data: ResponseValue,
-    errors: List[E]
+    payload: Json
   ): UIO[Unit] =
     sendQueue
       .offer(
@@ -170,8 +178,8 @@ object UzHttpAdapter {
             Json
               .obj(
                 "id"      -> Json.fromString(id),
-                "type"    -> Json.fromString("data"),
-                "payload" -> GraphQLResponse(data, errors).asJson
+                "type"    -> Json.fromString(messageType),
+                "payload" -> payload
               )
               .noSpaces
           )


### PR DESCRIPTION
As per subscriptions-transport-ws spec, send GQL_COMPLETE message to client, so that client can initiate GQL_CONNECTION_TERMINATE.  In case of failure, close the send queue, so that server terminates websocket connection.