### PR TITLE
Fix input fields in SchemaLoader.fromCaliban

### DIFF
--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -90,7 +90,7 @@ case class __Type(
             description,
             name.getOrElse(""),
             directives.getOrElse(Nil),
-            fields(__DeprecatedArgs(Some(true))).getOrElse(Nil).map(_.toInputValueDefinition)
+            inputFields.getOrElse(Nil).map(_.toInputValueDefinition)
           )
         )
       case _ => None


### PR DESCRIPTION
`InputObjectTypeDefinition` should get fields from `inputFields` instead of `fields`.