### PR TITLE
[Client] Add the option to drop null values from input objects

### DIFF
--- a/client-laminext/src/main/scala/caliban/client/laminext/package.scala
+++ b/client-laminext/src/main/scala/caliban/client/laminext/package.scala
@@ -29,18 +29,20 @@ package object laminext {
       uri: String,
       useVariables: Boolean = false,
       queryName: Option[String] = None,
+      dropInputNullValues: Boolean = false,
       middleware: FetchEventStreamBuilder => FetchEventStreamBuilder = identity
     )(implicit ev: IsOperation[Origin]): EventStream[Either[CalibanClientError, A]] =
-      toEventStreamWithExtensions[A1](uri, useVariables, queryName, middleware).map(_.map(_._1))
+      toEventStreamWithExtensions[A1](uri, useVariables, queryName, dropInputNullValues, middleware).map(_.map(_._1))
 
     def toEventStreamWithExtensions[A1 >: A](
       uri: String,
       useVariables: Boolean = false,
       queryName: Option[String] = None,
+      dropInputNullValues: Boolean = false,
       middleware: FetchEventStreamBuilder => FetchEventStreamBuilder = identity
     )(implicit ev: IsOperation[Origin]): EventStream[Either[CalibanClientError, (A, Option[Json])]] =
       middleware(Fetch.post(uri))
