### PR TITLE
Add a pure selection builder helper

### DIFF
--- a/client/src/main/scala/caliban/client/SelectionBuilder.scala
+++ b/client/src/main/scala/caliban/client/SelectionBuilder.scala
@@ -334,6 +334,7 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
 object SelectionBuilder {
 
   val __typename: SelectionBuilder[Any, String] = Field("__typename", Scalar[String]())
+  def pure[A](a: A): SelectionBuilder[Any, A]   = Pure(a)
 
   case class Field[Origin, A](
     name: String,
@@ -385,6 +386,21 @@ object SelectionBuilder {
     override def toSelectionSet: List[Selection] = builder.toSelectionSet
 
     override def withAlias(alias: String): SelectionBuilder[Origin, B] = Mapping(builder.withAlias(alias), f)
+  }
+  case class Pure[A](a: A) extends SelectionBuilder[Any, A] { self =>
+    override private[caliban] def toSelectionSet = Nil
+
+    override private[caliban] def fromGraphQL(value: Value) = Right(a)
+
+    /**
+     * Add the given directive to the selection
+     */
+    override def withDirective(directive: Directive): SelectionBuilder[Any, A] = self
+
+    /**
+     * Use the given alias for this selection
+     */
+    override def withAlias(alias: String): SelectionBuilder[Any, A] = self
   }
 
   def combineAll[Origin, A](

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -109,6 +109,10 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
         test("query name") {
           val query = Queries.character("Amos Burton")(Character.name) toGraphQL (queryName = Some("GetCharacter"))
           assert(query.query)(equalTo("""query GetCharacter {character(name:"Amos Burton"){name}}"""))
+        },
+        test("pure fields") {
+          val query = Queries.character("Amos Burton")(Character.name ~ SelectionBuilder.pure("Fake")) toGraphQL ()
+          assert(query.query)(equalTo("""query{character(name:"Amos Burton"){name}}"""))
         }
       ),
       suite("response parsing")(
@@ -210,6 +214,13 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
               )
             )
           assert(query.fromGraphQL(response))(isRight(equalTo(List(Some("Amos Burton"), Some("Naomi Nagata")))))
+        },
+        test("pure") {
+          val query = Queries.character("Amos Burton")(Character.name) ~ SelectionBuilder.pure("Fake")
+          val response = ObjectValue(
+            List("character" -> ObjectValue(List("name" -> StringValue("Amos Burton"))))
+          )
+          assert(query.fromGraphQL(response))(isRight(equalTo((Some("Amos Burton"), "Fake"))))
         }
       )
     )

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -111,7 +111,7 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
           assert(query.query)(equalTo("""query GetCharacter {character(name:"Amos Burton"){name}}"""))
         },
         test("pure fields") {
-          val query = Queries.character("Amos Burton")(Character.name ~ SelectionBuilder.pure("Fake")) toGraphQL ()
+          val query = Queries.character("Amos Burton")(Character.name ~ SelectionBuilder.pure("Fake")).toGraphQL()
           assert(query.query)(equalTo("""query{character(name:"Amos Burton"){name}}"""))
         }
       ),
@@ -221,6 +221,13 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
             List("character" -> ObjectValue(List("name" -> StringValue("Amos Burton"))))
           )
           assert(query.fromGraphQL(response))(isRight(equalTo((Some("Amos Burton"), "Fake"))))
+        },
+        test("skip") {
+          val query = Queries.character("Amos Burton")(if (false) Character.name else SelectionBuilder.pure("Fake"))
+          val response = ObjectValue(
+            List("character" -> ObjectValue(List("name" -> StringValue("Amos Burton"))))
+          )
+          assert(query.fromGraphQL(response))(isRight(equalTo(Some("Fake"))))
         }
       )
     )


### PR DESCRIPTION
Adds a pure selection helper to the `SelectionBuilder`, this enables building more expressive queries.

For instance say you wanted to emulate the `@include`/`@skip` directive. While you could do it with `withDirective` it is somewhat clumsy.

Now you can do:

```scala
case class Customer(id: String, subscription: Option[Subscription])

// Generated client...

//Query
(Customer.id ~ (if(skip) Customer.subscription else SelectionBuilder.pure(None)))
```

This also helps to align case classes in instances where you have an additional field that you want to include but it isn't part of the schema (and you don't want to perform intermediate transforms).