### PR TITLE
handle chunked websocket messages in akka http adapter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -231,10 +231,11 @@ lazy val akkaHttp = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http"           % "10.2.3",
-      "com.typesafe.akka" %% "akka-stream"         % akkaVersion,
-      "de.heikoseeberger" %% "akka-http-circe"     % "1.35.3" % Optional,
-      "de.heikoseeberger" %% "akka-http-play-json" % "1.35.3" % Optional,
+      "com.typesafe.akka" %% "akka-http"                  % "10.2.3",
+      "com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion,
+      "com.typesafe.akka" %% "akka-stream"                % akkaVersion,
+      "de.heikoseeberger" %% "akka-http-circe"            % "1.35.3" % Optional,
+      "de.heikoseeberger" %% "akka-http-play-json"        % "1.35.3" % Optional,
       compilerPlugin(
         ("org.typelevel" %% "kind-projector" % "0.11.3")
           .cross(CrossVersion.full)


### PR DESCRIPTION
Fixes #725 

Notes: 
* akka-http-circe and akka-http-play-json version 1.35.3 are pulling in akka-serialization-jackson version 2.6.10 which is not compatible with the explicit akka verrsion 2.6.11.  This causes a runtime exception when trying to run the akka example.  As 1.35.3 is the latest, I had to explicitly include akka-serialization-jackson.  Should be able to remove when the json libs catch up.
* The chunking assembly requires a timeout.  I added this as a parameter to the makeWebSocketService.  Set it to 5 seconds, as I figured that was a reasonable timeout, but happy to change the default.  I can't imagine many cases though where it would take longer.