### PR TITLE
Add benchmark for apollo-tracing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -293,7 +293,8 @@ lazy val benchmarks = project
   .settings(
     libraryDependencies ++= Seq(
       "org.sangria-graphql" %% "sangria"       % "2.0.0",
-      "org.sangria-graphql" %% "sangria-circe" % "1.3.0"
+      "org.sangria-graphql" %% "sangria-circe" % "1.3.0",
+      "org.sangria-graphql" %% "sangria-slowlog" % "2.0.0-M1"
     )
   )
 


### PR DESCRIPTION
On my local machine

```
[info] Benchmark                             Mode  Cnt      Score     Units
[info] GraphQLBenchmarks.introspectCaliban  thrpt    5   1741.766     5.363  ops/s
[info] GraphQLBenchmarks.introspectSangria  thrpt    5    529.047    12.656  ops/s
[info] GraphQLBenchmarks.simpleCaliban      thrpt    5  15478.432    90.606  ops/s
[info] GraphQLBenchmarks.simpleSangria      thrpt    5   8673.450   130.817  ops/s
[info] GraphQLBenchmarks.tracedCaliban      thrpt    5   6001.955    27.545  ops/s
[info] GraphQLBenchmarks.tracedSangria      thrpt    5   5707.312    55.514  ops/s
```