### PR TITLE
Fix federation orphan types

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -88,36 +88,35 @@ trait GraphQL[-R] { self =>
           ): URIO[R, GraphQLResponse[CalibanError]] =
             decompose(wrappers).flatMap {
               case (overallWrappers, parsingWrappers, validationWrappers, executionWrappers, fieldWrappers) =>
-                wrap(
-                  (request: GraphQLRequest) =>
-                    (for {
-                      doc   <- wrap(Parser.parseQuery)(parsingWrappers, request.query.getOrElse(""))
-                      intro = Introspector.isIntrospection(doc)
-                      _ <- IO.when(intro && !enableIntrospection) {
-                            IO.fail(CalibanError.ValidationError("Introspection is disabled", ""))
-                          }
-                      typeToValidate  = if (intro) introspectionRootType else rootType
-                      schemaToExecute = if (intro) introspectionRootSchema else schema
-                      validate = (doc: Document) =>
-                        Validator
-                          .prepare(
-                            doc,
-                            typeToValidate,
-                            schemaToExecute,
-                            request.operationName,
-                            request.variables.getOrElse(Map()),
-                            skipValidation
+                wrap((request: GraphQLRequest) =>
+                  (for {
+                    doc   <- wrap(Parser.parseQuery)(parsingWrappers, request.query.getOrElse(""))
+                    intro = Introspector.isIntrospection(doc)
+                    _ <- IO.when(intro && !enableIntrospection) {
+                          IO.fail(CalibanError.ValidationError("Introspection is disabled", ""))
+                        }
+                    typeToValidate  = if (intro) introspectionRootType else rootType
+                    schemaToExecute = if (intro) introspectionRootSchema else schema
+                    validate = (doc: Document) =>
+                      Validator
+                        .prepare(
+                          doc,
+                          typeToValidate,
+                          schemaToExecute,
+                          request.operationName,
+                          request.variables.getOrElse(Map()),
+                          skipValidation
                         )
-                      executionRequest <- wrap(validate)(validationWrappers, doc)
-                      op = executionRequest.operationType match {
-                        case OperationType.Query        => schemaToExecute.query
-                        case OperationType.Mutation     => schemaToExecute.mutation.getOrElse(schemaToExecute.query)
-                        case OperationType.Subscription => schemaToExecute.subscription.getOrElse(schemaToExecute.query)
-                      }
-                      execute = (req: ExecutionRequest) =>
-                        Executor.executeRequest(req, op.plan, request.variables.getOrElse(Map()), fieldWrappers)
-                      result <- wrap(execute)(executionWrappers, executionRequest)
-                    } yield result).catchAll(Executor.fail)
+                    executionRequest <- wrap(validate)(validationWrappers, doc)
+                    op = executionRequest.operationType match {
+                      case OperationType.Query        => schemaToExecute.query
+                      case OperationType.Mutation     => schemaToExecute.mutation.getOrElse(schemaToExecute.query)
+                      case OperationType.Subscription => schemaToExecute.subscription.getOrElse(schemaToExecute.query)
+                    }
+                    execute = (req: ExecutionRequest) =>
+                      Executor.executeRequest(req, op.plan, request.variables.getOrElse(Map()), fieldWrappers)
+                    result <- wrap(execute)(executionWrappers, executionRequest)
+                  } yield result).catchAll(Executor.fail)
                 )(overallWrappers, request)
             }
         }
@@ -173,14 +172,14 @@ trait GraphQL[-R] { self =>
     subscriptionsName: Option[String] = None
   ): GraphQL[R] = new GraphQL[R] {
     override protected val schemaBuilder: RootSchemaBuilder[R] = self.schemaBuilder.copy(
-      query = queriesName.fold(self.schemaBuilder.query)(
-        name => self.schemaBuilder.query.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
+      query = queriesName.fold(self.schemaBuilder.query)(name =>
+        self.schemaBuilder.query.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
       ),
-      mutation = mutationsName.fold(self.schemaBuilder.mutation)(
-        name => self.schemaBuilder.mutation.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
+      mutation = mutationsName.fold(self.schemaBuilder.mutation)(name =>
+        self.schemaBuilder.mutation.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
       ),
-      subscription = subscriptionsName.fold(self.schemaBuilder.subscription)(
-        name => self.schemaBuilder.subscription.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
+      subscription = subscriptionsName.fold(self.schemaBuilder.subscription)(name =>
+        self.schemaBuilder.subscription.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
       )
     )
     override protected val wrappers: List[Wrapper[R]]              = self.wrappers
@@ -216,8 +215,8 @@ object GraphQL {
     val schemaBuilder: RootSchemaBuilder[R] = RootSchemaBuilder(
       resolver.queryResolver.map(r => Operation(querySchema.toType_(), querySchema.resolve(r))),
       resolver.mutationResolver.map(r => Operation(mutationSchema.toType_(), mutationSchema.resolve(r))),
-      resolver.subscriptionResolver.map(
-        r => Operation(subscriptionSchema.toType_(isSubscription = true), subscriptionSchema.resolve(r))
+      resolver.subscriptionResolver.map(r =>
+        Operation(subscriptionSchema.toType_(isSubscription = true), subscriptionSchema.resolve(r))
       )
     )
     val wrappers: List[Wrapper[R]]              = Nil

--- a/core/src/main/scala/caliban/schema/RootSchemaBuilder.scala
+++ b/core/src/main/scala/caliban/schema/RootSchemaBuilder.scala
@@ -6,7 +6,8 @@ import caliban.schema.Types.collectTypes
 case class RootSchemaBuilder[-R](
   query: Option[Operation[R]],
   mutation: Option[Operation[R]],
-  subscription: Option[Operation[R]]
+  subscription: Option[Operation[R]],
+  additionalTypes: List[__Type] = Nil
 ) {
   def |+|[R1 <: R](that: RootSchemaBuilder[R1]): RootSchemaBuilder[R1] =
     RootSchemaBuilder(
@@ -16,7 +17,7 @@ case class RootSchemaBuilder[-R](
     )
 
   def types: List[__Type] = {
-    val empty = List.empty[__Type]
+    val empty = additionalTypes
     (query.map(_.opType).fold(empty)(collectTypes(_)) ++
       mutation.map(_.opType).fold(empty)(collectTypes(_)) ++
       subscription.map(_.opType).fold(empty)(collectTypes(_)))

--- a/federation/src/main/scala/caliban/federation/Federation.scala
+++ b/federation/src/main/scala/caliban/federation/Federation.scala
@@ -96,11 +96,13 @@ trait Federation {
       _fieldSet: FieldSet = FieldSet("")
     )
 
+    val withSDL = original.withAdditionalTypes(resolvers.map(_.toType))
+
     GraphQL.graphQL(
       RootResolver(
         Query(
           _entities = args => args.representations.map(rep => _Entity(rep.__typename, rep.fields)),
-          _service = ZQuery.succeed(_Service(original.render))
+          _service = ZQuery.succeed(_Service(withSDL.render))
         )
       ),
       federationDirectives

--- a/federation/src/test/scala/caliban/federation/FederationSpec.scala
+++ b/federation/src/test/scala/caliban/federation/FederationSpec.scala
@@ -4,13 +4,30 @@ import caliban.CalibanError.ValidationError
 import caliban.GraphQL._
 import caliban.Macros.gqldoc
 import caliban.TestUtils._
+import caliban.schema.Annotations.GQLDirective
+import caliban.schema.Schema
 import zio.test.Assertion._
 import zio.test._
 import zio.query.ZQuery
 
 object FederationSpec extends DefaultRunnableSpec {
+  @GQLDirective(Key("name"))
+  @GQLDirective(Extend)
+  case class Orphan(@GQLDirective(External) name: String, nicknames: List[String])
+
+  object Orphan {
+    implicit val schema: Schema[Any, Orphan] = Schema.gen[Orphan]
+  }
+
+  case class OrphanArgs(name: String)
+
   val entityResolver =
     EntityResolver[Any, CharacterArgs, Character](args => ZQuery.succeed(characters.find(_.name == args.name)))
+
+  val orphanResolver =
+    EntityResolver[Any, OrphanArgs, Orphan](args =>
+      ZQuery.succeed(characters.find(_.name == args.name).map(c => Orphan(c.name, c.nicknames)))
+    )
 
   override def spec = suite("FederationSpec")(
     testM("should resolve federated types") {
@@ -51,6 +68,16 @@ object FederationSpec extends DefaultRunnableSpec {
               "The target field of a field selection must be defined on the scoped type of the selection set. There are no limitations on alias names."
             )
           )
+        )
+      )
+    },
+    testM("should include orphan entities in sdl") {
+      val interpreter = federate(graphQL(resolver), orphanResolver).interpreter
+
+      val query = gqldoc("""{ _service { sdl } }""")
+      assertM(interpreter.flatMap(_.execute(query)).map(d => d.data.toString))(
+        containsString(
+          """type Orphan @key(fields: \"name\") @extends {\n  name: String! @external\n  nicknames: [String!]!\n}"""
         )
       )
     }


### PR DESCRIPTION
In federation it is possible that you declare a type which has no entry point in the graph but which is nonetheless required to be part of the outgoing schema. Consider:


```graphql
// Schema A
@key(fields:"id")
type User {
  id: String!
}

type Query {
  me: User!
}

```

```graphql
// Schema B
@key(fields:"id")
extends type User {
  id: String! @external
  team: Team!
}

type Query {
  team(id: String): Team
}
```


In the above graphs they should become federated with `User` gaining the `team` field through declaration, however currently the implementation ignores types which don't have entry points into the graph from `Query` so the users extension would be skipped.

This PR allows the schema to include these orphan types as long as there is an entity resolver defined for the typel.