### PR TITLE
Handle nested orphans

### DIFF
--- a/federation/src/main/scala/caliban/federation/Federation.scala
+++ b/federation/src/main/scala/caliban/federation/Federation.scala
@@ -96,7 +96,7 @@ trait Federation {
       _fieldSet: FieldSet = FieldSet("")
     )
 
-    val withSDL = original.withAdditionalTypes(resolvers.map(_.toType))
+    val withSDL = original.withAdditionalTypes(resolvers.map(_.toType).flatMap(Types.collectTypes(_)))
 
     GraphQL.graphQL(
       RootResolver(


### PR DESCRIPTION
Missed this when I did #584 , only the top level orphans were getting added to the `sdl` schema even though they were still appearing in the introspection call. This makes it so that all children of the orphaned types will also be added.