### PR TITLE
WIP - Partial union type query #446

### DIFF
--- a/client/src/main/scala/caliban/client/FieldBuilder.scala
+++ b/client/src/main/scala/caliban/client/FieldBuilder.scala
@@ -67,8 +67,21 @@ object FieldBuilder {
         case _                     => Left(DecodingError(s"Field $value is not an object"))
       }
 
-    override def toSelectionSet: List[Selection] =
+    override def toSelectionSet: List[Selection] = {
+      val filteredBuilderMap = builderMap.filter((f) => !isNullField(f._2));
       Selection.Field(None, "__typename", Nil, Nil, Nil, 0) ::
-        builderMap.map { case (k, v) => Selection.InlineFragment(k, v.toSelectionSet) }.toList
+        filteredBuilderMap.map { case (k, v) =>
+          Selection.InlineFragment(k, v.toSelectionSet)
+        }.toList
+    }
+  }
+  case object NullField extends FieldBuilder[Option[Nothing]] {
+    override def fromGraphQL(value: __Value): Either[DecodingError, Option[Nothing]] = Right(None)
+    override def toSelectionSet: List[Selection]                                     = Nil
+  }
+
+  def isNullField(p: Any): Boolean = p match {
+    case NullField => true
+    case _         => false
   }
 }

--- a/client/src/test/scala/caliban/client/TestData.scala
+++ b/client/src/test/scala/caliban/client/TestData.scala
@@ -74,6 +74,25 @@ object TestData {
           )
         )
       )
+    def roleOption[A](
+      onCaptain: Option[SelectionBuilder[Captain, A]] = None,
+      onEngineer: Option[SelectionBuilder[Engineer, A]] = None,
+      onMechanic: Option[SelectionBuilder[Mechanic, A]] = None,
+      onPilot: Option[SelectionBuilder[Pilot, A]] = None
+    ): SelectionBuilder[Character, Option[Option[A]]]        =
+      Field(
+        "role",
+        OptionOf(
+          ChoiceOf(
+            Map(
+              "Captain"  -> onCaptain.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "Engineer" -> onEngineer.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "Mechanic" -> onMechanic.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "Pilot"    -> onPilot.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a)))
+            )
+          )
+        )
+      )
   }
 
   // Auto-generated query

--- a/examples/src/main/scala/caliban/client/Client.scala
+++ b/examples/src/main/scala/caliban/client/Client.scala
@@ -59,6 +59,25 @@ object Client {
           )
         )
       )
+    def roleOption[A](
+      onCaptain: Option[SelectionBuilder[Captain, A]] = None,
+      onEngineer: Option[SelectionBuilder[Engineer, A]] = None,
+      onMechanic: Option[SelectionBuilder[Mechanic, A]] = None,
+      onPilot: Option[SelectionBuilder[Pilot, A]] = None
+    ): SelectionBuilder[Character, Option[Option[A]]] =
+      Field(
+        "role",
+        OptionOf(
+          ChoiceOf(
+            Map(
+              "Captain"  -> onCaptain.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "Engineer" -> onEngineer.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "Mechanic" -> onMechanic.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "Pilot"    -> onPilot.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a)))
+            )
+          )
+        )
+      )
   }
 
   type Pilot

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -340,6 +340,21 @@ object Client {
       onPilot: SelectionBuilder[Pilot, A]
     ): SelectionBuilder[Character, Option[A]] =
       Field("role", OptionOf(ChoiceOf(Map("Captain" -> Obj(onCaptain), "Pilot" -> Obj(onPilot)))))
+    def roleOption[A](
+      onCaptain: Option[SelectionBuilder[Captain, A]] = None,
+      onPilot: Option[SelectionBuilder[Pilot, A]] = None
+    ): SelectionBuilder[Character, Option[Option[A]]] =
+      Field(
+        "role",
+        OptionOf(
+          ChoiceOf(
+            Map(
+              "Captain" -> onCaptain.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "Pilot"   -> onPilot.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a)))
+            )
+          )
+        )
+      )
   }
 
 }


### PR DESCRIPTION
#446  
This is a work in progress. I originally worked on this last July and so I had to resolve merge conflicts. Everything compiles but when I tried to run the `scripted` test it fails with the following;
snipppet from console output:
```
[info] [info] compiling 3 Scala sources to /tmp/sbt_a58f20c8/target/scala-2.12/classes ...
[info] [error] /tmp/sbt_a58f20c8/src/main/scala/Client.scala:138:7: overriding method wait in class Object of type ()Unit;
[info] [error]  value wait cannot override final member
[info] [error]       wait: String
[info] [error]       ^
[info] [error] one error found
```


