### PR TITLE
Permit scalarMappings to be used with enumerations

### DIFF
--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -59,7 +59,10 @@ object ClientWriter {
 
     val inputs = schema.inputObjectTypeDefinitions.map(writeInputObject).mkString("\n")
 
-    val enums = schema.enumTypeDefinitions.map(writeEnum).mkString("\n")
+    val enums = schema.enumTypeDefinitions
+      .filter(e => !scalarMappings.scalarMap.exists(_.contains(e.name)))
+      .map(writeEnum)
+      .mkString("\n")
 
     val scalars = schema.scalarTypeDefinitions
       .filterNot(s => isScalarSupported(s.name))


### PR DESCRIPTION
There's a problem in the latest release of caliban, wherein if you attempt to use `scalarMapping` to remap an `enum`, it just interpolates the fully qualified type in the name position, which is syntacticly invalid.

Given: `--scalarMappings ExampleStreamType:com.example.myserver.constants.ExampleStreamType`, I get:

```scala
sealed trait com.example.myserver.constants.ExampleStreamType extends scala.Product with scala.Serializable
object com.example.myserver.constants.ExampleStreamType {
  case object FOO extends com.example.myserver.constants.ExampleStreamType
  case object BAR extends com.example.myserver.constants.ExampleStreamType
  ...

  implicit val decoder: ScalarDecoder[com.example.myserver.constants.ExampleStreamType] = {
    case __StringValue("FOO") => Right(com.example.myserver.constants.ExampleStreamType.FOO)
    case __StringValue("BAR") => Right(com.example.myserver.constants.ExampleStreamType.BAR)
    ...
    case other => Left(DecodingError(s"Can't build ExampleStreamType from input $other"))
  }
  implicit val encoder: ArgEncoder[ExampleStreamType] = new ArgEncoder[ExampleStreamType] {
    override def encode(value: com.example.myserver.constants.ExampleStreamType): __Value = value match {
      case ExampleStreamType.FOO => __EnumValue("FOO")
      case ExampleStreamType.BAR => __EnumValue("BAR")
      ...
    }
    override def typeName: String = "com.example.myserver.constants.ExampleStreamType"
  }
}
```

This PR addresses this issue by suppressing emitting the enumeration type if the enumeration name is in the `scalarMappings` map.