### PR TITLE
Fully qualifying FieldBuilder.Field in ClientWriter

### DIFF
--- a/codegen-sbt/src/sbt-test/codegen/test-compile/project/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/project/schema.graphql
@@ -60,6 +60,13 @@ enum Origin {
     BELT
 }
 
+# Regression test for a conflict with SelectionBuilder.Field (#917)
+enum Field {
+    name
+    nicknames
+    origin
+}
+
 # Union
 union Role = Captain | Pilot
 type Captain {

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -89,7 +89,6 @@ object ClientWriter {
           |""".stripMargin
       else ""}${if (objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty)
         """import caliban.client.FieldBuilder._
-          |import caliban.client.SelectionBuilder._
           |""".stripMargin
       else
         ""}${if (
@@ -434,7 +433,7 @@ object ClientWriter {
     ) =
       fieldInfo
 
-    s"""$description${deprecated}def $safeName$typeParam$args$innerSelection: SelectionBuilder[$typeName, $outputType] = Field("$name", $builder$argBuilder)"""
+    s"""$description${deprecated}def $safeName$typeParam$args$innerSelection: SelectionBuilder[$typeName, $outputType] = _root_.caliban.client.SelectionBuilder.Field("$name", $builder$argBuilder)"""
   }
 
   def collectFieldInfo(

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -38,15 +38,15 @@ object ClientWriterSpec extends DefaultRunnableSpec {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
 
   type Character
   object Character {
-    def name: SelectionBuilder[Character, String]            = Field("name", Scalar())
-    def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def nicknames: SelectionBuilder[Character, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }
 
 }
@@ -65,14 +65,13 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
 
   type Character
   object Character {
-    def `type`: SelectionBuilder[Character, String] = Field("type", Scalar())
+    def `type`: SelectionBuilder[Character, String] = _root_.caliban.client.SelectionBuilder.Field("type", Scalar())
   }
 
 }
@@ -96,7 +95,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -104,13 +102,14 @@ object Client {
   type Q
   object Q {
     def characters[A](innerSelection: SelectionBuilder[Character, A]): SelectionBuilder[Q, List[A]] =
-      Field("characters", ListOf(Obj(innerSelection)))
+      _root_.caliban.client.SelectionBuilder.Field("characters", ListOf(Obj(innerSelection)))
   }
 
   type Character
   object Character {
-    def name: SelectionBuilder[Character, String]            = Field("name", Scalar())
-    def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def nicknames: SelectionBuilder[Character, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }
 
 }
@@ -134,7 +133,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -142,13 +140,15 @@ object Client {
   type Q
   object Q {
     def character[A](name: String)(innerSelection: SelectionBuilder[Character, A]): SelectionBuilder[Q, Option[A]] =
-      Field("character", OptionOf(Obj(innerSelection)), arguments = List(Argument("name", name, "String!")))
+      _root_.caliban.client.SelectionBuilder
+        .Field("character", OptionOf(Obj(innerSelection)), arguments = List(Argument("name", name, "String!")))
   }
 
   type Character
   object Character {
-    def name: SelectionBuilder[Character, String]            = Field("name", Scalar())
-    def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def nicknames: SelectionBuilder[Character, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }
 
 }
@@ -176,7 +176,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 import caliban.client.Operations._
 
@@ -184,14 +183,15 @@ object Client {
 
   type Character
   object Character {
-    def name: SelectionBuilder[Character, String]            = Field("name", Scalar())
-    def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def nicknames: SelectionBuilder[Character, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }
 
   type Q = RootQuery
   object Q {
     def characters[A](innerSelection: SelectionBuilder[Character, A]): SelectionBuilder[RootQuery, List[A]] =
-      Field("characters", ListOf(Obj(innerSelection)))
+      _root_.caliban.client.SelectionBuilder.Field("characters", ListOf(Obj(innerSelection)))
   }
 
 }
@@ -324,19 +324,18 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
 
   type Captain
   object Captain {
-    def shipName: SelectionBuilder[Captain, String] = Field("shipName", Scalar())
+    def shipName: SelectionBuilder[Captain, String] = _root_.caliban.client.SelectionBuilder.Field("shipName", Scalar())
   }
 
   type Pilot
   object Pilot {
-    def shipName: SelectionBuilder[Pilot, String] = Field("shipName", Scalar())
+    def shipName: SelectionBuilder[Pilot, String] = _root_.caliban.client.SelectionBuilder.Field("shipName", Scalar())
   }
 
   type Character
@@ -344,8 +343,8 @@ object Client {
     def role[A](
       onCaptain: SelectionBuilder[Captain, A],
       onPilot: SelectionBuilder[Pilot, A]
-    ): SelectionBuilder[Character, Option[A]] =
-      Field("role", OptionOf(ChoiceOf(Map("Captain" -> Obj(onCaptain), "Pilot" -> Obj(onPilot)))))
+    ): SelectionBuilder[Character, Option[A]] = _root_.caliban.client.SelectionBuilder
+      .Field("role", OptionOf(ChoiceOf(Map("Captain" -> Obj(onCaptain), "Pilot" -> Obj(onPilot)))))
   }
 
 }
@@ -366,7 +365,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -378,9 +376,10 @@ object Client {
      * name
      */
     @deprecated("blah", "")
-    def name: SelectionBuilder[Character, String]            = Field("name", Scalar())
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
     @deprecated("", "")
-    def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def nicknames: SelectionBuilder[Character, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }
 
 }
@@ -401,7 +400,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             s"""import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -417,7 +415,7 @@ object Client {
 bar$tripleQuotes,
       ""
     )
-    def name: SelectionBuilder[Character, String] = Field("name", Scalar())
+    def name: SelectionBuilder[Character, String] = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
   }
 
 }