Full output
```
sbt scripted
[info] welcome to sbt 1.4.7 (Red Hat, Inc. Java 1.8.0_275)
[info] loading global plugins from /home/ahale/.sbt/1.0/plugins
[info] loading settings for project caliban-build from plugins.sbt ...
[info] loading project definition from /home/ahale/dev/github/caliban/project
[info] loading settings for project root from build.sbt ...
[info] resolving key references (15165 settings) ...
[info]    ____      _ _ _                 
[info]   / ___|__ _| (_) |__   __ _ _ __  
[info]  | |   / _` | | | '_ \ / _` | '_ \ 
[info]  | |__| (_| | | | |_) | (_| | | | |
[info]   \____\__,_|_|_|_.__/ \__,_|_| |_|  0.9.5+13-593726f0+20210303-0857-SNAPSHOT
[info] 
[info] Useful sbt tasks:
[info] > ~compile - Compile all modules with file-watch enabled
[info] > test - Run the unit test suite
[info] > fmt - Run scalafmt on the entire project
[info] > scripted - Run the scripted test suite
[info] > examples/runMain caliban.http4s.ExampleApp - Start the example server (http4s based)
[info] > examples/runMain caliban.akkahttp.ExampleApp - Start the example server (akka-http based)
[info] > benchmarks/jmh:run - Run the benchmarks
[info] > +publishLocal - Publish caliban locally
[info] Wrote /home/ahale/dev/github/caliban/core/target/scala-2.12/caliban_2.12-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.pom
[info] Wrote /home/ahale/dev/github/caliban/client/.jvm/target/scala-2.12/caliban-client_2.12-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.pom
[info] Wrote /home/ahale/dev/github/caliban/tools/target/scala-2.12/caliban-tools_2.12-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.pom
[info] Wrote /home/ahale/dev/github/caliban/macros/target/scala-2.12/caliban-macros_2.12-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.pom
[info] Wrote /home/ahale/dev/github/caliban/codegen-sbt/target/scala-2.12/sbt-1.0/caliban-codegen-sbt-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.pom
[info] Main Scala API documentation to /home/ahale/dev/github/caliban/macros/target/scala-2.12/api...
[info] Main Scala API documentation to /home/ahale/dev/github/caliban/client/.jvm/target/scala-2.12/api...
[info] Main Scala API documentation to /home/ahale/dev/github/caliban/core/target/scala-2.12/api...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Main Scala API documentation to /home/ahale/dev/github/caliban/tools/target/scala-2.12/api...
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Main Scala API documentation to /home/ahale/dev/github/caliban/codegen-sbt/target/scala-2.12/sbt-1.0/api...
model contains 5 documentable templates
model contains 6 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.github.ghostdogpr#caliban-macros_2.12;0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: 0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: integration :: Wed Mar 03 08:58:02 EST 2021
[info]  delivering ivy file to /home/ahale/dev/github/caliban/macros/target/scala-2.12/ivy-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.xml
[info]  published caliban-macros_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-macros_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/poms/caliban-macros_2.12.pom
[info]  published caliban-macros_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-macros_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/jars/caliban-macros_2.12.jar
[info]  published caliban-macros_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-macros_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/srcs/caliban-macros_2.12-sources.jar
[info]  published caliban-macros_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-macros_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/docs/caliban-macros_2.12-javadoc.jar
[info]  published ivy to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-macros_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/ivys/ivy.xml
model contains 92 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.github.ghostdogpr#caliban-codegen-sbt;0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: 0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: integration :: Wed Mar 03 08:58:03 EST 2021
[info]  delivering ivy file to /home/ahale/dev/github/caliban/codegen-sbt/target/scala-2.12/sbt-1.0/ivy-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.xml
[info]  published caliban-codegen-sbt to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-codegen-sbt/scala_2.12/sbt_1.0/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/poms/caliban-codegen-sbt.pom
[info]  published caliban-codegen-sbt to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-codegen-sbt/scala_2.12/sbt_1.0/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/jars/caliban-codegen-sbt.jar
[info]  published caliban-codegen-sbt to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-codegen-sbt/scala_2.12/sbt_1.0/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/srcs/caliban-codegen-sbt-sources.jar
[info]  published caliban-codegen-sbt to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-codegen-sbt/scala_2.12/sbt_1.0/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/docs/caliban-codegen-sbt-javadoc.jar
[info]  published ivy to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-codegen-sbt/scala_2.12/sbt_1.0/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/ivys/ivy.xml
model contains 64 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.github.ghostdogpr#caliban-tools_2.12;0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: 0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: integration :: Wed Mar 03 08:58:07 EST 2021
[info]  delivering ivy file to /home/ahale/dev/github/caliban/tools/target/scala-2.12/ivy-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.xml
[info] Main Scala API documentation successful.
[info]  published caliban-tools_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-tools_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/poms/caliban-tools_2.12.pom
[info]  published caliban-tools_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-tools_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/jars/caliban-tools_2.12.jar
[info]  published caliban-tools_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-tools_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/srcs/caliban-tools_2.12-sources.jar
[info]  published caliban-tools_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-tools_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/docs/caliban-tools_2.12-javadoc.jar
[info]  published ivy to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-tools_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/ivys/ivy.xml
[info] :: delivering :: com.github.ghostdogpr#caliban-client_2.12;0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: 0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: integration :: Wed Mar 03 08:58:08 EST 2021
[info]  delivering ivy file to /home/ahale/dev/github/caliban/client/.jvm/target/scala-2.12/ivy-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.xml
[info]  published caliban-client_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-client_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/poms/caliban-client_2.12.pom
[info]  published caliban-client_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-client_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/jars/caliban-client_2.12.jar
[info]  published caliban-client_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-client_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/srcs/caliban-client_2.12-sources.jar
[info]  published caliban-client_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-client_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/docs/caliban-client_2.12-javadoc.jar
[info]  published ivy to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban-client_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/ivys/ivy.xml
model contains 259 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.github.ghostdogpr#caliban_2.12;0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: 0.9.5+13-593726f0+20210303-0857-SNAPSHOT :: integration :: Wed Mar 03 08:58:29 EST 2021
[info]  delivering ivy file to /home/ahale/dev/github/caliban/core/target/scala-2.12/ivy-0.9.5+13-593726f0+20210303-0857-SNAPSHOT.xml
[info]  published caliban_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/poms/caliban_2.12.pom
[info]  published caliban_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/jars/caliban_2.12.jar
[info]  published caliban_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/srcs/caliban_2.12-sources.jar
[info]  published caliban_2.12 to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/docs/caliban_2.12-javadoc.jar
[info]  published ivy to /home/ahale/.ivy2/local/com.github.ghostdogpr/caliban_2.12/0.9.5+13-593726f0+20210303-0857-SNAPSHOT/ivys/ivy.xml
[info] Running 2 / 2 (100.00%) scripted tests with RunFromSourceMain
[info] Running codegen/gen-view-test-compile
[error] [info] [launcher] getting org.scala-sbt sbt 1.4.7  (this may take some time)...
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: retrieving :: org.scala-sbt#boot-app
[error]         confs: [default]
[error]         84 artifacts copied, 0 already retrieved
[error] [info] [launcher] getting Scala 2.12.12 (for sbt)...
[error] :: retrieving :: org.scala-sbt#boot-scala
[error]         confs: [default]
[error]         6 artifacts copied, 0 already retrieved
[info] [info] Updated file /tmp/sbt_a58f20c8/project/build.properties: set sbt.version to 1.4.7
[info] [info] welcome to sbt 1.4.7 (Red Hat, Inc. Java 1.8.0_275)
[info] [info] loading settings for project sbt_a58f20c8-build from plugins.sbt ...
[info] [info] loading project definition from /tmp/sbt_a58f20c8/project
[info] [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] [info] compiling 1 Scala source to /tmp/sbt_a58f20c8/project/target/scala-2.12/sbt-1.0/classes ...
[info] [info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.12. Compiling...
[info] [info]   Compilation completed in 9.317s.
[info] [info] done compiling
[info] [info] loading settings for project root from build.sbt ...
[info] [info] set current project to root (in build file:/tmp/sbt_a58f20c8/)
[info] [info] welcome to sbt 1.4.7 (Red Hat, Inc. Java 1.8.0_275)
[info] [info] loading settings for project sbt_a58f20c8-build from plugins.sbt ...
[info] [info] loading project definition from /tmp/sbt_a58f20c8/project
[info] [info] loading settings for project root from build.sbt ...
[info] [info] set current project to root (in build file:/tmp/sbt_a58f20c8/)
[info] Generating code for project/schema.graphql
[error] parsed config (v2.7.5): 
[info] Code generation done
CharacterView exists in ./src/main/scala/Client.scala
[info] Generating code for project/schema-to-check-name-uniqueness.graphql
[error] parsed config (v2.7.5): 
[info] Code generation done
StarshipView exists in ./src/main/scala/client/ClientNameUniqueness.scala
[info] Generating code for project/gitlab-schema.graphql
[error] parsed config (v2.7.5): 
[info] Code generation done
VulnerableProjectsByGradeView exists in ./src/main/scala/client/ClientGitLab.scala
[info] [info] compiling 3 Scala sources to /tmp/sbt_a58f20c8/target/scala-2.12/classes ...
[info] [error] /tmp/sbt_a58f20c8/src/main/scala/Client.scala:138:7: overriding method wait in class Object of type ()Unit;
[info] [error]  value wait cannot override final member
[info] [error]       wait: String
[info] [error]       ^
[info] [error] one error found
[info] [error] (Compile / compileIncremental) Compilation failed
[info] [error] Total time: 19 s, completed Mar 3, 2021 8:59:40 AM
[error] x codegen/gen-view-test-compile 
[error]  Cause of test exception: {line 16}  Command failed: compile failed
[info] Running codegen/test-compile
[error] [info] [launcher] getting org.scala-sbt sbt 1.4.7  (this may take some time)...
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: loading settings :: url = jar:file:/home/ahale/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.4.7/sbt-launch-1.4.7.jar!/org/apache/ivy/core/settings/ivysettings.xml
[error] :: retrieving :: org.scala-sbt#boot-app
[error]         confs: [default]
[error]         84 artifacts copied, 0 already retrieved
[error] [info] [launcher] getting Scala 2.12.12 (for sbt)...
[error] :: retrieving :: org.scala-sbt#boot-scala
[error]         confs: [default]
[error]         6 artifacts copied, 0 already retrieved
[info] [info] Updated file /tmp/sbt_1abbf140/project/build.properties: set sbt.version to 1.4.7
[info] [info] welcome to sbt 1.4.7 (Red Hat, Inc. Java 1.8.0_275)
[info] [info] loading settings for project sbt_1abbf140-build from plugins.sbt ...
[info] [info] loading project definition from /tmp/sbt_1abbf140/project
[info] [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] [info] compiling 1 Scala source to /tmp/sbt_1abbf140/project/target/scala-2.12/sbt-1.0/classes ...
[info] [info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.12. Compiling...
[info] [info]   Compilation completed in 9.097s.
[info] [info] done compiling
[info] [info] loading settings for project root from build.sbt ...
[info] [info] set current project to root (in build file:/tmp/sbt_1abbf140/)
[info] [info] welcome to sbt 1.4.7 (Red Hat, Inc. Java 1.8.0_275)
[info] [info] loading settings for project sbt_1abbf140-build from plugins.sbt ...
[info] [info] loading project definition from /tmp/sbt_1abbf140/project
[info] [info] loading settings for project root from build.sbt ...
[info] [info] set current project to root (in build file:/tmp/sbt_1abbf140/)
[info] Generating code for project/schema.graphql
[error] parsed config (v2.7.5): 
[info] Code generation done
[info] Generating code for project/schema-to-check-name-uniqueness.graphql
[error] parsed config (v2.7.5): 
[info] Code generation done
[info] Generating code for project/gitlab-schema.graphql
[error] parsed config (v2.7.5): 
[info] Code generation done
[info] [info] compiling 3 Scala sources to /tmp/sbt_1abbf140/target/scala-2.12/classes ...
[info] [error] /tmp/sbt_1abbf140/src/main/scala/Client.scala:82:7: overriding method wait in class Object of type ()Unit;
[info] [error]  value wait cannot override final member
[info] [error]       wait: String
[info] [error]       ^
[info] [error] one error found
[info] [error] (Compile / compileIncremental) Compilation failed
[info] [error] Total time: 13 s, completed Mar 3, 2021 9:00:39 AM
[error] x codegen/test-compile 
[error]  Cause of test exception: {line 14}  Command failed: compile failed
[error] java.lang.RuntimeException: Failed tests:
[error]         codegen/gen-view-test-compile
[error]         codegen/test-compile
[error] 
[error]         at scala.sys.package$.error(package.scala:30)
[error]         at sbt.scriptedtest.ScriptedRunner.reportErrors(ScriptedTests.scala:545)
[error]         at sbt.scriptedtest.ScriptedRunner.runAll(ScriptedTests.scala:548)
[error]         at sbt.scriptedtest.ScriptedRunner.run(ScriptedTests.scala:517)
[error]         at sbt.scriptedtest.ScriptedRunner.run(ScriptedTests.scala:417)
[error]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error]         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]         at java.lang.reflect.Method.invoke(Method.java:498)
[error]         at sbt.ScriptedPlugin$.$anonfun$scriptedTask$3(ScriptedPlugin.scala:204)
[error]         at sbt.ScriptedPlugin$.$anonfun$scriptedTask$3$adapted(ScriptedPlugin.scala:189)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error]         at sbt.Execute.work(Execute.scala:291)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error]         at java.lang.Thread.run(Thread.java:748)
[error] (codegenSbt / scripted) Failed tests:
[error]         codegen/gen-view-test-compile
[error]         codegen/test-compile
[error] Total time: 167 s (02:47), completed Mar 3, 2021 9:00:40 AM
```