### PR TITLE
fix client writer using non-working suffix "_"

### DIFF
--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -83,26 +83,27 @@ object ClientWriter {
       .map(t => writeRootSubscription(t, typesMap, mappingClashedTypeNames))
       .getOrElse("")
 
-    val imports = s"""${if (enums.nonEmpty)
-      """import caliban.client.CalibanClientError.DecodingError
-        |""".stripMargin
-    else ""}${if (objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty)
-      """import caliban.client.FieldBuilder._
-        |import caliban.client.SelectionBuilder._
-        |""".stripMargin
-    else
-      ""}${if (
-      enums.nonEmpty || objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty || inputs.nonEmpty
-    )
-      """import caliban.client._
-        |""".stripMargin
-    else ""}${if (queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty)
-      """import caliban.client.Operations._
-        |""".stripMargin
-    else ""}${if (enums.nonEmpty || inputs.nonEmpty)
-      """import caliban.client.__Value._
-        |""".stripMargin
-    else ""}"""
+    val imports =
+      s"""${if (enums.nonEmpty)
+        """import caliban.client.CalibanClientError.DecodingError
+          |""".stripMargin
+      else ""}${if (objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty)
+        """import caliban.client.FieldBuilder._
+          |import caliban.client.SelectionBuilder._
+          |""".stripMargin
+      else
+        ""}${if (
+        enums.nonEmpty || objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty || inputs.nonEmpty
+      )
+        """import caliban.client._
+          |""".stripMargin
+      else ""}${if (queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty)
+        """import caliban.client.Operations._
+          |""".stripMargin
+      else ""}${if (enums.nonEmpty || inputs.nonEmpty)
+        """import caliban.client.__Value._
+          |""".stripMargin
+      else ""}"""
 
     s"""${packageName.fold("")(p => s"package $p\n\n")}$imports
        |
@@ -376,7 +377,8 @@ object ClientWriter {
 
   def writeScalar(typedef: ScalarTypeDefinition, mappingClashedTypeNames: Map[String, String]): String =
     if (typedef.name == "Json") "type Json = io.circe.Json"
-    else s"""type ${safeTypeName(typedef.name, mappingClashedTypeNames)} = String
+    else
+      s"""type ${safeTypeName(typedef.name, mappingClashedTypeNames)} = String
         """
 
   def safeUnapplyName(name: String): String =
@@ -384,7 +386,7 @@ object ClientWriter {
     else name
 
   def safeName(name: String): String =
-    if (reservedKeywords.contains(name) || name.endsWith("_")) s"$name$$"
+    if (reservedKeywords.contains(name) || name.endsWith("_")) s"`$name`"
     else if (caseClassReservedFields.contains(name)) s"$name$$"
     else name
 
@@ -665,4 +667,5 @@ object ClientWriter {
     argBuilder: String,
     typeInfo: FieldTypeInfo
   )
+
 }

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -380,12 +380,12 @@ object ClientWriter {
         """
 
   def safeUnapplyName(name: String): String =
-    if (reservedKeywords.contains(name)) s"${name}_"
+    if (reservedKeywords.contains(name) || name.endsWith("_")) s"$name$$"
     else name
 
   def safeName(name: String): String =
-    if (reservedKeywords.contains(name)) s"`$name`"
-    else if (caseClassReservedFields.contains(name)) s"${name}_"
+    if (reservedKeywords.contains(name) || name.endsWith("_")) s"$name$$"
+    else if (caseClassReservedFields.contains(name)) s"$name$$"
     else name
 
   @tailrec

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -125,10 +125,9 @@ object ClientWriter {
       .map(name => name.toLowerCase -> name)
       .groupBy(_._1)
       .collect {
-        case (_, (_ :: typeNamesToRename)) if typeNamesToRename.nonEmpty =>
-          typeNamesToRename.zipWithIndex.map { case (((_, originalTypeName), index)) =>
-            val suffix = "_" * (index + 1)
-            originalTypeName -> s"$originalTypeName$suffix"
+        case (_, _ :: typeNamesToRename) if typeNamesToRename.nonEmpty =>
+          typeNamesToRename.map { case (_, originalTypeName) =>
+            originalTypeName -> s"`$originalTypeName`"
           }.toMap
       }
       .reduceOption(_ ++ _)

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -75,7 +75,7 @@ object Client {
              type Q {
                characters: [Character!]!
              }
-             
+
              type Character {
                name: String!
                nicknames: [String!]!
@@ -113,7 +113,7 @@ object Client {
              type Q {
                character(name: String!): Character
              }
-             
+
              type Character {
                name: String!
                nicknames: [String!]!
@@ -151,11 +151,11 @@ object Client {
              schema {
                query: Q
              }
-             
+
              type Q {
                characters: [Character!]!
              }
-             
+
              type Character {
                name: String!
                nicknames: [String!]!
@@ -301,15 +301,15 @@ object Client {
         val schema =
           """
              union Role = Captain | Pilot
-             
+
              type Captain {
                shipName: String!
              }
-             
+
              type Pilot {
                shipName: String!
              }
-             
+
              type Character {
                role: Role
              }
@@ -461,7 +461,7 @@ object Client {
         val schema =
           """
               scalar Json
-              
+
               type Query {
                 test: Json!
               }""".stripMargin
@@ -567,6 +567,34 @@ object Client {
   object character_ {
     def name: SelectionBuilder[character_, String]            = Field("name", Scalar())
     def nicknames: SelectionBuilder[character_, List[String]] = Field("nicknames", ListOf(Scalar()))
+  }
+
+}
+"""
+          )
+        )
+      },
+      testM("safe names with leading and tailing _") {
+        val schema =
+          """
+             type Character {
+               _name_: String
+               _nickname: String
+             }
+            """.stripMargin
+
+        assertM(gen(schema))(
+          equalTo(
+            """import caliban.client.FieldBuilder._
+import caliban.client.SelectionBuilder._
+import caliban.client._
+
+object Client {
+
+  type Character
+  object Character {
+    def `_name_` : SelectionBuilder[Character, Option[String]] = Field("_name_", OptionOf(Scalar()))
+    def _nickname: SelectionBuilder[Character, Option[String]] = Field("_nickname", OptionOf(Scalar()))
   }
 
 }

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -61,7 +61,7 @@ object Client {
 
   type Character
   object Character {
-    def type$ : SelectionBuilder[Character, String] = Field("type", Scalar())
+    def `type`: SelectionBuilder[Character, String] = Field("type", Scalar())
   }
 
 }
@@ -510,13 +510,13 @@ object Client {
     case object NEWHOPE extends Episode
     case object EMPIRE  extends Episode
     case object JEDI    extends Episode
-    case object jedi_$  extends Episode
+    case object `jedi_` extends Episode
 
     implicit val decoder: ScalarDecoder[Episode] = {
       case __StringValue("NEWHOPE") => Right(Episode.NEWHOPE)
       case __StringValue("EMPIRE")  => Right(Episode.EMPIRE)
       case __StringValue("JEDI")    => Right(Episode.JEDI)
-      case __StringValue("jedi")    => Right(Episode.jedi_$)
+      case __StringValue("jedi")    => Right(Episode.`jedi_`)
       case other                    => Left(DecodingError(s"Can't build Episode from input $other"))
     }
     implicit val encoder: ArgEncoder[Episode]    = new ArgEncoder[Episode] {
@@ -524,7 +524,7 @@ object Client {
         case Episode.NEWHOPE => __EnumValue("NEWHOPE")
         case Episode.EMPIRE  => __EnumValue("EMPIRE")
         case Episode.JEDI    => __EnumValue("JEDI")
-        case Episode.jedi_$  => __EnumValue("jedi")
+        case Episode.`jedi_` => __EnumValue("jedi")
       }
       override def typeName: String                = "Episode"
     }

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -510,13 +510,13 @@ object Client {
     case object NEWHOPE extends Episode
     case object EMPIRE  extends Episode
     case object JEDI    extends Episode
-    case object `jedi_` extends Episode
+    case object `jedi`  extends Episode
 
     implicit val decoder: ScalarDecoder[Episode] = {
       case __StringValue("NEWHOPE") => Right(Episode.NEWHOPE)
       case __StringValue("EMPIRE")  => Right(Episode.EMPIRE)
       case __StringValue("JEDI")    => Right(Episode.JEDI)
-      case __StringValue("jedi")    => Right(Episode.`jedi_`)
+      case __StringValue("jedi")    => Right(Episode.`jedi`)
       case other                    => Left(DecodingError(s"Can't build Episode from input $other"))
     }
     implicit val encoder: ArgEncoder[Episode]    = new ArgEncoder[Episode] {
@@ -524,7 +524,7 @@ object Client {
         case Episode.NEWHOPE => __EnumValue("NEWHOPE")
         case Episode.EMPIRE  => __EnumValue("EMPIRE")
         case Episode.JEDI    => __EnumValue("JEDI")
-        case Episode.`jedi_` => __EnumValue("jedi")
+        case Episode.`jedi`  => __EnumValue("jedi")
       }
       override def typeName: String                = "Episode"
     }
@@ -563,10 +563,10 @@ object Client {
     def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
   }
 
-  type character_
-  object character_ {
-    def name: SelectionBuilder[character_, String]            = Field("name", Scalar())
-    def nicknames: SelectionBuilder[character_, List[String]] = Field("nicknames", ListOf(Scalar()))
+  type `character`
+  object `character` {
+    def name: SelectionBuilder[`character`, String]            = Field("name", Scalar())
+    def nicknames: SelectionBuilder[`character`, List[String]] = Field("nicknames", ListOf(Scalar()))
   }
 
 }

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -61,7 +61,7 @@ object Client {
 
   type Character
   object Character {
-    def `type`: SelectionBuilder[Character, String] = Field("type", Scalar())
+    def type$ : SelectionBuilder[Character, String] = Field("type", Scalar())
   }
 
 }
@@ -283,11 +283,11 @@ import caliban.client.__Value._
 
 object Client {
 
-  case class CharacterInput(wait_ : String)
+  case class CharacterInput(wait$ : String)
   object CharacterInput {
     implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
       override def encode(value: CharacterInput): __Value =
-        __ObjectValue(List("wait" -> implicitly[ArgEncoder[String]].encode(value.wait_)))
+        __ObjectValue(List("wait" -> implicitly[ArgEncoder[String]].encode(value.wait$)))
       override def typeName: String                       = "CharacterInput"
     }
   }
@@ -510,13 +510,13 @@ object Client {
     case object NEWHOPE extends Episode
     case object EMPIRE  extends Episode
     case object JEDI    extends Episode
-    case object jedi_   extends Episode
+    case object jedi_$  extends Episode
 
     implicit val decoder: ScalarDecoder[Episode] = {
       case __StringValue("NEWHOPE") => Right(Episode.NEWHOPE)
       case __StringValue("EMPIRE")  => Right(Episode.EMPIRE)
       case __StringValue("JEDI")    => Right(Episode.JEDI)
-      case __StringValue("jedi")    => Right(Episode.jedi_)
+      case __StringValue("jedi")    => Right(Episode.jedi_$)
       case other                    => Left(DecodingError(s"Can't build Episode from input $other"))
     }
     implicit val encoder: ArgEncoder[Episode]    = new ArgEncoder[Episode] {
@@ -524,7 +524,7 @@ object Client {
         case Episode.NEWHOPE => __EnumValue("NEWHOPE")
         case Episode.EMPIRE  => __EnumValue("EMPIRE")
         case Episode.JEDI    => __EnumValue("JEDI")
-        case Episode.jedi_   => __EnumValue("jedi")
+        case Episode.jedi_$  => __EnumValue("jedi")
       }
       override def typeName: String                = "Episode"
     }

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -326,34 +326,34 @@ import caliban.client._
 
 object Client {
 
-  type `package`
-  object `package` {
+  type package$
+  object package$ {
 
     final case class packageView(name: Option[String])
 
-    type ViewSelection = SelectionBuilder[`package`, packageView]
+    type ViewSelection = SelectionBuilder[package$, packageView]
 
     def view: ViewSelection = name.map(name => packageView(name))
 
-    def name: SelectionBuilder[`package`, Option[String]] = Field("name", OptionOf(Scalar()))
+    def name: SelectionBuilder[package$, Option[String]] = Field("name", OptionOf(Scalar()))
   }
 
-  type `match`
-  object `match` {
+  type match$
+  object match$ {
 
-    final case class matchView[PackageSelection](`package`: Option[PackageSelection], version: Option[String])
+    final case class matchView[PackageSelection](package$ : Option[PackageSelection], version: Option[String])
 
-    type ViewSelection[PackageSelection] = SelectionBuilder[`match`, matchView[PackageSelection]]
+    type ViewSelection[PackageSelection] = SelectionBuilder[match$, matchView[PackageSelection]]
 
     def view[PackageSelection](
-      packageSelection: SelectionBuilder[`package`, PackageSelection]
-    ): ViewSelection[PackageSelection] = (`package`(packageSelection) ~ version).map { case (package_, version) =>
-      matchView(package_, version)
+      packageSelection: SelectionBuilder[package$, PackageSelection]
+    ): ViewSelection[PackageSelection] = (package$(packageSelection) ~ version).map { case (package$, version) =>
+      matchView(package$, version)
     }
 
-    def `package`[A](innerSelection: SelectionBuilder[`package`, A]): SelectionBuilder[`match`, Option[A]] =
+    def package$[A](innerSelection: SelectionBuilder[package$, A]): SelectionBuilder[match$, Option[A]] =
       Field("package", OptionOf(Obj(innerSelection)))
-    def version: SelectionBuilder[`match`, Option[String]]                                                 = Field("version", OptionOf(Scalar()))
+    def version: SelectionBuilder[match$, Option[String]]                                               = Field("version", OptionOf(Scalar()))
   }
 
 }

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -326,34 +326,34 @@ import caliban.client._
 
 object Client {
 
-  type package$
-  object package$ {
+  type `package`
+  object `package` {
 
     final case class packageView(name: Option[String])
 
-    type ViewSelection = SelectionBuilder[package$, packageView]
+    type ViewSelection = SelectionBuilder[`package`, packageView]
 
     def view: ViewSelection = name.map(name => packageView(name))
 
-    def name: SelectionBuilder[package$, Option[String]] = Field("name", OptionOf(Scalar()))
+    def name: SelectionBuilder[`package`, Option[String]] = Field("name", OptionOf(Scalar()))
   }
 
-  type match$
-  object match$ {
+  type `match`
+  object `match` {
 
-    final case class matchView[PackageSelection](package$ : Option[PackageSelection], version: Option[String])
+    final case class matchView[PackageSelection](`package`: Option[PackageSelection], version: Option[String])
 
-    type ViewSelection[PackageSelection] = SelectionBuilder[match$, matchView[PackageSelection]]
+    type ViewSelection[PackageSelection] = SelectionBuilder[`match`, matchView[PackageSelection]]
 
     def view[PackageSelection](
-      packageSelection: SelectionBuilder[package$, PackageSelection]
-    ): ViewSelection[PackageSelection] = (package$(packageSelection) ~ version).map { case (package$, version) =>
+      packageSelection: SelectionBuilder[`package`, PackageSelection]
+    ): ViewSelection[PackageSelection] = (`package`(packageSelection) ~ version).map { case (package$, version) =>
       matchView(package$, version)
     }
 
-    def package$[A](innerSelection: SelectionBuilder[package$, A]): SelectionBuilder[match$, Option[A]] =
+    def `package`[A](innerSelection: SelectionBuilder[`package`, A]): SelectionBuilder[`match`, Option[A]] =
       Field("package", OptionOf(Obj(innerSelection)))
-    def version: SelectionBuilder[match$, Option[String]]                                               = Field("version", OptionOf(Scalar()))
+    def version: SelectionBuilder[`match`, Option[String]]                                                 = Field("version", OptionOf(Scalar()))
   }
 
 }

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -338,7 +338,7 @@ object Types {
           equalTo(
             """object Types {
 
-  case class Character(private$ : String, object$ : String, type$ : String)
+  case class Character(`private`: String, `object`: String, `type`: String)
 
 }
 """

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -338,7 +338,7 @@ object Types {
           equalTo(
             """object Types {
 
-  case class Character(`private`: String, `object`: String, `type`: String)
+  case class Character(private$ : String, object$ : String, type$ : String)
 
 }
 """
@@ -357,7 +357,7 @@ object Types {
           equalTo(
             """object Types {
 
-  case class Character(wait_ : String)
+  case class Character(wait$ : String)
 
 }
 """


### PR DESCRIPTION
Resolves #775 

While working on the code, it turned out that `ClientWriter.safeUnapplyName()` also is affected and would require backticks. I added them accordingly.

If you require tests for these changes pls let me know.