@@ -439,7 +437,6 @@ bar$tripleQuotes,
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 import caliban.client.Operations._
 
@@ -451,7 +448,7 @@ object Client {
       first: Int,
       last: Option[Int] = None,
       origins: List[Option[String]] = Nil
-    ): SelectionBuilder[RootQuery, Option[String]] = Field(
+    ): SelectionBuilder[RootQuery, Option[String]] = _root_.caliban.client.SelectionBuilder.Field(
       "characters",
       OptionOf(Scalar()),
       arguments =
@@ -476,7 +473,6 @@ object Client {
         assertM(gen(schema, Map("Json" -> "io.circe.Json")))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 import caliban.client.Operations._
 
@@ -484,7 +480,8 @@ object Client {
 
   type Query = RootQuery
   object Query {
-    def test: SelectionBuilder[RootQuery, io.circe.Json] = Field("test", Scalar())
+    def test: SelectionBuilder[RootQuery, io.circe.Json] =
+      _root_.caliban.client.SelectionBuilder.Field("test", Scalar())
   }
 
 }
@@ -554,21 +551,22 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
 
   type Character
   object Character {
-    def name: SelectionBuilder[Character, String]            = Field("name", Scalar())
-    def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def nicknames: SelectionBuilder[Character, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }
 
   type character_1
   object character_1 {
-    def name: SelectionBuilder[character_1, String]            = Field("name", Scalar())
-    def nicknames: SelectionBuilder[character_1, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def name: SelectionBuilder[character_1, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def nicknames: SelectionBuilder[character_1, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }
 
 }
@@ -588,15 +586,16 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
 
   type Character
   object Character {
-    def `_name_` : SelectionBuilder[Character, Option[String]] = Field("_name_", OptionOf(Scalar()))
-    def _nickname: SelectionBuilder[Character, Option[String]] = Field("_nickname", OptionOf(Scalar()))
+    def `_name_` : SelectionBuilder[Character, Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("_name_", OptionOf(Scalar()))
+    def _nickname: SelectionBuilder[Character, Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("_nickname", OptionOf(Scalar()))
   }
 
 }
@@ -617,7 +616,6 @@ object Client {
         assertM(gen(schema, Map("OffsetDateTime" -> "java.time.OffsetDateTime"), List("java.util.UUID", "a.b._"))) {
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 import java.util.UUID
@@ -627,7 +625,8 @@ object Client {
 
   type Order
   object Order {
-    def date: SelectionBuilder[Order, java.time.OffsetDateTime] = Field("date", Scalar())
+    def date: SelectionBuilder[Order, java.time.OffsetDateTime] =
+      _root_.caliban.client.SelectionBuilder.Field("date", Scalar())
   }
 
 }

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -29,7 +29,6 @@ object ClientWriterViewSpec extends DefaultRunnableSpec {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -45,9 +44,10 @@ object Client {
       CharacterView(name, age, nicknames)
     }
 
-    def name: SelectionBuilder[Character, String]            = Field("name", Scalar())
-    def age: SelectionBuilder[Character, Int]                = Field("age", Scalar())
-    def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def age: SelectionBuilder[Character, Int]                = _root_.caliban.client.SelectionBuilder.Field("age", Scalar())
+    def nicknames: SelectionBuilder[Character, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }
 
 }
@@ -76,7 +76,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -92,7 +91,7 @@ object Client {
       users(usersSelection).map(users => QView(users))
 
     def users[A](innerSelection: SelectionBuilder[User, A]): SelectionBuilder[Q, List[A]] =
-      Field("users", ListOf(Obj(innerSelection)))
+      _root_.caliban.client.SelectionBuilder.Field("users", ListOf(Obj(innerSelection)))
   }
 
   type Character
@@ -106,10 +105,11 @@ object Client {
       case ((name, age), nicknames) => CharacterView(name, age, nicknames)
     }
 
-    def name: SelectionBuilder[Character, String]                                     = Field("name", Scalar())
-    def age: SelectionBuilder[Character, Int]                                         = Field("age", Scalar())
+    def name: SelectionBuilder[Character, String]                                     = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def age: SelectionBuilder[Character, Int]                                         = _root_.caliban.client.SelectionBuilder.Field("age", Scalar())
     def nicknames(arg: Option[Int] = None): SelectionBuilder[Character, List[String]] =
-      Field("nicknames", ListOf(Scalar()), arguments = List(Argument("arg", arg, "Int")))
+      _root_.caliban.client.SelectionBuilder
+        .Field("nicknames", ListOf(Scalar()), arguments = List(Argument("arg", arg, "Int")))
   }
 
   type User
@@ -125,7 +125,8 @@ object Client {
       characters(charactersName)(charactersSelection).map(characters => UserView(characters))
 
     def characters[A](name: String)(innerSelection: SelectionBuilder[Character, A]): SelectionBuilder[User, List[A]] =
-      Field("characters", ListOf(Obj(innerSelection)), arguments = List(Argument("name", name, "String!")))
+      _root_.caliban.client.SelectionBuilder
+        .Field("characters", ListOf(Obj(innerSelection)), arguments = List(Argument("name", name, "String!")))
   }
 
 }
@@ -146,7 +147,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -164,12 +164,12 @@ object Client {
       case ((name, age), friends) => CharacterView(name, age, friends)
     }
 
-    def name: SelectionBuilder[Character, String]                                           = Field("name", Scalar())
-    def age: SelectionBuilder[Character, Int]                                               = Field("age", Scalar())
-    def friends[A](
-      filter: Option[String] = None
-    )(innerSelection: SelectionBuilder[Character, A]): SelectionBuilder[Character, List[A]] =
-      Field("friends", ListOf(Obj(innerSelection)), arguments = List(Argument("filter", filter, "String")))
+    def name: SelectionBuilder[Character, String] = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def age: SelectionBuilder[Character, Int]     = _root_.caliban.client.SelectionBuilder.Field("age", Scalar())
+    def friends[A](filter: Option[String] = None)(
+      innerSelection: SelectionBuilder[Character, A]
+    ): SelectionBuilder[Character, List[A]]       = _root_.caliban.client.SelectionBuilder
+      .Field("friends", ListOf(Obj(innerSelection)), arguments = List(Argument("filter", filter, "String")))
   }
 
 }
@@ -207,7 +207,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -221,8 +220,10 @@ object Client {
 
     def view: ViewSelection = (id ~ name).map { case (id, name) => ProjectMemberView(id, name) }
 
-    def id: SelectionBuilder[ProjectMember, Option[Int]]      = Field("id", OptionOf(Scalar()))
-    def name: SelectionBuilder[ProjectMember, Option[String]] = Field("name", OptionOf(Scalar()))
+    def id: SelectionBuilder[ProjectMember, Option[Int]]      =
+      _root_.caliban.client.SelectionBuilder.Field("id", OptionOf(Scalar()))
+    def name: SelectionBuilder[ProjectMember, Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("name", OptionOf(Scalar()))
   }
 
   type ProjectMemberEdge
@@ -238,9 +239,10 @@ object Client {
       ProjectMemberEdgeView(cursor, node)
     }
 
-    def cursor: SelectionBuilder[ProjectMemberEdge, String]                                                         = Field("cursor", Scalar())
+    def cursor: SelectionBuilder[ProjectMemberEdge, String]                                                         =
+      _root_.caliban.client.SelectionBuilder.Field("cursor", Scalar())
     def node[A](innerSelection: SelectionBuilder[ProjectMember, A]): SelectionBuilder[ProjectMemberEdge, Option[A]] =
-      Field("node", OptionOf(Obj(innerSelection)))
+      _root_.caliban.client.SelectionBuilder.Field("node", OptionOf(Obj(innerSelection)))
   }
 
   type PageInfo
@@ -260,10 +262,14 @@ object Client {
         PageInfoView(endCursor, hasNextPage, hasPreviousPage, startCursor)
     }
 
-    def endCursor: SelectionBuilder[PageInfo, Option[String]]   = Field("endCursor", OptionOf(Scalar()))
-    def hasNextPage: SelectionBuilder[PageInfo, Boolean]        = Field("hasNextPage", Scalar())
-    def hasPreviousPage: SelectionBuilder[PageInfo, Boolean]    = Field("hasPreviousPage", Scalar())
-    def startCursor: SelectionBuilder[PageInfo, Option[String]] = Field("startCursor", OptionOf(Scalar()))
+    def endCursor: SelectionBuilder[PageInfo, Option[String]]   =
+      _root_.caliban.client.SelectionBuilder.Field("endCursor", OptionOf(Scalar()))
+    def hasNextPage: SelectionBuilder[PageInfo, Boolean]        =
+      _root_.caliban.client.SelectionBuilder.Field("hasNextPage", Scalar())
+    def hasPreviousPage: SelectionBuilder[PageInfo, Boolean]    =
+      _root_.caliban.client.SelectionBuilder.Field("hasPreviousPage", Scalar())
+    def startCursor: SelectionBuilder[PageInfo, Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("startCursor", OptionOf(Scalar()))
   }
 
   type ProjectMemberConnection
@@ -292,13 +298,13 @@ object Client {
     def edges[A](
       innerSelection: SelectionBuilder[ProjectMemberEdge, A]
     ): SelectionBuilder[ProjectMemberConnection, Option[List[Option[A]]]]                                        =
-      Field("edges", OptionOf(ListOf(OptionOf(Obj(innerSelection)))))
+      _root_.caliban.client.SelectionBuilder.Field("edges", OptionOf(ListOf(OptionOf(Obj(innerSelection)))))
     def nodes[A](
       innerSelection: SelectionBuilder[ProjectMember, A]
     ): SelectionBuilder[ProjectMemberConnection, Option[List[Option[A]]]]                                        =
-      Field("nodes", OptionOf(ListOf(OptionOf(Obj(innerSelection)))))
+      _root_.caliban.client.SelectionBuilder.Field("nodes", OptionOf(ListOf(OptionOf(Obj(innerSelection)))))
     def pageInfo[A](innerSelection: SelectionBuilder[PageInfo, A]): SelectionBuilder[ProjectMemberConnection, A] =
-      Field("pageInfo", Obj(innerSelection))
+      _root_.caliban.client.SelectionBuilder.Field("pageInfo", Obj(innerSelection))
   }
 
 }
@@ -322,7 +328,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -336,7 +341,8 @@ object Client {
 
     def view: ViewSelection = name.map(name => packageView(name))
 
-    def name: SelectionBuilder[`package`, Option[String]] = Field("name", OptionOf(Scalar()))
+    def name: SelectionBuilder[`package`, Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("name", OptionOf(Scalar()))
   }
 
   type `match`
@@ -353,8 +359,9 @@ object Client {
     }
 
     def `package`[A](innerSelection: SelectionBuilder[`package`, A]): SelectionBuilder[`match`, Option[A]] =
-      Field("package", OptionOf(Obj(innerSelection)))
-    def version: SelectionBuilder[`match`, Option[String]]                                                 = Field("version", OptionOf(Scalar()))
+      _root_.caliban.client.SelectionBuilder.Field("package", OptionOf(Obj(innerSelection)))
+    def version: SelectionBuilder[`match`, Option[String]]                                                 =
+      _root_.caliban.client.SelectionBuilder.Field("version", OptionOf(Scalar()))
   }
 
 }
@@ -383,7 +390,6 @@ object Client {
         assertM(gen(schema))(
           equalTo(
             """import caliban.client.FieldBuilder._
-import caliban.client.SelectionBuilder._
 import caliban.client._
 
 object Client {
@@ -402,13 +408,14 @@ object Client {
       case ((name, nicknames), role) => CharacterView(name, nicknames, role)
     }
 
-    def name: SelectionBuilder[Character, String]            = Field("name", Scalar())
-    def nicknames: SelectionBuilder[Character, List[String]] = Field("nicknames", ListOf(Scalar()))
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def nicknames: SelectionBuilder[Character, List[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
     def role[A](
       onCaptain: SelectionBuilder[Captain, A],
       onPilot: SelectionBuilder[Pilot, A]
-    ): SelectionBuilder[Character, Option[A]]                =
-      Field("role", OptionOf(ChoiceOf(Map("Captain" -> Obj(onCaptain), "Pilot" -> Obj(onPilot)))))
+    ): SelectionBuilder[Character, Option[A]]                = _root_.caliban.client.SelectionBuilder
+      .Field("role", OptionOf(ChoiceOf(Map("Captain" -> Obj(onCaptain), "Pilot" -> Obj(onPilot)))))
   }
 
   type Captain
@@ -420,7 +427,7 @@ object Client {
 
     def view: ViewSelection = shipName.map(shipName => CaptainView(shipName))
 
-    def shipName: SelectionBuilder[Captain, String] = Field("shipName", Scalar())
+    def shipName: SelectionBuilder[Captain, String] = _root_.caliban.client.SelectionBuilder.Field("shipName", Scalar())
   }
 
   type Pilot
@@ -432,7 +439,7 @@ object Client {
 
     def view: ViewSelection = shipName.map(shipName => PilotView(shipName))
 
-    def shipName: SelectionBuilder[Pilot, String] = Field("shipName", Scalar())
+    def shipName: SelectionBuilder[Pilot, String] = _root_.caliban.client.SelectionBuilder.Field("shipName", Scalar())
   }
 
 }


### PR DESCRIPTION
Resolves #917 

Removing FieldBuilder._ is acceptable, as `Field` seems to be the only
used member.