### PR TITLE
Add Play framework-related regex to codegen tool

### DIFF
--- a/codegen-sbt/src/sbt-test/codegen/test-compile/test
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/test
@@ -13,11 +13,11 @@ $ exists src/main/scala/client/ClientNameUniqueness.scala
 
 > calibanGenClient project/schema-to-check-name-uniqueness.graphql app/com/caliban/client/ClientPlayFramework.scala --packageName client 
 $ exists app/com/caliban/client/ClientPlayFramework.scala
-$ exec verify.sh ClientPlayFramework ./app/com/caliban/client/ClientPlayFramework.scala
+$ exec sh verify.sh ClientPlayFramework ./app/com/caliban/client/ClientPlayFramework.scala
 
 > calibanGenClient project/schema-to-check-name-uniqueness.graphql play23/com/caliban/client/ClientPlayFramework.scala --packageName client
 $ exists play23/com/caliban/client/ClientPlayFramework.scala
-$ exec verify.sh ClientPlayFramework ./play23/com/caliban/client/ClientPlayFramework.scala
+$ exec sh verify.sh ClientPlayFramework ./play23/com/caliban/client/ClientPlayFramework.scala
 
 $ mkdir src/main/scala/genview
 $ mkdir src/main/scala/genview/client

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/test
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/test
@@ -1,10 +1,23 @@
 $ absent src/main/scala/client/ClientNameUniqueness.scala
 $ absent src/main/scala/client/ClientGitLab.scala
+$ absent app/com/caliban/client/ClientPlayFramework.scala
+$ absent play23/com/caliban/client/ClientPlayFramework.scala
+
 $ mkdir src/main/scala
 $ mkdir src/main/scala/client
+$ mkdir app/com/caliban/client
+$ mkdir play23/com/caliban/client
 
 > calibanGenClient project/schema-to-check-name-uniqueness.graphql src/main/scala/client/ClientNameUniqueness.scala --packageName client
 $ exists src/main/scala/client/ClientNameUniqueness.scala
+
+> calibanGenClient project/schema-to-check-name-uniqueness.graphql app/com/caliban/client/ClientPlayFramework.scala --packageName client 
+$ exists app/com/caliban/client/ClientPlayFramework.scala
+$ exec verify.sh ClientPlayFramework ./app/com/caliban/client/ClientPlayFramework.scala
+
+> calibanGenClient project/schema-to-check-name-uniqueness.graphql play23/com/caliban/client/ClientPlayFramework.scala --packageName client
+$ exists play23/com/caliban/client/ClientPlayFramework.scala
+$ exec verify.sh ClientPlayFramework ./play23/com/caliban/client/ClientPlayFramework.scala
 
 $ mkdir src/main/scala/genview
 $ mkdir src/main/scala/genview/client

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -19,7 +19,7 @@ object Codegen {
     arguments: Options,
     genType: GenType
   ): Task[Unit] = {
-    val s                  = ".*/scala[^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
+    val s                  = ".*/(scala|play.*|app)[^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
     val packageName        = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
     val objectName         = s.map(_.group(2)).getOrElse("Client")
     val abstractEffectType = arguments.abstractEffectType.getOrElse(false)

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -19,7 +19,7 @@ object Codegen {
     arguments: Options,
     genType: GenType
   ): Task[Unit] = {
-    val s                  = ".*/(scala|play.*|app)[^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
+    val s                  = ".*/[scala|play.*|app][^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
     val packageName        = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
     val objectName         = s.map(_.group(2)).getOrElse("Client")
     val abstractEffectType = arguments.abstractEffectType.getOrElse(false)


### PR DESCRIPTION
Expanded the regex which previously accepted only path names with `/scala` to also accept `|play.*` or `|app` (The issue enclosed suggested to only add `play` but the scastie example provided has `/app` in the path name instead of `play`)

closes #950 