### PR TITLE
Update examples README to fix compilation issues

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,18 +3,21 @@
 To run the examples without the rest of the project, add this to your build.sbt:
 
 ```scala
+val calibanVersion = "1.1.0"
+
 libraryDependencies ++= Seq(
-  "com.github.ghostdogpr"         %% "caliban"                       % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-http4s"                % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-play"                  % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-akka-http"             % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-zio-http"              % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-cats"                  % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-monix"                 % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-finch"                 % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-federation"            % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-tapir"                 % "0.9.5",
-  "com.github.ghostdogpr"         %% "caliban-client"                % "0.9.5",
+  "com.github.ghostdogpr"         %% "caliban"                       % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-http4s"                % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-play"                  % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-akka-http"             % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-zio-http"              % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-cats"                  % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-monix"                 % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-finch"                 % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-federation"            % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-tapir"                 % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-client"                % calibanVersion,
+  "com.github.ghostdogpr"         %% "caliban-tools"                 % calibanVersion,
   "de.heikoseeberger"             %% "akka-http-circe"               % "1.36.0",
   "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % "3.2.3",
   "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"              % "0.17.18",
@@ -22,8 +25,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.play"             %% "play-akka-http-server"         % "2.8.8",
   "com.typesafe.akka"             %% "akka-actor-typed"              % "2.6.14",
 )
-
-scalacOptions += "-Ypartial-unification"
 ```
 
 Run `ExampleApp` and open [http://localhost:8088/graphiql](http://localhost:8088/graphiql)


### PR DESCRIPTION
Hi, when trying to compile the examples by following the readme I was getting errors with the 0.9.5 version of caliban (the artefacts couldn't be found), with the `-Ypartial-unification` option (`bad option: '-Ypartial-unification'`), and with a missing dependency on caliban-tools. This could be something to do with my setup although it's pretty standard (macOS, sbt 1.5.4) but updating the examples to the latest version of caliban, adding a dependency on caliban-tools, and removing the `-Ypartial-unification` compiler flag allowed compilation to complete.

Of course feel free to close this PR if it's not appropriate for any reason and thanks for the work on caliban!