### PR TITLE
Generate args prepending context object name

### DIFF
--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -160,7 +160,7 @@ object SchemaWriter {
       s"${args.map(arg => s"${safeName(arg.name)} : ${writeType(arg.ofType)}").mkString(", ")}"
 
     if (field.args.nonEmpty) {
-      val prefix = if(reservedType(of)) "" else of.name.capitalize
+      val prefix = if (reservedType(of)) "" else of.name.capitalize
       s"case class $prefix${field.name.capitalize}Args(${fields(field.args)})"
     } else {
       ""

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -367,13 +367,13 @@ object Types {
       testM("args unique class names") {
         val schema =
           """
-             |type Hero {
-             |  callAllies(number: Int!): [Hero!]!
-             |}
-             |
-             |type Villain {
-             |  callAllies(number: Int!, w: String!): [Villain!]!
-             |}
+            |type Hero {
+            |  callAllies(number: Int!): [Hero!]!
+            |}
+            |
+            |type Villain {
+            |  callAllies(number: Int!, w: String!): [Villain!]!
+            |}
             """.stripMargin
 
         assertM(gen(schema))(

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -36,18 +36,18 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
             (for {
               typeDef      <- doc.objectTypeDefinitions
               typeDefField <- typeDef.fields
-              argClass     = SchemaWriter.writeArguments(typeDefField) if argClass.length > 0
+              argClass     = SchemaWriter.writeArguments(typeDefField, typeDef) if argClass.length > 0
             } yield argClass).mkString("\n")
           }
           .flatMap(Formatter.format(_, None).map(_.trim))
 
         assertM(typeCaseClass)(
           equalTo(
-            "case class Hero(name: NameArgs () => String, nick: String, bday: Option[Int])"
+            "case class Hero(name: HeroNameArgs () => String, nick: String, bday: Option[Int])"
           )
         ) andThen assertM(typeCaseClassArgs)(
           equalTo(
-            "case class NameArgs(pad: Int)"
+            "case class HeroNameArgs(pad: Int)"
           )
         )
       },
@@ -361,6 +361,31 @@ object Types {
 
 }
 """
+          )
+        )
+      },
+      testM("args unique class names") {
+        val schema =
+          """
+             |type Hero {
+             |  callAllies(number: Int!): [Hero!]!
+             |}
+             |
+             |type Villain {
+             |  callAllies(number: Int!, w: String!): [Villain!]!
+             |}
+            """.stripMargin
+
+        assertM(gen(schema))(
+          equalTo(
+            """object Types {
+              |  case class HeroCallAlliesArgs(number: Int)
+              |  case class VillainCallAlliesArgs(number: Int, w: String)
+              |  case class Hero(callAllies: HeroCallAlliesArgs => List[Hero])
+              |  case class Villain(callAllies: VillainCallAlliesArgs => List[Villain])
+              |
+              |}
+              |""".stripMargin
           )
         )
       }


### PR DESCRIPTION
This should fix #367 and fix #552 

I had to pass the `ObjectTypeDefinition` to the `writeArguments` function to concatenate the required name.
In order to avoid having classes with "Mutation", "Query" and "Subscription" prefix, objects definitions have been checked against `reservedType` function.
When calling `writeField`, checks are done also on schema definition and union types. I don't think it is required in this case, but correct my if I'm wrong.

Let me know if you think additional changes are required