### PR TITLE
Rename classes to avoid name clashes

### DIFF
--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,12 +1,12 @@
 package caliban.client
 
-import caliban.client.Value.{ __BooleanValue, __ListValue, __NullValue, __NumberValue, __ObjectValue, __StringValue }
+import caliban.client.__Value.{ __BooleanValue, __ListValue, __NullValue, __NumberValue, __ObjectValue, __StringValue }
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
 
 /**
- * Typeclass that defines how to encode an argument of type `A` into a valid [[caliban.client.Value]].
+ * Typeclass that defines how to encode an argument of type `A` into a valid [[caliban.client.__Value]].
  * Every type that can be passed as an argument needs an instance of `ArgEncoder`.
  */
 @implicitNotFound(
@@ -16,7 +16,7 @@ Caliban needs it to know how to encode arguments of type ${A}.
 """
 )
 trait ArgEncoder[-A] {
-  def encode(value: A): Value
+  def encode(value: A): __Value
   def typeName: String
   def optional: Boolean      = false
   def formatTypeName: String = if (optional) typeName else s"$typeName!"
@@ -25,58 +25,58 @@ trait ArgEncoder[-A] {
 object ArgEncoder {
 
   implicit val int: ArgEncoder[Int] = new ArgEncoder[Int] {
-    override def encode(value: Int): Value = __NumberValue(value)
-    override def typeName: String          = "Int"
+    override def encode(value: Int): __Value = __NumberValue(value)
+    override def typeName: String            = "Int"
   }
 
   implicit val long: ArgEncoder[Long] = new ArgEncoder[Long] {
-    override def encode(value: Long): Value = __NumberValue(value)
-    override def typeName: String           = "Long"
+    override def encode(value: Long): __Value = __NumberValue(value)
+    override def typeName: String             = "Long"
   }
 
   implicit val bigInt: ArgEncoder[BigInt] = new ArgEncoder[BigInt] {
-    override def encode(value: BigInt): Value = __NumberValue(BigDecimal(value))
-    override def typeName: String             = "BigInt"
+    override def encode(value: BigInt): __Value = __NumberValue(BigDecimal(value))
+    override def typeName: String               = "BigInt"
   }
 
   implicit val double: ArgEncoder[Double] = new ArgEncoder[Double] {
-    override def encode(value: Double): Value = __NumberValue(value)
-    override def typeName: String             = "Double"
+    override def encode(value: Double): __Value = __NumberValue(value)
+    override def typeName: String               = "Double"
   }
 
   implicit val bigDecimal: ArgEncoder[BigDecimal] = new ArgEncoder[BigDecimal] {
-    override def encode(value: BigDecimal): Value = __NumberValue(value)
-    override def typeName: String                 = "BigDecimal"
+    override def encode(value: BigDecimal): __Value = __NumberValue(value)
+    override def typeName: String                   = "BigDecimal"
   }
 
   implicit val string: ArgEncoder[String] = new ArgEncoder[String] {
-    override def encode(value: String): Value = __StringValue(value)
-    override def typeName: String             = "String"
+    override def encode(value: String): __Value = __StringValue(value)
+    override def typeName: String               = "String"
   }
 
   implicit val boolean: ArgEncoder[Boolean] = new ArgEncoder[Boolean] {
-    override def encode(value: Boolean): Value = __BooleanValue(value)
-    override def typeName: String              = "Boolean"
+    override def encode(value: Boolean): __Value = __BooleanValue(value)
+    override def typeName: String                = "Boolean"
   }
 
   implicit val unit: ArgEncoder[Unit] = new ArgEncoder[Unit] {
-    override def encode(value: Unit): Value = __ObjectValue(Nil)
-    override def typeName: String           = "Unit"
+    override def encode(value: Unit): __Value = __ObjectValue(Nil)
+    override def typeName: String             = "Unit"
   }
 
   implicit def option[A](implicit ev: ArgEncoder[A]): ArgEncoder[Option[A]] = new ArgEncoder[Option[A]] {
-    override def encode(value: Option[A]): Value = value.fold(__NullValue: Value)(ev.encode)
-    override def typeName: String                = ev.typeName
-    override def optional: Boolean               = true
+    override def encode(value: Option[A]): __Value = value.fold(__NullValue: __Value)(ev.encode)
+    override def typeName: String                  = ev.typeName
+    override def optional: Boolean                 = true
   }
 
   implicit def list[A](implicit ev: ArgEncoder[A]): ArgEncoder[List[A]] = new ArgEncoder[List[A]] {
-    override def encode(value: List[A]): Value = __ListValue(value.map(ev.encode))
-    override def typeName: String              = s"[${ev.typeName}]"
+    override def encode(value: List[A]): __Value = __ListValue(value.map(ev.encode))
+    override def typeName: String                = s"[${ev.typeName}]"
   }
 
   implicit val json: ArgEncoder[Json] = new ArgEncoder[Json] {
-    override def encode(value: Json): Value = Value.valueDecoder.decodeJson(value).getOrElse(__NullValue)
-    override def typeName: String           = "Json"
+    override def encode(value: Json): __Value = __Value.valueDecoder.decodeJson(value).getOrElse(__NullValue)
+    override def typeName: String             = "Json"
   }
 }

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,6 +1,6 @@
 package caliban.client
 
-import caliban.client.Value.{ __NumberValue, __StringValue, BooleanValue, ListValue, NullValue, ObjectValue }
+import caliban.client.Value.{ __BooleanValue, __NumberValue, __StringValue, ListValue, NullValue, ObjectValue }
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
@@ -55,7 +55,7 @@ object ArgEncoder {
   }
 
   implicit val boolean: ArgEncoder[Boolean] = new ArgEncoder[Boolean] {
-    override def encode(value: Boolean): Value = BooleanValue(value)
+    override def encode(value: Boolean): Value = __BooleanValue(value)
     override def typeName: String              = "Boolean"
   }
 

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,6 +1,6 @@
 package caliban.client
 
-import caliban.client.Value.{ __BooleanValue, __NumberValue, __StringValue, ListValue, NullValue, ObjectValue }
+import caliban.client.Value.{ __BooleanValue, __ListValue, __NumberValue, __StringValue, NullValue, ObjectValue }
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
@@ -71,7 +71,7 @@ object ArgEncoder {
   }
 
   implicit def list[A](implicit ev: ArgEncoder[A]): ArgEncoder[List[A]] = new ArgEncoder[List[A]] {
-    override def encode(value: List[A]): Value = ListValue(value.map(ev.encode))
+    override def encode(value: List[A]): Value = __ListValue(value.map(ev.encode))
     override def typeName: String              = s"[${ev.typeName}]"
   }
 

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,6 +1,6 @@
 package caliban.client
 
-import caliban.client.Value.{ __BooleanValue, __ListValue, __NumberValue, __StringValue, NullValue, ObjectValue }
+import caliban.client.Value.{ __BooleanValue, __ListValue, __NumberValue, __ObjectValue, __StringValue, NullValue }
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
@@ -60,7 +60,7 @@ object ArgEncoder {
   }
 
   implicit val unit: ArgEncoder[Unit] = new ArgEncoder[Unit] {
-    override def encode(value: Unit): Value = ObjectValue(Nil)
+    override def encode(value: Unit): Value = __ObjectValue(Nil)
     override def typeName: String           = "Unit"
   }
 

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,6 +1,6 @@
 package caliban.client
 
-import caliban.client.Value.{ __BooleanValue, __ListValue, __NumberValue, __ObjectValue, __StringValue, NullValue }
+import caliban.client.Value.{ __BooleanValue, __ListValue, __NullValue, __NumberValue, __ObjectValue, __StringValue }
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
@@ -65,7 +65,7 @@ object ArgEncoder {
   }
 
   implicit def option[A](implicit ev: ArgEncoder[A]): ArgEncoder[Option[A]] = new ArgEncoder[Option[A]] {
-    override def encode(value: Option[A]): Value = value.fold(NullValue: Value)(ev.encode)
+    override def encode(value: Option[A]): Value = value.fold(__NullValue: Value)(ev.encode)
     override def typeName: String                = ev.typeName
     override def optional: Boolean               = true
   }
@@ -76,7 +76,7 @@ object ArgEncoder {
   }
 
   implicit val json: ArgEncoder[Json] = new ArgEncoder[Json] {
-    override def encode(value: Json): Value = Value.valueDecoder.decodeJson(value).getOrElse(NullValue)
+    override def encode(value: Json): Value = Value.valueDecoder.decodeJson(value).getOrElse(__NullValue)
     override def typeName: String           = "Json"
   }
 }

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,6 +1,6 @@
 package caliban.client
 
-import caliban.client.Value.{ __NumberValue, BooleanValue, ListValue, NullValue, ObjectValue, StringValue }
+import caliban.client.Value.{ __NumberValue, __StringValue, BooleanValue, ListValue, NullValue, ObjectValue }
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
@@ -50,7 +50,7 @@ object ArgEncoder {
   }
 
   implicit val string: ArgEncoder[String] = new ArgEncoder[String] {
-    override def encode(value: String): Value = StringValue(value)
+    override def encode(value: String): Value = __StringValue(value)
     override def typeName: String             = "String"
   }
 

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,6 +1,6 @@
 package caliban.client
 
-import caliban.client.Value.{ BooleanValue, ListValue, NullValue, NumberValue, ObjectValue, StringValue }
+import caliban.client.Value.{ __NumberValue, BooleanValue, ListValue, NullValue, ObjectValue, StringValue }
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
@@ -25,27 +25,27 @@ trait ArgEncoder[-A] {
 object ArgEncoder {
 
   implicit val int: ArgEncoder[Int] = new ArgEncoder[Int] {
-    override def encode(value: Int): Value = NumberValue(value)
+    override def encode(value: Int): Value = __NumberValue(value)
     override def typeName: String          = "Int"
   }
 
   implicit val long: ArgEncoder[Long] = new ArgEncoder[Long] {
-    override def encode(value: Long): Value = NumberValue(value)
+    override def encode(value: Long): Value = __NumberValue(value)
     override def typeName: String           = "Long"
   }
 
   implicit val bigInt: ArgEncoder[BigInt] = new ArgEncoder[BigInt] {
-    override def encode(value: BigInt): Value = NumberValue(BigDecimal(value))
+    override def encode(value: BigInt): Value = __NumberValue(BigDecimal(value))
     override def typeName: String             = "BigInt"
   }
 
   implicit val double: ArgEncoder[Double] = new ArgEncoder[Double] {
-    override def encode(value: Double): Value = NumberValue(value)
+    override def encode(value: Double): Value = __NumberValue(value)
     override def typeName: String             = "Double"
   }
 
   implicit val bigDecimal: ArgEncoder[BigDecimal] = new ArgEncoder[BigDecimal] {
-    override def encode(value: BigDecimal): Value = NumberValue(value)
+    override def encode(value: BigDecimal): Value = __NumberValue(value)
     override def typeName: String                 = "BigDecimal"
   }
 

--- a/client/src/main/scala/caliban/client/Argument.scala
+++ b/client/src/main/scala/caliban/client/Argument.scala
@@ -1,7 +1,7 @@
 package caliban.client
 
 import scala.annotation.tailrec
-import caliban.client.Value.NullValue
+import caliban.client.Value.__NullValue
 
 /**
  * Represents an argument in a GraphQL query. Requires an encoder for the argument type.
@@ -12,7 +12,7 @@ case class Argument[+A](name: String, value: A)(implicit encoder: ArgEncoder[A])
     variables: Map[String, (Value, String)]
   ): (String, Map[String, (Value, String)]) =
     encoder.encode(value) match {
-      case NullValue => ("", variables)
+      case `__NullValue` => ("", variables)
       case v =>
         if (useVariables) {
           val variableName = Argument.generateVariableName(name, v, variables)

--- a/client/src/main/scala/caliban/client/Argument.scala
+++ b/client/src/main/scala/caliban/client/Argument.scala
@@ -1,7 +1,7 @@
 package caliban.client
 
 import scala.annotation.tailrec
-import caliban.client.Value.__NullValue
+import caliban.client.__Value.__NullValue
 
 /**
  * Represents an argument in a GraphQL query. Requires an encoder for the argument type.
@@ -9,8 +9,8 @@ import caliban.client.Value.__NullValue
 case class Argument[+A](name: String, value: A)(implicit encoder: ArgEncoder[A]) {
   def toGraphQL(
     useVariables: Boolean,
-    variables: Map[String, (Value, String)]
-  ): (String, Map[String, (Value, String)]) =
+    variables: Map[String, (__Value, String)]
+  ): (String, Map[String, (__Value, String)]) =
     encoder.encode(value) match {
       case `__NullValue` => ("", variables)
       case v =>
@@ -28,8 +28,8 @@ object Argument {
   @tailrec
   def generateVariableName(
     name: String,
-    value: Value,
-    variables: Map[String, (Value, String)],
+    value: __Value,
+    variables: Map[String, (__Value, String)],
     index: Int = 0
   ): String = {
     val formattedName = if (index > 0) s"$name$index" else name

--- a/client/src/main/scala/caliban/client/FieldBuilder.scala
+++ b/client/src/main/scala/caliban/client/FieldBuilder.scala
@@ -35,7 +35,7 @@ object FieldBuilder {
   case class ListOf[A](builder: FieldBuilder[A]) extends FieldBuilder[List[A]] {
     override def fromGraphQL(value: Value): Either[DecodingError, List[A]] =
       value match {
-        case ListValue(items) =>
+        case __ListValue(items) =>
           items.map(builder.fromGraphQL).foldRight(Right(Nil): Either[DecodingError, List[A]]) { (e, acc) =>
             for (xs <- acc; x <- e) yield x :: xs
           }

--- a/client/src/main/scala/caliban/client/FieldBuilder.scala
+++ b/client/src/main/scala/caliban/client/FieldBuilder.scala
@@ -46,8 +46,8 @@ object FieldBuilder {
   case class OptionOf[A](builder: FieldBuilder[A]) extends FieldBuilder[Option[A]] {
     override def fromGraphQL(value: Value): Either[DecodingError, Option[A]] =
       value match {
-        case NullValue => Right(None)
-        case other     => builder.fromGraphQL(other).map(Some(_))
+        case `__NullValue` => Right(None)
+        case other         => builder.fromGraphQL(other).map(Some(_))
       }
     override def toSelectionSet: List[Selection] = builder.toSelectionSet
   }

--- a/client/src/main/scala/caliban/client/FieldBuilder.scala
+++ b/client/src/main/scala/caliban/client/FieldBuilder.scala
@@ -58,8 +58,8 @@ object FieldBuilder {
           for {
             typeNameValue <- fields.find(_._1 == "__typename").map(_._2).toRight(DecodingError("__typename is missing"))
             typeName <- typeNameValue match {
-                         case StringValue(value) => Right(value)
-                         case _                  => Left(DecodingError("__typename is not a String"))
+                         case __StringValue(value) => Right(value)
+                         case _                    => Left(DecodingError("__typename is not a String"))
                        }
             fieldType <- builderMap.get(typeName).toRight(DecodingError(s"type $typeName is unknown"))
             result    <- fieldType.fromGraphQL(value)

--- a/client/src/main/scala/caliban/client/FieldBuilder.scala
+++ b/client/src/main/scala/caliban/client/FieldBuilder.scala
@@ -27,8 +27,8 @@ object FieldBuilder {
   case class Obj[Origin, A](builder: SelectionBuilder[Origin, A]) extends FieldBuilder[A] {
     override def fromGraphQL(value: Value): Either[DecodingError, A] =
       value match {
-        case o: ObjectValue => builder.fromGraphQL(o)
-        case _              => Left(DecodingError(s"Field $value is not an object"))
+        case o: __ObjectValue => builder.fromGraphQL(o)
+        case _                => Left(DecodingError(s"Field $value is not an object"))
       }
     override def toSelectionSet: List[Selection] = builder.toSelectionSet
   }
@@ -54,7 +54,7 @@ object FieldBuilder {
   case class ChoiceOf[A](builderMap: Map[String, FieldBuilder[A]]) extends FieldBuilder[A] {
     override def fromGraphQL(value: Value): Either[DecodingError, A] =
       value match {
-        case ObjectValue(fields) =>
+        case __ObjectValue(fields) =>
           for {
             typeNameValue <- fields.find(_._1 == "__typename").map(_._2).toRight(DecodingError("__typename is missing"))
             typeName <- typeNameValue match {

--- a/client/src/main/scala/caliban/client/GraphQLRequest.scala
+++ b/client/src/main/scala/caliban/client/GraphQLRequest.scala
@@ -6,7 +6,7 @@ import io.circe.{ Encoder, Json }
 /**
  * Represents a GraphQL request, containing a query and a map of variables.
  */
-case class GraphQLRequest(query: String, variables: Map[String, Value])
+case class GraphQLRequest(query: String, variables: Map[String, __Value])
 
 object GraphQLRequest {
 

--- a/client/src/main/scala/caliban/client/GraphQLResponse.scala
+++ b/client/src/main/scala/caliban/client/GraphQLResponse.scala
@@ -1,27 +1,27 @@
 package caliban.client
 
-import caliban.client.Value.__ObjectValue
+import caliban.client.__Value.__ObjectValue
 import io.circe.{ Decoder, HCursor, Json }
 
 /**
  * Represents the result of a GraphQL query, containing a data object and a list of errors.
  */
 case class GraphQLResponse(
-  data: Option[Value],
+  data: Option[__Value],
   errors: List[GraphQLResponseError] = Nil,
   extensions: Option[Json] = None
 )
 
 object GraphQLResponse {
 
-  implicit val objectValueDecoder: Decoder[__ObjectValue] = Decoder[Value].emap {
+  implicit val objectValueDecoder: Decoder[__ObjectValue] = Decoder[__Value].emap {
     case o @ __ObjectValue(_) => Right(o)
     case _                    => Left("Invalid value, should be an object.")
   }
 
   implicit val decoder: Decoder[GraphQLResponse] = (c: HCursor) =>
     for {
-      data       <- c.downField("data").as[Option[Value]]
+      data       <- c.downField("data").as[Option[__Value]]
       errors     <- c.downField("errors").as[Option[List[GraphQLResponseError]]]
       extensions <- c.downField("extensions").as[Option[Json]]
     } yield GraphQLResponse(data, errors.getOrElse(Nil), extensions)

--- a/client/src/main/scala/caliban/client/GraphQLResponse.scala
+++ b/client/src/main/scala/caliban/client/GraphQLResponse.scala
@@ -1,6 +1,6 @@
 package caliban.client
 
-import caliban.client.Value.ObjectValue
+import caliban.client.Value.__ObjectValue
 import io.circe.{ Decoder, HCursor, Json }
 
 /**
@@ -14,9 +14,9 @@ case class GraphQLResponse(
 
 object GraphQLResponse {
 
-  implicit val objectValueDecoder: Decoder[ObjectValue] = Decoder[Value].emap {
-    case o @ ObjectValue(_) => Right(o)
-    case _                  => Left("Invalid value, should be an object.")
+  implicit val objectValueDecoder: Decoder[__ObjectValue] = Decoder[Value].emap {
+    case o @ __ObjectValue(_) => Right(o)
+    case _                    => Left("Invalid value, should be an object.")
   }
 
   implicit val decoder: Decoder[GraphQLResponse] = (c: HCursor) =>

--- a/client/src/main/scala/caliban/client/IntrospectionClient.scala
+++ b/client/src/main/scala/caliban/client/IntrospectionClient.scala
@@ -4,7 +4,7 @@ import caliban.client.CalibanClientError.DecodingError
 import caliban.client.FieldBuilder.{ ListOf, Obj, OptionOf, Scalar }
 import caliban.client.Operations.RootQuery
 import caliban.client.SelectionBuilder.Field
-import caliban.client.Value.{ EnumValue, StringValue }
+import caliban.client.Value.{ __EnumValue => EnumValue, StringValue }
 
 object IntrospectionClient {
 

--- a/client/src/main/scala/caliban/client/IntrospectionClient.scala
+++ b/client/src/main/scala/caliban/client/IntrospectionClient.scala
@@ -4,7 +4,7 @@ import caliban.client.CalibanClientError.DecodingError
 import caliban.client.FieldBuilder.{ ListOf, Obj, OptionOf, Scalar }
 import caliban.client.Operations.RootQuery
 import caliban.client.SelectionBuilder.Field
-import caliban.client.Value.{ __EnumValue => EnumValue, __StringValue }
+import caliban.client.__Value.{ __EnumValue => EnumValue, __StringValue }
 
 object IntrospectionClient {
 
@@ -31,7 +31,7 @@ object IntrospectionClient {
       case other                         => Left(DecodingError(s"Can't build __TypeKind from input $other"))
     }
     implicit val encoder: ArgEncoder[__TypeKind] = new ArgEncoder[__TypeKind] {
-      override def encode(value: __TypeKind): Value = value match {
+      override def encode(value: __TypeKind): __Value = value match {
         case __TypeKind.SCALAR       => EnumValue("SCALAR")
         case __TypeKind.OBJECT       => EnumValue("OBJECT")
         case __TypeKind.INTERFACE    => EnumValue("INTERFACE")
@@ -88,7 +88,7 @@ object IntrospectionClient {
       case other                                   => Left(DecodingError(s"Can't build __DirectiveLocation from input $other"))
     }
     implicit val encoder: ArgEncoder[__DirectiveLocation] = new ArgEncoder[__DirectiveLocation] {
-      override def encode(value: __DirectiveLocation): Value = value match {
+      override def encode(value: __DirectiveLocation): __Value = value match {
         case __DirectiveLocation.QUERY                  => EnumValue("QUERY")
         case __DirectiveLocation.MUTATION               => EnumValue("MUTATION")
         case __DirectiveLocation.SUBSCRIPTION           => EnumValue("SUBSCRIPTION")

--- a/client/src/main/scala/caliban/client/IntrospectionClient.scala
+++ b/client/src/main/scala/caliban/client/IntrospectionClient.scala
@@ -4,7 +4,7 @@ import caliban.client.CalibanClientError.DecodingError
 import caliban.client.FieldBuilder.{ ListOf, Obj, OptionOf, Scalar }
 import caliban.client.Operations.RootQuery
 import caliban.client.SelectionBuilder.Field
-import caliban.client.Value.{ __EnumValue => EnumValue, StringValue }
+import caliban.client.Value.{ __EnumValue => EnumValue, __StringValue }
 
 object IntrospectionClient {
 
@@ -20,15 +20,15 @@ object IntrospectionClient {
     case object NON_NULL     extends __TypeKind
 
     implicit val decoder: ScalarDecoder[__TypeKind] = {
-      case StringValue("SCALAR")       => Right(__TypeKind.SCALAR)
-      case StringValue("OBJECT")       => Right(__TypeKind.OBJECT)
-      case StringValue("INTERFACE")    => Right(__TypeKind.INTERFACE)
-      case StringValue("UNION")        => Right(__TypeKind.UNION)
-      case StringValue("ENUM")         => Right(__TypeKind.ENUM)
-      case StringValue("INPUT_OBJECT") => Right(__TypeKind.INPUT_OBJECT)
-      case StringValue("LIST")         => Right(__TypeKind.LIST)
-      case StringValue("NON_NULL")     => Right(__TypeKind.NON_NULL)
-      case other                       => Left(DecodingError(s"Can't build __TypeKind from input $other"))
+      case __StringValue("SCALAR")       => Right(__TypeKind.SCALAR)
+      case __StringValue("OBJECT")       => Right(__TypeKind.OBJECT)
+      case __StringValue("INTERFACE")    => Right(__TypeKind.INTERFACE)
+      case __StringValue("UNION")        => Right(__TypeKind.UNION)
+      case __StringValue("ENUM")         => Right(__TypeKind.ENUM)
+      case __StringValue("INPUT_OBJECT") => Right(__TypeKind.INPUT_OBJECT)
+      case __StringValue("LIST")         => Right(__TypeKind.LIST)
+      case __StringValue("NON_NULL")     => Right(__TypeKind.NON_NULL)
+      case other                         => Left(DecodingError(s"Can't build __TypeKind from input $other"))
     }
     implicit val encoder: ArgEncoder[__TypeKind] = new ArgEncoder[__TypeKind] {
       override def encode(value: __TypeKind): Value = value match {
@@ -67,25 +67,25 @@ object IntrospectionClient {
     case object INPUT_FIELD_DEFINITION extends __DirectiveLocation
 
     implicit val decoder: ScalarDecoder[__DirectiveLocation] = {
-      case StringValue("QUERY")                  => Right(__DirectiveLocation.QUERY)
-      case StringValue("MUTATION")               => Right(__DirectiveLocation.MUTATION)
-      case StringValue("SUBSCRIPTION")           => Right(__DirectiveLocation.SUBSCRIPTION)
-      case StringValue("FIELD")                  => Right(__DirectiveLocation.FIELD)
-      case StringValue("FRAGMENT_DEFINITION")    => Right(__DirectiveLocation.FRAGMENT_DEFINITION)
-      case StringValue("FRAGMENT_SPREAD")        => Right(__DirectiveLocation.FRAGMENT_SPREAD)
-      case StringValue("INLINE_FRAGMENT")        => Right(__DirectiveLocation.INLINE_FRAGMENT)
-      case StringValue("SCHEMA")                 => Right(__DirectiveLocation.SCHEMA)
-      case StringValue("SCALAR")                 => Right(__DirectiveLocation.SCALAR)
-      case StringValue("OBJECT")                 => Right(__DirectiveLocation.OBJECT)
-      case StringValue("FIELD_DEFINITION")       => Right(__DirectiveLocation.FIELD_DEFINITION)
-      case StringValue("ARGUMENT_DEFINITION")    => Right(__DirectiveLocation.ARGUMENT_DEFINITION)
-      case StringValue("INTERFACE")              => Right(__DirectiveLocation.INTERFACE)
-      case StringValue("UNION")                  => Right(__DirectiveLocation.UNION)
-      case StringValue("ENUM")                   => Right(__DirectiveLocation.ENUM)
-      case StringValue("ENUM_VALUE")             => Right(__DirectiveLocation.ENUM_VALUE)
-      case StringValue("INPUT_OBJECT")           => Right(__DirectiveLocation.INPUT_OBJECT)
-      case StringValue("INPUT_FIELD_DEFINITION") => Right(__DirectiveLocation.INPUT_FIELD_DEFINITION)
-      case other                                 => Left(DecodingError(s"Can't build __DirectiveLocation from input $other"))
+      case __StringValue("QUERY")                  => Right(__DirectiveLocation.QUERY)
+      case __StringValue("MUTATION")               => Right(__DirectiveLocation.MUTATION)
+      case __StringValue("SUBSCRIPTION")           => Right(__DirectiveLocation.SUBSCRIPTION)
+      case __StringValue("FIELD")                  => Right(__DirectiveLocation.FIELD)
+      case __StringValue("FRAGMENT_DEFINITION")    => Right(__DirectiveLocation.FRAGMENT_DEFINITION)
+      case __StringValue("FRAGMENT_SPREAD")        => Right(__DirectiveLocation.FRAGMENT_SPREAD)
+      case __StringValue("INLINE_FRAGMENT")        => Right(__DirectiveLocation.INLINE_FRAGMENT)
+      case __StringValue("SCHEMA")                 => Right(__DirectiveLocation.SCHEMA)
+      case __StringValue("SCALAR")                 => Right(__DirectiveLocation.SCALAR)
+      case __StringValue("OBJECT")                 => Right(__DirectiveLocation.OBJECT)
+      case __StringValue("FIELD_DEFINITION")       => Right(__DirectiveLocation.FIELD_DEFINITION)
+      case __StringValue("ARGUMENT_DEFINITION")    => Right(__DirectiveLocation.ARGUMENT_DEFINITION)
+      case __StringValue("INTERFACE")              => Right(__DirectiveLocation.INTERFACE)
+      case __StringValue("UNION")                  => Right(__DirectiveLocation.UNION)
+      case __StringValue("ENUM")                   => Right(__DirectiveLocation.ENUM)
+      case __StringValue("ENUM_VALUE")             => Right(__DirectiveLocation.ENUM_VALUE)
+      case __StringValue("INPUT_OBJECT")           => Right(__DirectiveLocation.INPUT_OBJECT)
+      case __StringValue("INPUT_FIELD_DEFINITION") => Right(__DirectiveLocation.INPUT_FIELD_DEFINITION)
+      case other                                   => Left(DecodingError(s"Can't build __DirectiveLocation from input $other"))
     }
     implicit val encoder: ArgEncoder[__DirectiveLocation] = new ArgEncoder[__DirectiveLocation] {
       override def encode(value: __DirectiveLocation): Value = value match {

--- a/client/src/main/scala/caliban/client/ScalarDecoder.scala
+++ b/client/src/main/scala/caliban/client/ScalarDecoder.scala
@@ -60,11 +60,11 @@ object ScalarDecoder {
     case other               => Left(DecodingError(s"Can't build a Boolean from input $other"))
   }
   implicit val string: ScalarDecoder[String] = {
-    case StringValue(value) => Right(value)
-    case other              => Left(DecodingError(s"Can't build a String from input $other"))
+    case __StringValue(value) => Right(value)
+    case other                => Left(DecodingError(s"Can't build a String from input $other"))
   }
   implicit val uuid: ScalarDecoder[UUID] = {
-    case StringValue(value) =>
+    case __StringValue(value) =>
       Try(UUID.fromString(value)).toEither.left
         .map(ex => DecodingError(s"Can't build a UUID from input $value", Some(ex)))
     case other => Left(DecodingError(s"Can't build a UUID from input $other"))

--- a/client/src/main/scala/caliban/client/ScalarDecoder.scala
+++ b/client/src/main/scala/caliban/client/ScalarDecoder.scala
@@ -70,8 +70,8 @@ object ScalarDecoder {
     case other => Left(DecodingError(s"Can't build a UUID from input $other"))
   }
   implicit val unit: ScalarDecoder[Unit] = {
-    case ObjectValue(Nil) => Right(())
-    case other            => Left(DecodingError(s"Can't build Unit from input $other"))
+    case __ObjectValue(Nil) => Right(())
+    case other              => Left(DecodingError(s"Can't build Unit from input $other"))
   }
   implicit val json: ScalarDecoder[Json] = value => Right(Value.valueEncoder(value))
 }

--- a/client/src/main/scala/caliban/client/ScalarDecoder.scala
+++ b/client/src/main/scala/caliban/client/ScalarDecoder.scala
@@ -56,8 +56,8 @@ object ScalarDecoder {
     case other                => Left(DecodingError(s"Can't build a BigDecimal from input $other"))
   }
   implicit val boolean: ScalarDecoder[Boolean] = {
-    case BooleanValue(value) => Right(value)
-    case other               => Left(DecodingError(s"Can't build a Boolean from input $other"))
+    case __BooleanValue(value) => Right(value)
+    case other                 => Left(DecodingError(s"Can't build a Boolean from input $other"))
   }
   implicit val string: ScalarDecoder[String] = {
     case __StringValue(value) => Right(value)

--- a/client/src/main/scala/caliban/client/ScalarDecoder.scala
+++ b/client/src/main/scala/caliban/client/ScalarDecoder.scala
@@ -24,17 +24,17 @@ trait ScalarDecoder[+A] {
 
 object ScalarDecoder {
   implicit val int: ScalarDecoder[Int] = {
-    case NumberValue(value) =>
+    case __NumberValue(value) =>
       Try(value.toIntExact).toEither.left.map(ex => DecodingError(s"Can't build an Int from input $value", Some(ex)))
     case other => Left(DecodingError(s"Can't build an Int from input $other"))
   }
   implicit val long: ScalarDecoder[Long] = {
-    case NumberValue(value) =>
+    case __NumberValue(value) =>
       Try(value.toLongExact).toEither.left.map(ex => DecodingError(s"Can't build a Long from input $value", Some(ex)))
     case other => Left(DecodingError(s"Can't build a Long from input $other"))
   }
   implicit val bigInt: ScalarDecoder[BigInt] = {
-    case NumberValue(value) =>
+    case __NumberValue(value) =>
       Try(value.toBigIntExact).toEither.left
         .map(ex => DecodingError(s"Can't build a BigInt from input $value", Some(ex)))
         .flatMap {
@@ -44,16 +44,16 @@ object ScalarDecoder {
     case other => Left(DecodingError(s"Can't build a BigInt from input $other"))
   }
   implicit val float: ScalarDecoder[Float] = {
-    case NumberValue(value) => Right(value.toFloat)
-    case other              => Left(DecodingError(s"Can't build a Float from input $other"))
+    case __NumberValue(value) => Right(value.toFloat)
+    case other                => Left(DecodingError(s"Can't build a Float from input $other"))
   }
   implicit val double: ScalarDecoder[Double] = {
-    case NumberValue(value) => Right(value.toDouble)
-    case other              => Left(DecodingError(s"Can't build a Double from input $other"))
+    case __NumberValue(value) => Right(value.toDouble)
+    case other                => Left(DecodingError(s"Can't build a Double from input $other"))
   }
   implicit val bigDecimal: ScalarDecoder[BigDecimal] = {
-    case NumberValue(value) => Right(value)
-    case other              => Left(DecodingError(s"Can't build a BigDecimal from input $other"))
+    case __NumberValue(value) => Right(value)
+    case other                => Left(DecodingError(s"Can't build a BigDecimal from input $other"))
   }
   implicit val boolean: ScalarDecoder[Boolean] = {
     case BooleanValue(value) => Right(value)

--- a/client/src/main/scala/caliban/client/ScalarDecoder.scala
+++ b/client/src/main/scala/caliban/client/ScalarDecoder.scala
@@ -4,7 +4,7 @@ import scala.util.Try
 import java.util.UUID
 
 import caliban.client.CalibanClientError.DecodingError
-import caliban.client.Value._
+import caliban.client.__Value._
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
@@ -19,7 +19,7 @@ Caliban needs it to know how to decode a scalar of type ${A}.
 """
 )
 trait ScalarDecoder[+A] {
-  def decode(value: Value): Either[DecodingError, A]
+  def decode(value: __Value): Either[DecodingError, A]
 }
 
 object ScalarDecoder {
@@ -73,5 +73,5 @@ object ScalarDecoder {
     case __ObjectValue(Nil) => Right(())
     case other              => Left(DecodingError(s"Can't build Unit from input $other"))
   }
-  implicit val json: ScalarDecoder[Json] = value => Right(Value.valueEncoder(value))
+  implicit val json: ScalarDecoder[Json] = value => Right(__Value.valueEncoder(value))
 }

