### PR TITLE
Add benchmarks 

### DIFF
--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmark.scala
@@ -1,0 +1,198 @@
+package caliban.execution
+
+import java.util.concurrent.TimeUnit
+
+import caliban.GraphQL.graphQL
+import caliban.{CalibanError, GraphQLInterpreter, RootResolver}
+import org.openjdk.jmh.annotations._
+import zio.{BootstrapRuntime, Runtime, ZEnv}
+import zio.internal.Platform
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class NestedZQueryBenchmark {
+
+  val runtime: Runtime[ZEnv] = new BootstrapRuntime {
+    override val platform: Platform = Platform.benchmark
+  }
+
+  import NestedZQueryBenchmarkSchema._
+
+  val simple100: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.simple100Elements)).interpreter)
+  val simple1000: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.simple1000Elements)).interpreter)
+  val simple10000: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.simple10000Elements)).interpreter)
+
+  val multifield100: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.multifield100Elements)).interpreter)
+  val multifield1000: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.multifield1000Elements)).interpreter)
+  val multifield10000: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.multifield10000Elements)).interpreter)
+
+  val deep100: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.deep100Elements)).interpreter)
+  val deep1000: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.deep1000Elements)).interpreter)
+  val deep10000: GraphQLInterpreter[Any, CalibanError] = runtime.unsafeRun(graphQL(RootResolver(NestedZQueryBenchmarkSchema.deep10000Elements)).interpreter)
+
+  @Benchmark
+  def simpleParallelQuery100(): Any = {
+    val io = simple100.execute(simpleQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def simpleParallelQuery1000(): Any = {
+    val io = simple1000.execute(simpleQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def simpleParallelQuery10000(): Any = {
+    val io = simple10000.execute(simpleQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def simpleSequentialQuery100(): Any = {
+    val io = simple100.execute(simpleQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def simpleSequentialQuery1000(): Any = {
+    val io = simple1000.execute(simpleQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def simpleSequentialQuery10000(): Any = {
+    val io = simple10000.execute(simpleQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def simpleBatchedQuery100(): Any = {
+    val io = simple100.execute(simpleQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def simpleBatchedQuery1000(): Any = {
+    val io = simple1000.execute(simpleQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def simpleBatchedQuery10000(): Any = {
+    val io = simple10000.execute(simpleQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldParallelQuery100(): Any = {
+    val io = multifield100.execute(multifieldQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldParallelQuery1000(): Any = {
+    val io = multifield1000.execute(multifieldQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldParallelQuery10000(): Any = {
+    val io = multifield10000.execute(multifieldQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldSequentialQuery100(): Any = {
+    val io = multifield100.execute(multifieldQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldSequentialQuery1000(): Any = {
+    val io = multifield1000.execute(multifieldQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldSequentialQuery10000(): Any = {
+    val io = multifield10000.execute(multifieldQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldBatchedQuery100(): Any = {
+    val io = multifield100.execute(multifieldQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldBatchedQuery1000(): Any = {
+    val io = multifield1000.execute(multifieldQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def multifieldBatchedQuery10000(): Any = {
+    val io = multifield10000.execute(multifieldQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepParallelQuery100(): Any = {
+    val io = deep100.execute(deepQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepParallelQuery1000(): Any = {
+    val io = deep1000.execute(deepQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepParallelQuery10000(): Any = {
+    val io = deep10000.execute(deepQuery, queryExecution = QueryExecution.Parallel)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepSequentialQuery100(): Any = {
+    val io = deep100.execute(deepQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepSequentialQuery1000(): Any = {
+    val io = deep1000.execute(deepQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepSequentialQuery10000(): Any = {
+    val io = deep10000.execute(deepQuery, queryExecution = QueryExecution.Sequential)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepBatchedQuery100(): Any = {
+    val io = deep100.execute(deepQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepBatchedQuery1000(): Any = {
+    val io = deep1000.execute(deepQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+
+  @Benchmark
+  def deepBatchedQuery10000(): Any = {
+    val io = deep10000.execute(deepQuery, queryExecution = QueryExecution.Batched)
+    runtime.unsafeRun(io)
+  }
+}

--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
@@ -1,0 +1,86 @@
+package caliban.execution
+
+import caliban.schema.GenericSchema
+import zio.query.ZQuery
+
+object NestedZQueryBenchmarkSchema extends GenericSchema[Any] {
+  type Query[A] = ZQuery[Any, Throwable, A]
+
+  case class SimpleRoot(entities: Query[List[SimpleEntity]])
+  case class SimpleEntity(id: Int, nested: Query[Int])
+  case class MultifieldRoot(entities: Query[List[MultifieldEntity]])
+  case class MultifieldEntity(id: Int, nested0: Query[Int], nested1: Query[Int], nested2: Query[Int], nested3: Query[Int], nested4: Query[Int])
+  case class DeepRoot(entities: Query[List[DeepEntity]])
+  case class DeepEntity(next: Query[Option[DeepEntity]], nested: Query[Int])
+
+  val simple100Elements: SimpleRoot = generateSimple(100)
+  val simple1000Elements: SimpleRoot = generateSimple(1000)
+  val simple10000Elements: SimpleRoot = generateSimple(10000)
+
+  val simpleQuery: String = """{
+    entities {
+      id
+      nested
+    }
+  }""".stripMargin
+
+  val multifield100Elements: MultifieldRoot = generateMulti(100)
+  val multifield1000Elements: MultifieldRoot = generateMulti(1000)
+  val multifield10000Elements: MultifieldRoot = generateMulti(10000)
+
+  val multifieldQuery: String = """{
+    entities {
+      id
+      nested0
+      nested1
+      nested2
+      nested3
+      nested4
+    }
+  }""".stripMargin
+
+  val deep100Elements: DeepRoot = generateDeep(100)
+  val deep1000Elements: DeepRoot = generateDeep(1000)
+  val deep10000Elements: DeepRoot = generateDeep(10000)
+
+  val deepQuery: String = """{
+    entities {
+      nested
+      next {
+        nested
+        next {
+          nested
+          next {
+            nested
+            next {
+              nested
+            }
+          }
+        }
+      }
+    }
+  }""".stripMargin
+
+  private def generateSimple(n: Int) = {
+    val entities = (1 to n).map(i => SimpleEntity(i, ZQuery.succeed(i))).toList
+    SimpleRoot(ZQuery.succeed(entities))
+  }
+
+  private def generateMulti(n: Int) = {
+    val entities = (1 to n).map(i => MultifieldEntity(i, ZQuery.succeed(i), ZQuery.succeed(i), ZQuery.succeed(i), ZQuery.succeed(i), ZQuery.succeed(i))).toList
+    MultifieldRoot(ZQuery.succeed(entities))
+  }
+
+  private def generateDeep(n: Int) = {
+    def loop(n: Int): DeepEntity =
+      if (n == 0)
+        DeepEntity(ZQuery.none, ZQuery.succeed(n))
+      else {
+        val next = loop(n - 1)
+        DeepEntity(ZQuery.some(next), ZQuery.succeed(n))
+      }
+
+    val entities = (1 to n).map(_ => loop(5)).toList
+    DeepRoot(ZQuery.succeed(entities))
+  }
+}


### PR DESCRIPTION
Add benchmarks for different query execution strategies with different nested ZQuery layouts, related to [#692](https://github.com/ghostdogpr/caliban/pull/692)

On my machine (TR 1950x)
```
[info] Benchmark                                              Mode  Cnt     Score    Error  Units
[info] NestedZQueryBenchmark.deepBatchedQuery100             thrpt    5   742.754 ± 17.999  ops/s
[info] NestedZQueryBenchmark.deepBatchedQuery1000            thrpt    5    72.575 ±  1.435  ops/s
[info] NestedZQueryBenchmark.deepBatchedQuery10000           thrpt    5     7.053 ±  0.137  ops/s
[info] NestedZQueryBenchmark.deepParallelQuery100            thrpt    5   278.289 ±  4.749  ops/s
[info] NestedZQueryBenchmark.deepParallelQuery1000           thrpt    5    29.888 ±  0.946  ops/s
[info] NestedZQueryBenchmark.deepParallelQuery10000          thrpt    5     2.675 ±  0.072  ops/s
[info] NestedZQueryBenchmark.deepSequentialQuery100          thrpt    5   751.157 ± 11.852  ops/s
[info] NestedZQueryBenchmark.deepSequentialQuery1000         thrpt    5    75.271 ±  0.638  ops/s
[info] NestedZQueryBenchmark.deepSequentialQuery10000        thrpt    5     7.209 ±  0.074  ops/s
[info] NestedZQueryBenchmark.multifieldBatchedQuery100       thrpt    5   994.140 ± 24.777  ops/s
[info] NestedZQueryBenchmark.multifieldBatchedQuery1000      thrpt    5    91.833 ±  1.888  ops/s
[info] NestedZQueryBenchmark.multifieldBatchedQuery10000     thrpt    5     8.942 ±  0.317  ops/s
[info] NestedZQueryBenchmark.multifieldParallelQuery100      thrpt    5   222.349 ±  6.209  ops/s
[info] NestedZQueryBenchmark.multifieldParallelQuery1000     thrpt    5    24.628 ±  1.107  ops/s
[info] NestedZQueryBenchmark.multifieldParallelQuery10000    thrpt    5     2.238 ±  0.034  ops/s
[info] NestedZQueryBenchmark.multifieldSequentialQuery100    thrpt    5   924.286 ±  8.635  ops/s
[info] NestedZQueryBenchmark.multifieldSequentialQuery1000   thrpt    5    97.160 ±  1.731  ops/s
[info] NestedZQueryBenchmark.multifieldSequentialQuery10000  thrpt    5     9.454 ±  0.128  ops/s
[info] NestedZQueryBenchmark.simpleBatchedQuery100           thrpt    5  3134.714 ± 76.324  ops/s
[info] NestedZQueryBenchmark.simpleBatchedQuery1000          thrpt    5   286.424 ±  7.048  ops/s
[info] NestedZQueryBenchmark.simpleBatchedQuery10000         thrpt    5    25.934 ±  6.328  ops/s
[info] NestedZQueryBenchmark.simpleParallelQuery100          thrpt    5   727.713 ± 10.914  ops/s
[info] NestedZQueryBenchmark.simpleParallelQuery1000         thrpt    5    74.215 ±  1.995  ops/s
[info] NestedZQueryBenchmark.simpleParallelQuery10000        thrpt    5     7.463 ±  0.201  ops/s
```