### PR TITLE
Add handrolled schema helpers

### DIFF
--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -11,7 +11,7 @@ import caliban.introspection.adt.__Type
 import caliban.parsing.adt.LocationInfo
 import caliban.schema.Annotations.{ GQLInterface, GQLName }
 import caliban.schema.{ Schema, Step, Types }
-import zio.{ IO, NonEmptyChunk, UIO, ZIO }
+import zio.{ IO, UIO, ZIO }
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test._
@@ -630,7 +630,7 @@ object ExecutionSpec extends DefaultRunnableSpec {
         )
 
         implicit lazy val groupSchema: Schema[Any, Group] = obj("Group", Some("A group of users"))(implicit ft =>
-          NonEmptyChunk(
+          List(
             field("id")(_.id),
             field("parent")(_.parent),
             field("organization")(_.organization)
@@ -638,9 +638,16 @@ object ExecutionSpec extends DefaultRunnableSpec {
         )
         implicit lazy val orgSchema: Schema[Any, Organization] =
           obj("Organization", Some("An organization of groups"))(implicit ft =>
-            NonEmptyChunk(
+            List(
               field("id")(_.id),
               field("groups")(_.groups)
+            )
+          )
+
+        implicit val querySchema: Schema[Any, Query] =
+          obj("Query")(implicit ft =>
+            List(
+              fieldWithArgs[Query, String]("organization")(_.organization)
             )
           )
 

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -263,7 +263,7 @@ import caliban.schema.Schema.{obj, field}
 
 implicit lazy val groupSchema: Schema[Any, Group] = obj("Group", Some("A group of users"))(
   implicit ft =>
-    NonEmptyChunk(
+    List(
       field("id")(_.id),
       field("users")(_.users),
       field("parent")(_.parent),
@@ -272,7 +272,7 @@ implicit lazy val groupSchema: Schema[Any, Group] = obj("Group", Some("A group o
 )
 implicit lazy val orgSchema: Schema[Any, Organization] = obj("Organization", Some("An organization of groups"))(
   implicit ft =>
-    NonEmptyChunk(
+    List(
       field("id")(_.id),
       field("groups")(_.groups)
     )
@@ -280,7 +280,7 @@ implicit lazy val orgSchema: Schema[Any, Organization] = obj("Organization", Som
 
 implicit lazy val userSchema: Schema[Any, User] = obj("User", Some("A user of the service"))(
   implicit ft =>
-    NonEmptyChunk(
+    List(
       field("id")(_.id),
       field("group")(_.group)
     )

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -244,7 +244,7 @@ By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. Thi
 
 ## Building Schemas by hand
 
-Sometimes the for what ever reason schema generation fails. This can sometimes happen if your schema has co-recursive types and Magnolia is unable
+Sometimes for whatever reason schema generation fails. This can happen if your schema has co-recursive types and Magnolia is unable
 to generate a schema for them. In cases like these you may need to instead create your own schema by hand.
 
 Consider the case where you have three types which create cyclical dependencies on one another

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -241,3 +241,48 @@ The generated code will be formatted with Scalafmt using the configuration defin
 The package of the generated code is derived from the folder of `outputPath`. This can be overridden by providing an alternative package with the `--packageName` option.
 
 By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. This can be overridden by providing an alternative effect with the `--effect` option.
+
+## Building Schemas by hand
+
+Sometimes the for what ever reason schema generation fails. This can sometimes happen if your schema has co-recursive types and Magnolia is unable
+to generate a schema for them. In cases like these you may need to instead create your own schema by hand.
+
+Consider the case where you have three types which create cyclical dependencies on one another
+
+```scala
+case class Group(id: String, users: UIO[List[User]], parent: UIO[Option[Group]], organization: UIO[Organization])
+case class Organization(id: String, groups: UIO[List[Group]])
+case class User(id: String, group: UIO[Group])
+```
+
+These three types all depend on one another and if you attempt to generate a schema from them you will either end up with compiler errors or you will end up with a nasty runtime
+error from a `NullPointerException`. To help the compiler out we can hand generate the types for these case classes instead.
+
+```scala
+import caliban.schema.Schema.{obj, field}
+
+implicit lazy val groupSchema: Schema[Any, Group] = obj("Group", Some("A group of users"))(
+  implicit ft =>
+    NonEmptyChunk(
+      field("id")(_.id),
+      field("users")(_.users),
+      field("parent")(_.parent),
+      field("organization")(_.organization)
+    )
+)
+implicit lazy val orgSchema: Schema[Any, Organization] = obj("Organization", Some("An organization of groups"))(
+  implicit ft =>
+    NonEmptyChunk(
+      field("id")(_.id),
+      field("groups")(_.groups)
+    )
+)
+
+implicit lazy val userSchema: Schema[Any, User] = obj("User", Some("A user of the service"))(
+  implicit ft =>
+    NonEmptyChunk(
+      field("id")(_.id),
+      field("group")(_.group)
+    )
+)
+```


### PR DESCRIPTION
Makes it easier to craft handrolled schema's directly when the `gen` isn't sufficient (usually in the case of mutually- or self- recursive types).