### PR TITLE
Make interfaces support recursive types

### DIFF
--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -534,19 +534,21 @@ trait DerivationSchema[R] extends LowPriorityDerivedSchema {
           )
         ) { _ =>
           val impl         = subtypes.map(_._1.copy(interfaces = () => Some(List(toType(isInput, isSubscription)))))
-          val commonFields = impl
-            .flatMap(_.fields(__DeprecatedArgs(Some(true))))
-            .flatten
-            .groupBy(_.name)
-            .collect {
-              case (name, list)
-                  if impl.forall(_.fields(__DeprecatedArgs(Some(true))).getOrElse(Nil).exists(_.name == name)) &&
-                    list.map(t => Types.name(t.`type`())).distinct.length == 1 =>
-                list.headOption
-            }
-            .flatten
+          val commonFields = () =>
+            impl
+              .flatMap(_.fields(__DeprecatedArgs(Some(true))))
+              .flatten
+              .groupBy(_.name)
+              .collect {
+                case (name, list)
+                    if impl.forall(_.fields(__DeprecatedArgs(Some(true))).getOrElse(Nil).exists(_.name == name)) &&
+                      list.map(t => Types.name(t.`type`())).distinct.length == 1 =>
+                  list.headOption
+              }
+              .flatten
+              .toList
 
-          makeInterface(Some(getName(ctx)), getDescription(ctx), commonFields.toList, impl, Some(ctx.typeName.full))
+          makeInterface(Some(getName(ctx)), getDescription(ctx), commonFields, impl, Some(ctx.typeName.full))
         }
       }
     }

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -76,7 +76,7 @@ object Types {
   def makeInterface(
     name: Option[String],
     description: Option[String],
-    fields: List[__Field],
+    fields: () => List[__Field],
     subTypes: List[__Type],
     origin: Option[String] = None
   ): __Type =
@@ -85,7 +85,7 @@ object Types {
       name,
       description,
       fields =
-        args => if (args.includeDeprecated.getOrElse(false)) Some(fields) else Some(fields.filter(!_.isDeprecated)),
+        args => if (args.includeDeprecated.getOrElse(false)) Some(fields()) else Some(fields().filter(!_.isDeprecated)),
       possibleTypes = Some(subTypes),
       origin = origin
     )

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -300,8 +300,8 @@ object TestUtils {
             )
           )
 
-      val interfaceA = Types.makeInterface(Some("InterfaceA"), None, makeFields("a"), Nil)
-      val interfaceB = Types.makeInterface(Some("InterfaceB"), None, makeFields("b"), Nil)
+      val interfaceA = Types.makeInterface(Some("InterfaceA"), None, () => makeFields("a"), Nil)
+      val interfaceB = Types.makeInterface(Some("InterfaceB"), None, () => makeFields("b"), Nil)
 
       val objectWrongInterfaceFieldType = __Type(
         name = Some("ObjectWrongInterfaceFieldType"),
@@ -365,7 +365,7 @@ object TestUtils {
       val fieldInterface             = Types.makeInterface(
         name = Some("FieldInterface"),
         description = None,
-        fields = List(__Field("a", None, Nil, () => Types.string)),
+        fields = () => List(__Field("a", None, Nil, () => Types.string)),
         subTypes = Nil
       )
       val fieldObject                = __Type(
@@ -377,7 +377,7 @@ object TestUtils {
       val withListFieldInterface     = Types.makeInterface(
         name = Some("WithListFieldInterface"),
         description = None,
-        fields = List(__Field("a", None, Nil, () => Types.makeList(fieldInterface))),
+        fields = () => List(__Field("a", None, Nil, () => Types.makeList(fieldInterface))),
         subTypes = Nil
       )
       val objectWrongListItemSubtype = __Type(
@@ -456,15 +456,16 @@ object TestUtils {
       val withNullableExtraArgs: __Type = Types.makeInterface(
         name = Some("WithNullableExtraArgs"),
         description = None,
-        fields = List(
-          __Field(
-            name = "fieldWithArg",
-            description = None,
-            `type` = () => Types.string,
-            args =
-              List(__InputValue(name = "arg", description = None, `type` = () => Types.string, defaultValue = None))
-          )
-        ),
+        fields = () =>
+          List(
+            __Field(
+              name = "fieldWithArg",
+              description = None,
+              `type` = () => Types.string,
+              args =
+                List(__InputValue(name = "arg", description = None, `type` = () => Types.string, defaultValue = None))
+            )
+          ),
         subTypes = List(nullableExtraArgsObject)
       )
     }

--- a/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
@@ -155,10 +155,11 @@ object ValidationSchemaSpec extends DefaultRunnableSpec {
               Types.makeInterface(
                 name = Some("DuplicateNamesInterface"),
                 description = None,
-                fields = List(
-                  __Field("A", None, List.empty, `type` = () => __Type(__TypeKind.SCALAR)),
-                  __Field("A", None, List.empty, `type` = () => __Type(__TypeKind.SCALAR))
-                ),
+                fields = () =>
+                  List(
+                    __Field("A", None, List.empty, `type` = () => __Type(__TypeKind.SCALAR)),
+                    __Field("A", None, List.empty, `type` = () => __Type(__TypeKind.SCALAR))
+                  ),
                 subTypes = Nil
               ),
               "Interface 'DuplicateNamesInterface' has repeated fields: A"
@@ -175,14 +176,15 @@ object ValidationSchemaSpec extends DefaultRunnableSpec {
               Types.makeInterface(
                 name = Some("InputTypeFieldInterface"),
                 description = None,
-                fields = List(
-                  __Field(
-                    "InputField",
-                    None,
-                    List.empty,
-                    `type` = () => __Type(name = Some("InputType"), kind = __TypeKind.INPUT_OBJECT)
-                  )
-                ),
+                fields = () =>
+                  List(
+                    __Field(
+                      "InputField",
+                      None,
+                      List.empty,
+                      `type` = () => __Type(name = Some("InputType"), kind = __TypeKind.INPUT_OBJECT)
+                    )
+                  ),
                 subTypes = Nil
               ),
               "InputType of Field 'InputField' of Interface 'InputTypeFieldInterface' is of kind INPUT_OBJECT, must be an OutputType"


### PR DESCRIPTION
Prevent stack overflows when using `GQLInterface` with recursive types.