--- a/client/src/main/scala/caliban/client/Selection.scala
+++ b/client/src/main/scala/caliban/client/Selection.scala
@@ -17,8 +17,8 @@ object Selection {
   case class Directive(name: String, arguments: List[Argument[_]] = Nil) {
     def toGraphQL(
       useVariables: Boolean,
-      variables: Map[String, (Value, String)]
-    ): (String, Map[String, (Value, String)]) = {
+      variables: Map[String, (__Value, String)]
+    ): (String, Map[String, (__Value, String)]) = {
       val (newArgs, newVariables) = arguments.foldLeft((List.empty[String], variables)) {
         case ((args, variables), arg) =>
           val (arg2, variables2) = arg.toGraphQL(useVariables, variables)

--- a/client/src/main/scala/caliban/client/SelectionBuilder.scala
+++ b/client/src/main/scala/caliban/client/SelectionBuilder.scala
@@ -5,7 +5,7 @@ import caliban.client.CalibanClientError.{ CommunicationError, DecodingError, Se
 import caliban.client.FieldBuilder.Scalar
 import caliban.client.Operations.IsOperation
 import caliban.client.Selection.Directive
-import caliban.client.Value.ObjectValue
+import caliban.client.Value.__ObjectValue
 import io.circe.parser
 import sttp.client._
 import sttp.client.circe._
@@ -99,8 +99,8 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
                      .map(ex => DecodingError("Json deserialization error", Some(ex)))
           data <- if (parsed.errors.nonEmpty) Left(ServerError(parsed.errors)) else Right(parsed.data)
           objectValue <- data match {
-                          case Some(o: ObjectValue) => Right(o)
-                          case _                    => Left(DecodingError("Result is not an object"))
+                          case Some(o: __ObjectValue) => Right(o)
+                          case _                      => Left(DecodingError("Result is not an object"))
                         }
           result <- fromGraphQL(objectValue)
         } yield (result, parsed.extensions)
@@ -345,7 +345,7 @@ object SelectionBuilder {
   ) extends SelectionBuilder[Origin, A] { self =>
     override def fromGraphQL(value: Value): Either[DecodingError, A] =
       value match {
-        case ObjectValue(fields) =>
+        case __ObjectValue(fields) =>
           fields.find {
             case (o, _) => alias.getOrElse(name) + math.abs(self.hashCode) == o || alias.contains(o) || name == o
           }.toRight(DecodingError(s"Missing field $name"))

--- a/client/src/main/scala/caliban/client/Value.scala
+++ b/client/src/main/scala/caliban/client/Value.scala
@@ -23,7 +23,7 @@ object Value {
   case class __BooleanValue(value: Boolean) extends Value {
     override def toString: String = value.toString
   }
-  case class ListValue(values: List[Value]) extends Value {
+  case class __ListValue(values: List[Value]) extends Value {
     override def toString: String = values.map(_.toString).mkString("[", ",", "]")
   }
   case class ObjectValue(fields: List[(String, Value)]) extends Value {
@@ -37,7 +37,7 @@ object Value {
       __BooleanValue,
       number => __NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
       __StringValue,
-      array => Value.ListValue(array.toList.map(jsonToValue)),
+      array => Value.__ListValue(array.toList.map(jsonToValue)),
       obj => Value.ObjectValue(obj.toList.map { case (k, v) => k -> jsonToValue(v) })
     )
 
@@ -47,7 +47,7 @@ object Value {
     case __StringValue(value)  => Json.fromString(value)
     case __EnumValue(value)    => Json.fromString(value)
     case __BooleanValue(value) => Json.fromBoolean(value)
-    case ListValue(values)     => Json.fromValues(values.map(valueToJson))
+    case __ListValue(values)   => Json.fromValues(values.map(valueToJson))
     case ObjectValue(fields)   => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
   }
 

--- a/client/src/main/scala/caliban/client/Value.scala
+++ b/client/src/main/scala/caliban/client/Value.scala
@@ -17,7 +17,7 @@ object Value {
   case class __EnumValue(value: String) extends Value {
     override def toString: String = value
   }
-  case class StringValue(value: String) extends Value {
+  case class __StringValue(value: String) extends Value {
     override def toString: String = s""""${value.replace("\"", "\\\"")}""""
   }
   case class BooleanValue(value: Boolean) extends Value {
@@ -36,7 +36,7 @@ object Value {
       NullValue,
       BooleanValue,
       number => __NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
-      StringValue,
+      __StringValue,
       array => Value.ListValue(array.toList.map(jsonToValue)),
       obj => Value.ObjectValue(obj.toList.map { case (k, v) => k -> jsonToValue(v) })
     )
@@ -44,7 +44,7 @@ object Value {
   private def valueToJson(a: Value): Json = a match {
     case NullValue            => Json.Null
     case __NumberValue(value) => Json.fromBigDecimal(value)
-    case StringValue(value)   => Json.fromString(value)
+    case __StringValue(value) => Json.fromString(value)
     case __EnumValue(value)   => Json.fromString(value)
     case BooleanValue(value)  => Json.fromBoolean(value)
     case ListValue(values)    => Json.fromValues(values.map(valueToJson))

--- a/client/src/main/scala/caliban/client/Value.scala
+++ b/client/src/main/scala/caliban/client/Value.scala
@@ -11,7 +11,7 @@ object Value {
   case object NullValue extends Value {
     override def toString: String = "null"
   }
-  case class NumberValue(value: BigDecimal) extends Value {
+  case class __NumberValue(value: BigDecimal) extends Value {
     override def toString: String = s"$value"
   }
   case class __EnumValue(value: String) extends Value {
@@ -35,20 +35,20 @@ object Value {
     json.fold(
       NullValue,
       BooleanValue,
-      number => NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
+      number => __NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
       StringValue,
       array => Value.ListValue(array.toList.map(jsonToValue)),
       obj => Value.ObjectValue(obj.toList.map { case (k, v) => k -> jsonToValue(v) })
     )
 
   private def valueToJson(a: Value): Json = a match {
-    case NullValue           => Json.Null
-    case NumberValue(value)  => Json.fromBigDecimal(value)
-    case StringValue(value)  => Json.fromString(value)
-    case __EnumValue(value)  => Json.fromString(value)
-    case BooleanValue(value) => Json.fromBoolean(value)
-    case ListValue(values)   => Json.fromValues(values.map(valueToJson))
-    case ObjectValue(fields) => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
+    case NullValue            => Json.Null
+    case __NumberValue(value) => Json.fromBigDecimal(value)
+    case StringValue(value)   => Json.fromString(value)
+    case __EnumValue(value)   => Json.fromString(value)
+    case BooleanValue(value)  => Json.fromBoolean(value)
+    case ListValue(values)    => Json.fromValues(values.map(valueToJson))
+    case ObjectValue(fields)  => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
   }
 
   implicit val valueDecoder: Decoder[Value] = Decoder.instance(hcursor => Right(jsonToValue(hcursor.value)))

--- a/client/src/main/scala/caliban/client/Value.scala
+++ b/client/src/main/scala/caliban/client/Value.scala
@@ -8,7 +8,7 @@ import io.circe.{ Decoder, Encoder, Json }
 sealed trait Value
 
 object Value {
-  case object NullValue extends Value {
+  case object __NullValue extends Value {
     override def toString: String = "null"
   }
   case class __NumberValue(value: BigDecimal) extends Value {
@@ -33,7 +33,7 @@ object Value {
 
   private def jsonToValue(json: Json): Value =
     json.fold(
-      NullValue,
+      __NullValue,
       __BooleanValue,
       number => __NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
       __StringValue,
@@ -42,7 +42,7 @@ object Value {
     )
 
   private def valueToJson(a: Value): Json = a match {
-    case NullValue             => Json.Null
+    case `__NullValue`         => Json.Null
     case __NumberValue(value)  => Json.fromBigDecimal(value)
     case __StringValue(value)  => Json.fromString(value)
     case __EnumValue(value)    => Json.fromString(value)

--- a/client/src/main/scala/caliban/client/Value.scala
+++ b/client/src/main/scala/caliban/client/Value.scala
@@ -26,7 +26,7 @@ object Value {
   case class __ListValue(values: List[Value]) extends Value {
     override def toString: String = values.map(_.toString).mkString("[", ",", "]")
   }
-  case class ObjectValue(fields: List[(String, Value)]) extends Value {
+  case class __ObjectValue(fields: List[(String, Value)]) extends Value {
     override def toString: String =
       fields.map { case (name, value) => s"""$name:${value.toString}""" }.mkString("{", ",", "}")
   }
@@ -38,7 +38,7 @@ object Value {
       number => __NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
       __StringValue,
       array => Value.__ListValue(array.toList.map(jsonToValue)),
-      obj => Value.ObjectValue(obj.toList.map { case (k, v) => k -> jsonToValue(v) })
+      obj => Value.__ObjectValue(obj.toList.map { case (k, v) => k -> jsonToValue(v) })
     )
 
   private def valueToJson(a: Value): Json = a match {
@@ -48,7 +48,7 @@ object Value {
     case __EnumValue(value)    => Json.fromString(value)
     case __BooleanValue(value) => Json.fromBoolean(value)
     case __ListValue(values)   => Json.fromValues(values.map(valueToJson))
-    case ObjectValue(fields)   => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
+    case __ObjectValue(fields) => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
   }
 
   implicit val valueDecoder: Decoder[Value] = Decoder.instance(hcursor => Right(jsonToValue(hcursor.value)))

--- a/client/src/main/scala/caliban/client/Value.scala
+++ b/client/src/main/scala/caliban/client/Value.scala
@@ -14,7 +14,7 @@ object Value {
   case class NumberValue(value: BigDecimal) extends Value {
     override def toString: String = s"$value"
   }
-  case class EnumValue(value: String) extends Value {
+  case class __EnumValue(value: String) extends Value {
     override def toString: String = value
   }
   case class StringValue(value: String) extends Value {
@@ -45,7 +45,7 @@ object Value {
     case NullValue           => Json.Null
     case NumberValue(value)  => Json.fromBigDecimal(value)
     case StringValue(value)  => Json.fromString(value)
-    case EnumValue(value)    => Json.fromString(value)
+    case __EnumValue(value)  => Json.fromString(value)
     case BooleanValue(value) => Json.fromBoolean(value)
     case ListValue(values)   => Json.fromValues(values.map(valueToJson))
     case ObjectValue(fields) => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)

--- a/client/src/main/scala/caliban/client/Value.scala
+++ b/client/src/main/scala/caliban/client/Value.scala
@@ -20,7 +20,7 @@ object Value {
   case class __StringValue(value: String) extends Value {
     override def toString: String = s""""${value.replace("\"", "\\\"")}""""
   }
-  case class BooleanValue(value: Boolean) extends Value {
+  case class __BooleanValue(value: Boolean) extends Value {
     override def toString: String = value.toString
   }
   case class ListValue(values: List[Value]) extends Value {
@@ -34,7 +34,7 @@ object Value {
   private def jsonToValue(json: Json): Value =
     json.fold(
       NullValue,
-      BooleanValue,
+      __BooleanValue,
       number => __NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
       __StringValue,
       array => Value.ListValue(array.toList.map(jsonToValue)),
@@ -42,13 +42,13 @@ object Value {
     )
 
   private def valueToJson(a: Value): Json = a match {
-    case NullValue            => Json.Null
-    case __NumberValue(value) => Json.fromBigDecimal(value)
-    case __StringValue(value) => Json.fromString(value)
-    case __EnumValue(value)   => Json.fromString(value)
-    case BooleanValue(value)  => Json.fromBoolean(value)
-    case ListValue(values)    => Json.fromValues(values.map(valueToJson))
-    case ObjectValue(fields)  => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
+    case NullValue             => Json.Null
+    case __NumberValue(value)  => Json.fromBigDecimal(value)
+    case __StringValue(value)  => Json.fromString(value)
+    case __EnumValue(value)    => Json.fromString(value)
+    case __BooleanValue(value) => Json.fromBoolean(value)
+    case ListValue(values)     => Json.fromValues(values.map(valueToJson))
+    case ObjectValue(fields)   => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
   }
 
   implicit val valueDecoder: Decoder[Value] = Decoder.instance(hcursor => Right(jsonToValue(hcursor.value)))

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -5,43 +5,43 @@ import io.circe.{ Decoder, Encoder, Json }
 /**
  * Value that can be returned by the server or sent as an argument.
  */
-sealed trait Value
+sealed trait __Value
 
-object Value {
-  case object __NullValue extends Value {
+object __Value {
+  case object __NullValue extends __Value {
     override def toString: String = "null"
   }
-  case class __NumberValue(value: BigDecimal) extends Value {
+  case class __NumberValue(value: BigDecimal) extends __Value {
     override def toString: String = s"$value"
   }
-  case class __EnumValue(value: String) extends Value {
+  case class __EnumValue(value: String) extends __Value {
     override def toString: String = value
   }
-  case class __StringValue(value: String) extends Value {
+  case class __StringValue(value: String) extends __Value {
     override def toString: String = s""""${value.replace("\"", "\\\"")}""""
   }
-  case class __BooleanValue(value: Boolean) extends Value {
+  case class __BooleanValue(value: Boolean) extends __Value {
     override def toString: String = value.toString
   }
-  case class __ListValue(values: List[Value]) extends Value {
+  case class __ListValue(values: List[__Value]) extends __Value {
     override def toString: String = values.map(_.toString).mkString("[", ",", "]")
   }
-  case class __ObjectValue(fields: List[(String, Value)]) extends Value {
+  case class __ObjectValue(fields: List[(String, __Value)]) extends __Value {
     override def toString: String =
       fields.map { case (name, value) => s"""$name:${value.toString}""" }.mkString("{", ",", "}")
   }
 
-  private def jsonToValue(json: Json): Value =
+  private def jsonToValue(json: Json): __Value =
     json.fold(
       __NullValue,
       __BooleanValue,
       number => __NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
       __StringValue,
-      array => Value.__ListValue(array.toList.map(jsonToValue)),
-      obj => Value.__ObjectValue(obj.toList.map { case (k, v) => k -> jsonToValue(v) })
+      array => __Value.__ListValue(array.toList.map(jsonToValue)),
+      obj => __Value.__ObjectValue(obj.toList.map { case (k, v) => k -> jsonToValue(v) })
     )
 
-  private def valueToJson(a: Value): Json = a match {
+  private def valueToJson(a: __Value): Json = a match {
     case `__NullValue`         => Json.Null
     case __NumberValue(value)  => Json.fromBigDecimal(value)
     case __StringValue(value)  => Json.fromString(value)
@@ -51,7 +51,7 @@ object Value {
     case __ObjectValue(fields) => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
   }
 
-  implicit val valueDecoder: Decoder[Value] = Decoder.instance(hcursor => Right(jsonToValue(hcursor.value)))
+  implicit val valueDecoder: Decoder[__Value] = Decoder.instance(hcursor => Right(jsonToValue(hcursor.value)))
 
-  implicit val valueEncoder: Encoder[Value] = (a: Value) => valueToJson(a)
+  implicit val valueEncoder: Encoder[__Value] = (a: __Value) => valueToJson(a)
 }

--- a/client/src/test/scala/caliban/client/GraphQLResponseSpec.scala
+++ b/client/src/test/scala/caliban/client/GraphQLResponseSpec.scala
@@ -73,7 +73,7 @@ object GraphQLResponseSpec extends DefaultRunnableSpec {
 
         for {
           response   <- ZIO.fromEither(decode[GraphQLResponse](responseRawJson))
-          data       <- ZIO.fromEither(decode[Value](dataRawJson))
+          data       <- ZIO.fromEither(decode[__Value](dataRawJson))
           extensions <- ZIO.fromEither(decode[Json](extensionsRawJson))
         } yield {
           assert(response)(

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -3,7 +3,7 @@ package caliban.client
 import caliban.client.Operations.RootQuery
 import caliban.client.Selection.Directive
 import caliban.client.TestData._
-import caliban.client.Value.{ __ListValue, __StringValue, ObjectValue }
+import caliban.client.Value.{ __ListValue, __ObjectValue, __StringValue }
 import zio.test.Assertion._
 import zio.test.environment.TestEnvironment
 import zio.test._
@@ -122,7 +122,7 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
               Character.name
             }
           val response =
-            ObjectValue(List("characters" -> __ListValue(List(ObjectValue(List("name" -> __StringValue("Amos")))))))
+            __ObjectValue(List("characters" -> __ListValue(List(__ObjectValue(List("name" -> __StringValue("Amos")))))))
           assert(query.fromGraphQL(response))(isRight(equalTo(List("Amos"))))
         },
         test("combine 2 fields") {
@@ -131,11 +131,11 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
               Character.name ~ Character.nicknames
             }
           val response =
-            ObjectValue(
+            __ObjectValue(
               List(
                 "characters" -> __ListValue(
                   List(
-                    ObjectValue(
+                    __ObjectValue(
                       List(
                         "name"      -> __StringValue("Amos Burton"),
                         "nicknames" -> __ListValue(List(__StringValue("Amos")))
@@ -159,15 +159,15 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
             }
 
           val response =
-            ObjectValue(
+            __ObjectValue(
               List(
                 "characters" -> __ListValue(
                   List(
-                    ObjectValue(
+                    __ObjectValue(
                       List(
                         "name"      -> __StringValue("Amos Burton"),
                         "nicknames" -> __ListValue(List(__StringValue("Amos"))),
-                        "role" -> ObjectValue(
+                        "role" -> __ObjectValue(
                           List(
                             "__typename" -> __StringValue("Mechanic"),
                             "shipName"   -> __StringValue("Rocinante")
@@ -196,10 +196,10 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
                 }
                 .copy(alias = Some("naomi"))
           val response =
-            ObjectValue(
+            __ObjectValue(
               List(
-                "amos"  -> ObjectValue(List("name" -> __StringValue("Amos Burton"))),
-                "naomi" -> ObjectValue(List("name" -> __StringValue("Naomi Nagata")))
+                "amos"  -> __ObjectValue(List("name" -> __StringValue("Amos Burton"))),
+                "naomi" -> __ObjectValue(List("name" -> __StringValue("Naomi Nagata")))
               )
             )
           assert(query.fromGraphQL(response))(isRight(equalTo((Some("Amos Burton"), Some("Naomi Nagata")))))
@@ -210,25 +210,25 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
             Queries.character("Naomi Nagata")(Character.name).copy(alias = Some("naomi"))
           )
           val response =
-            ObjectValue(
+            __ObjectValue(
               List(
-                "amos"  -> ObjectValue(List("name" -> __StringValue("Amos Burton"))),
-                "naomi" -> ObjectValue(List("name" -> __StringValue("Naomi Nagata")))
+                "amos"  -> __ObjectValue(List("name" -> __StringValue("Amos Burton"))),
+                "naomi" -> __ObjectValue(List("name" -> __StringValue("Naomi Nagata")))
               )
             )
           assert(query.fromGraphQL(response))(isRight(equalTo(List(Some("Amos Burton"), Some("Naomi Nagata")))))
         },
         test("pure") {
           val query = Queries.character("Amos Burton")(Character.name) ~ SelectionBuilder.pure("Fake")
-          val response = ObjectValue(
-            List("character" -> ObjectValue(List("name" -> __StringValue("Amos Burton"))))
+          val response = __ObjectValue(
+            List("character" -> __ObjectValue(List("name" -> __StringValue("Amos Burton"))))
           )
           assert(query.fromGraphQL(response))(isRight(equalTo((Some("Amos Burton"), "Fake"))))
         },
         test("skip") {
           val query = Queries.character("Amos Burton")(if (false) Character.name else SelectionBuilder.pure("Fake"))
-          val response = ObjectValue(
-            List("character" -> ObjectValue(List("name" -> __StringValue("Amos Burton"))))
+          val response = __ObjectValue(
+            List("character" -> __ObjectValue(List("name" -> __StringValue("Amos Burton"))))
           )
           assert(query.fromGraphQL(response))(isRight(equalTo(Some("Fake"))))
         }

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -3,7 +3,7 @@ package caliban.client
 import caliban.client.Operations.RootQuery
 import caliban.client.Selection.Directive
 import caliban.client.TestData._
-import caliban.client.Value.{ __StringValue, ListValue, ObjectValue }
+import caliban.client.Value.{ __ListValue, __StringValue, ObjectValue }
 import zio.test.Assertion._
 import zio.test.environment.TestEnvironment
 import zio.test._
@@ -122,7 +122,7 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
               Character.name
             }
           val response =
-            ObjectValue(List("characters" -> ListValue(List(ObjectValue(List("name" -> __StringValue("Amos")))))))
+            ObjectValue(List("characters" -> __ListValue(List(ObjectValue(List("name" -> __StringValue("Amos")))))))
           assert(query.fromGraphQL(response))(isRight(equalTo(List("Amos"))))
         },
         test("combine 2 fields") {
@@ -133,12 +133,12 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
           val response =
             ObjectValue(
               List(
-                "characters" -> ListValue(
+                "characters" -> __ListValue(
                   List(
                     ObjectValue(
                       List(
                         "name"      -> __StringValue("Amos Burton"),
-                        "nicknames" -> ListValue(List(__StringValue("Amos")))
+                        "nicknames" -> __ListValue(List(__StringValue("Amos")))
                       )
                     )
                   )
@@ -161,12 +161,12 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
           val response =
             ObjectValue(
               List(
-                "characters" -> ListValue(
+                "characters" -> __ListValue(
                   List(
                     ObjectValue(
                       List(
                         "name"      -> __StringValue("Amos Burton"),
-                        "nicknames" -> ListValue(List(__StringValue("Amos"))),
+                        "nicknames" -> __ListValue(List(__StringValue("Amos"))),
                         "role" -> ObjectValue(
                           List(
                             "__typename" -> __StringValue("Mechanic"),

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -3,7 +3,7 @@ package caliban.client
 import caliban.client.Operations.RootQuery
 import caliban.client.Selection.Directive
 import caliban.client.TestData._
-import caliban.client.Value.{ ListValue, ObjectValue, StringValue }
+import caliban.client.Value.{ __StringValue, ListValue, ObjectValue }
 import zio.test.Assertion._
 import zio.test.environment.TestEnvironment
 import zio.test._
@@ -81,8 +81,8 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
                 .withAlias("naomi")
           val (s, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
           assert(s)(equalTo("""amos:character(name:$name){name} naomi:character(name:$name1){name}""")) &&
-          assert(variables.get("name"))(isSome(equalTo((StringValue("Amos Burton"), "String!")))) &&
-          assert(variables.get("name1"))(isSome(equalTo((StringValue("Naomi Nagata"), "String!"))))
+          assert(variables.get("name"))(isSome(equalTo((__StringValue("Amos Burton"), "String!")))) &&
+          assert(variables.get("name1"))(isSome(equalTo((__StringValue("Naomi Nagata"), "String!"))))
         },
         test("directives") {
           val query =
@@ -103,8 +103,8 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
               .withDirective(Directive("yo", List(Argument("value", "what's up"))))
           val (s, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
           assert(s)(equalTo("""character(name:$name) @yo(value:$value){name}""")) &&
-          assert(variables.get("name"))(isSome(equalTo((StringValue("Amos Burton"), "String!")))) &&
-          assert(variables.get("value"))(isSome(equalTo((StringValue("what's up"), "String!"))))
+          assert(variables.get("name"))(isSome(equalTo((__StringValue("Amos Burton"), "String!")))) &&
+          assert(variables.get("value"))(isSome(equalTo((__StringValue("what's up"), "String!"))))
         },
         test("query name") {
           val query = Queries.character("Amos Burton")(Character.name) toGraphQL (queryName = Some("GetCharacter"))
@@ -122,7 +122,7 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
               Character.name
             }
           val response =
-            ObjectValue(List("characters" -> ListValue(List(ObjectValue(List("name" -> StringValue("Amos")))))))
+            ObjectValue(List("characters" -> ListValue(List(ObjectValue(List("name" -> __StringValue("Amos")))))))
           assert(query.fromGraphQL(response))(isRight(equalTo(List("Amos"))))
         },
         test("combine 2 fields") {
@@ -136,7 +136,10 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
                 "characters" -> ListValue(
                   List(
                     ObjectValue(
-                      List("name" -> StringValue("Amos Burton"), "nicknames" -> ListValue(List(StringValue("Amos"))))
+                      List(
+                        "name"      -> __StringValue("Amos Burton"),
+                        "nicknames" -> ListValue(List(__StringValue("Amos")))
+                      )
                     )
                   )
                 )
@@ -162,12 +165,12 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
                   List(
                     ObjectValue(
                       List(
-                        "name"      -> StringValue("Amos Burton"),
-                        "nicknames" -> ListValue(List(StringValue("Amos"))),
+                        "name"      -> __StringValue("Amos Burton"),
+                        "nicknames" -> ListValue(List(__StringValue("Amos"))),
                         "role" -> ObjectValue(
                           List(
-                            "__typename" -> StringValue("Mechanic"),
-                            "shipName"   -> StringValue("Rocinante")
+                            "__typename" -> __StringValue("Mechanic"),
+                            "shipName"   -> __StringValue("Rocinante")
                           )
                         )
                       )
@@ -195,8 +198,8 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
           val response =
             ObjectValue(
               List(
-                "amos"  -> ObjectValue(List("name" -> StringValue("Amos Burton"))),
-                "naomi" -> ObjectValue(List("name" -> StringValue("Naomi Nagata")))
+                "amos"  -> ObjectValue(List("name" -> __StringValue("Amos Burton"))),
+                "naomi" -> ObjectValue(List("name" -> __StringValue("Naomi Nagata")))
               )
             )
           assert(query.fromGraphQL(response))(isRight(equalTo((Some("Amos Burton"), Some("Naomi Nagata")))))
@@ -209,8 +212,8 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
           val response =
             ObjectValue(
               List(
-                "amos"  -> ObjectValue(List("name" -> StringValue("Amos Burton"))),
-                "naomi" -> ObjectValue(List("name" -> StringValue("Naomi Nagata")))
+                "amos"  -> ObjectValue(List("name" -> __StringValue("Amos Burton"))),
+                "naomi" -> ObjectValue(List("name" -> __StringValue("Naomi Nagata")))
               )
             )
           assert(query.fromGraphQL(response))(isRight(equalTo(List(Some("Amos Burton"), Some("Naomi Nagata")))))
@@ -218,14 +221,14 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
         test("pure") {
           val query = Queries.character("Amos Burton")(Character.name) ~ SelectionBuilder.pure("Fake")
           val response = ObjectValue(
-            List("character" -> ObjectValue(List("name" -> StringValue("Amos Burton"))))
+            List("character" -> ObjectValue(List("name" -> __StringValue("Amos Burton"))))
           )
           assert(query.fromGraphQL(response))(isRight(equalTo((Some("Amos Burton"), "Fake"))))
         },
         test("skip") {
           val query = Queries.character("Amos Burton")(if (false) Character.name else SelectionBuilder.pure("Fake"))
           val response = ObjectValue(
-            List("character" -> ObjectValue(List("name" -> StringValue("Amos Burton"))))
+            List("character" -> ObjectValue(List("name" -> __StringValue("Amos Burton"))))
           )
           assert(query.fromGraphQL(response))(isRight(equalTo(Some("Fake"))))
         }

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -3,7 +3,7 @@ package caliban.client
 import caliban.client.Operations.RootQuery
 import caliban.client.Selection.Directive
 import caliban.client.TestData._
-import caliban.client.Value.{ __ListValue, __ObjectValue, __StringValue }
+import caliban.client.__Value.{ __ListValue, __ObjectValue, __StringValue }
 import zio.test.Assertion._
 import zio.test.environment.TestEnvironment
 import zio.test._

--- a/client/src/test/scala/caliban/client/TestData.scala
+++ b/client/src/test/scala/caliban/client/TestData.scala
@@ -5,7 +5,7 @@ import caliban.client.FieldBuilder._
 import caliban.client.Operations.RootQuery
 import caliban.client.SelectionBuilder.Field
 import caliban.client.TestData.Role._
-import caliban.client.Value.StringValue
+import caliban.client.Value.__StringValue
 
 object TestData {
 
@@ -16,16 +16,16 @@ object TestData {
     case object BELT  extends Origin
 
     implicit val originDecoder: ScalarDecoder[Origin] = {
-      case StringValue("EARTH") => Right(Origin.EARTH)
-      case StringValue("MARS")  => Right(Origin.MARS)
-      case StringValue("BELT")  => Right(Origin.BELT)
-      case other                => Left(DecodingError(s"Can't build an Origin from input $other"))
+      case __StringValue("EARTH") => Right(Origin.EARTH)
+      case __StringValue("MARS")  => Right(Origin.MARS)
+      case __StringValue("BELT")  => Right(Origin.BELT)
+      case other                  => Left(DecodingError(s"Can't build an Origin from input $other"))
     }
     implicit val originEncoder: ArgEncoder[Origin] = new ArgEncoder[Origin] {
       override def encode(value: Origin): Value = value match {
-        case EARTH => StringValue("EARTH")
-        case MARS  => StringValue("MARS")
-        case BELT  => StringValue("BELT")
+        case EARTH => __StringValue("EARTH")
+        case MARS  => __StringValue("MARS")
+        case BELT  => __StringValue("BELT")
       }
       override def typeName: String = "Origin"
     }

--- a/client/src/test/scala/caliban/client/TestData.scala
+++ b/client/src/test/scala/caliban/client/TestData.scala
@@ -5,7 +5,7 @@ import caliban.client.FieldBuilder._
 import caliban.client.Operations.RootQuery
 import caliban.client.SelectionBuilder.Field
 import caliban.client.TestData.Role._
-import caliban.client.Value.__StringValue
+import caliban.client.__Value.__StringValue
 
 object TestData {
 
@@ -22,7 +22,7 @@ object TestData {
       case other                  => Left(DecodingError(s"Can't build an Origin from input $other"))
     }
     implicit val originEncoder: ArgEncoder[Origin] = new ArgEncoder[Origin] {
-      override def encode(value: Origin): Value = value match {
+      override def encode(value: Origin): __Value = value match {
         case EARTH => __StringValue("EARTH")
         case MARS  => __StringValue("MARS")
         case BELT  => __StringValue("BELT")

--- a/examples/src/main/scala/caliban/client/Client.scala
+++ b/examples/src/main/scala/caliban/client/Client.scala
@@ -22,9 +22,9 @@ object Client {
     }
     implicit val encoder: ArgEncoder[Origin] = new ArgEncoder[Origin] {
       override def encode(value: Origin): Value = value match {
-        case Origin.BELT  => EnumValue("BELT")
-        case Origin.EARTH => EnumValue("EARTH")
-        case Origin.MARS  => EnumValue("MARS")
+        case Origin.BELT  => __EnumValue("BELT")
+        case Origin.EARTH => __EnumValue("EARTH")
+        case Origin.MARS  => __EnumValue("MARS")
       }
       override def typeName: String = "Origin"
     }

--- a/examples/src/main/scala/caliban/client/Client.scala
+++ b/examples/src/main/scala/caliban/client/Client.scala
@@ -4,7 +4,7 @@ import caliban.client.CalibanClientError.DecodingError
 import caliban.client.FieldBuilder._
 import caliban.client.SelectionBuilder._
 import caliban.client.Operations._
-import caliban.client.Value._
+import caliban.client.__Value._
 
 object Client {
 
@@ -21,7 +21,7 @@ object Client {
       case other                  => Left(DecodingError(s"Can't build Origin from input $other"))
     }
     implicit val encoder: ArgEncoder[Origin] = new ArgEncoder[Origin] {
-      override def encode(value: Origin): Value = value match {
+      override def encode(value: Origin): __Value = value match {
         case Origin.BELT  => __EnumValue("BELT")
         case Origin.EARTH => __EnumValue("EARTH")
         case Origin.MARS  => __EnumValue("MARS")

--- a/examples/src/main/scala/caliban/client/Client.scala
+++ b/examples/src/main/scala/caliban/client/Client.scala
@@ -15,10 +15,10 @@ object Client {
     case object MARS  extends Origin
 
     implicit val decoder: ScalarDecoder[Origin] = {
-      case StringValue("BELT")  => Right(Origin.BELT)
-      case StringValue("EARTH") => Right(Origin.EARTH)
-      case StringValue("MARS")  => Right(Origin.MARS)
-      case other                => Left(DecodingError(s"Can't build Origin from input $other"))
+      case __StringValue("BELT")  => Right(Origin.BELT)
+      case __StringValue("EARTH") => Right(Origin.EARTH)
+      case __StringValue("MARS")  => Right(Origin.MARS)
+      case other                  => Left(DecodingError(s"Can't build Origin from input $other"))
     }
     implicit val encoder: ArgEncoder[Origin] = new ArgEncoder[Origin] {
       override def encode(value: Origin): Value = value match {

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -75,7 +75,7 @@ object ClientWriter {
       """import caliban.client.Operations._
         |""".stripMargin
     else ""}${if (enums.nonEmpty || inputs.nonEmpty)
-      """import caliban.client.Value._
+      """import caliban.client.__Value._
         |""".stripMargin
     else ""}"""
 
@@ -129,7 +129,7 @@ object ClientWriter {
     s"""case class ${typedef.name}(${writeArgumentFields(typedef.fields)})
        |object ${typedef.name} {
        |  implicit val encoder: ArgEncoder[${typedef.name}] = new ArgEncoder[${typedef.name}] {
-       |    override def encode(value: ${typedef.name}): Value =
+       |    override def encode(value: ${typedef.name}): __Value =
        |      __ObjectValue(List(${typedef.fields
          .map(f => s""""${f.name}" -> ${writeInputValue(f.ofType, s"value.${safeName(f.name)}", typedef.name)}""")
          .mkString(", ")}))
@@ -143,11 +143,11 @@ object ClientWriter {
         if (name == typeName) s"encode($fieldName)"
         else s"implicitly[ArgEncoder[${mapTypeName(name)}]].encode($fieldName)"
       case NamedType(name, false) =>
-        s"$fieldName.fold(__NullValue: Value)(value => ${writeInputValue(NamedType(name, nonNull = true), "value", typeName)})"
+        s"$fieldName.fold(__NullValue: __Value)(value => ${writeInputValue(NamedType(name, nonNull = true), "value", typeName)})"
       case ListType(ofType, true) =>
         s"__ListValue($fieldName.map(value => ${writeInputValue(ofType, "value", typeName)}))"
       case ListType(ofType, false) =>
-        s"$fieldName.fold(__NullValue: Value)(value => ${writeInputValue(ListType(ofType, nonNull = true), "value", typeName)})"
+        s"$fieldName.fold(__NullValue: __Value)(value => ${writeInputValue(ListType(ofType, nonNull = true), "value", typeName)})"
     }
 
   def writeEnum(typedef: EnumTypeDefinition): String =
@@ -164,7 +164,7 @@ object ClientWriter {
             case other => Left(DecodingError(s"Can't build ${typedef.name} from input $$other"))
           }
           implicit val encoder: ArgEncoder[${typedef.name}] = new ArgEncoder[${typedef.name}] {
-            override def encode(value: ${typedef.name}): Value = value match {
+            override def encode(value: ${typedef.name}): __Value = value match {
               ${typedef.enumValuesDefinition
       .map(v => s"""case ${typedef.name}.${safeName(v.enumValue)} => __EnumValue("${v.enumValue}")""")
       .mkString("\n")}

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -130,7 +130,7 @@ object ClientWriter {
        |object ${typedef.name} {
        |  implicit val encoder: ArgEncoder[${typedef.name}] = new ArgEncoder[${typedef.name}] {
        |    override def encode(value: ${typedef.name}): Value =
-       |      ObjectValue(List(${typedef.fields
+       |      __ObjectValue(List(${typedef.fields
          .map(f => s""""${f.name}" -> ${writeInputValue(f.ofType, s"value.${safeName(f.name)}", typedef.name)}""")
          .mkString(", ")}))
        |    override def typeName: String = "${typedef.name}"
@@ -143,11 +143,11 @@ object ClientWriter {
         if (name == typeName) s"encode($fieldName)"
         else s"implicitly[ArgEncoder[${mapTypeName(name)}]].encode($fieldName)"
       case NamedType(name, false) =>
-        s"$fieldName.fold(NullValue: Value)(value => ${writeInputValue(NamedType(name, nonNull = true), "value", typeName)})"
+        s"$fieldName.fold(__NullValue: Value)(value => ${writeInputValue(NamedType(name, nonNull = true), "value", typeName)})"
       case ListType(ofType, true) =>
-        s"ListValue($fieldName.map(value => ${writeInputValue(ofType, "value", typeName)}))"
+        s"__ListValue($fieldName.map(value => ${writeInputValue(ofType, "value", typeName)}))"
       case ListType(ofType, false) =>
-        s"$fieldName.fold(NullValue: Value)(value => ${writeInputValue(ListType(ofType, nonNull = true), "value", typeName)})"
+        s"$fieldName.fold(__NullValue: Value)(value => ${writeInputValue(ListType(ofType, nonNull = true), "value", typeName)})"
     }
 
   def writeEnum(typedef: EnumTypeDefinition): String =
@@ -159,14 +159,14 @@ object ClientWriter {
       
           implicit val decoder: ScalarDecoder[${typedef.name}] = {
             ${typedef.enumValuesDefinition
-      .map(v => s"""case StringValue ("${v.enumValue}") => Right(${typedef.name}.${safeName(v.enumValue)})""")
+      .map(v => s"""case __StringValue ("${v.enumValue}") => Right(${typedef.name}.${safeName(v.enumValue)})""")
       .mkString("\n")}
             case other => Left(DecodingError(s"Can't build ${typedef.name} from input $$other"))
           }
           implicit val encoder: ArgEncoder[${typedef.name}] = new ArgEncoder[${typedef.name}] {
             override def encode(value: ${typedef.name}): Value = value match {
               ${typedef.enumValuesDefinition
-      .map(v => s"""case ${typedef.name}.${safeName(v.enumValue)} => EnumValue("${v.enumValue}")""")
+      .map(v => s"""case ${typedef.name}.${safeName(v.enumValue)} => __EnumValue("${v.enumValue}")""")
       .mkString("\n")}
             }
             override def typeName: String = "${typedef.name}"

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -202,7 +202,7 @@ object Client {
           equalTo(
             """import caliban.client.CalibanClientError.DecodingError
 import caliban.client._
-import caliban.client.Value._
+import caliban.client.__Value._
 
 object Client {
 
@@ -219,7 +219,7 @@ object Client {
       case other                  => Left(DecodingError(s"Can't build Origin from input $other"))
     }
     implicit val encoder: ArgEncoder[Origin] = new ArgEncoder[Origin] {
-      override def encode(value: Origin): Value = value match {
+      override def encode(value: Origin): __Value = value match {
         case Origin.EARTH => __EnumValue("EARTH")
         case Origin.MARS  => __EnumValue("MARS")
         case Origin.BELT  => __EnumValue("BELT")
@@ -245,14 +245,14 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client._
-import caliban.client.Value._
+import caliban.client.__Value._
 
 object Client {
 
   case class CharacterInput(name: String, nicknames: List[String] = Nil)
   object CharacterInput {
     implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
-      override def encode(value: CharacterInput): Value =
+      override def encode(value: CharacterInput): __Value =
         __ObjectValue(
           List(
             "name"      -> implicitly[ArgEncoder[String]].encode(value.name),
@@ -279,14 +279,14 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client._
-import caliban.client.Value._
+import caliban.client.__Value._
 
 object Client {
 
   case class CharacterInput(wait_ : String)
   object CharacterInput {
     implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
-      override def encode(value: CharacterInput): Value =
+      override def encode(value: CharacterInput): __Value =
         __ObjectValue(List("wait" -> implicitly[ArgEncoder[String]].encode(value.wait_)))
       override def typeName: String = "CharacterInput"
     }

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -213,16 +213,16 @@ object Client {
     case object BELT  extends Origin
 
     implicit val decoder: ScalarDecoder[Origin] = {
-      case StringValue("EARTH") => Right(Origin.EARTH)
-      case StringValue("MARS")  => Right(Origin.MARS)
-      case StringValue("BELT")  => Right(Origin.BELT)
-      case other                => Left(DecodingError(s"Can't build Origin from input $other"))
+      case __StringValue("EARTH") => Right(Origin.EARTH)
+      case __StringValue("MARS")  => Right(Origin.MARS)
+      case __StringValue("BELT")  => Right(Origin.BELT)
+      case other                  => Left(DecodingError(s"Can't build Origin from input $other"))
     }
     implicit val encoder: ArgEncoder[Origin] = new ArgEncoder[Origin] {
       override def encode(value: Origin): Value = value match {
-        case Origin.EARTH => EnumValue("EARTH")
-        case Origin.MARS  => EnumValue("MARS")
-        case Origin.BELT  => EnumValue("BELT")
+        case Origin.EARTH => __EnumValue("EARTH")
+        case Origin.MARS  => __EnumValue("MARS")
+        case Origin.BELT  => __EnumValue("BELT")
       }
       override def typeName: String = "Origin"
     }
@@ -253,10 +253,10 @@ object Client {
   object CharacterInput {
     implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
       override def encode(value: CharacterInput): Value =
-        ObjectValue(
+        __ObjectValue(
           List(
             "name"      -> implicitly[ArgEncoder[String]].encode(value.name),
-            "nicknames" -> ListValue(value.nicknames.map(value => implicitly[ArgEncoder[String]].encode(value)))
+            "nicknames" -> __ListValue(value.nicknames.map(value => implicitly[ArgEncoder[String]].encode(value)))
           )
         )
       override def typeName: String = "CharacterInput"
@@ -287,7 +287,7 @@ object Client {
   object CharacterInput {
     implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
       override def encode(value: CharacterInput): Value =
-        ObjectValue(List("wait" -> implicitly[ArgEncoder[String]].encode(value.wait_)))
+        __ObjectValue(List("wait" -> implicitly[ArgEncoder[String]].encode(value.wait_)))
       override def typeName: String = "CharacterInput"
     }
   }


### PR DESCRIPTION
This PR solves the issue https://github.com/ghostdogpr/caliban/issues/543.

https://github.com/ghostdogpr/caliban/issues/543#issuecomment-670833351
> How about renaming those internal classes to __???Value directly?

As suggested by @ghostdogpr, I've changed the internal class names.

- NullValue to __NullValue
- NumberValue to __NumberValue
- EnumValue to __EnumValue
- StringValue to __StringValue
- BooleanValue to __BooleanValue
- ListValue to __ListValue
- ObjectValue to __ObjectValue