### PR TITLE
Fix string escaping problem

### DIFF
--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -30,7 +30,7 @@ object __Value {
     override def toString: String = value
   }
   case class __StringValue(value: String)                   extends __Value {
-    override def toString: String = s""""${value.replace("\"", "\\\"")}""""
+    override def toString: String = Json.fromString(value).toString
   }
   case class __BooleanValue(value: Boolean)                 extends __Value {
     override def toString: String = value.toString

--- a/client/src/test/scala/caliban/client/ArgEncoderSpec.scala
+++ b/client/src/test/scala/caliban/client/ArgEncoderSpec.scala
@@ -1,0 +1,25 @@
+package caliban.client
+
+import zio.test.Assertion.equalTo
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+object ArgEncoderSpec extends DefaultRunnableSpec {
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("ArgEncoderSpec")(
+      suite("__StringValue")(
+        test("regular string") {
+          assert(ArgEncoder.string.encode("abcde who am i?").toString)(equalTo(""""abcde who am i?""""))
+        },
+        test("string with quotes") {
+          assert(ArgEncoder.string.encode("abcde \"who am i?\"").toString)(equalTo(""""abcde \"who am i?\"""""))
+        },
+        test("string with new line") {
+          assert(ArgEncoder.string.encode("abcde\n who\n am\n i\n").toString)(equalTo(""""abcde\n who\n am\n i\n""""))
+        },
+        test("string with null characters") {
+          assert(ArgEncoder.string.encode("abcde who am i\u0000").toString)(equalTo("\"abcde who am i\\u0000\""))
+        }
+      )
+    )
+}


### PR DESCRIPTION
since there are quite a bit of works needed to escape string arguments so that it can be used in graphql queries + mutations, I made it to use circe's json string encoders and added tests for that.
It's only done for the client side only for now since there are no circe dependency in the server side. In the future, we can probably make our own escapers