### PR TITLE
Add a scripted test for caliban-codegen-sbt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.12! core/test http4s/compile akkaHttp/compile finch/compile play/compile examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test
+      - run: sbt ++2.12.12! core/test http4s/compile akkaHttp/compile finch/compile play/compile examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test codegenSbt/scripted
       - save_cache:
           key: sbtcache
           paths:
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.3! core/test http4s/compile akkaHttp/compile finch/compile play/compile examples/compile catsInterop/compile monixInterop/compile tapirInterop/test clientJVM/test federation/test
+      - run: sbt ++2.13.3! core/test http4s/compile akkaHttp/compile finch/compile play/compile examples/compile catsInterop/compile monixInterop/compile tapirInterop/test clientJVM/test federation/test codegenSbt/scripted
       - save_cache:
           key: sbtcache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.3! core/test http4s/compile akkaHttp/compile finch/compile play/compile examples/compile catsInterop/compile monixInterop/compile tapirInterop/test clientJVM/test federation/test codegenSbt/scripted
+      - run: sbt ++2.13.3! core/test http4s/compile akkaHttp/compile finch/compile play/compile examples/compile catsInterop/compile monixInterop/compile tapirInterop/test clientJVM/test federation/test
       - save_cache:
           key: sbtcache
           paths:

--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,20 @@ lazy val codegenSbt = project
       "dev.zio" %% "zio-test-sbt" % zioVersion % "test"
     )
   )
+  .enablePlugins(SbtPlugin)
+  .settings(
+    scriptedLaunchOpts := {
+      scriptedLaunchOpts.value ++
+        Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+    },
+    scriptedBufferLog := false,
+    scriptedDependencies := {
+      (core / publishLocal).value
+      (clientJVM / publishLocal).value
+      (tools / publishLocal).value
+      publishLocal.value
+    }
+  )
   .dependsOn(tools)
 
 lazy val catsInterop = project

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/build.sbt
@@ -1,0 +1,8 @@
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(CodegenPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.ghostdogpr" %% "caliban-client" % Version.pluginVersion
+    )
+  )

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/project/Version.scala
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/project/Version.scala
@@ -1,0 +1,7 @@
+object Version {
+  def pluginVersion: String =
+    sys.props.get("plugin.version") match {
+      case Some(x) => x
+      case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                                   |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+    }}

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/project/plugins.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/project/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/project/schema.graphql
@@ -1,0 +1,73 @@
+# Schema
+schema {
+    query: Q
+}
+
+# Query
+type Q {
+    # nested object type
+    characters: [Character!]!
+    # nested object type with argument
+    character(name: String!): Character
+
+    # default arguments for optional and list arguments
+    characters2(
+        first: Int!
+        last: Int
+        origins: [String]!
+    ): String
+
+    testJson: Json!
+}
+
+# Input object
+input CharacterInput {
+    name: String!
+    nicknames: [String!]!
+    nicknames2: [String]!
+    nicknames3: [String!]
+    nicknames4: [String]
+
+    # reserved name
+    wait: String!
+}
+
+# Object
+type Character {
+    name: String!
+    nicknames: [String!]!
+
+    # reserved name
+    type: String!
+
+    # enum
+    origin: Origin
+
+    # union
+    role: Role
+
+    # Deperecated field + comment
+    oldName: String! @deprecated(reason: "blah")
+    oldNicknames: [String!]! @deprecated
+    # Deprecated field + comment newline
+    oldName2: String! @deprecated(reason: "foo\nbar")
+}
+
+# Enum
+enum Origin {
+    EARTH
+    MARS
+    BELT
+}
+
+# Union
+union Role = Captain | Pilot
+type Captain {
+    shipName: String!
+}
+type Pilot {
+    shipName: String!
+}
+
+# Json
+scalar Json

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/test
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/test
@@ -1,0 +1,8 @@
+$ exists project/schema.graphql
+$ absent src/main/scala/Client.scala
+$ mkdir src/main/scala
+
+> calibanGenClient project/schema.graphql src/main/scala/Client.scala
+$ exists src/main/scala/Client.scala
+
+> compile

--- a/project/ConsoleHelper.scala
+++ b/project/ConsoleHelper.scala
@@ -19,6 +19,7 @@ object ConsoleHelper {
             |${item("~compile")} - Compile all modules with file-watch enabled
             |${item("test")} - Run the unit test suite
             |${item("fmt")} - Run scalafmt on the entire project
+            |${item("scripted")} - Run the scripted test suite
             |${item("examples/runMain caliban.http4s.ExampleApp")} - Start the example server (http4s based)
             |${item("examples/runMain caliban.akkahttp.ExampleApp")} - Start the example server (akka-http based)
             |${item("benchmarks/jmh:run")} - Run the benchmarks


### PR DESCRIPTION
Add a scripted test that verifies `caliban-codegen-sbt` generated code compiles or not.

As you may know, a scripted test can test a `sbt-plugin`.
See https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html for details.

This PR includes
- Add a scripted test that verifies `caliban-codegen-sbt` generated code compiles or not
- Add help for scripted tests to sbt console
- Enable scripted tests in CI pipeline

Unfortunately, I'm not a GraphQL expert, so I'm not sure that added tests cover all (or enough) GraphQL syntax.

The GraphQL schema written in `codegen-sbt/src/sbt-test/codegen/test-compile/project/schema.graphql` is picked up from
https://github.com/ghostdogpr/caliban/blob/master/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala .
