### PR TITLE
Add union type redirect

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -22,9 +22,16 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
 
   type Typeclass[T] = Schema[R, T]
 
+  def isValueType[T](ctx: ReadOnlyCaseClass[Typeclass, T]): Boolean =
+    ctx.annotations.exists {
+      case GQLValueType() => true
+      case _              => false
+    }
+
   def combine[T](ctx: ReadOnlyCaseClass[Typeclass, T]): Typeclass[T] = new Typeclass[T] {
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
-      if (ctx.isValueClass && ctx.parameters.nonEmpty) ctx.parameters.head.typeclass.toType_(isInput, isSubscription)
+      if ((ctx.isValueClass || isValueType(ctx)) && ctx.parameters.nonEmpty)
+        ctx.parameters.head.typeclass.toType_(isInput, isSubscription)
       else if (isInput)
         makeInputObject(
           Some(ctx.annotations.collectFirst { case GQLInputName(suffix) => suffix }

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -77,7 +77,7 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
 
     override def resolve(value: T): Step[R] =
       if (ctx.isObject) PureStep(EnumValue(getName(ctx)))
-      else if (ctx.isValueClass && ctx.parameters.nonEmpty) {
+      else if ((ctx.isValueClass || isValueType(ctx)) && ctx.parameters.nonEmpty) {
         val head = ctx.parameters.head
         head.typeclass.resolve(head.dereference(value))
       } else {

--- a/core/src/main/scala/caliban/schema/Annotations.scala
+++ b/core/src/main/scala/caliban/schema/Annotations.scala
@@ -41,4 +41,9 @@ object Annotations {
    * Annotation to make a sealed trait a union instead of an enum
    */
   case class GQLUnion() extends StaticAnnotation
+
+  /**
+   * Annotation to make a union or interface redirect to a value type
+   */
+  case class GQLValueType() extends StaticAnnotation
 }

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -122,6 +122,40 @@ type Mechanic {
 }
 ```
 
+If your type needs to be shared between multiple unions you can use the `@GQLValueType` annotation to have caliban
+proxy to another type beyond the sealed trait.
+
+```scala
+case class Pilot(callSign: String)
+
+sealed trait Role
+object Role {
+  case class Captain(shipName: String) extends Role
+  case class Engineer(specialty: String) extends Role
+  
+  @GQLValueType
+  case class Proxy(pilot: Pilot)
+}
+```
+
+This will produce the following GraphQL Types:
+
+```graphql
+union Role = Captain | Engineer | Pilot
+
+type Captain {
+  shipName: String!
+}
+
+type Engineer {
+  specialty: String!
+}
+
+type Pilot {
+  callSign: String!
+}
+```
+
 If you prefer an `Interface` instead of a `Union` type, add the `@GQLInterface` annotation to your sealed trait.
 An interface will be created with all the fields that are common to the case classes extending the sealed trait, as long as they return the same type.
 
@@ -181,6 +215,7 @@ Caliban supports a few annotations to enrich data types:
 - `@GQLDeprecated("reason")` allows deprecating a field or an enum value.
 - `@GQLInterface` to force a sealed trait generating an interface instead of a union.
 - `@GQLDirective(directive: Directive)` to add a directive to a field or type.
+- `@GQLValueType` forces a type to behave as a value type for derivation. Meaning that caliban will ignore the outer type and take the first case class parameter as the real type.
 
 ## Java 8 Time types
 


### PR DESCRIPTION
Adds the ability to redirect a type union to to a different type. This allows you to reuse types between unions like:

```scala
sealed trait MyUnion
object MyUnion {
  @GQLValueType
  case class Redirect(value: UserProfile) extends MyUnion
  case class Error(msg: String) extends MyUnion
}

// Doesn't need to be part of the sealed trait anymore so can be reused for other types.
case class UserProfile(id: String, email: String)
```

producing a graphql union with the `Redirect` type removed and the `UserProfile` treated as part of the union instead.

```graphql
type UserProfile {
  id: String!
  email: String!
}

type Error {
  msg: String!
}


union MyUnion = UserProfile | Error

```