### PR TITLE
Exposing a distinct "value" parameter for enumeration members, to avoid relying on default toString()

### DIFF
--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -363,10 +363,12 @@ object ClientWriter {
     def safeEnumValue(enumValue: String): String =
       safeName(mappingClashedEnumValues.getOrElse(enumValue, enumValue))
 
-    s"""sealed trait $enumName extends scala.Product with scala.Serializable
+    s"""sealed trait $enumName extends scala.Product with scala.Serializable { def value: String }
         object $enumName {
           ${typedef.enumValuesDefinition
-      .map(v => s"case object ${safeEnumValue(v.enumValue)} extends $enumName")
+      .map(v =>
+        s"case object ${safeEnumValue(v.enumValue)} extends $enumName { val value: String = ${"\"" + safeEnumValue(v.enumValue) + "\""} }"
+      )
       .mkString("\n")}
 
           implicit val decoder: ScalarDecoder[$enumName] = {

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -219,11 +219,11 @@ import caliban.client.__Value._
 
 object Client {
 
-  sealed trait Origin extends scala.Product with scala.Serializable
+  sealed trait Origin extends scala.Product with scala.Serializable { def value: String }
   object Origin {
-    case object EARTH extends Origin
-    case object MARS  extends Origin
-    case object BELT  extends Origin
+    case object EARTH extends Origin { val value: String = "EARTH" }
+    case object MARS  extends Origin { val value: String = "MARS"  }
+    case object BELT  extends Origin { val value: String = "BELT"  }
 
     implicit val decoder: ScalarDecoder[Origin] = {
       case __StringValue("EARTH") => Right(Origin.EARTH)
@@ -272,11 +272,11 @@ import caliban.client.__Value._
 
 object Client {
 
-  sealed trait Origin extends scala.Product with scala.Serializable
+  sealed trait Origin extends scala.Product with scala.Serializable { def value: String }
   object Origin {
-    case object EARTH extends Origin
-    case object MARS  extends Origin
-    case object BELT  extends Origin
+    case object EARTH extends Origin { val value: String = "EARTH" }
+    case object MARS  extends Origin { val value: String = "MARS"  }
+    case object BELT  extends Origin { val value: String = "BELT"  }
 
     implicit val decoder: ScalarDecoder[Origin] = {
       case __StringValue("EARTH") => Right(Origin.EARTH)
@@ -579,12 +579,12 @@ import caliban.client.__Value._
 
 object Client {
 
-  sealed trait Episode extends scala.Product with scala.Serializable
+  sealed trait Episode extends scala.Product with scala.Serializable { def value: String }
   object Episode {
-    case object NEWHOPE extends Episode
-    case object EMPIRE  extends Episode
-    case object JEDI    extends Episode
-    case object jedi_1  extends Episode
+    case object NEWHOPE extends Episode { val value: String = "NEWHOPE" }
+    case object EMPIRE  extends Episode { val value: String = "EMPIRE"  }
+    case object JEDI    extends Episode { val value: String = "JEDI"    }
+    case object jedi_1  extends Episode { val value: String = "jedi_1"  }
 
     implicit val decoder: ScalarDecoder[Episode] = {
       case __StringValue("NEWHOPE") => Right(Episode.NEWHOPE)


### PR DESCRIPTION
- `def value: String` on containing enumeration could be a `val value: String` if you prefer. I think having a weak reference there is better for some reason, but I can't remember why or if this is true.
- This is motivated by having been bit by refactors that change a member from a discrete type to an `Option[A]` or `List[A]` or otherwise, but relying on the default `.toString()` doesn't flag this as an error. This also provides an alternative for those using wartremover's `ToString` wart, which prevents relying on the default `toString` as well.

This was able to be merged without conflict after applying #934, another reason for not changing too much about emitted classes