### PR TITLE
feat: Add zio-http adapter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.13! core/test http4s/compile akkaHttp/compile finch/compile play/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test codegenSbt/scripted
+      - run: sbt ++2.12.13! core/test http4s/compile akkaHttp/compile finch/compile play/test zioHttp/compile examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test codegenSbt/scripted
       - save_cache:
           key: sbtcache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.13! core/test http4s/compile akkaHttp/compile finch/compile play/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test codegenSbt/scripted
+      - run: sbt ++2.12.13! core/test http4s/compile akkaHttp/compile finch/compile play/test zioHttp/compile examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test codegenSbt/scripted
       - save_cache:
           key: sbtcache
           paths:
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.5! core/test http4s/compile akkaHttp/compile finch/compile play/test examples/compile catsInterop/compile monixInterop/compile tapirInterop/test clientJVM/test federation/test
+      - run: sbt ++2.13.5! core/test http4s/compile akkaHttp/compile finch/compile play/test zioHttp/compile examples/compile catsInterop/compile monixInterop/compile tapirInterop/test clientJVM/test federation/test
       - save_cache:
           key: sbtcache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.13! core/test http4s/compile akkaHttp/compile finch/compile play/test zioHttp/compile examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test codegenSbt/scripted
+      - run: sbt ++2.12.13! core/test http4s/compile akkaHttp/compile finch/compile play/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test codegenSbt/scripted
       - save_cache:
           key: sbtcache
           paths:

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -84,10 +84,10 @@ object ZHttpAdapter {
   private def socketHandler[R <: Has[_], E](
     subscriptions: Ref[Map[String, Promise[Any, Unit]]],
     interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    keepAliveTime: Option[Duration] = None,
-    queryExecution: QueryExecution = QueryExecution.Parallel
+    skipValidation: Boolean,
+    enableIntrospection: Boolean,
+    keepAliveTime: Option[Duration],
+    queryExecution: QueryExecution
   ): SocketApp[R with Clock, E] = {
     val routes = Socket.collect[WebSocketFrame] { case Text(text) =>
       ZStream

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -177,16 +177,16 @@ object ZHttpAdapter {
 
   private val protocol = SocketProtocol.subProtocol("graphql-ws")
 
-  private val keepAlive                                                                                            = (keepAlive: Option[Duration]) =>
+  private val keepAlive                                  = (keepAlive: Option[Duration]) =>
     keepAlive.fold(ZStream.empty)(duration =>
       ZStream
         .succeed(Text("""{"type":"ka"}"""))
         .repeat(Schedule.spaced(duration))
     )
-  private val connectionError                                                                                      = ZStream.succeed(Text("""{"type":"connection_error"}"""))
-  private val connectionAck                                                                                        = ZStream.succeed(Text("""{"type":"connection_ack"}"""))
-  private val close                                                                                                = ZStream.succeed(WebSocketFrame.close(1000))
-  private def toStreamError[E](id: Option[String], e: E)                                                           = ZStream.succeed(
+  private val connectionError                            = ZStream.succeed(Text("""{"type":"connection_error"}"""))
+  private val connectionAck                              = ZStream.succeed(Text("""{"type":"connection_ack"}"""))
+  private val close                                      = ZStream.succeed(WebSocketFrame.close(1000))
+  private def toStreamError[E](id: Option[String], e: E) = ZStream.succeed(
     Text(
       Json
         .obj(
@@ -197,6 +197,7 @@ object ZHttpAdapter {
         .toString()
     )
   )
+
   private def toResponse[E](id: String, fieldName: String, r: ResponseValue, errors: List[E]): WebSocketFrame.Text =
     toResponse(
       id,

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -178,13 +178,11 @@ object ZHttpAdapter {
   private val protocol = SocketProtocol.subProtocol("graphql-ws")
 
   private val keepAlive                                                                                            = (keepAlive: Option[Duration]) =>
-    keepAlive match {
-      case None          => ZStream.empty
-      case Some(timeout) =>
-        ZStream
-          .succeed(Text("""{"type":"ka"}"""))
-          .repeat(Schedule.spaced(timeout))
-    }
+    keepAlive.fold(ZStream.empty)(duration =>
+      ZStream
+        .succeed(Text("""{"type":"ka"}"""))
+        .repeat(Schedule.spaced(duration))
+    )
   private val connectionError                                                                                      = ZStream.succeed(Text("""{"type":"connection_error"}"""))
   private val connectionAck                                                                                        = ZStream.succeed(Text("""{"type":"connection_ack"}"""))
   private val close                                                                                                = ZStream.succeed(WebSocketFrame.close(1000))

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -161,9 +161,7 @@ object ZHttpAdapter {
         }
       )
 
-    (resp ++ complete(id)).catchAll { _ =>
-      connectionError
-    }
+    (resp ++ complete(id)).catchAll(toStreamError(Option(id), _))
   }
 
   private def executeToJson[R, E](

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -1,0 +1,239 @@
+package caliban
+
+import zio._
+import zio.clock.Clock
+import zio.duration._
+import zio.stream._
+
+import caliban.{ GraphQLInterpreter, GraphQLRequest, GraphQLResponse }
+import caliban.ResponseValue.{ ObjectValue, StreamValue }
+import caliban.ResponseValue
+import caliban.Value.NullValue
+import caliban.execution.QueryExecution
+import io.circe._
+import io.circe.parser._
+import io.circe.syntax._
+import zhttp.http._
+import zhttp.service._
+import zhttp.socket.SocketApp
+import zhttp.socket.WebSocketFrame.Text
+import zhttp.socket._
+
+object ZHttpAdapter {
+  case class GraphQLWSRequest(`type`: String, id: Option[String], payload: Option[GraphQLRequest])
+  object GraphQLWSRequest {
+    import io.circe._
+    import io.circe.generic.semiauto._
+
+    implicit val decodeGraphQLWSRequest: Decoder[GraphQLWSRequest] = deriveDecoder[GraphQLWSRequest]
+  }
+
+  def makeHttpService[R, E](
+    interpreter: GraphQLInterpreter[R, E],
+    skipValidation: Boolean = false,
+    enableIntrospection: Boolean = true,
+    queryExecution: QueryExecution = QueryExecution.Parallel
+  ): HttpApp[R, HttpError] =
+    Http.collectM {
+      case req @ Method.POST -> _ =>
+        (for {
+          query           <- ZIO.fromEither(decode[GraphQLRequest](req.getBodyAsString.getOrElse("")))
+          queryWithTracing = req.headers
+                               .find(r => r.name == "apollo-federation-include-trace" && r.value == "ftv1")
+                               .foldLeft(query)((q, _) => q.withFederatedTracing)
+          resp            <- executeToJson(interpreter, queryWithTracing, skipValidation, enableIntrospection, queryExecution)
+        } yield Response.jsonString(resp.toString)).handleHTTPError
+      case req @ Method.GET -> _  =>
+        val params = List("query", "operationName", "variables", "extensions")
+          .collect({ case k =>
+            k -> req.url.queryParams.get(k).flatMap(_.headOption).getOrElse("")
+          })
+          .toMap
+
+        (for {
+          query <- ZIO.fromEither(decode[GraphQLRequest](params.asJson.noSpaces))
+          resp  <- executeToJson(interpreter, query, skipValidation, enableIntrospection, queryExecution)
+        } yield Response.jsonString(resp.toString())).handleHTTPError
+
+      case req @ Method.OPTIONS -> _ =>
+        ZIO.succeed(Response.http(Status.NO_CONTENT))
+    }
+
+  def makeWebSocketService[R <: Has[_], E](
+    interpreter: GraphQLInterpreter[R, E],
+    skipValidation: Boolean = false,
+    enableIntrospection: Boolean = true,
+    keepAliveTime: Option[Duration] = None,
+    queryExecution: QueryExecution = QueryExecution.Parallel
+  ) =
+    HttpApp.responseM(
+      for {
+        ref <- Ref.make(Map.empty[String, Promise[Any, Unit]])
+      } yield Response.socket(
+        socketHandler(
+          ref,
+          interpreter,
+          skipValidation,
+          enableIntrospection,
+          keepAliveTime,
+          queryExecution
+        )
+      )
+    )
+
+  private def socketHandler[R <: Has[_], E](
+    subscriptions: Ref[Map[String, Promise[Any, Unit]]],
+    interpreter: GraphQLInterpreter[R, E],
+    skipValidation: Boolean = false,
+    enableIntrospection: Boolean = true,
+    keepAliveTime: Option[Duration] = None,
+    queryExecution: QueryExecution = QueryExecution.Parallel
+  ): SocketApp[R with Clock, E] = {
+    val routes = Socket.collect[WebSocketFrame] { case Text(text) =>
+      ZStream
+        .fromEffect(ZIO.fromEither(decode[GraphQLWSRequest](text)))
+        .collect({
+          case GraphQLWSRequest("connection_init", _, _)      => connectionAck ++ keepAlive(keepAliveTime)
+          case GraphQLWSRequest("connection_terminate", _, _) => close
+          case GraphQLWSRequest("start", id, payload)         =>
+            payload match {
+              case Some(req) =>
+                generateGraphQLResponse(
+                  req,
+                  id.getOrElse(""),
+                  interpreter,
+                  skipValidation,
+                  enableIntrospection,
+                  queryExecution,
+                  subscriptions
+                ).catchAll(toStreamError(id, _))
+              case None      => connectionError
+            }
+          case GraphQLWSRequest("stop", id, _)                =>
+            removeSubscription(id, subscriptions)
+              .flatMap(_ => ZStream.empty)
+
+        })
+        .flatten
+        .catchAll(_ => connectionError)
+    }
+
+    SocketApp.message(routes) ++ SocketApp.protocol(protocol)
+  }
+
+  private def generateGraphQLResponse[R, E](
+    payload: GraphQLRequest,
+    id: String,
+    interpreter: GraphQLInterpreter[R, E],
+    skipValidation: Boolean,
+    enableIntrospection: Boolean,
+    queryExecution: QueryExecution,
+    subscriptions: Subscriptions
+  ): ZStream[R, E, Text] =
+    ZStream
+      .fromEffect(
+        interpreter
+          .executeRequest(payload, skipValidation, enableIntrospection, queryExecution)
+      )
+      .flatMap(res =>
+        res.data match {
+          case ObjectValue((fieldName, StreamValue(stream)) :: Nil) =>
+            trackSubscription(id, subscriptions).flatMap { p =>
+              stream.map(toResponse(id, fieldName, _, res.errors)).interruptWhen(p)
+            }
+          case other                                                =>
+            ZStream.succeed(toResponse(id, GraphQLResponse(other, res.errors)))
+        }
+      )
+      .catchAll { _ =>
+        connectionError
+      }
+
+  private def executeToJson[R, E](
+    interpreter: GraphQLInterpreter[R, E],
+    request: GraphQLRequest,
+    skipValidation: Boolean,
+    enableIntrospection: Boolean,
+    queryExecution: QueryExecution
+  ): URIO[R, Json] =
+    interpreter
+      .executeRequest(
+        request,
+        skipValidation = skipValidation,
+        enableIntrospection = enableIntrospection,
+        queryExecution
+      )
+      .foldCause(cause => GraphQLResponse(NullValue, cause.defects).asJson, _.asJson)
+
+  implicit class HttpErrorOps[R, E <: Throwable, A](private val zio: ZIO[R, io.circe.Error, A]) extends AnyVal {
+    def handleHTTPError: ZIO[R, HttpError, A] = zio.mapError({
+      case DecodingFailure(error)     =>
+        HttpError.BadRequest.apply(s"Invalid json: $error")
+      case ParsingFailure(message, _) =>
+        HttpError.BadRequest.apply(message)
+      case t: Throwable               => HttpError.InternalServerError.apply("Internal Server Error", Some(t.getCause()))
+    })
+  }
+
+  private val protocol = SocketProtocol.subProtocol("graphql-ws")
+
+  private val keepAlive                                                                                            = (keepAlive: Option[Duration]) =>
+    keepAlive match {
+      case None          => ZStream.empty
+      case Some(timeout) =>
+        ZStream
+          .succeed(Text("""{"type":"ka"}"""))
+          .repeat(Schedule.spaced(timeout))
+    }
+  private val connectionError                                                                                      = ZStream.succeed(Text("""{"type":"connection_error"}"""))
+  private val connectionAck                                                                                        = ZStream.succeed(Text("""{"type":"connection_ack"}"""))
+  private val close                                                                                                = ZStream.succeed(WebSocketFrame.close(1000))
+  private def toStreamError[E](id: Option[String], e: E)                                                           = ZStream.succeed(
+    Text(
+      Json
+        .obj(
+          "id"      -> Json.fromString(id.getOrElse("")),
+          "type"    -> Json.fromString("error"),
+          "message" -> Json.fromString(e.toString())
+        )
+        .toString()
+    )
+  )
+  private def toResponse[E](id: String, fieldName: String, r: ResponseValue, errors: List[E]): WebSocketFrame.Text =
+    toResponse(
+      id,
+      GraphQLResponse(
+        ObjectValue(List(fieldName -> r)),
+        errors
+      )
+    )
+
+  private def toResponse[E](id: String, r: GraphQLResponse[E]) = Text(
+    Json
+      .obj("id" -> Json.fromString(id), "type" -> Json.fromString("data"), "payload" -> r.asJson)
+      .toString()
+  )
+
+  type Subscriptions = Ref[Map[String, Promise[Any, Unit]]]
+
+  private def trackSubscription(id: String, subs: Subscriptions) =
+    ZStream
+      .fromEffect(for {
+        p <- Promise.make[Any, Unit]
+        _ <- subs.update(m => m.updated(id, p))
+      } yield p)
+
+  private def removeSubscription(id: Option[String], subs: Subscriptions) =
+    ZStream
+      .fromEffect(
+        id.map(id =>
+          subs
+            .modify(map => (map.get(id), map - id))
+            .flatMap { p =>
+              IO.whenCase(p) { case Some(p) =>
+                p.interrupt
+              }
+            }
+        ).getOrElse(ZIO.unit)
+      )
+}

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -242,15 +242,11 @@ object ZHttpAdapter {
 
   private def removeSubscription(id: Option[String], subs: Subscriptions) =
     ZStream
-      .fromEffect(
-        id.map(id =>
-          subs
-            .modify(map => (map.get(id), map - id))
-            .flatMap { p =>
-              IO.whenCase(p) { case Some(p) =>
-                p.succeed(())
-              }
-            }
-        ).getOrElse(ZIO.unit)
-      )
+      .fromEffect(IO.whenCase(id) { case Some(id) =>
+        subs.modify(map => (map.get(id), map - id)).flatMap { p =>
+          IO.whenCase(p) { case Some(p) =>
+            p.succeed(())
+          }
+        }
+      })
 }

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -14,7 +14,6 @@ import io.circe._
 import io.circe.parser._
 import io.circe.syntax._
 import zhttp.http._
-import zhttp.service._
 import zhttp.socket.SocketApp
 import zhttp.socket.WebSocketFrame.Text
 import zhttp.socket._
@@ -55,7 +54,7 @@ object ZHttpAdapter {
           resp  <- executeToJson(interpreter, query, skipValidation, enableIntrospection, queryExecution)
         } yield Response.jsonString(resp.toString())).handleHTTPError
 
-      case req @ Method.OPTIONS -> _ =>
+      case _ @Method.OPTIONS -> _ =>
         ZIO.succeed(Response.http(Status.NO_CONTENT))
     }
 
@@ -167,7 +166,7 @@ object ZHttpAdapter {
 
   implicit class HttpErrorOps[R, E <: Throwable, A](private val zio: ZIO[R, io.circe.Error, A]) extends AnyVal {
     def handleHTTPError: ZIO[R, HttpError, A] = zio.mapError({
-      case DecodingFailure(error)     =>
+      case DecodingFailure(error, _)  =>
         HttpError.BadRequest.apply(s"Invalid json: $error")
       case ParsingFailure(message, _) =>
         HttpError.BadRequest.apply(message)

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -5,9 +5,7 @@ import zio.clock.Clock
 import zio.duration._
 import zio.stream._
 
-import caliban.{ GraphQLInterpreter, GraphQLRequest, GraphQLResponse }
 import caliban.ResponseValue.{ ObjectValue, StreamValue }
-import caliban.ResponseValue
 import caliban.Value.NullValue
 import caliban.execution.QueryExecution
 import io.circe._

--- a/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHTTPAdapter.scala
@@ -177,12 +177,15 @@ object ZHttpAdapter {
 
   private val protocol = SocketProtocol.subProtocol("graphql-ws")
 
-  private val keepAlive                                  = (keepAlive: Option[Duration]) =>
-    keepAlive.fold(ZStream.empty)(duration =>
-      ZStream
-        .succeed(Text("""{"type":"ka"}"""))
-        .repeat(Schedule.spaced(duration))
-    )
+  private val keepAlive = (keepAlive: Option[Duration]) =>
+    keepAlive match {
+      case None           => ZStream.empty
+      case Some(duration) =>
+        ZStream
+          .succeed(Text("""{"type":"ka"}"""))
+          .repeat(Schedule.spaced(duration))
+    }
+
   private val connectionError                            = ZStream.succeed(Text("""{"type":"connection_error"}"""))
   private val connectionAck                              = ZStream.succeed(Text("""{"type":"connection_ack"}"""))
   private val close                                      = ZStream.succeed(WebSocketFrame.close(1000))

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ lazy val root = project
     http4s,
     akkaHttp,
     play,
+    zioHttp,
     catsInterop,
     monixInterop,
     tapirInterop,
@@ -77,8 +78,7 @@ lazy val root = project
     clientJS,
     tools,
     codegenSbt,
-    federation,
-    zioHttp
+    federation
   )
 
 lazy val macros = project

--- a/build.sbt
+++ b/build.sbt
@@ -243,6 +243,7 @@ lazy val zioHttp = project
     libraryDependencies ++= Seq(
       "io.d11"           %% "zhttp"          % zioHttpVersion,
       "io.circe"         %% "circe-parser"   % circeVersion,
+      "io.circe"         %% "circe-generic"  % circeVersion,
       compilerPlugin(
         ("org.typelevel" %% "kind-projector" % "0.11.3")
           .cross(CrossVersion.full)

--- a/build.sbt
+++ b/build.sbt
@@ -326,6 +326,10 @@ lazy val clientJS  = client.js.settings(
 lazy val examples = project
   .in(file("examples"))
   .settings(commonSettings)
+  .settings(
+    scalaVersion := scala13,
+    crossScalaVersions := Seq(scala13)
+  )
   .settings(publish / skip := true)
   .settings(
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,8 @@ lazy val root = project
     clientJS,
     tools,
     codegenSbt,
-    federation
+    federation,
+    zioHttp
   )
 
 lazy val macros = project
@@ -229,9 +230,12 @@ lazy val http4s = project
 
 lazy val zioHttp = project
   .in(file("adapters/zio-http"))
-  .settings(scalaVersion := scala13)
   .settings(name := "caliban-zio-http")
   .settings(commonSettings)
+  .settings(
+    scalaVersion := scala13,
+    crossScalaVersions := Seq(scala13)
+  )
   .settings(
     resolvers ++= Seq(
       "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots"
@@ -242,9 +246,7 @@ lazy val zioHttp = project
       compilerPlugin(
         ("org.typelevel" %% "kind-projector" % "0.11.3")
           .cross(CrossVersion.full)
-      ),
-      compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
-      "com.github.ghik"   % "silencer-lib"   % silencerVersion % Provided cross CrossVersion.full
+      )
     )
   )
   .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val zioConfigVersion      = "1.0.4"
 val zqueryVersion         = "0.2.8"
 val zioJsonVersion        = "0.1.4"
 // needs to be snapshot right now.
-val zioHttpVersion        = "1.0.0.0-RC15+33-c11af52b-SNAPSHOT"
+val zioHttpVersion        = "1.0.0.0-RC16"
 
 inThisBuild(
   List(
@@ -233,13 +233,6 @@ lazy val zioHttp = project
   .settings(name := "caliban-zio-http")
   .settings(commonSettings)
   .settings(
-    scalaVersion := scala13,
-    crossScalaVersions := Seq(scala13)
-  )
-  .settings(
-    resolvers ++= Seq(
-      "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots"
-    ),
     libraryDependencies ++= Seq(
       "io.d11"           %% "zhttp"          % zioHttpVersion,
       "io.circe"         %% "circe-parser"   % circeVersion,
@@ -327,10 +320,6 @@ lazy val clientJS  = client.js.settings(
 lazy val examples = project
   .in(file("examples"))
   .settings(commonSettings)
-  .settings(
-    scalaVersion := scala13,
-    crossScalaVersions := Seq(scala13)
-  )
   .settings(publish / skip := true)
   .settings(
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,7 @@
 import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 
 val mainScala = "2.12.13"
-val scala13   = "2.13.5"
-val allScala  = Seq(scala13, mainScala)
+val allScala  = Seq("2.13.5", mainScala)
 
 val akkaVersion           = "2.6.14"
 val catsEffectVersion     = "2.5.0"

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ val zioInteropCatsVersion = "2.4.1.0"
 val zioConfigVersion      = "1.0.4"
 val zqueryVersion         = "0.2.8"
 val zioJsonVersion        = "0.1.4"
-// needs to be snapshot right now.
 val zioHttpVersion        = "1.0.0.0-RC16"
 
 inThisBuild(

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ libraryDependencies ++= Seq(
   "com.github.ghostdogpr"         %% "caliban-http4s"                % "0.9.5",
   "com.github.ghostdogpr"         %% "caliban-play"                  % "0.9.5",
   "com.github.ghostdogpr"         %% "caliban-akka-http"             % "0.9.5",
+  "com.github.ghostdogpr"         %% "caliban-zio-http"              % "0.9.5",
   "com.github.ghostdogpr"         %% "caliban-cats"                  % "0.9.5",
   "com.github.ghostdogpr"         %% "caliban-monix"                 % "0.9.5",
   "com.github.ghostdogpr"         %% "caliban-finch"                 % "0.9.5",

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -4,11 +4,14 @@ import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
 
 import zio._
+import zio.stream._
 import zhttp.http._
 import zhttp.service.Server
 import caliban.ZHttpAdapter
 
 object ExampleApp extends App {
+  val graphiql = Http.succeed(Response.http(content = HttpData.fromStream(ZStream.fromResource("graphiql.html"))))
+
   override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
     (for {
       interpreter <- ExampleApi.api.interpreter
@@ -17,7 +20,9 @@ object ExampleApp extends App {
                          8088,
                          Http.route {
                            case _ -> Root / "api" / "graphql" => ZHttpAdapter.makeHttpService(interpreter)
-                           case _ -> Root / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
+                           case _ -> Root / "ws" / "graphql"  =>
+                             ZHttpAdapter.makeWebSocketService(interpreter)
+                           case _ -> Root / "graphiql"        => graphiql
                          }
                        )
                        .forever

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -1,26 +1,27 @@
 package example.zhttp
 
 import example.ExampleData._
-import example.ExampleService.ExampleService
 import example.{ ExampleApi, ExampleService }
 
 import zio._
-import zhttp._
 import zhttp.http._
-import caliban.ZHTTPAdapter
+import zhttp.service.Server
+import caliban.ZHttpAdapter
 
 object ExampleApp extends App {
-  override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] = {
-    val routes = Http.route {
-      case "/api/graphql" => ZHttpAdapter.makeHttpService(interpreter)
-      case "/ws/graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
-    }
-
+  override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
     (for {
       interpreter <- ExampleApi.api.interpreter
-      _           <- Server.start(8088, routes).forever
+      _           <- Server
+                       .start(
+                         8088,
+                         Http.route {
+                           case _ -> Root / "api" / "graphql" => ZHttpAdapter.makeHttpService(interpreter)
+                           case _ -> Root / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
+                         }
+                       )
+                       .forever
     } yield ())
       .provideCustomLayer(ExampleService.make(sampleCharacters))
       .exitCode
-  }
 }

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -1,0 +1,26 @@
+package example.zhttp
+
+import example.ExampleData._
+import example.ExampleService.ExampleService
+import example.{ ExampleApi, ExampleService }
+
+import zio._
+import zhttp._
+import zhttp.http._
+import caliban.ZHTTPAdapter
+
+object ExampleApp extends App {
+  override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] = {
+    val routes = Http.route {
+      case "/api/graphql" => ZHttpAdapter.makeHttpService(interpreter)
+      case "/ws/graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
+    }
+
+    (for {
+      interpreter <- ExampleApi.api.interpreter
+      _           <- Server.start(8088, routes).forever
+    } yield ())
+      .provideCustomLayer(ExampleService.make(sampleCharacters))
+      .exitCode
+  }
+}

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -26,6 +26,7 @@ libraryDependencies += "com.github.ghostdogpr" %% "caliban-http4s"     % "0.9.5"
 libraryDependencies += "com.github.ghostdogpr" %% "caliban-akka-http"  % "0.9.5" // routes for akka-http
 libraryDependencies += "com.github.ghostdogpr" %% "caliban-play"       % "0.9.5" // routes for play
 libraryDependencies += "com.github.ghostdogpr" %% "caliban-finch"      % "0.9.5" // routes for finch
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-zio-http"   % "0.9.5" // routes for zio-http
 libraryDependencies += "com.github.ghostdogpr" %% "caliban-cats"       % "0.9.5" // interop with cats effect
 libraryDependencies += "com.github.ghostdogpr" %% "caliban-monix"      % "0.9.5" // interop with monix
 libraryDependencies += "com.github.ghostdogpr" %% "caliban-federation" % "0.9.5" // interop with apollo federation
@@ -118,7 +119,7 @@ A `CalibanError` can be:
 - a `ValidationError`: the query was parsed but does not match the schema
 - an `ExecutionError`: an error happened while executing the query
 
-Caliban itself is not tied to any web framework, you are free to expose this function using the protocol and library of your choice. The [caliban-http4s](https://github.com/ghostdogpr/caliban/tree/master/adapters/http4s) module provides an `Http4sAdapter` that exposes an interpreter over HTTP and WebSocket using http4s. There are also similar adapters for Akka HTTP, Play and Finch.
+Caliban itself is not tied to any web framework, you are free to expose this function using the protocol and library of your choice. The [caliban-http4s](https://github.com/ghostdogpr/caliban/tree/master/adapters/http4s) module provides an `Http4sAdapter` that exposes an interpreter over HTTP and WebSocket using http4s. There are also similar adapters for Akka HTTP, Play, Finch and zio-http.
 
 ::: tip Combining GraphQL APIs
 You don't have to define all your root fields into a single case class: you can use smaller case classes and combine `GraphQL` objects using the `|+|` operator.

--- a/vuepress/docs/docs/examples.md
+++ b/vuepress/docs/docs/examples.md
@@ -4,6 +4,7 @@ The [examples](https://github.com/ghostdogpr/caliban/tree/master/examples/) proj
 - [GraphQL API exposed with Akka HTTP](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/akkahttp)
 - [GraphQL API exposed with finch](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/finch)
 - [GraphQL API exposed with play](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/play)
+- [GraphQL API exposed with zio-http](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/ziohttp)
 - [GraphQL Client usage](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/client)
 - [Optimization with ZQuery](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/optimizations)
 - [Interop with Cats Effect](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/interop/cats)


### PR DESCRIPTION
Hi!

This is a WIP adapter for [zio-http](https://github.com/dream11/zio-http).

Me and a colleague have it fully working in another project, but have run into some sbt-related snags that I'm not quite sure about how to get around.

I think it may be due to the fact that zio-http only supports Scala 2.13. When I try to compile that sub project via `sbt zioHttp / compile` I get weird errors about not finding a snapshot jar of caliban (which I'm guessing it shouldn't be looking for in the first place?).

```console
[error] (zioHttp / update) sbt.librarymanagement.ResolveException: Error downloading com.github.ghostdogpr:caliban_2.13:0.9.5+69-e64a35f7+20210507-1445-SNAPSHOT
[error]   Not found
[error]   Not found
[error]   not found: ~/.ivy2/localcom.github.ghostdogpr/caliban_2.13/0.9.5+69-e64a35f7+20210507-1445-SNAPSHOT/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/com/github/ghostdogpr/caliban_2.13/0.9.5+69-e64a35f7+20210507-1445-SNAPSHOT/caliban_2.13-0.9.5+69-e64a35f7+20210507-1445-SNAPSHOT.pom
[error]   not found: https://s01.oss.sonatype.org/content/repositories/snapshots/com/github/ghostdogpr/caliban_2.13/0.9.5+69-e64a35f7+20210507-1445-SNAPSHOT/caliban_2.13-0.9.5+69-e64a35f7+20210507-1445-SNAPSHOT.pom
[error] Total time: 2 s, completed 7 May 2021, 15:05:18
```

We also need the snapshot version of zio-http since it has some much needed fixes in order for this to work. I'm not sure what you think about that @ghostdogpr?

`scalafmt` also seems to have gone crazy about some lines, not really sure what to do about that either since I guess it's the formatting style of the project? :)