### PR TITLE
Add RemoteSchema for parsing and working with remote schemas via introspection

### DIFF
--- a/tools/src/main/scala/caliban/tools/RemoteSchema.scala
+++ b/tools/src/main/scala/caliban/tools/RemoteSchema.scala
@@ -1,0 +1,313 @@
+package caliban.tools
+
+import caliban.parsing.adt._
+import caliban.Value.StringValue
+import caliban.introspection.adt._
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
+import caliban.parsing.adt.Definition.TypeSystemDefinition._
+
+object RemoteSchema {
+
+  /**
+   * Turns an introspection schema into a caliban.parsing.adt.__Schema
+   * which can in turn be used for more advanced use cases such as schema
+   * stitching.
+   */
+  def parseRemoteSchema(doc: Document): Option[__Schema] = {
+    val queries = doc.schemaDefinition
+      .flatMap(_.query)
+      .flatMap(doc.objectTypeDefinition(_))
+
+    val mutations = doc.schemaDefinition
+      .flatMap(_.mutation)
+      .flatMap(doc.objectTypeDefinition(_))
+
+    queries
+      .map(queries =>
+        __Schema(
+          queryType = toObjectType(queries, doc.typeDefinitions),
+          mutationType = mutations.map(toObjectType(_, doc.typeDefinitions)),
+          subscriptionType = None,
+          types = doc.typeDefinitions.map(toTypeDefinition(_, doc.typeDefinitions)),
+          directives = doc.directiveDefinitions.map(toDirective(_, doc.typeDefinitions))
+        )
+      )
+  }
+
+  private def toObjectType(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.ObjectTypeDefinition,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): __Type =
+    __Type(
+      kind = __TypeKind.OBJECT,
+      name = Some(definition.name),
+      description = definition.description,
+      interfaces = toInterfaces(definition.implements, definitions),
+      directives = toDirectives(definition.directives),
+      fields = (args: __DeprecatedArgs) => {
+        if (definition.fields.length > 0)
+          Some(
+            definition.fields
+              .map(toField(_, definitions))
+              .filter(filterDeprecated(_, args))
+          )
+        else None
+      }
+    )
+
+  private def toField(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.FieldDefinition,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): __Field =
+    __Field(
+      name = definition.name,
+      description = definition.description,
+      args = definition.args.map(toInputValue(_, definitions)),
+      `type` = toType(definition.ofType, definitions),
+      isDeprecated = isDeprecated(definition.directives),
+      deprecationReason = deprecationReason(definition.directives),
+      directives = toDirectives(definition.directives)
+    )
+
+  private def toType(
+    definition: Type,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): () => __Type = { () =>
+    definition match {
+      case Type.ListType(t, nonNull) =>
+        if (nonNull)
+          __Type(
+            kind = __TypeKind.NON_NULL,
+            ofType = Some(
+              __Type(
+                kind = __TypeKind.LIST,
+                ofType = Some(
+                  toType(t, definitions)()
+                )
+              )
+            )
+          )
+        else
+          __Type(
+            kind = __TypeKind.LIST,
+            ofType = Some(
+              toType(t, definitions)()
+            )
+          )
+
+      case Type.NamedType(name, nonNull) =>
+        if (nonNull)
+          __Type(
+            kind = __TypeKind.NON_NULL,
+            ofType = Some(
+              toType(name, definitions)
+            )
+          )
+        else
+          toType(name, definitions)
+    }
+  }
+
+  private def toType(
+    name: String,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ) =
+    definitions.find(_.name == name) match {
+      case Some(value) =>
+        value match {
+          case e: EnumTypeDefinition        => toEnumType(e)
+          case s: ScalarTypeDefinition      => toScalar(s)
+          case u: UnionTypeDefinition       => toUnionType(u, definitions)
+          case o: ObjectTypeDefinition      => toObjectType(o, definitions)
+          case i: InputObjectTypeDefinition =>
+            toInputObjectType(i, definitions)
+          case i: InterfaceTypeDefinition   =>
+            toInterfaceType(i, definitions)
+        }
+      case None        => __Type(kind = __TypeKind.SCALAR, name = Some(name))
+    }
+
+  private def toDirectives(directives: List[Directive]): Option[List[Directive]] =
+    if (directives.length > 0) Some(directives.filter(_.name != "deprecated"))
+    else None
+
+  private def toInterfaces(
+    interfaces: List[Type.NamedType],
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): () => Some[List[__Type]] = { () =>
+    Some(
+      interfaces
+        .map(t => toType(t.name, definitions))
+    )
+  }
+
+  private def toInterfaceType(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.InterfaceTypeDefinition,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): __Type =
+    __Type(
+      kind = __TypeKind.INTERFACE,
+      name = Some(definition.name),
+      description = definition.description,
+      fields = (args: __DeprecatedArgs) =>
+        if (definition.fields.length > 0)
+          Some(
+            definition.fields
+              .map(t => toField(t, definitions))
+              .filter(filterDeprecated(_, args))
+          )
+        else None,
+      directives = toDirectives(definition.directives)
+    )
+
+  private def toInputValue(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.InputValueDefinition,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): __InputValue =
+    __InputValue(
+      name = definition.name,
+      description = definition.description,
+      `type` = toType(definition.ofType, definitions),
+      defaultValue = definition.defaultValue.map(_.toString),
+      directives = toDirectives(definition.directives)
+    )
+
+  private def toEnumType(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.EnumTypeDefinition
+  ): __Type =
+    __Type(
+      kind = __TypeKind.ENUM,
+      name = Some(definition.name),
+      enumValues = (args: __DeprecatedArgs) =>
+        if (definition.enumValuesDefinition.length > 0)
+          Some(definition.enumValuesDefinition.map(toEnumValue(_)).filter(filterDeprecated(_, args)))
+        else None,
+      directives = toDirectives(definition.directives)
+    )
+
+  private def toEnumValue(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.EnumValueDefinition
+  ): __EnumValue =
+    __EnumValue(
+      name = definition.enumValue,
+      description = definition.description,
+      isDeprecated = isDeprecated(definition.directives),
+      deprecationReason = deprecationReason(definition.directives)
+    )
+
+  private def toInputObjectType(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.InputObjectTypeDefinition,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): __Type =
+    __Type(
+      kind = __TypeKind.INPUT_OBJECT,
+      name = Some(definition.name),
+      description = definition.description,
+      inputFields =
+        if (definition.fields.length > 0)
+          Some(
+            definition.fields
+              .map(f => toInputValue(f, definitions))
+          )
+        else None,
+      directives = toDirectives(definition.directives)
+    )
+
+  private def toUnionType(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.UnionTypeDefinition,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): __Type =
+    __Type(
+      kind = __TypeKind.UNION,
+      name = Some(definition.name),
+      description = definition.description,
+      possibleTypes =
+        if (definition.memberTypes.length > 0)
+          Some(
+            definition.memberTypes
+              .map(t => toType(t, definitions))
+          )
+        else None,
+      directives = toDirectives(definition.directives)
+    )
+
+  private def toScalar(
+    definition: Definition.TypeSystemDefinition.TypeDefinition.ScalarTypeDefinition
+  ): __Type =
+    __Type(
+      kind = __TypeKind.SCALAR,
+      name = Some(definition.name),
+      description = definition.description,
+      directives = toDirectives(definition.directives)
+    )
+
+  private def toTypeDefinition(
+    definition: Definition.TypeSystemDefinition.TypeDefinition,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): __Type =
+    definition match {
+      case o: ObjectTypeDefinition      => toObjectType(o, definitions)
+      case s: ScalarTypeDefinition      => toScalar(s)
+      case e: EnumTypeDefinition        => toEnumType(e)
+      case u: UnionTypeDefinition       => toUnionType(u, definitions)
+      case i: InterfaceTypeDefinition   => toInterfaceType(i, definitions)
+      case i: InputObjectTypeDefinition =>
+        toInputObjectType(i, definitions)
+    }
+
+  private def toDirective(
+    definition: Definition.TypeSystemDefinition.DirectiveDefinition,
+    definitions: List[Definition.TypeSystemDefinition.TypeDefinition]
+  ): __Directive =
+    __Directive(
+      name = definition.name,
+      description = definition.description,
+      args = definition.args.map(toInputValue(_, definitions)),
+      locations = definition.locations.map(toDirectiveLocation(_)).toSet
+    )
+
+  private def toDirectiveLocation(loc: DirectiveLocation): __DirectiveLocation =
+    loc match {
+      case DirectiveLocation.ExecutableDirectiveLocation.QUERY                  => __DirectiveLocation.QUERY
+      case DirectiveLocation.ExecutableDirectiveLocation.MUTATION               => __DirectiveLocation.MUTATION
+      case DirectiveLocation.ExecutableDirectiveLocation.SUBSCRIPTION           => __DirectiveLocation.SUBSCRIPTION
+      case DirectiveLocation.ExecutableDirectiveLocation.FIELD                  => __DirectiveLocation.FIELD
+      case DirectiveLocation.ExecutableDirectiveLocation.FRAGMENT_DEFINITION    => __DirectiveLocation.FRAGMENT_DEFINITION
+      case DirectiveLocation.ExecutableDirectiveLocation.FRAGMENT_SPREAD        => __DirectiveLocation.FRAGMENT_SPREAD
+      case DirectiveLocation.ExecutableDirectiveLocation.INLINE_FRAGMENT        => __DirectiveLocation.INLINE_FRAGMENT
+      case DirectiveLocation.TypeSystemDirectiveLocation.SCHEMA                 => __DirectiveLocation.SCHEMA
+      case DirectiveLocation.TypeSystemDirectiveLocation.SCALAR                 => __DirectiveLocation.SCALAR
+      case DirectiveLocation.TypeSystemDirectiveLocation.OBJECT                 => __DirectiveLocation.OBJECT
+      case DirectiveLocation.TypeSystemDirectiveLocation.FIELD_DEFINITION       => __DirectiveLocation.FIELD_DEFINITION
+      case DirectiveLocation.TypeSystemDirectiveLocation.ARGUMENT_DEFINITION    => __DirectiveLocation.ARGUMENT_DEFINITION
+      case DirectiveLocation.TypeSystemDirectiveLocation.INTERFACE              => __DirectiveLocation.INTERFACE
+      case DirectiveLocation.TypeSystemDirectiveLocation.UNION                  => __DirectiveLocation.UNION
+      case DirectiveLocation.TypeSystemDirectiveLocation.ENUM                   => __DirectiveLocation.ENUM
+      case DirectiveLocation.TypeSystemDirectiveLocation.ENUM_VALUE             => __DirectiveLocation.ENUM_VALUE
+      case DirectiveLocation.TypeSystemDirectiveLocation.INPUT_OBJECT           => __DirectiveLocation.INPUT_OBJECT
+      case DirectiveLocation.TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION =>
+        __DirectiveLocation.INPUT_FIELD_DEFINITION
+    }
+
+  private def filterDeprecated(x: __Field, deprecated: __DeprecatedArgs): Boolean =
+    if (deprecated.includeDeprecated.getOrElse(true)) true
+    else !x.isDeprecated
+
+  private def filterDeprecated(x: __EnumValue, deprecated: __DeprecatedArgs): Boolean =
+    if (deprecated.includeDeprecated.getOrElse(true)) true
+    else !x.isDeprecated
+
+  private def isDeprecated(directives: List[Directive]): Boolean =
+    deprecationReason(directives).isDefined
+
+  private def deprecationReason(directives: List[Directive]): Option[String] =
+    directives.collectFirst {
+      case d if (d.name == "deprecated") =>
+        d.arguments
+          .get("reason")
+          .collect({ case StringValue(value) =>
+            value
+          })
+          .getOrElse("deprecated")
+    }
+}