-        .body(self.toGraphQL(useVariables, queryName))
+        .body(self.toGraphQL(useVariables, queryName, dropInputNullValues))
         .text
         .map(response => self.decode(response.data))
         .recover {

--- a/client-laminext/src/main/scala/caliban/client/laminext/package.scala
+++ b/client-laminext/src/main/scala/caliban/client/laminext/package.scala
@@ -29,20 +29,20 @@ package object laminext {
       uri: String,
       useVariables: Boolean = false,
       queryName: Option[String] = None,
-      dropInputNullValues: Boolean = false,
+      dropNullInputValues: Boolean = false,
       middleware: FetchEventStreamBuilder => FetchEventStreamBuilder = identity
     )(implicit ev: IsOperation[Origin]): EventStream[Either[CalibanClientError, A]] =
-      toEventStreamWithExtensions[A1](uri, useVariables, queryName, dropInputNullValues, middleware).map(_.map(_._1))
+      toEventStreamWithExtensions[A1](uri, useVariables, queryName, dropNullInputValues, middleware).map(_.map(_._1))
 
     def toEventStreamWithExtensions[A1 >: A](
       uri: String,
       useVariables: Boolean = false,
       queryName: Option[String] = None,
-      dropInputNullValues: Boolean = false,
+      dropNullInputValues: Boolean = false,
       middleware: FetchEventStreamBuilder => FetchEventStreamBuilder = identity
     )(implicit ev: IsOperation[Origin]): EventStream[Either[CalibanClientError, (A, Option[Json])]] =
       middleware(Fetch.post(uri))
-        .body(self.toGraphQL(useVariables, queryName, dropInputNullValues))
+        .body(self.toGraphQL(useVariables, queryName, dropNullInputValues))
         .text
         .map(response => self.decode(response.data))
         .recover {

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -15,8 +15,10 @@ import scala.annotation.implicitNotFound
 Caliban needs it to know how to encode arguments of type ${A}.
 """
 )
-trait ArgEncoder[-A] {
+trait ArgEncoder[-A] { self =>
   def encode(value: A): __Value
+
+  def dropNullValues: ArgEncoder[A] = (value: A) => self.encode(value).dropNullValues
 }
 
 object ArgEncoder {

--- a/client/src/main/scala/caliban/client/Argument.scala
+++ b/client/src/main/scala/caliban/client/Argument.scala
@@ -9,13 +9,13 @@ import caliban.client.__Value.__NullValue
 case class Argument[+A](name: String, value: A, typeInfo: String)(implicit encoder: ArgEncoder[A]) {
   def toGraphQL(
     useVariables: Boolean,
-    dropInputNullValues: Boolean,
+    dropNullInputValues: Boolean,
     variables: Map[String, (__Value, String)]
   ): (String, Map[String, (__Value, String)]) =
     encoder.encode(value) match {
       case `__NullValue` => ("", variables)
       case v             =>
-        val value = if (dropInputNullValues) v.dropNullValues else v
+        val value = if (dropNullInputValues) v.dropNullValues else v
         if (useVariables) {
           val variableName = Argument.generateVariableName(name, value, variables)
           (s"$name:$$$variableName", variables.updated(variableName, (value, typeInfo)))

--- a/client/src/main/scala/caliban/client/Argument.scala
+++ b/client/src/main/scala/caliban/client/Argument.scala
@@ -9,16 +9,18 @@ import caliban.client.__Value.__NullValue
 case class Argument[+A](name: String, value: A, typeInfo: String)(implicit encoder: ArgEncoder[A]) {
   def toGraphQL(
     useVariables: Boolean,
+    dropInputNullValues: Boolean,
     variables: Map[String, (__Value, String)]
   ): (String, Map[String, (__Value, String)]) =
     encoder.encode(value) match {
       case `__NullValue` => ("", variables)
       case v             =>
+        val value = if (dropInputNullValues) v.dropNullValues else v
         if (useVariables) {
-          val variableName = Argument.generateVariableName(name, v, variables)
-          (s"$name:$$$variableName", variables.updated(variableName, (v, typeInfo)))
+          val variableName = Argument.generateVariableName(name, value, variables)
+          (s"$name:$$$variableName", variables.updated(variableName, (value, typeInfo)))
         } else {
-          (s"$name:${v.toString}", variables)
+          (s"$name:${value.toString}", variables)
         }
     }
 }

--- a/client/src/main/scala/caliban/client/Selection.scala
+++ b/client/src/main/scala/caliban/client/Selection.scala
@@ -17,12 +17,12 @@ object Selection {
   case class Directive(name: String, arguments: List[Argument[_]] = Nil) {
     def toGraphQL(
       useVariables: Boolean,
-      dropInputNullValues: Boolean,
+      dropNullInputValues: Boolean,
       variables: Map[String, (__Value, String)]
     ): (String, Map[String, (__Value, String)]) = {
       val (newArgs, newVariables) = arguments.foldLeft((List.empty[String], variables)) {
         case ((args, variables), arg) =>
-          val (arg2, variables2) = arg.toGraphQL(useVariables, dropInputNullValues, variables)
+          val (arg2, variables2) = arg.toGraphQL(useVariables, dropNullInputValues, variables)
           (arg2 :: args, variables2)
       }
       (s"@$name(${newArgs.reverse.mkString(",")})", newVariables)

--- a/client/src/main/scala/caliban/client/Selection.scala
+++ b/client/src/main/scala/caliban/client/Selection.scala
@@ -17,11 +17,12 @@ object Selection {
   case class Directive(name: String, arguments: List[Argument[_]] = Nil) {
     def toGraphQL(
       useVariables: Boolean,
+      dropInputNullValues: Boolean,
       variables: Map[String, (__Value, String)]
     ): (String, Map[String, (__Value, String)]) = {
       val (newArgs, newVariables) = arguments.foldLeft((List.empty[String], variables)) {
         case ((args, variables), arg) =>
-          val (arg2, variables2) = arg.toGraphQL(useVariables, variables)
+          val (arg2, variables2) = arg.toGraphQL(useVariables, dropInputNullValues, variables)
           (arg2 :: args, variables2)
       }
       (s"@$name(${newArgs.reverse.mkString(",")})", newVariables)

--- a/client/src/main/scala/caliban/client/SelectionBuilder.scala
+++ b/client/src/main/scala/caliban/client/SelectionBuilder.scala
@@ -69,15 +69,15 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
    * Transforms a root selection into a GraphQL request.
    * @param useVariables if true, all arguments will be passed as variables (default: false)
    * @param queryName if specified, use the given query name
-   * @param dropInputNullValues if true, drop all null values from input object arguments (default: false)
+   * @param dropNullInputValues if true, drop all null values from input object arguments (default: false)
    */
   def toGraphQL[A1 >: A, Origin1 <: Origin](
     useVariables: Boolean = false,
     queryName: Option[String] = None,
-    dropInputNullValues: Boolean = false
+    dropNullInputValues: Boolean = false
   )(implicit ev: IsOperation[Origin1]): GraphQLRequest = {
     val (fields, variables) =
-      SelectionBuilder.toGraphQL(toSelectionSet, useVariables, dropInputNullValues)
+      SelectionBuilder.toGraphQL(toSelectionSet, useVariables, dropNullInputValues)
     val variableDef         =
       if (variables.nonEmpty)
         s"(${variables.map { case (name, (_, typeName)) => s"$$$name: $typeName" }.mkString(",")})"
@@ -92,16 +92,16 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
    * @param uri the URL of the GraphQL server
    * @param useVariables if true, all arguments will be passed as variables (default: false)
    * @param queryName if specified, use the given query name
-   * @param dropInputNullValues if true, drop all null values from input object arguments (default: false)
+   * @param dropNullInputValues if true, drop all null values from input object arguments (default: false)
    * @return an STTP request
    */
   def toRequest[A1 >: A, Origin1 <: Origin](
     uri: Uri,
     useVariables: Boolean = false,
     queryName: Option[String] = None,
-    dropInputNullValues: Boolean = false
+    dropNullInputValues: Boolean = false
   )(implicit ev: IsOperation[Origin1]): Request[Either[CalibanClientError, A1], Any] =
-    toRequestWithExtensions[A1, Origin1](uri, useVariables, queryName, dropInputNullValues)(ev).mapResponse {
+    toRequestWithExtensions[A1, Origin1](uri, useVariables, queryName, dropNullInputValues)(ev).mapResponse {
       case Right((r, _)) => Right(r)
       case Left(l)       => Left(l)
     }
@@ -111,18 +111,18 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
    * @param uri the URL of the GraphQL server
    * @param useVariables if true, all arguments will be passed as variables (default: false)
    * @param queryName if specified, use the given query name
-   * @param dropInputNullValues if true, drop all null values from input object arguments (default: false)
+   * @param dropNullInputValues if true, drop all null values from input object arguments (default: false)
    * @return an STTP request
    */
   def toRequestWithExtensions[A1 >: A, Origin1 <: Origin](
     uri: Uri,
     useVariables: Boolean = false,
     queryName: Option[String] = None,
-    dropInputNullValues: Boolean = false
+    dropNullInputValues: Boolean = false
   )(implicit ev: IsOperation[Origin1]): Request[Either[CalibanClientError, (A1, Option[Json])], Any] =
     basicRequest
       .post(uri)
-      .body(toGraphQL(useVariables, queryName, dropInputNullValues))
+      .body(toGraphQL(useVariables, queryName, dropNullInputValues))
       .mapResponse(_.left.map(CommunicationError(_)).flatMap(decode))
 
   /**
@@ -431,21 +431,21 @@ object SelectionBuilder {
   def toGraphQL(
     fields: List[Selection],
     useVariables: Boolean,
-    dropInputNullValues: Boolean = false,
+    dropNullInputValues: Boolean = false,
     variables: SMap[String, (__Value, String)] = SMap()
   ): (String, SMap[String, (__Value, String)]) = {
     val fieldNames            = fields.collect { case f: Selection.Field => f }.groupBy(_.name).map { case (k, v) => k -> v.size }
     val (fields2, variables2) = fields
       .foldLeft((List.empty[String], variables)) {
         case ((fields, variables), Selection.InlineFragment(onType, selection)) =>
-          val (f, v) = toGraphQL(selection, useVariables, dropInputNullValues, variables)
+          val (f, v) = toGraphQL(selection, useVariables, dropNullInputValues, variables)
           (s"... on $onType{$f}" :: fields, v)
 
         case ((fields, variables), Selection.Field(alias, name, arguments, directives, selection, code)) =>
           // format arguments
           val (args, variables2) = arguments
             .foldLeft((List.empty[String], variables)) { case ((args, variables), a) =>
-              val (a2, v2) = a.toGraphQL(useVariables, dropInputNullValues, variables)
+              val (a2, v2) = a.toGraphQL(useVariables, dropNullInputValues, variables)
               (a2 :: args, v2)
             }
           val argString          = args.filterNot(_.isEmpty).reverse.mkString(",") match {
@@ -456,7 +456,7 @@ object SelectionBuilder {
           // format directives
           val (dirs, variables3) = directives
             .foldLeft((List.empty[String], variables2)) { case ((dirs, variables), d) =>
-              val (d2, v2) = d.toGraphQL(useVariables, dropInputNullValues, variables)
+              val (d2, v2) = d.toGraphQL(useVariables, dropNullInputValues, variables)
               (d2 :: dirs, v2)
             }
           val dirString          = dirs.reverse.mkString(" ") match {
@@ -470,7 +470,7 @@ object SelectionBuilder {
                              else alias).fold("")(_ + ":")
 
           // format selection
-          val (sel, variables4) = toGraphQL(selection, useVariables, dropInputNullValues, variables3)
+          val (sel, variables4) = toGraphQL(selection, useVariables, dropNullInputValues, variables3)
           val selString         = if (sel.nonEmpty) s"{$sel}" else ""
 
           (s"$aliasString$name$argString$dirString$selString" :: fields, variables4)

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -5,7 +5,19 @@ import io.circe.{ Decoder, Encoder, Json }
 /**
  * Value that can be returned by the server or sent as an argument.
  */
-sealed trait __Value
+sealed trait __Value { self =>
+  def dropNullValues: __Value = self match {
+    case __Value.__ListValue(values)   => __Value.__ListValue(values.map(_.dropNullValues))
+    case __Value.__ObjectValue(fields) =>
+      __Value.__ObjectValue(fields.flatMap { case (name, value) =>
+        value match {
+          case __Value.__NullValue => None
+          case _                   => Some(name -> value.dropNullValues)
+        }
+      })
+    case _                             => self
+  }
+}
 
 object __Value {
   case object __NullValue                                   extends __Value {

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -264,7 +264,7 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
 
           val query = Query.addCharacter(CharacterInput("name", None, Nil))(Character.name)
 
-          assert(query.toGraphQL(dropInputNullValues = true).query)(
+          assert(query.toGraphQL(dropNullInputValues = true).query)(
             equalTo("""query{addCharacter(character:{name:"name",nicknames:[]}){name}}""")
           )
         },

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -1,7 +1,9 @@
 package caliban.client
 
+import caliban.client.FieldBuilder._
 import caliban.client.Operations.RootQuery
 import caliban.client.Selection.Directive
+import caliban.client.SelectionBuilder.Field
 import caliban.client.TestData._
 import caliban.client.__Value.{ __ListValue, __ObjectValue, __StringValue }
 import zio.test.Assertion._
@@ -231,6 +233,77 @@ object SelectionBuilderSpec extends DefaultRunnableSpec {
             List("character" -> __ObjectValue(List("name" -> __StringValue("Amos Burton"))))
           )
           assert(query.fromGraphQL(response))(isRight(equalTo(Some("Fake"))))
+        },
+        test("drop null values in input object") {
+          import caliban.client.__Value._
+
+          case class CharacterInput(name: String, description: Option[String], nicknames: List[String] = Nil)
+          object CharacterInput {
+            implicit val encoder: ArgEncoder[CharacterInput] = (value: CharacterInput) =>
+              __ObjectValue(
+                List(
+                  "name"        -> implicitly[ArgEncoder[String]].encode(value.name),
+                  "description" -> implicitly[ArgEncoder[Option[String]]].encode(value.description),
+                  "nicknames"   -> __ListValue(value.nicknames.map(value => implicitly[ArgEncoder[String]].encode(value)))
+                )
+              )
+          }
+
+          object Query {
+            def addCharacter[A](
+              character: CharacterInput
+            )(sel: SelectionBuilder[Character, A])(implicit
+              encoder: ArgEncoder[CharacterInput]
+            ): Field[RootQuery, Option[A]] =
+              Field(
+                "addCharacter",
+                OptionOf(Obj(sel)),
+                arguments = List(Argument("character", character, "CharacterInput!")(encoder))
+              )
+          }
+
+          val query = Query.addCharacter(CharacterInput("name", None, Nil))(Character.name)
+
+          assert(query.toGraphQL(dropInputNullValues = true).query)(
+            equalTo("""query{addCharacter(character:{name:"name",nicknames:[]}){name}}""")
+          )
+        },
+        test("drop null values in input object by explicit ArgEncoder") {
+          import caliban.client.__Value._
+
+          case class CharacterInput(name: String, description: Option[String], nicknames: List[String] = Nil)
+          object CharacterInput {
+            implicit val encoder: ArgEncoder[CharacterInput] = (value: CharacterInput) =>
+              __ObjectValue(
+                List(
+                  "name"        -> implicitly[ArgEncoder[String]].encode(value.name),
+                  "description" -> implicitly[ArgEncoder[Option[String]]].encode(value.description),
+                  "nicknames"   -> __ListValue(value.nicknames.map(value => implicitly[ArgEncoder[String]].encode(value)))
+                )
+              )
+          }
+
+          object Query {
+            def addCharacter[A](
+              character: CharacterInput
+            )(sel: SelectionBuilder[Character, A])(implicit
+              encoder: ArgEncoder[CharacterInput]
+            ): Field[RootQuery, Option[A]] =
+              Field(
+                "addCharacter",
+                OptionOf(Obj(sel)),
+                arguments = List(Argument("character", character, "CharacterInput!")(encoder))
+              )
+          }
+
+          implicit val encoderWithoutNull: ArgEncoder[CharacterInput] =
+            CharacterInput.encoder.dropNullValues
+
+          val query = Query.addCharacter(CharacterInput("name", None, Nil))(Character.name)
+
+          assert(query.toGraphQL().query)(
+            equalTo("""query{addCharacter(character:{name:"name",nicknames:[]}){name}}""")
+          )
         }
       )
     )

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -139,9 +139,10 @@ object Client {
 
   type Q
   object Q {
-    def character[A](name: String)(innerSelection: SelectionBuilder[Character, A]): SelectionBuilder[Q, Option[A]] =
-      _root_.caliban.client.SelectionBuilder
-        .Field("character", OptionOf(Obj(innerSelection)), arguments = List(Argument("name", name, "String!")))
+    def character[A](name: String)(
+      innerSelection: SelectionBuilder[Character, A]
+    )(implicit encoder0: ArgEncoder[String]): SelectionBuilder[Q, Option[A]] = _root_.caliban.client.SelectionBuilder
+      .Field("character", OptionOf(Obj(innerSelection)), arguments = List(Argument("name", name, "String!")(encoder0)))
   }
 
   type Character
@@ -444,15 +445,18 @@ object Client {
 
   type Query = RootQuery
   object Query {
-    def characters(
-      first: Int,
-      last: Option[Int] = None,
-      origins: List[Option[String]] = Nil
+    def characters(first: Int, last: Option[Int] = None, origins: List[Option[String]] = Nil)(implicit
+      encoder0: ArgEncoder[Int],
+      encoder1: ArgEncoder[Option[Int]],
+      encoder2: ArgEncoder[List[Option[String]]]
     ): SelectionBuilder[RootQuery, Option[String]] = _root_.caliban.client.SelectionBuilder.Field(
       "characters",
       OptionOf(Scalar()),
-      arguments =
-        List(Argument("first", first, "Int!"), Argument("last", last, "Int"), Argument("origins", origins, "[String]!"))
+      arguments = List(
+        Argument("first", first, "Int!")(encoder0),
+        Argument("last", last, "Int")(encoder1),
+        Argument("origins", origins, "[String]!")(encoder2)
+      )
     )
   }
 

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -449,7 +449,7 @@ object Client {
       encoder0: ArgEncoder[Int],
       encoder1: ArgEncoder[Option[Int]],
       encoder2: ArgEncoder[List[Option[String]]]
-    ): SelectionBuilder[_root_.caliban.client.RootQuery, Option[String]] =
+    ): SelectionBuilder[_root_.caliban.client.Operations.RootQuery, Option[String]] =
       _root_.caliban.client.SelectionBuilder.Field(
         "characters",
         OptionOf(Scalar()),

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -105,11 +105,12 @@ object Client {
       case ((name, age), nicknames) => CharacterView(name, age, nicknames)
     }
 
-    def name: SelectionBuilder[Character, String]                                     = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
-    def age: SelectionBuilder[Character, Int]                                         = _root_.caliban.client.SelectionBuilder.Field("age", Scalar())
-    def nicknames(arg: Option[Int] = None): SelectionBuilder[Character, List[String]] =
-      _root_.caliban.client.SelectionBuilder
-        .Field("nicknames", ListOf(Scalar()), arguments = List(Argument("arg", arg, "Int")))
+    def name: SelectionBuilder[Character, String] = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def age: SelectionBuilder[Character, Int]     = _root_.caliban.client.SelectionBuilder.Field("age", Scalar())
+    def nicknames(arg: Option[Int] = None)(implicit
+      encoder0: ArgEncoder[Option[Int]]
+    ): SelectionBuilder[Character, List[String]]  = _root_.caliban.client.SelectionBuilder
+      .Field("nicknames", ListOf(Scalar()), arguments = List(Argument("arg", arg, "Int")(encoder0)))
   }
 
   type User
@@ -124,9 +125,10 @@ object Client {
     )(charactersSelection: SelectionBuilder[Character, CharactersSelection]): ViewSelection[CharactersSelection] =
       characters(charactersName)(charactersSelection).map(characters => UserView(characters))
 
-    def characters[A](name: String)(innerSelection: SelectionBuilder[Character, A]): SelectionBuilder[User, List[A]] =
-      _root_.caliban.client.SelectionBuilder
-        .Field("characters", ListOf(Obj(innerSelection)), arguments = List(Argument("name", name, "String!")))
+    def characters[A](name: String)(
+      innerSelection: SelectionBuilder[Character, A]
+    )(implicit encoder0: ArgEncoder[String]): SelectionBuilder[User, List[A]] = _root_.caliban.client.SelectionBuilder
+      .Field("characters", ListOf(Obj(innerSelection)), arguments = List(Argument("name", name, "String!")(encoder0)))
   }
 
 }
@@ -166,10 +168,10 @@ object Client {
 
     def name: SelectionBuilder[Character, String] = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
     def age: SelectionBuilder[Character, Int]     = _root_.caliban.client.SelectionBuilder.Field("age", Scalar())
-    def friends[A](filter: Option[String] = None)(
-      innerSelection: SelectionBuilder[Character, A]
+    def friends[A](filter: Option[String] = None)(innerSelection: SelectionBuilder[Character, A])(implicit
+      encoder0: ArgEncoder[Option[String]]
     ): SelectionBuilder[Character, List[A]]       = _root_.caliban.client.SelectionBuilder
-      .Field("friends", ListOf(Obj(innerSelection)), arguments = List(Argument("filter", filter, "String")))
+      .Field("friends", ListOf(Obj(innerSelection)), arguments = List(Argument("filter", filter, "String")(encoder0)))
   }
 
 }

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -210,7 +210,7 @@ Once your query or mutation is created, it is time to execute it. To do that, yo
 This function takes the URL of your GraphQL server and some options:
 - a boolean `useVariables` that determines if arguments should be using variables or not (default: false)
 - an optional string `queryName` if you want to name your query (default: no name)
-- a boolean `dropInputNullValues` that determines if null fields from input objects should be dropped (default: false)
+- a boolean `dropNullInputValues` that determines if null fields from input objects should be dropped (default: false)
 
 You can then simply run the `sttp` request with the backend of your choice. See the [sttp docs](https://sttp.readthedocs.io/en/latest/) if you are not familiar with it.
 

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -205,7 +205,12 @@ val characterWithOriginOnlyDetails: SelectionBuilder[Character, Character.Charac
 
 ## Request execution
 
-Once your query or mutation is created, it is time to execute it. To do that, you can transform your `SelectionBuilder` into an `sttp` request by calling `.toRequest`. This function takes the URL of your GraphQL server and an optional boolean `useVariables` that determines if arguments should be using variables or not (default: false).
+Once your query or mutation is created, it is time to execute it. To do that, you can transform your `SelectionBuilder` into an `sttp` request by calling `.toRequest`.
+
+This function takes the URL of your GraphQL server and some options:
+- a boolean `useVariables` that determines if arguments should be using variables or not (default: false)
+- an optional string `queryName` if you want to name your query (default: no name)
+- a boolean `dropInputNullValues` that determines if null fields from input objects should be dropped (default: false)
 
 You can then simply run the `sttp` request with the backend of your choice. See the [sttp docs](https://sttp.readthedocs.io/en/latest/) if you are not familiar with it.
 


### PR DESCRIPTION
Closes #778

2 options: 
- pass `dropInputNullValues` when building the request to drop all of them
- pass a custom `ArgEncoder` when building the query to customize the behavior per input object type