### PR TITLE
Reduce runtime required for interpreter creation in cats interop

### DIFF
--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -38,12 +38,12 @@ object CatsInterop {
 
   def checkAsync[F[_]: Async, R](
     graphQL: GraphQLInterpreter[R, Any]
-  )(query: String)(implicit runtime: Runtime[R]): F[Unit] =
+  )(query: String)(implicit runtime: Runtime[Any]): F[Unit] =
     Async[F].async(cb => runtime.unsafeRunAsync(graphQL.check(query))(exit => cb(exit.toEither)))
 
   def interpreterAsync[F[_]: Async, R](
     graphQL: GraphQL[R]
-  )(implicit runtime: Runtime[R]): F[GraphQLInterpreter[R, CalibanError]] =
+  )(implicit runtime: Runtime[Any]): F[GraphQLInterpreter[R, CalibanError]] =
     Async[F].async(cb => runtime.unsafeRunAsync(graphQL.interpreter)(exit => cb(exit.toEither)))
 
   def schema[F[_]: Effect, R, A](implicit ev: Schema[R, A]): Schema[R, F[A]] =

--- a/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/implicits/package.scala
@@ -28,12 +28,12 @@ package object implicits {
         queryExecution
       )
 
-    def checkAsync[F[_]: Async](query: String)(implicit runtime: Runtime[R]): F[Unit] =
+    def checkAsync[F[_]: Async](query: String)(implicit runtime: Runtime[Any]): F[Unit] =
       CatsInterop.checkAsync(underlying)(query)
   }
 
   implicit class CatsEffectGraphQL[R, E](underlying: GraphQL[R]) {
-    def interpreterAsync[F[_]: Async](implicit runtime: Runtime[R]): F[GraphQLInterpreter[R, CalibanError]] =
+    def interpreterAsync[F[_]: Async](implicit runtime: Runtime[Any]): F[GraphQLInterpreter[R, CalibanError]] =
       CatsInterop.interpreterAsync(underlying)
   }
 

--- a/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
+++ b/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
@@ -38,12 +38,14 @@ object MonixInterop {
       runtime.unsafeRunAsync(execution)(exit => cb(exit.toEither))
     }
 
-  def checkAsync[R](graphQL: GraphQLInterpreter[R, Any])(query: String)(implicit runtime: Runtime[R]): MonixTask[Unit] =
+  def checkAsync[R](
+    graphQL: GraphQLInterpreter[R, Any]
+  )(query: String)(implicit runtime: Runtime[Any]): MonixTask[Unit] =
     MonixTask.async(cb => runtime.unsafeRunAsync(graphQL.check(query))(exit => cb(exit.toEither)))
 
   def interpreterAsync[R](
     graphQL: GraphQL[R]
-  )(implicit runtime: Runtime[R]): MonixTask[GraphQLInterpreter[R, CalibanError]] =
+  )(implicit runtime: Runtime[Any]): MonixTask[GraphQLInterpreter[R, CalibanError]] =
     MonixTask.async(cb => runtime.unsafeRunAsync(graphQL.interpreter)(exit => cb(exit.toEither)))
 
   def taskSchema[R, A](implicit ev: Schema[R, A], ev2: ConcurrentEffect[MonixTask]): Schema[R, MonixTask[A]] =

--- a/interop/monix/src/main/scala/caliban/interop/monix/implicits/package.scala
+++ b/interop/monix/src/main/scala/caliban/interop/monix/implicits/package.scala
@@ -30,12 +30,12 @@ package object implicits {
         queryExecution
       )
 
-    def checkAsync(query: String)(implicit runtime: Runtime[R]): Task[Unit] =
+    def checkAsync(query: String)(implicit runtime: Runtime[Any]): Task[Unit] =
       MonixInterop.checkAsync(underlying)(query)
   }
 
   implicit class MonixGraphQL[R, E](underlying: GraphQL[R]) {
-    def interpreterAsync(implicit runtime: Runtime[R]): Task[GraphQLInterpreter[R, CalibanError]] =
+    def interpreterAsync(implicit runtime: Runtime[Any]): Task[GraphQLInterpreter[R, CalibanError]] =
       MonixInterop.interpreterAsync(underlying)
   }
 


### PR DESCRIPTION
I noticed that the `interpreterAsync[F]` requires a `Runtime[R]` but doesn't actually need it to produce the interpreter.

This PR lowers that constraint to a `Runtime[Any]` to allow providing layers later to the interpreter,