### PR TITLE
Fix execution error pass through on die

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -249,6 +249,12 @@ object Executor {
           case other             => Cause.fail(ExecutionError("Effect failure", path.reverse, locationInfo, Some(other)))
         }
       case Right(cause) =>
-        Cause.die(ExecutionError("Effect failure", path.reverse, locationInfo, cause.defects.headOption))
+        cause.defects.headOption.fold(
+          Cause.die(ExecutionError("Effect failure", path.reverse, locationInfo, None))
+        ) {
+          case e: ExecutionError => Cause.die(e.copy(path = path.reverse, locationInfo = locationInfo))
+          case other             => Cause.die(ExecutionError("Effect failure", path.reverse, locationInfo, Some(other)))
+        }
+
     }
 }


### PR DESCRIPTION
In the case of a fiber death (indicating an unrecoverable error on a non-nullable field usually) we should deal with the error in the same way we do for normal errors, by forwarding an `ExecutionError` rather than throwing away the error message.