### PR TITLE
Automatically regenerate when configs change

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
@@ -21,8 +21,10 @@ object CalibanSourceGenerator {
       sources: Seq[File],
       fileSettings: Seq[CalibanFileSettings],
       urlSettings: Seq[CalibanUrlSettings]
-    ): TrackedSettings =
-      TrackedSettings(Seq.empty)
+    ): TrackedSettings = {
+      val allSettings: Seq[CalibanSettings] = sources.toList.map(collectSettingsFor(fileSettings, _)) ++ urlSettings
+      TrackedSettings(allSettings.map(renderArgs))
+    }
 
     implicit val analysisIso = LList.iso[TrackedSettings, Seq[Seq[String]] :*: LNil](
       { case TrackedSettings(arguments) => ("args", arguments) :*: LNil },


### PR DESCRIPTION
Resolves #958

- Takes all available settings
- Renders them to equivalent CLI args
- Uses that as a tracked input for whether to run the codegen