### PR TITLE
Clarifies CodeGen sbt dependency and plugin instructions in client and schema docs

### DIFF
--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -21,12 +21,16 @@ Caliban-client is available for ScalaJS.
 
 The first step for building GraphQL queries with `caliban-client` is to generate boilerplate code from a GraphQL schema. For that, you need a file containing your schema (if your backend uses `caliban`, you can get it by calling `GraphQL#render` on your API).
 
-To use this feature, add the `caliban-codegen-sbt` sbt plugin to your project and enable it.
-
+To use this feature, add the `caliban-codegen-sbt` sbt plugin to your `project/plugins.sbt` file:
 ```scala
 addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % "0.9.2")
+```
+
+And enable it in your `build.sbt` file:
+```scala
 enablePlugins(CodegenPlugin)
 ```
+
 Then call the `calibanGenClient` sbt command.
 ```scala
 calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2]

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -15,7 +15,11 @@ To use `caliban-client`, add the following line in your `build.sbt` file:
 libraryDependencies += "com.github.ghostdogpr" %% "caliban-client" % "0.9.2"
 ```
 
-Caliban-client is available for ScalaJS.
+Caliban-client is available for ScalaJS. To use it in a ScalaJS project, instead add this line to your `build.sbt` file:
+
+```
+libraryDependencies += "com.github.ghostdogpr" %%% "caliban-client" % "0.9.2"
+```
 
 ## Code generation
 

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -211,12 +211,16 @@ Value classes (`case class SomeWrapper(self: SomeType) extends AnyVal`) will be 
 
 Caliban can automatically generate Scala code from a GraphQL schema.
 
-In order to use this feature, add the `caliban-codegen-sbt` sbt plugin to your project and enable it.
-
+In order to use this feature, add the `caliban-codegen-sbt` sbt plugin to your `project/plugins.sbt` file:
 ```scala
 addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % "0.9.2")
+```
+
+And enable it in your `build.sbt` file:
+```scala
 enablePlugins(CodegenPlugin)
 ```
+
 Then call the `calibanGenSchema` sbt command.
 ```scala
 calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect]


### PR DESCRIPTION
The `caliban-codegen-sbt` plugin needs to be added via the `project/plugins.sbt` file and enabled through the `build.sbt` file in order to be used in an sbt project. This change clarifies that the call to `addSbtPlugin` should be in `project/plugins.sbt`, and the call to `enablePlugins` should be in `build.sbt`.