### PR TITLE
add scalar mappings

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CodegenPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CodegenPlugin.scala
@@ -1,6 +1,6 @@
 package caliban.codegen
 
-import caliban.tools.Codegen.{ Client, GenType, Schema }
+import caliban.tools.Codegen.GenType
 import caliban.tools._
 import sbt.Keys.commands
 import sbt.{ AutoPlugin, Command, State }
@@ -14,14 +14,14 @@ object CodegenPlugin extends AutoPlugin {
     genCommand(
       "calibanGenSchema",
       genSchemaHelpMsg,
-      Schema
+      GenType.Schema
     )
 
   lazy val genClientCommand =
     genCommand(
       "calibanGenClient",
       genClientHelpMsg,
-      Client
+      GenType.Client
     )
 
   def genCommand(

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -16,9 +16,9 @@ object ClientWriter {
 
   def write(
     schema: Document,
-    genView: Boolean,
     objectName: String = "Client",
     packageName: Option[String] = None,
+    genView: Boolean = false,
     additionalImports: Option[List[String]] = None
   )(implicit scalarMappings: ScalarMappings): String = {
     val schemaDef = schema.schemaDefinition

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -18,7 +18,8 @@ object ClientWriter {
     schema: Document,
     genView: Boolean,
     objectName: String = "Client",
-    packageName: Option[String] = None
+    packageName: Option[String] = None,
+    additionalImports: Option[List[String]] = None
   )(implicit scalarMappings: ScalarMappings): String = {
     val schemaDef = schema.schemaDefinition
 
@@ -80,6 +81,8 @@ object ClientWriter {
       .map(writeRootSubscription)
       .getOrElse("")
 
+    val additionalImportsString = additionalImports.fold("")(_.map(i => s"import $i").mkString("\n"))
+
     val imports =
       s"""${if (enums.nonEmpty)
         """import caliban.client.CalibanClientError.DecodingError
@@ -102,7 +105,8 @@ object ClientWriter {
           |""".stripMargin
       else ""}"""
 
-    s"""${packageName.fold("")(p => s"package $p\n\n")}$imports
+    s"""${packageName.fold("")(p => s"package $p\n\n")}$imports\n
+       |$additionalImportsString
        |
        |object $objectName {
        |

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -9,9 +9,11 @@ object Codegen {
 
   sealed trait GenType
 
-  object Schema extends GenType
+  object GenType {
+    object Schema extends GenType
 
-  object Client extends GenType
+    object Client extends GenType
+  }
 
   def generate(
     arguments: Options,
@@ -27,10 +29,10 @@ object Codegen {
     for {
       schema    <- loader.load
       code       = genType match {
-                     case Schema =>
+                     case GenType.Schema =>
                        SchemaWriter.write(schema, packageName, effect, arguments.imports)(ScalarMappings(scalarMappings))
-                     case Client =>
-                       ClientWriter.write(schema, genView, objectName, packageName, arguments.imports)(
+                     case GenType.Client =>
+                       ClientWriter.write(schema, objectName, packageName, genView, arguments.imports)(
                          ScalarMappings(scalarMappings)
                        )
                    }

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -27,9 +27,12 @@ object Codegen {
     for {
       schema    <- loader.load
       code       = genType match {
-                     case Schema => SchemaWriter.write(schema, packageName, effect)(ScalarMappings(scalarMappings))
+                     case Schema =>
+                       SchemaWriter.write(schema, packageName, effect, arguments.imports)(ScalarMappings(scalarMappings))
                      case Client =>
-                       ClientWriter.write(schema, genView, objectName, packageName)(ScalarMappings(scalarMappings))
+                       ClientWriter.write(schema, genView, objectName, packageName, arguments.imports)(
+                         ScalarMappings(scalarMappings)
+                       )
                    }
       formatted <- Formatter.format(code, arguments.fmtPath)
       _         <- Task(new PrintWriter(new File(arguments.toPath)))

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -2,24 +2,35 @@ package caliban.tools
 
 import java.io.{ File, PrintWriter }
 
-import caliban.parsing.adt.Document
+import caliban.tools.implicits.ScalarMappings
 import zio.{ Task, UIO }
 
 object Codegen {
 
+  sealed trait GenType
+
+  object Schema extends GenType
+
+  object Client extends GenType
+
   def generate(
     arguments: Options,
-    writer: (Document, String, Option[String], Boolean, String) => String
+    genType: GenType
   ): Task[Unit] = {
-    val s           = ".*/scala/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
-    val packageName = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
-    val objectName  = s.map(_.group(2)).getOrElse("Client")
-    val effect      = arguments.effect.getOrElse("zio.UIO")
-    val genView     = arguments.genView.getOrElse(false)
-    val loader      = getSchemaLoader(arguments.schemaPath, arguments.headers)
+    val s              = ".*/scala/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
+    val packageName    = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
+    val objectName     = s.map(_.group(2)).getOrElse("Client")
+    val effect         = arguments.effect.getOrElse("zio.UIO")
+    val genView        = arguments.genView.getOrElse(false)
+    val scalarMappings = arguments.scalarMappings
+    val loader         = getSchemaLoader(arguments.schemaPath, arguments.headers)
     for {
       schema    <- loader.load
-      code       = writer(schema, objectName, packageName, genView, effect)
+      code       = genType match {
+                     case Schema => SchemaWriter.write(schema, packageName, effect)(ScalarMappings(scalarMappings))
+                     case Client =>
+                       ClientWriter.write(schema, genView, objectName, packageName)(ScalarMappings(scalarMappings))
+                   }
       formatted <- Formatter.format(code, arguments.fmtPath)
       _         <- Task(new PrintWriter(new File(arguments.toPath)))
                      .bracket(q => UIO(q.close()), pw => Task(pw.println(formatted)))

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -12,8 +12,7 @@ import caliban.parsing.adt.Definition.TypeSystemDefinition.{ DirectiveDefinition
 import caliban.parsing.adt.Type.{ ListType, NamedType }
 import caliban.parsing.adt.{ Directive, Document, Type }
 import sttp.client3._
-import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
-import sttp.client3.asynchttpclient.zio._
+import sttp.client3.asynchttpclient.zio.{ AsyncHttpClientZioBackend, _ }
 import sttp.model.Uri
 import zio.{ IO, RIO, Task }
 

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -12,7 +12,7 @@ import caliban.parsing.adt.Definition.TypeSystemDefinition.{ DirectiveDefinition
 import caliban.parsing.adt.Type.{ ListType, NamedType }
 import caliban.parsing.adt.{ Directive, Document, Type }
 import sttp.client3._
-import sttp.client3.asynchttpclient.zio.{ AsyncHttpClientZioBackend, _ }
+import sttp.client3.asynchttpclient.zio._
 import sttp.model.Uri
 import zio.{ IO, RIO, Task }
 

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -11,7 +11,8 @@ final case class Options(
   packageName: Option[String],
   genView: Option[Boolean],
   effect: Option[String],
-  scalarMappings: Option[Map[String, String]]
+  scalarMappings: Option[Map[String, String]],
+  imports: Option[List[String]]
 )
 
 object Options {
@@ -22,7 +23,8 @@ object Options {
     packageName: Option[String],
     genView: Option[Boolean],
     effect: Option[String],
-    scalarMappings: Option[List[String]]
+    scalarMappings: Option[List[String]],
+    imports: Option[List[String]]
   )
 
   def fromArgs(args: List[String]): Option[Options] =
@@ -59,7 +61,8 @@ object Options {
                   case _                    => None
                 }
               }.toMap
-            }
+            },
+            rawOpts.imports
           )
         }
       case _                             => None

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -1,7 +1,7 @@
 package caliban.tools
 
-import zio.config.{ read, ConfigDescriptor, ConfigSource }
 import zio.config.magnolia.DeriveConfigDescriptor.descriptor
+import zio.config.{ read, ConfigDescriptor, ConfigSource }
 
 final case class Options(
   schemaPath: String,
@@ -10,7 +10,8 @@ final case class Options(
   headers: Option[List[Options.Header]],
   packageName: Option[String],
   genView: Option[Boolean],
-  effect: Option[String]
+  effect: Option[String],
+  scalarMappings: Option[Map[String, String]]
 )
 
 object Options {
@@ -20,7 +21,8 @@ object Options {
     headers: Option[List[String]],
     packageName: Option[String],
     genView: Option[Boolean],
-    effect: Option[String]
+    effect: Option[String],
+    scalarMappings: Option[List[String]]
   )
 
   def fromArgs(args: List[String]): Option[Options] =
@@ -49,7 +51,15 @@ object Options {
             },
             rawOpts.packageName,
             rawOpts.genView,
-            rawOpts.effect
+            rawOpts.effect,
+            rawOpts.scalarMappings.map {
+              _.flatMap { rawMapping =>
+                rawMapping.split(":").toList match {
+                  case name :: value :: Nil => Some(name -> value)
+                  case _                    => None
+                }
+              }.toMap
+            }
           )
         }
       case _                             => None

--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -11,7 +11,8 @@ object SchemaWriter {
   def write(
     schema: Document,
     packageName: Option[String] = None,
-    effect: String = "zio.UIO"
+    effect: String = "zio.UIO",
+    imports: Option[List[String]] = None
   )(implicit scalarMappings: ScalarMappings): String = {
     val schemaDef = schema.schemaDefinition
 
@@ -55,6 +56,8 @@ object SchemaWriter {
       .map(t => writeRootSubscriptionDef(t))
       .getOrElse("")
 
+    val additionalImportsString = imports.fold("")(_.map(i => s"import $i").mkString("\n"))
+
     val hasSubscriptions = subscriptions.nonEmpty
     val hasTypes         = argsTypes.length + objects.length + enums.length + unions.length + inputs.length > 0
     val hasOperations    = queries.length + mutations.length + subscriptions.length > 0
@@ -81,7 +84,8 @@ object SchemaWriter {
 
     s"""${packageName.fold("")(p => s"package $p\n\n")}${if (hasTypes && hasOperations) "import Types._\n" else ""}
           ${if (typesAndOperations.contains("@GQL")) "import caliban.schema.Annotations._\n" else ""}
-          ${if (hasSubscriptions) "import zio.stream.ZStream" else ""}
+          ${if (hasSubscriptions) "import zio.stream.ZStream\n" else ""}
+          $additionalImportsString
 
       $typesAndOperations
       """

--- a/tools/src/main/scala/caliban/tools/implicits/Implicits.scala
+++ b/tools/src/main/scala/caliban/tools/implicits/Implicits.scala
@@ -1,0 +1,14 @@
+package caliban.tools.implicits
+
+import caliban.parsing.adt.Definition.TypeSystemDefinition
+
+import scala.language.implicitConversions
+
+object Implicits {
+  implicit def typesMapToMap(typesMap: TypesMap): Map[String, TypeSystemDefinition.TypeDefinition] = typesMap.typesMap
+
+  implicit def scalarMappingsToMap(typeMappings: ScalarMappings): Option[Map[String, String]] = typeMappings.scalarMap
+
+  implicit def mappingClashedTypeNamesToMap(mappingClashedTypeNames: MappingClashedTypeNames): Map[String, String] =
+    mappingClashedTypeNames.clashedTypesMap
+}

--- a/tools/src/main/scala/caliban/tools/implicits/MappingClashedTypeNames.scala
+++ b/tools/src/main/scala/caliban/tools/implicits/MappingClashedTypeNames.scala
@@ -1,0 +1,3 @@
+package caliban.tools.implicits
+
+case class MappingClashedTypeNames(clashedTypesMap: Map[String, String])

--- a/tools/src/main/scala/caliban/tools/implicits/ScalarMappings.scala
+++ b/tools/src/main/scala/caliban/tools/implicits/ScalarMappings.scala
@@ -1,0 +1,3 @@
+package caliban.tools.implicits
+
+case class ScalarMappings(scalarMap: Option[Map[String, String]])

--- a/tools/src/main/scala/caliban/tools/implicits/TypesMap.scala
+++ b/tools/src/main/scala/caliban/tools/implicits/TypesMap.scala
@@ -1,0 +1,5 @@
+package caliban.tools.implicits
+
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition
+
+case class TypesMap(typesMap: Map[String, TypeDefinition])

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -17,7 +17,7 @@ object ClientWriterSpec extends DefaultRunnableSpec {
     .parseQuery(schema)
     .flatMap(doc =>
       Formatter.format(
-        ClientWriter.write(doc, genView = false, additionalImports = Some(additionalImports))(
+        ClientWriter.write(doc, additionalImports = Some(additionalImports))(
           ScalarMappings(Some(scalarMappings))
         ),
         None

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -1,17 +1,18 @@
 package caliban.tools
 
 import caliban.parsing.Parser
+import caliban.tools.implicits.ScalarMappings
 import zio.Task
 import zio.test.Assertion._
-import zio.test.environment.TestEnvironment
 import zio.test._
+import zio.test.environment.TestEnvironment
 
 object ClientWriterViewSpec extends DefaultRunnableSpec {
 
   val gen: String => Task[String] = (schema: String) =>
     Parser
       .parseQuery(schema)
-      .flatMap(doc => Formatter.format(ClientWriter.write(doc, "Client", None, genView = true), None))
+      .flatMap(doc => Formatter.format(ClientWriter.write(doc, genView = true)(ScalarMappings(None)), None))
 
   override def spec: ZSpec[TestEnvironment, Any] =
     suite("ClientWriterViewSpec")(

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -174,7 +174,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
-                Some(List("a.b.Clazz", "b.c._")),
+                Some(List("a.b.Clazz", "b.c._"))
               )
             )
           )

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -22,6 +22,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -42,6 +43,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -54,7 +56,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         assert(result)(
           equalTo(
             Some(
-              Options("schema", "output", None, None, None, None, None, None)
+              Options("schema", "output", None, None, None, None, None, None, None)
             )
           )
         )
@@ -87,6 +89,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 Some("com.github.ghostdogpr"),
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -107,6 +110,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some("cats.effect.IO"),
+                None,
                 None
               )
             )
@@ -126,6 +130,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some(true),
+                None,
                 None,
                 None
               )
@@ -147,7 +152,29 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
-                Some(Map("Long" -> "scala.Long"))
+                Some(Map("Long" -> "scala.Long")),
+                None
+              )
+            )
+          )
+        )
+      },
+      test("provide imports") {
+        val input  = List("schema", "output", "--imports", "a.b.Clazz,b.c._")
+        val result = Options.fromArgs(input)
+        assert(result)(
+          equalTo(
+            Some(
+              Options(
+                "schema",
+                "output",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(List("a.b.Clazz", "b.c._")),
               )
             )
           )

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -21,6 +21,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 Some(List(Header("header1", "value1"), Header("header2", "value2"))),
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -40,6 +41,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 Some(List(Header("header1", "value1"), Header("header2", "value2"))),
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -52,7 +54,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         assert(result)(
           equalTo(
             Some(
-              Options("schema", "output", None, None, None, None, None)
+              Options("schema", "output", None, None, None, None, None, None)
             )
           )
         )
@@ -84,6 +86,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 Some("com.github.ghostdogpr"),
                 None,
+                None,
                 None
               )
             )
@@ -103,7 +106,8 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
-                Some("cats.effect.IO")
+                Some("cats.effect.IO"),
+                None
               )
             )
           )
@@ -122,7 +126,28 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some(true),
+                None,
                 None
+              )
+            )
+          )
+        )
+      },
+      test("provide scalarMappings") {
+        val input  = List("schema", "output", "--scalarMappings", "Long:scala.Long")
+        val result = Options.fromArgs(input)
+        assert(result)(
+          equalTo(
+            Some(
+              Options(
+                "schema",
+                "output",
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(Map("Long" -> "scala.Long"))
               )
             )
           )

--- a/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
@@ -1,10 +1,9 @@
 package caliban.tools
 
-import caliban.CalibanError
 import caliban.GraphQL.graphQL
-import caliban.RootResolver
 import caliban.parsing.Parser
 import caliban.tools.SchemaComparison.compareDocuments
+import caliban.{ CalibanError, RootResolver }
 import zio.ZIO
 import zio.test.Assertion._
 import zio.test._

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -183,6 +183,9 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
           )
         )
       },
+      testM("empty schema test") {
+        assertM(gen(""))(equalTo(System.lineSeparator))
+      },
       testM("enum type") {
         val schema =
           """

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -2,7 +2,7 @@ package caliban.tools
 
 import caliban.parsing.Parser
 import caliban.tools.implicits.ScalarMappings
-import zio.{ Task, ZIO }
+import zio.Task
 import zio.test.Assertion.equalTo
 import zio.test._
 import zio.test.environment.TestEnvironment

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -17,7 +17,10 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
     customImports: List[String] = List.empty
   ): Task[String] = Parser
     .parseQuery(schema)
-    .flatMap(doc => Formatter.format(SchemaWriter.write(doc, imports = Some(customImports))(ScalarMappings(Some(scalarMappings))), None))
+    .flatMap(doc =>
+      Formatter
+        .format(SchemaWriter.write(doc, imports = Some(customImports))(ScalarMappings(Some(scalarMappings))), None)
+    )
 
   override def spec: ZSpec[TestEnvironment, Any] =
     suite("SchemaWriterSpec")(

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -37,7 +37,7 @@ enablePlugins(CodegenPlugin)
 
 Then call the `calibanGenClient` sbt command.
 ```scala
-calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--genView true|false]
+calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--genView true|false] [--scalarMappings gqlType:f.q.d.n.Type,gqlType2:f.q.d.n.Type2]
 
 calibanGenClient project/schema.graphql src/main/client/Client.scala --genView true  
 ```
@@ -49,6 +49,8 @@ The package of the generated code is derived from the folder of `outputPath`.
 This can be overridden by providing an alternative package with the `--packageName`
 option.
 Provide `--genView true` option if you want to generate a view for the GraphQL types. 
+If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
+`--scalarMappings` option. 
 
 ## Query building
 

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -37,7 +37,7 @@ enablePlugins(CodegenPlugin)
 
 Then call the `calibanGenClient` sbt command.
 ```scala
-calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--genView true|false] [--scalarMappings gqlType:f.q.d.n.Type,gqlType2:f.q.d.n.Type2]
+calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--genView true|false] [--scalarMappings gqlType:f.q.d.n.Type,gqlType2:f.q.d.n.Type2] [--imports a.b.c._,c.d.E]
 
 calibanGenClient project/schema.graphql src/main/client/Client.scala --genView true  
 ```
@@ -50,7 +50,7 @@ This can be overridden by providing an alternative package with the `--packageNa
 option.
 Provide `--genView true` option if you want to generate a view for the GraphQL types. 
 If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
-`--scalarMappings` option. 
+`--scalarMappings` option. Also you can add imports for example for your ArgEncoder implicits by providing `--imports` option.
 
 ## Query building
 

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -230,7 +230,7 @@ enablePlugins(CodegenPlugin)
 
 Then call the `calibanGenSchema` sbt command.
 ```scala
-calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--scalarMappings gqlType:f.q.d.n.Type,gqlType2:f.q.d.n.Type2]
+calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--scalarMappings gqlType:f.q.d.n.Type,gqlType2:f.q.d.n.Type2] [--imports a.b.c._,c.d.E]
 
 calibanGenSchema project/schema.graphql src/main/MyAPI.scala
 ```
@@ -243,7 +243,7 @@ The package of the generated code is derived from the folder of `outputPath`. Th
 By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. This can be overridden by providing an alternative effect with the `--effect` option.
 
 If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
-`--scalarMappings` option. 
+`--scalarMappings` option. Also you can add imports for example for your ScalarDecoder implicits by providing `--imports` option.
 
 ## Building Schemas by hand
 

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -243,7 +243,7 @@ The package of the generated code is derived from the folder of `outputPath`. Th
 By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. This can be overridden by providing an alternative effect with the `--effect` option.
 
 If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
-`--scalarMappings` option. Also you can add imports for example for your ScalarDecoder implicits by providing `--imports` option.
+`--scalarMappings` option. Also you can add additional imports by providing `--imports` option.
 
 ## Building Schemas by hand
 

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -230,7 +230,7 @@ enablePlugins(CodegenPlugin)
 
 Then call the `calibanGenSchema` sbt command.
 ```scala
-calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect]
+calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--scalarMappings gqlType:f.q.d.n.Type,gqlType2:f.q.d.n.Type2]
 
 calibanGenSchema project/schema.graphql src/main/MyAPI.scala
 ```
@@ -241,6 +241,9 @@ The generated code will be formatted with Scalafmt using the configuration defin
 The package of the generated code is derived from the folder of `outputPath`. This can be overridden by providing an alternative package with the `--packageName` option.
 
 By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. This can be overridden by providing an alternative effect with the `--effect` option.
+
+If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
+`--scalarMappings` option. 
 
 ## Building Schemas by hand
 


### PR DESCRIPTION
Resolves #453

* sealed trait Codegen.GenType instead of passing writer lambda (see Codegen)
* use implicits in SchemaWriter and ClientWriter
* add additional command line option --scalarMappings
* update client.md and schema.md