### PR TITLE
Print full stack trace (in red) in printErrors wrapper

### DIFF
--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -1,15 +1,17 @@
 package caliban.wrappers
 
 import caliban.CalibanError.{ ExecutionError, ValidationError }
-import caliban.{ GraphQLRequest, GraphQLResponse }
 import caliban.Value.NullValue
 import caliban.execution.Field
 import caliban.parsing.adt.Document
 import caliban.wrappers.Wrapper.{ OverallWrapper, ValidationWrapper }
+import caliban.{ GraphQLRequest, GraphQLResponse }
 import zio.clock.Clock
-import zio.console.{ putStrLn, Console }
+import zio.console.{ putStrLn, putStrLnErr, Console }
 import zio.duration._
-import zio.{ IO, UIO, URIO, ZIO }
+import zio.{ Chunk, IO, UIO, URIO, ZIO }
+
+import scala.annotation.tailrec
 
 object Wrappers {
 
@@ -18,8 +20,19 @@ object Wrappers {
    */
   lazy val printErrors: OverallWrapper[Console] =
     OverallWrapper { process => request =>
-      process(request).tap(response => ZIO.when(response.errors.nonEmpty)(putStrLn(response.errors.mkString("\n"))))
+      process(request).tap(response =>
+        ZIO.when(response.errors.nonEmpty)(
+          putStrLnErr(response.errors.flatMap(prettyStackStrace).mkString("", "\n", "\n"))
+        )
+      )
     }
+
+  private def prettyStackStrace(t: Throwable): Chunk[String] = {
+    @tailrec def go(acc: Chunk[String], t: Throwable): Chunk[String] =
+      if (t == null) acc
+      else go(acc ++ (t.toString +: Chunk.fromArray(t.getStackTrace).map("\tat " + _.toString)), t.getCause)
+    go(Chunk(""), t)
+  }
 
   /**
    * Returns a wrapper that prints slow queries


### PR DESCRIPTION
**Change this:**

<img width="724" alt="caliban-error-pre" src="https://user-images.githubusercontent.com/21149055/102692586-0ca60f80-41f3-11eb-8b7e-76a2ffce57c1.png">

**for this:**

<img width="805" alt="caliban-error-post" src="https://user-images.githubusercontent.com/21149055/102692593-1760a480-41f3-11eb-882f-cb2258b08c6f.png">

Ok ?
