### PR TITLE
http4s adapter update

### DIFF
--- a/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -292,7 +292,7 @@ object Http4sAdapter {
    */
   def provideSomeLayerFromRequest[R <: Has[_], R1 <: Has[_]](
     route: HttpRoutes[RIO[R with R1, *]],
-    f: Request[RIO[R, *]] => TaskLayer[R1]
+    f: Request[RIO[R, *]] => RLayer[R, R1]
   )(implicit tagged: Tag[R1]): HttpRoutes[RIO[R, *]] =
     Kleisli { req: Request[RIO[R, *]] =>
       val to: RIO[R, *] ~> RIO[R with R1, *] = FunctionK.lift[RIO[R, *], RIO[R with R1, *]](identity)


### PR DESCRIPTION
This might me helpful for others too. We needed to parse token with the help of configured `AuthService` from common top layer in our project. It is just widening app so backwards compatible.