### PR TITLE
Exposing the set of members of emitted enumerations

### DIFF
--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -380,6 +380,10 @@ object ClientWriter {
       .map(v => s"""case ${typedef.name}.${safeEnumValue(v.enumValue)} => __EnumValue("${v.enumValue}")""")
       .mkString("\n")}
           }
+
+          val values: Vector[${enumName}] = Vector(${typedef.enumValuesDefinition
+      .map(v => safeEnumValue(v.enumValue))
+      .mkString(", ")})
         }
        """
   }

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -236,6 +236,8 @@ object Client {
       case Origin.MARS  => __EnumValue("MARS")
       case Origin.BELT  => __EnumValue("BELT")
     }
+
+    val values: Vector[Origin] = Vector(EARTH, MARS, BELT)
   }
 
 }
@@ -289,6 +291,8 @@ object Client {
       case Origin.MARS  => __EnumValue("MARS")
       case Origin.BELT  => __EnumValue("BELT")
     }
+
+    val values: Vector[Origin] = Vector(EARTH, MARS, BELT)
   }
 
   case class Routes(origin: Origin, destinations: List[com.example.Destination] = Nil)
@@ -599,6 +603,8 @@ object Client {
       case Episode.JEDI    => __EnumValue("JEDI")
       case Episode.jedi_1  => __EnumValue("jedi")
     }
+
+    val values: Vector[Episode] = Vector(NEWHOPE, EMPIRE, JEDI, jedi_1)
   }
 
 }


### PR DESCRIPTION
This is needed for more dynamic mapping of known values in enumerations. Example:

```scala
val (notInterested, interested) = categories.values.partition(user.preferredCateogry.contains _)
```

Again, I'm still onboarding onto GraphQL workflows, so if this PR doesn't make sense, thank you for your patience.