### PR TITLE
Codegen args root

### DIFF
--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -91,28 +91,28 @@ object SchemaWriter {
   def reservedType(typeDefinition: ObjectTypeDefinition): Boolean =
     typeDefinition.name == "Query" || typeDefinition.name == "Mutation" || typeDefinition.name == "Subscription"
 
-  def writeRootField(field: FieldDefinition, effect: String): String = {
-    val argsName = if (field.args.nonEmpty) s" ${field.name.capitalize}Args =>" else ""
+  def writeRootField(field: FieldDefinition, od: ObjectTypeDefinition, effect: String): String = {
+    val argsName = if (field.args.nonEmpty) s" ${generateArgsName(field, od)} =>" else ""
     s"${safeName(field.name)} :$argsName $effect[${writeType(field.ofType)}]"
   }
 
   def writeRootQueryOrMutationDef(op: ObjectTypeDefinition, effect: String): String =
     s"""
        |${writeDescription(op.description)}case class ${op.name}(
-       |${op.fields.map(c => writeRootField(c, effect)).mkString(",\n")}
+       |${op.fields.map(c => writeRootField(c, op, effect)).mkString(",\n")}
        |)""".stripMargin
 
-  def writeSubscriptionField(field: FieldDefinition): String =
+  def writeSubscriptionField(field: FieldDefinition, od: ObjectTypeDefinition): String =
     "%s:%s ZStream[Any, Nothing, %s]".format(
       safeName(field.name),
-      if (field.args.nonEmpty) s" ${field.name.capitalize}Args =>" else "",
+      if (field.args.nonEmpty) s" ${generateArgsName(field, od)} =>" else "",
       writeType(field.ofType)
     )
 
   def writeRootSubscriptionDef(op: ObjectTypeDefinition): String =
     s"""
        |${writeDescription(op.description)}case class ${op.name}(
-       |${op.fields.map(c => writeSubscriptionField(c)).mkString(",\n")}
+       |${op.fields.map(c => writeSubscriptionField(c, op)).mkString(",\n")}
        |)""".stripMargin
 
   def writeObject(typedef: ObjectTypeDefinition): String =
@@ -160,11 +160,16 @@ object SchemaWriter {
       s"${args.map(arg => s"${safeName(arg.name)} : ${writeType(arg.ofType)}").mkString(", ")}"
 
     if (field.args.nonEmpty) {
-      val prefix = if (reservedType(of)) "" else of.name.capitalize
-      s"case class $prefix${field.name.capitalize}Args(${fields(field.args)})"
+      s"case class ${generateArgsName(field, of)}(${fields(field.args)})"
     } else {
       ""
     }
+  }
+
+  private def generateArgsName(field: FieldDefinition, od: ObjectTypeDefinition): String = {
+//    val prefix = if (reservedType(od)) "" else od.name.capitalize
+//    s"$prefix${field.name.capitalize}Args"
+    s"${od.name.capitalize}${field.name.capitalize}Args"
   }
 
   def escapeDoubleQuotes(input: String): String =

--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -92,8 +92,8 @@ object SchemaWriter {
     typeDefinition.name == "Query" || typeDefinition.name == "Mutation" || typeDefinition.name == "Subscription"
 
   def writeRootField(field: FieldDefinition, od: ObjectTypeDefinition, effect: String): String = {
-    val argsName = if (field.args.nonEmpty) s" ${generateArgsName(field, od)} =>" else ""
-    s"${safeName(field.name)} :$argsName $effect[${writeType(field.ofType)}]"
+    val argsTypeName = if (field.args.nonEmpty) s" ${argsName(field, od)} =>" else ""
+    s"${safeName(field.name)} :$argsTypeName $effect[${writeType(field.ofType)}]"
   }
 
   def writeRootQueryOrMutationDef(op: ObjectTypeDefinition, effect: String): String =
@@ -105,7 +105,7 @@ object SchemaWriter {
   def writeSubscriptionField(field: FieldDefinition, od: ObjectTypeDefinition): String =
     "%s:%s ZStream[Any, Nothing, %s]".format(
       safeName(field.name),
-      if (field.args.nonEmpty) s" ${generateArgsName(field, od)} =>" else "",
+      if (field.args.nonEmpty) s" ${argsName(field, od)} =>" else "",
       writeType(field.ofType)
     )
 
@@ -147,7 +147,7 @@ object SchemaWriter {
 
   def writeField(field: FieldDefinition, of: ObjectTypeDefinition): String =
     if (field.args.nonEmpty) {
-      s"${writeDescription(field.description)}${safeName(field.name)} : ${of.name.capitalize}${field.name.capitalize}Args => ${writeType(field.ofType)}"
+      s"${writeDescription(field.description)}${safeName(field.name)} : ${argsName(field, of)} => ${writeType(field.ofType)}"
     } else {
       s"""${writeDescription(field.description)}${safeName(field.name)} : ${writeType(field.ofType)}"""
     }
@@ -160,17 +160,14 @@ object SchemaWriter {
       s"${args.map(arg => s"${safeName(arg.name)} : ${writeType(arg.ofType)}").mkString(", ")}"
 
     if (field.args.nonEmpty) {
-      s"case class ${generateArgsName(field, of)}(${fields(field.args)})"
+      s"case class ${argsName(field, of)}(${fields(field.args)})"
     } else {
       ""
     }
   }
 
-  private def generateArgsName(field: FieldDefinition, od: ObjectTypeDefinition): String = {
-//    val prefix = if (reservedType(od)) "" else od.name.capitalize
-//    s"$prefix${field.name.capitalize}Args"
+  private def argsName(field: FieldDefinition, od: ObjectTypeDefinition): String =
     s"${od.name.capitalize}${field.name.capitalize}Args"
-  }
 
   def escapeDoubleQuotes(input: String): String =
     input.replace("\"", "\\\"")

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -74,7 +74,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
         assertM(result)(
           equalTo(
             """case class Query(
-  user: UserArgs => zio.UIO[Option[User]],
+  user: QueryUserArgs => zio.UIO[Option[User]],
   userList: zio.UIO[List[Option[User]]]
 )""".stripMargin
           )
@@ -99,7 +99,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
         assertM(result)(
           equalTo(
             """case class Mutation(
-              |  setMessage: SetMessageArgs => zio.UIO[Option[String]]
+              |  setMessage: MutationSetMessageArgs => zio.UIO[Option[String]]
               |)""".stripMargin
           )
         )
@@ -120,7 +120,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
           equalTo(
             """
               |case class Subscription(
-              |UserWatch: UserWatchArgs => ZStream[Any, Nothing, String]
+              |UserWatch: SubscriptionUserWatchArgs => ZStream[Any, Nothing, String]
               |)""".stripMargin
           )
         )
@@ -150,7 +150,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
               |import zio.stream.ZStream
               |
               |object Types {
-              |  case class AddPostArgs(author: Option[String], comment: Option[String])
+              |  case class MutationAddPostArgs(author: Option[String], comment: Option[String])
               |  case class Post(author: Option[String], comment: Option[String])
               |
               |}
@@ -162,7 +162,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
               |  )
               |
               |  case class Mutation(
-              |    addPost: AddPostArgs => zio.UIO[Option[Post]]
+              |    addPost: MutationAddPostArgs => zio.UIO[Option[Post]]
               |  )
               |
               |  case class Subscription(

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -388,6 +388,55 @@ object Types {
               |""".stripMargin
           )
         )
+      },
+      testM("args names root level") {
+        val schema =
+          """
+            |schema {
+            |  query: Query
+            |  subscription: Subscription
+            |}
+            |
+            |type Params {
+            |  p: Int!
+            |}
+            |
+            |type Query {
+            |  characters(p: Params!): Int!
+            |}
+            |
+            |type Subscription {
+            |  characters(p: Params!): Int!
+            |}
+            """.stripMargin
+
+        assertM(gen(schema))(
+          equalTo(
+            """import Types._
+              |
+              |import zio.stream.ZStream
+              |
+              |object Types {
+              |  case class QueryCharactersArgs(p: Params)
+              |  case class SubscriptionCharactersArgs(p: Params)
+              |  case class Params(p: Int)
+              |
+              |}
+              |
+              |object Operations {
+              |
+              |  case class Query(
+              |    characters: QueryCharactersArgs => zio.UIO[Int]
+              |  )
+              |
+              |  case class Subscription(
+              |    characters: SubscriptionCharactersArgs => ZStream[Any, Nothing, Int]
+              |  )
+              |
+              |}
+              |""".stripMargin
+          )
+        )
       }
     ) @@ TestAspect.sequential
 }


### PR DESCRIPTION

This PR closes #560

Fix misalignment in arguments type names also at schema root levels (`Query`, `Mutation` and `Subscription`).
All arguments types names are now generated using the same function, so there should not be other similar issues.

The function prepends the "parent" name to the arguments type, in order to avoid possible duplications.

**Note**: names generated since this version will be different from the previous ones.

### Example

The schema
```
type Query {
   user(id: Int): User!
}

type Mutation {
   setMessage(message: String): String!
}
```

is now generated as

<pre>
case class Query(
   user: <b>Query</b>UserArgs => zio.UIO[User]
)

case class Mutation(
   setMessage: <b>Mutation</b>SetMessageArgs => zio.UIO[String]
)
</pre>

while in the previous versions was

```
case class Query(
   user: UserArgs => zio.UIO[User]
)

case class Mutation(
   setMessage: SetMessageArgs => zio.UIO[String]
)
```

