### PR TITLE
Support growing enums in the client code generator

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
@@ -15,6 +15,7 @@ sealed trait CalibanSettings {
   def imports: Seq[String]
   def splitFiles: Option[Boolean]
   def enableFmt: Option[Boolean]
+  def extensibleEnums: Option[Boolean]
 
   def append(other: Type): Type
 }
@@ -28,7 +29,8 @@ case class CalibanFileSettings(
   scalarMappings: Seq[(String, String)],
   imports: Seq[String],
   splitFiles: Option[Boolean],
-  enableFmt: Option[Boolean]
+  enableFmt: Option[Boolean],
+  extensibleEnums: Option[Boolean]
 ) extends CalibanSettings {
   type Type = CalibanFileSettings
   val headers = Seq.empty // Not applicable for file generator
@@ -43,7 +45,8 @@ case class CalibanFileSettings(
       scalarMappings = scalarMappings ++ other.scalarMappings,
       imports = imports ++ other.imports,
       splitFiles = other.splitFiles.orElse(splitFiles),
-      enableFmt = other.enableFmt.orElse(enableFmt)
+      enableFmt = other.enableFmt.orElse(enableFmt),
+      extensibleEnums = other.extensibleEnums.orElse(extensibleEnums)
     )
 
   def clientName(value: String): CalibanFileSettings                 = this.copy(clientName = Some(value))
@@ -55,6 +58,7 @@ case class CalibanFileSettings(
   def imports(values: String*): CalibanFileSettings                  = this.copy(imports = this.imports ++ values)
   def splitFiles(value: Boolean): CalibanFileSettings                = this.copy(splitFiles = Some(value))
   def enableFmt(value: Boolean): CalibanFileSettings                 = this.copy(enableFmt = Some(value))
+  def extensibleEnums(value: Boolean): CalibanFileSettings           = this.copy(extensibleEnums = Some(value))
 }
 
 case class CalibanUrlSettings(
@@ -67,7 +71,8 @@ case class CalibanUrlSettings(
   scalarMappings: Seq[(String, String)],
   imports: Seq[String],
   splitFiles: Option[Boolean],
-  enableFmt: Option[Boolean]
+  enableFmt: Option[Boolean],
+  extensibleEnums: Option[Boolean]
 ) extends CalibanSettings {
   type Type = CalibanUrlSettings
   def append(other: CalibanUrlSettings): CalibanUrlSettings =
@@ -81,7 +86,8 @@ case class CalibanUrlSettings(
       scalarMappings = scalarMappings ++ other.scalarMappings,
       imports = imports ++ other.imports,
       splitFiles = other.splitFiles.orElse(splitFiles),
-      enableFmt = other.enableFmt.orElse(enableFmt)
+      enableFmt = other.enableFmt.orElse(enableFmt),
+      extensibleEnums = other.extensibleEnums.orElse(extensibleEnums)
     )
 
   def clientName(value: String): CalibanUrlSettings                 = this.copy(clientName = Some(value))
@@ -95,6 +101,7 @@ case class CalibanUrlSettings(
   def imports(values: String*): CalibanUrlSettings                  = this.copy(imports = this.imports ++ values)
   def splitFiles(value: Boolean): CalibanUrlSettings                = this.copy(splitFiles = Some(value))
   def enableFmt(value: Boolean): CalibanUrlSettings                 = this.copy(enableFmt = Some(value))
+  def extensibleEnums(value: Boolean): CalibanUrlSettings           = this.copy(extensibleEnums = Some(value))
 }
 
 object CalibanSettings {
@@ -108,7 +115,8 @@ object CalibanSettings {
     scalarMappings = Seq.empty[(String, String)],
     imports = Seq.empty[String],
     splitFiles = Option.empty[Boolean],
-    enableFmt = Option.empty[Boolean]
+    enableFmt = Option.empty[Boolean],
+    extensibleEnums = Option.empty[Boolean]
   )
 
   def emptyUrl(url: URL): CalibanUrlSettings = CalibanUrlSettings(
@@ -121,6 +129,7 @@ object CalibanSettings {
     scalarMappings = Seq.empty[(String, String)],
     imports = Seq.empty[String],
     splitFiles = Option.empty[Boolean],
-    enableFmt = Option.empty[Boolean]
+    enableFmt = Option.empty[Boolean],
+    extensibleEnums = Option.empty[Boolean]
   )
 }

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
@@ -92,7 +92,11 @@ object CalibanSourceGenerator {
       "--enableFmt",
       settings.enableFmt.map(_.toString())
     ) // NB: Presuming zio-config can read toString'd booleans
-    scalafmtPath ++ headers ++ packageName ++ genView ++ scalarMappings ++ imports ++ splitFiles ++ enableFmt
+    val extensibleEnums = singleOpt(
+      "--extensibleEnums",
+      settings.enableFmt.map(_.toString())
+    ) // NB: Presuming zio-config can read toString'd booleans
+    scalafmtPath ++ headers ++ packageName ++ genView ++ scalarMappings ++ imports ++ splitFiles ++ enableFmt ++ extensibleEnums
   }
 
   def apply(

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -30,6 +30,7 @@ object Codegen {
     val scalarMappings     = arguments.scalarMappings
     val splitFiles         = arguments.splitFiles.getOrElse(false)
     val enableFmt          = arguments.enableFmt.getOrElse(true)
+    val extensibleEnums    = arguments.extensibleEnums.getOrElse(false)
     val loader             = getSchemaLoader(arguments.schemaPath, arguments.headers)
     for {
       schema    <- loader.load
@@ -41,7 +42,15 @@ object Codegen {
                          )
                        )
                      case GenType.Client =>
-                       ClientWriter.write(schema, objectName, packageName, genView, arguments.imports, splitFiles)(
+                       ClientWriter.write(
+                         schema,
+                         objectName,
+                         packageName,
+                         genView,
+                         arguments.imports,
+                         splitFiles,
+                         extensibleEnums
+                       )(
                          ScalarMappings(scalarMappings)
                        )
                    }

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -15,7 +15,8 @@ final case class Options(
   imports: Option[List[String]],
   abstractEffectType: Option[Boolean],
   splitFiles: Option[Boolean],
-  enableFmt: Option[Boolean]
+  enableFmt: Option[Boolean],
+  extensibleEnums: Option[Boolean]
 )
 
 object Options {
@@ -30,7 +31,8 @@ object Options {
     imports: Option[List[String]],
     abstractEffectType: Option[Boolean],
     splitFiles: Option[Boolean],
-    enableFmt: Option[Boolean]
+    enableFmt: Option[Boolean],
+    extensibleEnums: Option[Boolean]
   )
 
   def fromArgs(args: List[String]): Option[Options] =
@@ -71,7 +73,8 @@ object Options {
             rawOpts.imports,
             rawOpts.abstractEffectType,
             rawOpts.splitFiles,
-            rawOpts.enableFmt
+            rawOpts.enableFmt,
+            rawOpts.extensibleEnums
           )
         }
       case _                             => None

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -26,6 +26,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -50,6 +51,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -62,7 +64,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         assert(result)(
           equalTo(
             Some(
-              Options("schema", "output", None, None, None, None, None, None, None, None, None, None)
+              Options("schema", "output", None, None, None, None, None, None, None, None, None, None, None)
             )
           )
         )
@@ -99,6 +101,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -119,6 +122,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some("cats.effect.IO"),
+                None,
                 None,
                 None,
                 None,
@@ -147,7 +151,33 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
+              )
+            )
+          )
+        )
+      },
+      test("provide extensibleEnums") {
+        val input  = List("schema", "output", "--extensibleEnums", "true")
+        val result = Options.fromArgs(input)
+        assert(result)(
+          equalTo(
+            Some(
+              Options(
+                "schema",
+                "output",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(true)
               )
             )
           )
@@ -168,6 +198,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some(Map("Long" -> "scala.Long")),
+                None,
                 None,
                 None,
                 None,
@@ -195,6 +226,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 Some(List("a.b.Clazz", "b.c._")),
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -219,6 +251,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 Some(true),
                 None,
+                None,
                 None
               )
             )
@@ -236,6 +269,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 "output",
                 Some("fmtPath"),
                 Some(List(Header("aaa", "bbb:ccc"))),
+                None,
                 None,
                 None,
                 None,


### PR DESCRIPTION
In GraphQL, adding new values to Enums is not considered a breaking change. It would be nice to be able to handle such cases of schema evolution in the generated clients. This pull request adds a new configuration option to the client code generator (`--extensibleEnums`). When this option is specified, all unknown enum values will be mapped to an `__Unknown` case class, instead of producing a DecodingError.

There is at least one GraphQL library that uses the same approach: https://opensource.expediagroup.com/graphql-kotlin/docs/client/client-features#default-enum-values.

