### PR TITLE
Fix: custom directives can be added and used in wrappers

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -87,7 +87,7 @@ object Field {
       Field("", fieldType, None, fields = fieldList.result())
     }
 
-    loop(selectionSet, fieldType)
+    loop(selectionSet, fieldType).copy(directives = directives)
   }
 
   private def checkDirectives(directives: List[Directive], variableValues: Map[String, InputValue]): Boolean =

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -97,7 +97,7 @@ object Validator {
               }
           }).map(operation =>
             ExecutionRequest(
-              F(op.selectionSet, fragments, variables, operation.opType, document.sourceMapper, Nil),
+              F(op.selectionSet, fragments, variables, operation.opType, document.sourceMapper, op.directives),
               op.operationType,
               op.variableDefinitions
             )
@@ -239,7 +239,7 @@ object Validator {
       directives <- collectAllDirectives(context)
       _ <- IO.foreach_(directives) {
             case (d, location) =>
-              Introspector.directives.find(_.name == d.name) match {
+              (Introspector.directives ++ context.rootType.additionalDirectives).find(_.name == d.name) match {
                 case None =>
                   failValidation(
                     s"Directive '${d.name}' is not supported.",


### PR DESCRIPTION
I encountered some issues while trying to add a custom directive to our server.
This fixes those issues.

Directives can be added on many levels - I've only tested on the level of `__DirectiveLocation .QUERY` and `__DirectiveLocation .MUTATION`. Maybe it's worth adding tests for other DirectiveLocations as well.