### PR TITLE
[Client] Add toRequestWith

### DIFF
--- a/client-laminext/src/main/scala/caliban/client/laminext/package.scala
+++ b/client-laminext/src/main/scala/caliban/client/laminext/package.scala
@@ -32,19 +32,25 @@ package object laminext {
       dropNullInputValues: Boolean = false,
       middleware: FetchEventStreamBuilder => FetchEventStreamBuilder = identity
     )(implicit ev: IsOperation[Origin]): EventStream[Either[CalibanClientError, A]] =
-      toEventStreamWithExtensions[A1](uri, useVariables, queryName, dropNullInputValues, middleware).map(_.map(_._1))
+      toEventStreamWith[A1, A](uri, useVariables, queryName, dropNullInputValues, middleware)((res, _, _) => res)
 
-    def toEventStreamWithExtensions[A1 >: A](
+    def toEventStreamWith[A1 >: A, B](
       uri: String,
       useVariables: Boolean = false,
       queryName: Option[String] = None,
       dropNullInputValues: Boolean = false,
       middleware: FetchEventStreamBuilder => FetchEventStreamBuilder = identity
-    )(implicit ev: IsOperation[Origin]): EventStream[Either[CalibanClientError, (A, Option[Json])]] =
+    )(
+      mapResponse: (A, List[GraphQLResponseError], Option[Json]) => B
+    )(implicit ev: IsOperation[Origin]): EventStream[Either[CalibanClientError, B]] =
       middleware(Fetch.post(uri))
         .body(self.toGraphQL(useVariables, queryName, dropNullInputValues))
         .text
-        .map(response => self.decode(response.data))
+        .map(response =>
+          self.decode(response.data).map { case (result, errors, extensions) =>
+            mapResponse(result, errors, extensions)
+          }
+        )
         .recover {
           case err: CalibanClientError => Some(Left(err))
           case other                   => Some(Left(CommunicationError("", Some(other))))
@@ -55,24 +61,28 @@ package object laminext {
       useVariables: Boolean = false,
       queryName: Option[String] = None
     )(implicit ev1: IsOperation[Origin], ev2: Origin <:< RootSubscription): Subscription[A] = {
-      val subscription = toSubscriptionWithExtensions[A1](ws, useVariables, queryName)
+      val subscription = toSubscriptionWith[A1, A](ws, useVariables, queryName)((res, _, _) => res)
       new Subscription[A] {
-        def received: EventStream[Either[CalibanClientError, A]] = subscription.received.map(_.map(_._1))
+        def received: EventStream[Either[CalibanClientError, A]] = subscription.received
         def unsubscribe(): Unit                                  = subscription.unsubscribe()
       }
     }
 
-    def toSubscriptionWithExtensions[A1 >: A](
+    def toSubscriptionWith[A1 >: A, B](
       ws: WebSocket[GraphQLWSResponse, GraphQLWSRequest],
       useVariables: Boolean = false,
       queryName: Option[String] = None
-    )(implicit ev1: IsOperation[Origin], ev2: Origin <:< RootSubscription): Subscription[(A, Option[Json])] = {
+    )(
+      mapResponse: (A, List[GraphQLResponseError], Option[Json]) => B
+    )(implicit ev1: IsOperation[Origin], ev2: Origin <:< RootSubscription): Subscription[B] = {
       val id = UUID.randomUUID().toString
       ws.sendOne(GraphQLWSRequest("start", Some(id), Some(self.toGraphQL(useVariables, queryName))))
-      new Subscription[(A, Option[Json])] {
-        def received: EventStream[Either[CalibanClientError, (A, Option[Json])]] =
+      new Subscription[B] {
+        def received: EventStream[Either[CalibanClientError, B]] =
           ws.received.collect { case GraphQLWSResponse("data", Some(`id`), Some(payload)) =>
-            self.decode(payload.noSpaces)
+            self.decode(payload.noSpaces).map { case (result, errors, extensions) =>
+              mapResponse(result, errors, extensions)
+            }
           }
 
         def unsubscribe(): Unit =


### PR DESCRIPTION
More powerful version of `toRequestWithExtensions` that also gives you access to partial errors.
Also, no longer fail the request in case of partial errors.