### PR TITLE
fix: error in Monix interop example

### DIFF
--- a/vuepress/docs/docs/interop.md
+++ b/vuepress/docs/docs/interop.md
@@ -65,11 +65,11 @@ import caliban.interop.monix.implicits._
 import cats.effect.ExitCode
 import monix.eval.{ Task, TaskApp }
 import monix.execution.Scheduler
-import zio.DefaultRuntime
+import zio.Runtime
 
 object ExampleMonixInterop extends TaskApp {
 
-  implicit val runtime = new DefaultRuntime {}
+  implicit val runtime = Runtime.default
   implicit val monixScheduler: Scheduler = scheduler
 
   case class Queries(numbers: List[Int], randomNumber: Task[Int])


### PR DESCRIPTION
Hey guys. Stumbled upon an error in Monix interop example. There was an error in creation of default ZIO runtime. Fixed so nobody else has to struggle after mindlessly copying the code.