### PR TITLE
Escape `\\` on the server side

### DIFF
--- a/core/src/main/scala-2/caliban/parsing/Parser.scala
+++ b/core/src/main/scala-2/caliban/parsing/Parser.scala
@@ -100,7 +100,7 @@ object Parser {
   private def escapedUnicode[_: P]: P[String] =
     P(hexDigit ~~ hexDigit ~~ hexDigit ~~ hexDigit).!.map(Integer.parseInt(_, 16).toChar.toString)
 
-  private def escapedCharacter[_: P]: P[String] = P(CharIn("\"\\/bfnrt").!).map {
+  private def escapedCharacter[_: P]: P[String] = P(CharIn("\"\\\\/bfnrt").!).map {
     case "b"   => "\b"
     case "n"   => "\n"
     case "f"   => "\f"

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -74,6 +74,28 @@ object ParserSpec extends DefaultRunnableSpec {
           )
         )
       },
+      testM("arguments with a backslash") {
+        val query = """{
+                      |  human(id: "1000\\") {
+                      |    name
+                      |  }
+                      |}""".stripMargin
+        assertM(Parser.parseQuery(query))(
+          equalTo(
+            simpleQuery(
+              selectionSet = List(
+                simpleField(
+                  "human",
+                  arguments = Map("id" -> StringValue("1000\\")),
+                  selectionSet = List(simpleField("name", index = 30)),
+                  index = 4
+                )
+              ),
+              sourceMapper = SourceMapper(query)
+            )
+          )
+        )
+      },
       testM("aliases") {
         val query = """{
                       |  empireHero: hero(episode: EMPIRE) {


### PR DESCRIPTION
`CharIn` requires "\\\\\\\\" to be accepted as single `\` character