### PR TITLE
Wrap derived schema in Exported wrapper

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,18 @@ lazy val root = project
     federation
   )
 
+lazy val macros = project
+  .in(file("macros"))
+  .settings(name := "caliban")
+  .settings(commonSettings)
+  .settings(
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
+    libraryDependencies ++= Seq(
+      "com.propensive" %% "magnolia" % "0.17.0",
+      "com.propensive" %% "mercator" % "0.2.1"
+    )
+  )
+
 lazy val core = project
   .in(file("core"))
   .settings(name := "caliban")
@@ -94,6 +106,7 @@ lazy val core = project
       compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
     )
   )
+  .dependsOn(macros)
   .settings(
     fork in Test := true,
     fork in run := true

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -8,7 +8,7 @@ import caliban.schema.{ Operation, RootSchema, RootType, Schema, Types }
 
 object Introspector {
 
-  implicit lazy val typeSchema: Schema[Any, __Type] = Schema.gen[__Type]
+  implicit lazy val typeSchema: Schema[Any, __Type] = Schema.gen[__Type].instance
 
   private[caliban] val directives = List(
     __Directive(
@@ -44,7 +44,7 @@ object Introspector {
       ),
       args => types.find(_.name.contains(args.name)).get
     )
-    val introspectionSchema = Schema.gen[__Introspection]
+    val introspectionSchema = Schema.gen[__Introspection].instance
     RootSchema(Operation(introspectionSchema.toType_(), introspectionSchema.resolve(resolver)), None, None)
   }
 

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -89,7 +89,11 @@ trait Schema[-R, T] { self =>
   }
 }
 
-object Schema extends GenericSchema[Any]
+object Schema extends GenericSchema[Any] with LowPriorityExportedSchema
+
+private[schema] trait LowPriorityExportedSchema {
+  implicit def exportedSchema[R, T](implicit exported: Exported[Schema[R, T]]): Schema[R, T] = exported.instance
+}
 
 trait GenericSchema[R] extends DerivationSchema[R] with TemporalSchema {
 
@@ -542,8 +546,7 @@ trait DerivationSchema[R] {
   private def getDescription[Typeclass[_], Type](ctx: ReadOnlyParam[Typeclass, Type]): Option[String] =
     getDescription(ctx.annotations)
 
-  implicit def gen[T]: Typeclass[T] = macro Magnolia.gen[T]
-
+  implicit def gen[T]: Exported[Typeclass[T]] = macro ExportedMagnolia.exportedMagnolia[Typeclass, T]
 }
 
 trait TemporalSchema {

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -61,7 +61,7 @@ object TestUtils {
   )
 
   object Character {
-    implicit val schema: Schema[Any, Character] = Schema.gen[Character]
+    implicit val schema: Schema[Any, Character] = Schema.gen[Character].instance
   }
 
   val characters = List(

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -35,7 +35,7 @@ object SchemaSpec extends DefaultRunnableSpec {
         case class Field(value: ZQuery[Console, Nothing, String])
         case class Queries(field: ZQuery[Blocking, Nothing, Field])
         object MySchema extends GenericSchema[Console with Blocking] {
-          implicit lazy val queriesSchema = gen[Queries]
+          implicit lazy val queriesSchema = gen[Queries].instance
         }
         assert(MySchema.queriesSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL)))
@@ -67,13 +67,13 @@ object SchemaSpec extends DefaultRunnableSpec {
 
         case class A(s: String)
         object A {
-          implicit val aSchema: Schema[Blocking, A] = blockingSchema.gen[A]
+          implicit val aSchema: Schema[Blocking, A] = blockingSchema.gen[A].instance
         }
         case class B(a: List[Option[A]])
 
         A.aSchema.toType_()
 
-        val schema: Schema[Blocking, B] = blockingSchema.gen[B]
+        val schema: Schema[Blocking, B] = blockingSchema.gen[B].instance
 
         assert(Types.collectTypes(schema.toType_()).map(_.name.getOrElse("")))(
           not(contains("SomeA")) && not(contains("OptionA")) && not(contains("None"))

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -62,6 +62,23 @@ object SchemaSpec extends DefaultRunnableSpec {
           contains("GenericOptionDouble") && contains("GenericOptionInt")
         )
       },
+      test("nested types with explicit schema in companion object") {
+        object blockingSchema extends GenericSchema[Blocking]
+
+        case class A(s: String)
+        object A {
+          implicit val aSchema: Schema[Blocking, A] = blockingSchema.gen[A]
+        }
+        case class B(a: List[Option[A]])
+
+        A.aSchema.toType_()
+
+        val schema: Schema[Blocking, B] = blockingSchema.gen[B]
+
+        assert(Types.collectTypes(schema.toType_()).map(_.name.getOrElse("")))(
+          not(contains("SomeA")) && not(contains("OptionA")) && not(contains("None"))
+        )
+      },
       test("UUID field should be converted to ID") {
         assert(introspect[IDSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
           isSome(hasField[__Type, String]("id", _.ofType.flatMap(_.name).get, equalTo("ID")))

--- a/examples/src/main/scala/caliban/ExampleApi.scala
+++ b/examples/src/main/scala/caliban/ExampleApi.scala
@@ -26,10 +26,10 @@ object ExampleApi extends GenericSchema[ExampleService] {
   case class Mutations(deleteCharacter: CharacterArgs => URIO[ExampleService, Boolean])
   case class Subscriptions(characterDeleted: ZStream[ExampleService, Nothing, String])
 
-  implicit val roleSchema           = gen[Role]
-  implicit val characterSchema      = gen[Character]
-  implicit val characterArgsSchema  = gen[CharacterArgs]
-  implicit val charactersArgsSchema = gen[CharactersArgs]
+  implicit val roleSchema           = gen[Role].instance
+  implicit val characterSchema      = gen[Character].instance
+  implicit val characterArgsSchema  = gen[CharacterArgs].instance
+  implicit val charactersArgsSchema = gen[CharactersArgs].instance
 
   val api: GraphQL[Console with Clock with ExampleService] =
     graphQL(

--- a/examples/src/main/scala/caliban/federation/FederatedApi.scala
+++ b/examples/src/main/scala/caliban/federation/FederatedApi.scala
@@ -44,12 +44,12 @@ object FederatedApi {
     case class Mutations(deleteCharacter: CharacterArgs => URIO[CharacterService, Boolean])
     case class Subscriptions(characterDeleted: ZStream[CharacterService, Nothing, String])
 
-    implicit val roleSchema                                            = gen[Role]
-    implicit lazy val episodeSchema: Schema[CharacterService, Episode] = gen[Episode]
-    implicit val characterSchema                                       = gen[Character]
-    implicit val characterArgsSchema                                   = gen[CharacterArgs]
-    implicit val charactersArgsSchema                                  = gen[CharactersArgs]
-    implicit val episodeArgs                                           = gen[EpisodeArgs]
+    implicit val roleSchema                                            = gen[Role].instance
+    implicit lazy val episodeSchema: Schema[CharacterService, Episode] = gen[Episode].instance
+    implicit val characterSchema                                       = gen[Character].instance
+    implicit val characterArgsSchema                                   = gen[CharacterArgs].instance
+    implicit val charactersArgsSchema                                  = gen[CharactersArgs].instance
+    implicit val episodeArgs                                           = gen[EpisodeArgs].instance
     implicit val episodeArgBuilder: ArgBuilder[EpisodeArgs]            = ArgBuilder.gen[EpisodeArgs]
 
     val api: GraphQL[Console with Clock with CharacterService] =
@@ -88,9 +88,9 @@ object FederatedApi {
       episodes: EpisodesArgs => URIO[EpisodeService, List[Episode]]
     )
 
-    implicit val episodeArgsSchema  = gen[EpisodeArgs]
-    implicit val episodesArgsSchema = gen[EpisodesArgs]
-    implicit val episodeSchema      = gen[Episode]
+    implicit val episodeArgsSchema  = gen[EpisodeArgs].instance
+    implicit val episodesArgsSchema = gen[EpisodesArgs].instance
+    implicit val episodeSchema      = gen[Episode].instance
 
     val api: GraphQL[Console with Clock with EpisodeService] =
       federate(

--- a/examples/src/main/scala/caliban/optimizations/NaiveTest.scala
+++ b/examples/src/main/scala/caliban/optimizations/NaiveTest.scala
@@ -73,13 +73,13 @@ object NaiveTest extends App with GenericSchema[Console] {
       )
     )
 
-  implicit val viewerMetadataSchema: Schema[Any, ViewerMetadata] = Schema.gen[ViewerMetadata]
-  implicit val tagSchema: Schema[Any, Tag]                       = Schema.gen[Tag]
-  implicit val venueSchema: Schema[Any, Venue]                   = Schema.gen[Venue]
-  implicit val userArgsSchema: Schema[Any, UserArgs]             = Schema.gen[UserArgs]
-  implicit val sizeArgsSchema: Schema[Any, SizeArgs]             = Schema.gen[SizeArgs]
-  implicit val firstArgsSchema: Schema[Any, FirstArgs]           = Schema.gen[FirstArgs]
-  implicit lazy val user: Schema[Console, User]                  = gen[User]
+  implicit val viewerMetadataSchema: Schema[Any, ViewerMetadata] = Schema.gen[ViewerMetadata].instance
+  implicit val tagSchema: Schema[Any, Tag]                       = Schema.gen[Tag].instance
+  implicit val venueSchema: Schema[Any, Venue]                   = Schema.gen[Venue].instance
+  implicit val userArgsSchema: Schema[Any, UserArgs]             = Schema.gen[UserArgs].instance
+  implicit val sizeArgsSchema: Schema[Any, SizeArgs]             = Schema.gen[SizeArgs].instance
+  implicit val firstArgsSchema: Schema[Any, FirstArgs]           = Schema.gen[FirstArgs].instance
+  implicit lazy val user: Schema[Console, User]                  = gen[User].instance
 
   val resolver = Queries(args => getUser(args.id))
   val api      = GraphQL.graphQL(RootResolver(resolver))

--- a/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
+++ b/examples/src/main/scala/caliban/optimizations/OptimizedTest.scala
@@ -110,13 +110,13 @@ object OptimizedTest extends App with GenericSchema[Console] {
   def getUpcomingEventIdsForUser(id: Int, first: Int): ConsoleQuery[List[Int]] =
     ZQuery.fromRequest(GetUpcomingEventIdsForUser(id, first))(UpcomingEventDataSource)
 
-  implicit val viewerMetadataSchema: Schema[Any, ViewerMetadata] = Schema.gen[ViewerMetadata]
-  implicit val tagSchema: Schema[Any, Tag]                       = Schema.gen[Tag]
-  implicit val venueSchema: Schema[Any, Venue]                   = Schema.gen[Venue]
-  implicit val userArgsSchema: Schema[Any, UserArgs]             = Schema.gen[UserArgs]
-  implicit val sizeArgsSchema: Schema[Any, SizeArgs]             = Schema.gen[SizeArgs]
-  implicit val firstArgsSchema: Schema[Any, FirstArgs]           = Schema.gen[FirstArgs]
-  implicit lazy val user: Schema[Console, User]                  = gen[User]
+  implicit val viewerMetadataSchema: Schema[Any, ViewerMetadata] = Schema.gen[ViewerMetadata].instance
+  implicit val tagSchema: Schema[Any, Tag]                       = Schema.gen[Tag].instance
+  implicit val venueSchema: Schema[Any, Venue]                   = Schema.gen[Venue].instance
+  implicit val userArgsSchema: Schema[Any, UserArgs]             = Schema.gen[UserArgs].instance
+  implicit val sizeArgsSchema: Schema[Any, SizeArgs]             = Schema.gen[SizeArgs].instance
+  implicit val firstArgsSchema: Schema[Any, FirstArgs]           = Schema.gen[FirstArgs].instance
+  implicit lazy val user: Schema[Console, User]                  = gen[User].instance
 
   val resolver = Queries(args => getUser(args.id))
   val api      = GraphQL.graphQL(RootResolver(resolver))

--- a/federation/src/test/scala/caliban/federation/FederationSpec.scala
+++ b/federation/src/test/scala/caliban/federation/FederationSpec.scala
@@ -16,7 +16,7 @@ object FederationSpec extends DefaultRunnableSpec {
   case class Orphan(@GQLDirective(External) name: String, nicknames: List[String])
 
   object Orphan {
-    implicit val schema: Schema[Any, Orphan] = Schema.gen[Orphan]
+    implicit val schema: Schema[Any, Orphan] = Schema.gen[Orphan].instance
   }
 
   case class OrphanArgs(name: String)

--- a/macros/src/main/scala/caliban/schema/Exported.scala
+++ b/macros/src/main/scala/caliban/schema/Exported.scala
@@ -1,0 +1,4 @@
+package caliban.schema
+
+case class Exported[T](instance: T) extends AnyVal
+

--- a/macros/src/main/scala/caliban/schema/ExportedMagnolia.scala
+++ b/macros/src/main/scala/caliban/schema/ExportedMagnolia.scala
@@ -3,7 +3,6 @@ package caliban.schema
 object ExportedMagnolia {
   import magnolia.Magnolia
 
-  import scala.language.higherKinds
   import scala.reflect.macros.whitebox
 
   // Wrap the output of Magnolia in an Exported to force it to a lower priority.

--- a/macros/src/main/scala/caliban/schema/ExportedMagnolia.scala
+++ b/macros/src/main/scala/caliban/schema/ExportedMagnolia.scala
@@ -1,0 +1,17 @@
+package caliban.schema
+
+object ExportedMagnolia {
+  import magnolia.Magnolia
+
+  import scala.language.higherKinds
+  import scala.reflect.macros.whitebox
+
+  // Wrap the output of Magnolia in an Exported to force it to a lower priority.
+  // This seems to work, despite magnolia hardcode checks for `macroApplication` symbol
+  // and relying on getting an diverging implicit expansion error for auto-mode.
+  // Thankfully at least it doesn't check the output type of its `macroApplication`
+  def exportedMagnolia[TC[_], A: c.WeakTypeTag](c: whitebox.Context): c.Expr[Exported[TC[A]]] = {
+    val magnoliaTree = c.Expr[TC[A]](Magnolia.gen[A](c))
+    c.universe.reify(Exported(magnoliaTree.splice))
+  }
+}


### PR DESCRIPTION
This PR fights with issue described on this issues:
  - https://github.com/propensive/magnolia/issues/89 
  - https://github.com/propensive/magnolia/issues/213
  - https://github.com/propensive/magnolia/issues/107

Short version: macro derivation sometimes conflicts with builtin schemas defined in Schema companion object.

On this PR I followed solution described by @neko-kai on [this comment](https://github.com/propensive/magnolia/issues/107#issuecomment-589289260).

In first commit I added failing test so it can be tested it in isolation.
