### PR TITLE
Add rendering description for argument fields

### DIFF
--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -85,9 +85,10 @@ object Rendering {
       case _                       => ""
     }
 
-  private def renderDescription(description: Option[String]): String = description match {
-    case None        => ""
-    case Some(value) => if (value.contains("\n")) s"""\"\"\"\n$value\"\"\"\n""" else s""""$value"\n"""
+  private def renderDescription(description: Option[String], newline: Boolean = true): String = description match {
+    case None                   => ""
+    case Some(value) if newline => if (value.contains("\n")) s"""\"\"\"\n$value\"\"\"\n""" else s""""$value"\n"""
+    case Some(value)            => if (value.contains("\n")) s"""\"\"\"$value\"\"\" """ else s""""$value" """
   }
 
   private def renderDirectiveArgument(value: InputValue): Option[String] = value match {
@@ -134,7 +135,8 @@ object Rendering {
 
   private def renderArguments(arguments: List[__InputValue]): String = arguments match {
     case Nil  => ""
-    case list => s"(${list.map(a => s"${a.name}: ${renderTypeName(a.`type`())}").mkString(", ")})"
+    case list =>
+      s"(${list.map(a => s"${renderDescription(a.description, newline = false)}${a.name}: ${renderTypeName(a.`type`())}").mkString(", ")})"
   }
 
   private def isBuiltinScalar(name: String): Boolean =

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -83,6 +83,7 @@ object RenderingSpec extends DefaultRunnableSpec {
                                      |
                                      |type MutationTest {
                                      |  id(id: Int!, user: UserTestInput!): Boolean!
+                                     |  fetch(nameLike: String!, "is user active currently" active: Boolean!): Boolean!
                                      |}
                                      |
                                      |type QueryTest {

--- a/core/src/test/scala/caliban/RenderingSpecSchema.scala
+++ b/core/src/test/scala/caliban/RenderingSpecSchema.scala
@@ -7,11 +7,16 @@ object RenderingSpecSchema {
   case class UserTest(name: String, @GQLDescription("field-description") age: Int)
   case class UserComplex(id: Int, user: UserTest)
 
+  case class UserParams(nameLike: String, @GQLDescription("is user active currently") active: Boolean)
+
   case class QueryTest(allUsers: () => List[UserTest])
-  case class MutationTest(id: UserComplex => Boolean)
+  case class MutationTest(
+    id: UserComplex => Boolean,
+    fetch: UserParams => Boolean
+  )
 
   val resolverSchema = RootResolver(
     QueryTest(() => List()),
-    MutationTest(c => true)
+    MutationTest(c => true, params => true)
   )
 }


### PR DESCRIPTION
Because rendered schema never contained description for argument fields a 'schema comparison' tool always complained that there are differences.
Should be okay now.

maybe for multiline descriptions for arguments it should do something similar to types(parameter per line), e.g.:
```
fetch(
  nameLike: String!,
  "is user active currently"
  active: Boolean!
  """ multi
  line
  desc
  """
  multi: String
): Boolean!
```

just a tip if someone got moment to improve it even further :)