### PR TITLE
add clientName option to calibanGenClient

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
@@ -69,7 +69,7 @@ object CalibanCli {
 
   private val genClientHelpMsg =
     s"""
-       |calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--genView true|false]
+       |calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--clientName name] [--genView true|false]
        |
        |This command will create a Scala file in `outputPath` containing client code for all the
        |typed defined in the provided GraphQL schema defined at `schemaPath`. Instead of a path,

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -21,7 +21,7 @@ object Codegen {
   ): Task[List[File]] = {
     val s                  = ".*/[scala|play.*|app][^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
     val packageName        = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
-    val objectName         = s.map(_.group(2)).getOrElse("Client")
+    val objectName         = arguments.clientName.orElse(s.map(_.group(2))).getOrElse("Client")
     val abstractEffectType = arguments.abstractEffectType.getOrElse(false)
     val effect             = arguments.effect.getOrElse {
       if (abstractEffectType) "F" else "zio.UIO"

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -9,6 +9,7 @@ final case class Options(
   fmtPath: Option[String],
   headers: Option[List[Options.Header]],
   packageName: Option[String],
+  clientName: Option[String],
   genView: Option[Boolean],
   effect: Option[String],
   scalarMappings: Option[Map[String, String]],
@@ -25,6 +26,7 @@ object Options {
     scalafmtPath: Option[String],
     headers: Option[List[String]],
     packageName: Option[String],
+    clientName: Option[String],
     genView: Option[Boolean],
     effect: Option[String],
     scalarMappings: Option[List[String]],
@@ -60,6 +62,7 @@ object Options {
               }
             },
             rawOpts.packageName,
+            rawOpts.clientName,
             rawOpts.genView,
             rawOpts.effect,
             rawOpts.scalarMappings.map {

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -137,7 +137,6 @@ object OptionsSpec extends DefaultRunnableSpec {
           )
         )
       },
-
       test("provide effect") {
         val input  = List("schema", "output", "--effect", "cats.effect.IO")
         val result = Options.fromArgs(input)

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -27,6 +27,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -52,6 +53,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -64,7 +66,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         assert(result)(
           equalTo(
             Some(
-              Options("schema", "output", None, None, None, None, None, None, None, None, None, None, None)
+              Options("schema", "output", None, None, None, None, None, None, None, None, None, None, None, None)
             )
           )
         )
@@ -102,12 +104,40 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
           )
         )
       },
+      test("provide client name") {
+        val input  = List("schema", "output", "--clientName", "GraphqlClient.scala")
+        val result = Options.fromArgs(input)
+        assert(result)(
+          equalTo(
+            Some(
+              Options(
+                "schema",
+                "output",
+                None,
+                None,
+                None,
+                Some("GraphqlClient.scala"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None
+              )
+            )
+          )
+        )
+      },
+
       test("provide effect") {
         val input  = List("schema", "output", "--effect", "cats.effect.IO")
         val result = Options.fromArgs(input)
@@ -117,6 +147,7 @@ object OptionsSpec extends DefaultRunnableSpec {
               Options(
                 "schema",
                 "output",
+                None,
                 None,
                 None,
                 None,
@@ -142,6 +173,7 @@ object OptionsSpec extends DefaultRunnableSpec {
               Options(
                 "schema",
                 "output",
+                None,
                 None,
                 None,
                 None,
@@ -177,6 +209,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 Some(true)
               )
             )
@@ -192,6 +225,7 @@ object OptionsSpec extends DefaultRunnableSpec {
               Options(
                 "schema",
                 "output",
+                None,
                 None,
                 None,
                 None,
@@ -223,6 +257,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 Some(List("a.b.Clazz", "b.c._")),
                 None,
                 None,
@@ -242,6 +277,7 @@ object OptionsSpec extends DefaultRunnableSpec {
               Options(
                 "schema",
                 "output",
+                None,
                 None,
                 None,
                 None,
@@ -269,6 +305,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 "output",
                 Some("fmtPath"),
                 Some(List(Header("aaa", "bbb:ccc"))),
+                None,
                 None,
                 None,
                 None,

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -103,6 +103,7 @@ If you provide a URL for `schemaPath`, you can provide request headers with `--h
 The package of the generated code is derived from the folder of `outputPath`.
 This can be overridden by providing an alternative package with the `--packageName`
 option.
+The generated object name is derived from `outputPath` file name but can be overridden with the `--clientName` option.
 Provide `--genView true` option if you want to generate a view for the GraphQL types. 
 If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
 `--scalarMappings` option. Also you can add imports for example for your ArgEncoder implicits by providing `--imports` option.


### PR DESCRIPTION
Added a new option which defines name of the scala object used for generated client. The current file name semantics is not reliable when generating client to an external location which has no [scala|play|app] in the directory name. packageName works well for it's part but if the file path does not contain [scala|play|app] it will always fallback use Client name even though the file name is Foo.scala.

An explciit option makes it more reliable and independent of the specific file path.

I chose clientName to stay consistent as it is already used in CalibanSettings