### PR TITLE
Fix issue with fragment on union

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -66,7 +66,9 @@ object Field {
             .foreach { f =>
               val t =
                 innerType.possibleTypes.flatMap(_.find(_.name.contains(f.typeCondition.name))).getOrElse(fieldType)
-              fieldList ++= loop(f.selectionSet, t).fields.map(_.copy(condition = Some(f.typeCondition.name)))
+              fieldList ++= loop(f.selectionSet, t).fields.map(field =>
+                if (field.condition.isDefined) field else field.copy(condition = Some(f.typeCondition.name))
+              )
             }
         case InlineFragment(typeCondition, directives, selectionSet) if checkDirectives(directives, variableValues) =>
           val t = innerType.possibleTypes
@@ -74,8 +76,11 @@ object Field {
             .getOrElse(fieldType)
           val field = loop(selectionSet, t)
           typeCondition match {
-            case None           => fieldList ++= field.fields
-            case Some(typeName) => fieldList ++= field.fields.map(_.copy(condition = Some(typeName.name)))
+            case None => fieldList ++= field.fields
+            case Some(typeName) =>
+              fieldList ++= field.fields.map(field =>
+                if (field.condition.isDefined) field else field.copy(condition = Some(typeName.name))
+              )
           }
         case _ =>
       }

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -112,6 +112,27 @@ object ExecutionSpec extends DefaultRunnableSpec {
           equalTo("""{"amos":{"name":"Amos Burton"}}""")
         )
       },
+      testM("fragment on union") {
+        val interpreter = graphQL(resolver).interpreter
+        val query       = gqldoc("""
+             {
+               amos: character(name: "Amos Burton") {
+                 role {
+                   ...roleF
+                 }
+               }
+             }
+
+             fragment roleF on Role {
+               ... on Mechanic {
+                 shipName
+               }
+             }""")
+
+        assertM(interpreter.flatMap(_.execute(query)).map(_.data.toString))(
+          equalTo("""{"amos":{"role":{"shipName":"Rocinante"}}}""")
+        )
+      },
       testM("inline fragment") {
         val interpreter = graphQL(resolver).interpreter
         val query       = gqldoc("""


### PR DESCRIPTION
In case of nested fragment (e.g. an inline fragment inside a regular fragment), the inner type should be used instead of the outer type.