### PR TITLE
Allow for Abstract Effect Type in Schema Gen

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
@@ -51,7 +51,7 @@ object CalibanCli {
 
   private val genSchemaHelpMsg =
     s"""
-       |calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect]
+       |calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--abstractEffectType]
        |
        |This command will create a Scala file in `outputPath` containing all the types
        |defined in the provided GraphQL schema defined at `schemaPath`. Instead of a path,
@@ -61,6 +61,9 @@ object CalibanCli {
        |
        |By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. 
        |This can be overridden by providing an alternative effect with the `--effect` option.
+       |The --abstractEffectType flag can also be used to indicate that the effect
+       |type is abstract, so that it will be added as a type parameter to the generated
+       |Query and Mutation classes (if applicable).
        |""".stripMargin
 
   private val genClientHelpMsg =

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
@@ -51,7 +51,7 @@ object CalibanCli {
 
   private val genSchemaHelpMsg =
     s"""
-       |calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--abstractEffectType]
+       |calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--abstractEffectType true|false]
        |
        |This command will create a Scala file in `outputPath` containing all the types
        |defined in the provided GraphQL schema defined at `schemaPath`. Instead of a path,
@@ -63,7 +63,8 @@ object CalibanCli {
        |This can be overridden by providing an alternative effect with the `--effect` option.
        |The --abstractEffectType flag can also be used to indicate that the effect
        |type is abstract, so that it will be added as a type parameter to the generated
-       |Query and Mutation classes (if applicable).
+       |Query and Mutation classes (if applicable).  In such cases `F` will be used by
+       |as the type parameter unless the `--effect` option is explicitly given.
        |""".stripMargin
 
   private val genClientHelpMsg =

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -19,18 +19,23 @@ object Codegen {
     arguments: Options,
     genType: GenType
   ): Task[Unit] = {
-    val s              = ".*/scala[^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
-    val packageName    = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
-    val objectName     = s.map(_.group(2)).getOrElse("Client")
-    val effect         = arguments.effect.getOrElse("zio.UIO")
-    val genView        = arguments.genView.getOrElse(false)
-    val scalarMappings = arguments.scalarMappings
-    val loader         = getSchemaLoader(arguments.schemaPath, arguments.headers)
+    val s                  = ".*/scala[^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
+    val packageName        = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
+    val objectName         = s.map(_.group(2)).getOrElse("Client")
+    val abstractEffectType = arguments.abstractEffectType.getOrElse(false)
+    val effect             = arguments.effect.getOrElse {
+      if (abstractEffectType) "F" else "zio.UIO"
+    }
+    val genView            = arguments.genView.getOrElse(false)
+    val scalarMappings     = arguments.scalarMappings
+    val loader             = getSchemaLoader(arguments.schemaPath, arguments.headers)
     for {
       schema    <- loader.load
       code       = genType match {
                      case GenType.Schema =>
-                       SchemaWriter.write(schema, packageName, effect, arguments.imports)(ScalarMappings(scalarMappings))
+                       SchemaWriter.write(schema, packageName, effect, arguments.imports, abstractEffectType)(
+                         ScalarMappings(scalarMappings)
+                       )
                      case GenType.Client =>
                        ClientWriter.write(schema, objectName, packageName, genView, arguments.imports)(
                          ScalarMappings(scalarMappings)

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -12,7 +12,8 @@ final case class Options(
   genView: Option[Boolean],
   effect: Option[String],
   scalarMappings: Option[Map[String, String]],
-  imports: Option[List[String]]
+  imports: Option[List[String]],
+  abstractEffectType: Option[Boolean]
 )
 
 object Options {
@@ -24,7 +25,8 @@ object Options {
     genView: Option[Boolean],
     effect: Option[String],
     scalarMappings: Option[List[String]],
-    imports: Option[List[String]]
+    imports: Option[List[String]],
+    abstractEffectType: Option[Boolean]
   )
 
   def fromArgs(args: List[String]): Option[Options] =
@@ -62,7 +64,8 @@ object Options {
                 }
               }.toMap
             },
-            rawOpts.imports
+            rawOpts.imports,
+            rawOpts.abstractEffectType
           )
         }
       case _                             => None

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -23,6 +23,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -44,6 +45,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -56,7 +58,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         assert(result)(
           equalTo(
             Some(
-              Options("schema", "output", None, None, None, None, None, None, None)
+              Options("schema", "output", None, None, None, None, None, None, None, None)
             )
           )
         )
@@ -90,6 +92,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -111,6 +114,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 Some("cats.effect.IO"),
                 None,
+                None,
                 None
               )
             )
@@ -130,6 +134,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some(true),
+                None,
                 None,
                 None,
                 None
@@ -153,6 +158,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some(Map("Long" -> "scala.Long")),
+                None,
                 None
               )
             )
@@ -174,7 +180,30 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
-                Some(List("a.b.Clazz", "b.c._"))
+                Some(List("a.b.Clazz", "b.c._")),
+                None
+              )
+            )
+          )
+        )
+      },
+      test("provide abstractEffectType") {
+        val input  = List("schema", "output", "--effect", "F", "--abstractEffectType", "true")
+        val result = Options.fromArgs(input)
+        assert(result)(
+          equalTo(
+            Some(
+              Options(
+                "schema",
+                "output",
+                None,
+                None,
+                None,
+                None,
+                Some("F"),
+                None,
+                None,
+                Some(true)
               )
             )
           )
@@ -191,6 +220,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 "output",
                 Some("fmtPath"),
                 Some(List(Header("aaa", "bbb:ccc"))),
+                None,
                 None,
                 None,
                 None,

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -234,7 +234,7 @@ enablePlugins(CalibanPlugin)
 
 Then call the `calibanGenSchema` sbt command.
 ```scala
-calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--scalarMappings gqlType:f.q.d.n.Type,gqlType2:f.q.d.n.Type2] [--imports a.b.c._,c.d.E]
+calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--scalarMappings gqlType:f.q.d.n.Type,gqlType2:f.q.d.n.Type2] [--imports a.b.c._,c.d.E] [--abstractEffectType true|false]
 
 calibanGenSchema project/schema.graphql src/main/MyAPI.scala
 ```
@@ -245,6 +245,8 @@ The generated code will be formatted with Scalafmt using the configuration defin
 The package of the generated code is derived from the folder of `outputPath`. This can be overridden by providing an alternative package with the `--packageName` option.
 
 By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. This can be overridden by providing an alternative effect with the `--effect` option.
+
+You can also indicate that the effect type is abstract via `--abstractEffectType true`, in which case `Query` will be replaced by `Query[F[_]]` and so on (note `F` will be used unless `--effect <effect>` is explicitly given in which case `<effect>` would be used in place of `F`).
 
 If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
 `--scalarMappings` option. Also you can add additional imports by providing `--imports` option.


### PR DESCRIPTION
Hi! This PR allows the effect type of generated the generated `Queries` and `Mutations` classes to be abstract, ie:

```scala
case class Mutations[F[_]](
    foo: FooArgs => F[Foo],
    bar: BarArgs => F[Bar]
)
```

To do this, you can use the `--abstractEffectType` argument (hopefully I've added doc in the right place for this).

Currently the `effect` parameter will be used as the abstract type value so to get the above example you would have to `--abstractEffectType true --effect F`, though I'm unsure if this is best since `effect` defaults to the concrete type `zio.UIO` (so you would get `Mutations[UIO[_]]` without specifying `F` :fearful: ).  I was thinking maybe ignore the value of `effect` if `--abstractEffectType` is set and always use `F`, what do you think?

Let me know what you think... or if this is just a terrible idea :slightly_smiling_face: 