### PR TITLE
recover queue offer in onExit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tags
 
 .bloop
 .metals
+.vscode
 project/metals.sbt
 *.class
 *.log

--- a/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -188,9 +188,9 @@ trait AkkaHttpAdapter {
                       IO.fromFuture(_ =>
                           sendTo.offer(TextMessage(json.encodeWSError(messageId, cause.squash.toString)))
                         )
-                        .orDie
+                        .ignore
                     case _ =>
-                      IO.fromFuture(_ => sendTo.offer(TextMessage(s"""{"type":"complete","id":"$messageId"}"""))).orDie
+                      IO.fromFuture(_ => sendTo.offer(TextMessage(s"""{"type":"complete","id":"$messageId"}"""))).ignore
                   }
                   .forkDaemon
                   .flatMap(fiber => subscriptions.update(_.updated(Option(messageId), fiber)))


### PR DESCRIPTION
This is to address an issue reported by @rleibman a couple weeks ago in the discord channel.

```
╠─An unchecked error was produced.
║ akka.stream.StreamDetachedException: Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1@695b003b stopped before async invocation was processed
║
```
```
║ Fiber:Id(1597334107257,677) execution trace:
║   at caliban.AkkaHttpAdapter.makeWebSocketService(AkkaHttpAdapter.scala:182)
║   at caliban.wrappers.ApolloTracing$.apolloTracingOverall(ApolloTracing.scala:117)
```

This appears to arise when the akka stream has closed already (i.e. can be caused by force close from client), but still attempt to offer to the `Source.queue` used for sending messages downstream.  The `offer` on source queue is simply a future that we wrap with I`O.fromFuture`, but map it to a `URIO` with `orDie` as it is called in `onExit`.  This PR simply recovers the `Future` with an empty partial function (as there is little else we could do at this juncture anyhow).