--- a/tools/src/main/scala/caliban/tools/RemoteSchema.scala
+++ b/tools/src/main/scala/caliban/tools/RemoteSchema.scala
@@ -45,7 +45,7 @@ object RemoteSchema {
       interfaces = toInterfaces(definition.implements, definitions),
       directives = toDirectives(definition.directives),
       fields = (args: __DeprecatedArgs) => {
-        if (definition.fields.length > 0)
+        if (definition.fields.nonEmpty)
           Some(
             definition.fields
               .map(toField(_, definitions))
@@ -127,9 +127,12 @@ object RemoteSchema {
       case None        => __Type(kind = __TypeKind.SCALAR, name = Some(name))
     }
 
-  private def toDirectives(directives: List[Directive]): Option[List[Directive]] =
-    if (directives.length > 0) Some(directives.filter(_.name != "deprecated"))
+  private def toDirectives(directives: List[Directive]): Option[List[Directive]] = {
+    val filtered = directives.filter(_.name != "deprecated")
+
+    if (filtered.nonEmpty) Some(filtered)
     else None
+  }
 
   private def toInterfaces(
     interfaces: List[Type.NamedType],
@@ -150,7 +153,7 @@ object RemoteSchema {
       name = Some(definition.name),
       description = definition.description,
       fields = (args: __DeprecatedArgs) =>
-        if (definition.fields.length > 0)
+        if (definition.fields.nonEmpty)
           Some(
             definition.fields
               .map(t => toField(t, definitions))
@@ -179,7 +182,7 @@ object RemoteSchema {
       kind = __TypeKind.ENUM,
       name = Some(definition.name),
       enumValues = (args: __DeprecatedArgs) =>
-        if (definition.enumValuesDefinition.length > 0)
+        if (definition.enumValuesDefinition.nonEmpty)
           Some(definition.enumValuesDefinition.map(toEnumValue(_)).filter(filterDeprecated(_, args)))
         else None,
       directives = toDirectives(definition.directives)
@@ -204,7 +207,7 @@ object RemoteSchema {
       name = Some(definition.name),
       description = definition.description,
       inputFields =
-        if (definition.fields.length > 0)
+        if (definition.fields.nonEmpty)
           Some(
             definition.fields
               .map(f => toInputValue(f, definitions))
@@ -222,7 +225,7 @@ object RemoteSchema {
       name = Some(definition.name),
       description = definition.description,
       possibleTypes =
-        if (definition.memberTypes.length > 0)
+        if (definition.memberTypes.nonEmpty)
           Some(
             definition.memberTypes
               .map(t => toType(t, definitions))
@@ -305,9 +308,9 @@ object RemoteSchema {
       case d if (d.name == "deprecated") =>
         d.arguments
           .get("reason")
-          .collect({ case StringValue(value) =>
+          .collect { case StringValue(value) =>
             value
-          })
+          }
           .getOrElse("deprecated")
     }
 }

--- a/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
+++ b/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
@@ -1,0 +1,80 @@
+package caliban.tools
+
+import caliban.GraphQL._
+import caliban._
+import caliban.introspection.adt._
+import caliban.schema._
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+object RemoteSchemaSpec extends DefaultRunnableSpec {
+  sealed trait EnumType  extends Product with Serializable
+  case object EnumValue1 extends EnumType
+  case object EnumValue2 extends EnumType
+
+  sealed trait UnionType                extends Product with Serializable
+  case class UnionValue1(field: String) extends UnionType
+
+  case class Object(
+    field: Int,
+    optionalField: Option[Float],
+    withDefault: Option[String] = Some("defaultValue"),
+    enumField: EnumType,
+    unionField: UnionType
+  )
+
+  object Resolvers {
+    def getObject(arg: String = "defaultValue"): Object =
+      Object(
+        field = 1,
+        optionalField = None,
+        enumField = EnumValue1,
+        unionField = UnionValue1("value")
+      )
+  }
+
+  case class Queries(
+    getObject: String => Object
+  )
+
+  val queries = Queries(
+    getObject = Resolvers.getObject
+  )
+
+  val api = graphQL(
+    RootResolver(
+      queries
+    )
+  )
+
+  def spec = suite("ParserSpec")(
+    testM("is isomorphic") {
+      for {
+        introspected <- SchemaLoader.fromCaliban(api).load
+        remoteSchema <- ZIO.fromOption(RemoteSchema.parseRemoteSchema(introspected))
+        remoteAPI    <- ZIO.effectTotal(fromRemoteSchema(remoteSchema))
+        sdl           = api.render
+        remoteSDL     = remoteAPI.render
+      } yield assert(remoteSDL)(equalTo(sdl))
+    }
+  )
+
+  def fromRemoteSchema(s: __Schema): GraphQL[Any] =
+    new GraphQL[Any] {
+      protected val schemaBuilder                                 =
+        RootSchemaBuilder(
+          query = Some(
+            Operation[Any](
+              s.queryType,
+              Step.NullStep
+            )
+          ),
+          mutation = None,
+          subscription = None
+        )
+      protected val additionalDirectives: List[__Directive]       = List()
+      protected val wrappers: List[caliban.wrappers.Wrapper[Any]] = List()
+    }
+
+}


### PR DESCRIPTION
Hi!

As we've talked a bit about on Discord I've been working on making the result from the `SchemaLoader` transformable to an actual `Schema`.

This opens up some very powerful use-cases like schema stitching.

This PR only includes the actual transformation from `caliban.parsing.adt` to `caliban.introspection.adt`. The only thing I haven't gotten fully working is default values for `__InputValue`s, but I haven't actually managed to create a field with a default value via Caliban either so it's probably something I'm missing.

I have some additional helper code that either turns an entire schema into a remotely executing one, [found in this gist](https://gist.github.com/frekw/61c786b83e043fd347ed8e958f2c85d6#file-exector-scala). This should allow you to define something along the lines of:

```scala
val remoteApi: GraphQL[SttpClient] = for {
    schema <- schemaLoader.load
    remoteSchema <- ZIO.fromOption(RemoteSchema.parseRemoteSchema(schema))
    remoteAPI = 
  } yield RemoteExecutor.fromRemoteAPI(remoteSchema, "http://graphql-api.com")
```

which could then be used (at least in theory, some more work may be needed in `Step.combine`) to do stitching via `api |+| remoteApi`.

[The next piece of code](https://gist.github.com/frekw/61c786b83e043fd347ed8e958f2c85d6#file-remoteschema-scala) is more interesting (at least I think so) because it allows you to define a `Schema[R, A]` which uses a remote API to do the resolution. This becomes incredibly powerful since you can include only parts of a schema, or merge in branch of a remote schema deeper in a schema of your own.

```scala
case class RemoteEntity(id: String)

  case class Dummy(
      id: String,
      description: String,
      remoteEntity: RemoteEntity
  )

  case class Queries(
      dummy: String => Dummy
  )

  val api = for {
    schema <- schemaLoader.load
    remoteSchema <- ZIO.fromOption(parseSchema(schema))
    remoteResolvers = RemoteResolver.fromSchema(remoteSchema, "https://graphql-api.com")
    sttpClient <- ZIO.service[SttpClient.Service]
  } yield {
    implicit val remoteEntitySchema: Schema[Any, RemoteEntity] = remoteResolvers
      .remoteResolver("RemoteEntity")(
        (re: RemoteEntity, args: caliban.execution.Field) => {
          // Rewrite the query for remote entity to a root level query
          // in the API we're wrapping
          args.copy(name = "getRemoteEntity", arguments = Map("id" -> caliban.Value.StringValue(re.id)))
        })
      .provide(Has(sttpClient))
```

My use case for the above is that I have an existing GraphQL that I wish to break apart using GraphQL federation. However, the federation spec doesn't support GraphQL subscriptions which is a hard requirement in order to maintain backwards compatibility.

Using this, I can add subscriptions on top of the federated schema, and then use the federated schema itself to resolve the queries from the subscriptions, thus almost getting the best of both worlds (the subscription app will be a monolith, but at the same time a very thin layer on top of the already federated schema).

The reason why I haven't included those additional helpers yet is that I'm not sure where to put them since they currently depend on both `sttp` as well as `circe`. Should we add more dependencies to `caliban-tools` or add another package, maybe `caliban-stitching`?

I also need to wrap up something that can wrap an `execution.Field` to a proper query correctly. The code I'm using for that right now isn't very robust and falls apart for queries that include unions.

Would love to get some more eyes and feedback on this!