### PR TITLE
Adding cli driver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,8 +82,14 @@ lazy val root = project
     clientLaminext,
     tools,
     codegenSbt,
+    cliProject,
     federation
   )
+
+lazy val cliProject = project
+  .in(file("cli"))
+  .settings(publish / skip := true)
+  .dependsOn(tools)
 
 lazy val macros = project
   .in(file("macros"))
@@ -491,3 +497,5 @@ val commonSettings = Def.settings(
     case _            => Nil
   })
 )
+
+addCommandAlias("cli", s"cliProject/run")

--- a/cli/src/main/scala/caliban/cli/Launch.scala
+++ b/cli/src/main/scala/caliban/cli/Launch.scala
@@ -2,13 +2,34 @@ package caliban.codegen
 
 import _root_.caliban.tools.Codegen.GenType
 import _root_.caliban.tools._
+import java.nio.file.{ Path, Paths }
 import zio._
 import zio.config.{ read, ConfigDescriptor, ConfigSource, ReadError }
 import zio.console._
 
+case class MissingGenType(args: List[String]) extends NoSuchElementException {
+  override def toString() = s"MissingGenType(${args.mkString(" ")})"
+}
+
 object Launch extends App {
+  val extractType: List[String] => IO[NoSuchElementException, (GenType, List[String])] = {
+    case "client" +: rest => UIO((GenType.Client, rest))
+    case "schema" +: rest => UIO((GenType.Schema, rest))
+    case args             => ZIO.fail(MissingGenType(args))
+  }
+
+  def mkDirs(path: Path): Task[Unit] =
+    Task(path.toFile.mkdirs).as(())
+
   def run(args: List[String]) = (for {
-    opts  <- ZIO.fromEither(Options.fromArgs(args))
-    files <- Codegen.generate(opts, GenType.Client)
-  } yield ()).catchSome({ case mv: ReadError[_] => putStrLn(mv.toString()) }).exitCode
+    (tpe, rest) <- extractType(args)
+    opts        <- ZIO.fromEither(Options.fromArgs(rest))
+    _           <- mkDirs(Paths.get(opts.toPath).getParent)
+    files       <- Codegen.generate(opts, tpe)
+  } yield ())
+    .catchSome({
+      case mv: ReadError[_]     => putStrLn(mv.toString())
+      case MissingGenType(args) => putStrLn("cli {client|schema} [opts [opts...]]")
+    })
+    .exitCode
 }

--- a/cli/src/main/scala/caliban/cli/Launch.scala
+++ b/cli/src/main/scala/caliban/cli/Launch.scala
@@ -3,11 +3,12 @@ package caliban.codegen
 import _root_.caliban.tools.Codegen.GenType
 import _root_.caliban.tools._
 import zio._
+import zio.config.{ read, ConfigDescriptor, ConfigSource, ReadError }
 import zio.console._
 
 object Launch extends App {
   def run(args: List[String]) = (for {
-    opts  <- ZIO.fromOption(Options.fromArgs(args))
-    files <- Codegen.generate(opts, GenType.Client).asSomeError
-  } yield ()).exitCode
+    opts  <- ZIO.fromEither(Options.fromArgs(args))
+    files <- Codegen.generate(opts, GenType.Client)
+  } yield ()).catchSome({ case mv: ReadError[_] => putStrLn(mv.toString()) }).exitCode
 }

--- a/cli/src/main/scala/caliban/cli/Launch.scala
+++ b/cli/src/main/scala/caliban/cli/Launch.scala
@@ -1,0 +1,13 @@
+package caliban.codegen
+
+import _root_.caliban.tools.Codegen.GenType
+import _root_.caliban.tools._
+import zio._
+import zio.console._
+
+object Launch extends App {
+  def run(args: List[String]) = (for {
+    opts  <- ZIO.fromOption(Options.fromArgs(args))
+    files <- Codegen.generate(opts, GenType.Client).asSomeError
+  } yield ()).exitCode
+}

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
@@ -84,13 +84,13 @@ object CalibanCli {
     genType: GenType
   ): RIO[Console, Unit] =
     Options.fromArgs(args) match {
-      case Some(arguments) =>
+      case Right(arguments) =>
         for {
           _ <- putStrLn(s"Generating code for ${arguments.schemaPath}")
           _ <- Codegen.generate(arguments, genType)
           _ <- putStrLn(s"Code generation done")
         } yield ()
-      case None            => putStrLn(helpMsg)
+      case Left(err)        => putStrLn(helpMsg)
     }
 
   def projectSettings = Seq(commands ++= Seq(genSchemaCommand, genClientCommand))

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
@@ -72,7 +72,7 @@ object CalibanSourceGenerator {
       def generateFileSource(graphql: File, settings: CalibanSettings): IO[Option[Throwable], List[File]] = for {
         generatedSource <- ZIO.succeed(transformFile(sourceRoot, sourceManaged, settings)(graphql))
         _               <- Task(sbt.IO.createDirectory(generatedSource.toPath.getParent.toFile)).asSomeError
-        opts            <- ZIO.fromOption(Some(settings.toOptions(graphql.toString, generatedSource.toString)))
+        opts             = settings.toOptions(graphql.toString, generatedSource.toString)
         files           <- Codegen.generate(opts, GenType.Client).asSomeError
       } yield files
 
@@ -82,7 +82,7 @@ object CalibanSourceGenerator {
             transformFile(sourceRoot, sourceManaged, settings)(new java.io.File(graphql.getPath.stripPrefix("/")))
           )
         _               <- Task(sbt.IO.createDirectory(generatedSource.toPath.getParent.toFile)).asSomeError
-        opts            <- ZIO.fromOption(Some(settings.toOptions(graphql.toString, generatedSource.toString)))
+        opts             = settings.toOptions(graphql.toString, generatedSource.toString)
         files           <- Codegen.generate(opts, GenType.Client).asSomeError
       } yield files
 

--- a/project/ConsoleHelper.scala
+++ b/project/ConsoleHelper.scala
@@ -20,6 +20,7 @@ object ConsoleHelper {
             |${item("test")} - Run the unit test suite
             |${item("fmt")} - Run scalafmt on the entire project
             |${item("scripted")} - Run the scripted test suite
+            |${item("cli")} - Run CLI directly in the sbt shell
             |${item("examples/runMain example.http4s.ExampleApp")} - Start the example server (http4s based)
             |${item("examples/runMain example.akkahttp.ExampleApp")} - Start the example server (akka-http based)
             |${item("benchmarks/jmh:run")} - Run the benchmarks

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -1,6 +1,7 @@
 package caliban.tools
 
 import caliban.tools.Options.Header
+import zio.config.ReadError
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestEnvironment
@@ -13,7 +14,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -39,7 +40,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -65,7 +66,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options("schema", "output", None, None, None, None, None, None, None, None, None, None, None, None)
             )
           )
@@ -74,23 +75,23 @@ object OptionsSpec extends DefaultRunnableSpec {
       test("not enough arguments") {
         val input  = List("schema")
         val result = Options.fromArgs(input)
-        assert(result)(equalTo(None))
+        assert(result)(isLeft(isSubtype[ReadError[Any]](anything)))
       },
       test("--scalafmtPath value missing") {
         val input  = List("schema", "output", "--scalafmtPath", "--headers", "header1:value1,header2:value2")
         val result = Options.fromArgs(input)
-        assert(result)(equalTo(None))
+        assert(result)(isLeft(isSubtype[ReadError[Any]](anything)))
       },
       test("empty list") {
         val result = Options.fromArgs(Nil)
-        assert(result)(equalTo(None))
+        assert(result)(isLeft(isSubtype[ReadError[Any]](anything)))
       },
       test("provide package name") {
         val input  = List("schema", "output", "--packageName", "com.github.ghostdogpr")
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -116,7 +117,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -142,7 +143,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -168,7 +169,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -194,7 +195,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -220,7 +221,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -246,7 +247,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -272,7 +273,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",
@@ -298,7 +299,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         val result = Options.fromArgs(input)
         assert(result)(
           equalTo(
-            Some(
+            Right(
               Options(
                 "schema",
                 "output",


### PR DESCRIPTION
Looking for feedback on if this is a useful development tool, or if it's already provided by something else I haven't seen yet.

Usage:

```
cli ./codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/schema.graphql /tmp/foop/src/main/scala/example/Schema.scala --splitFiles true
```

I also wasn't able to find where in zio-config something like `--help` would be able to be registered, presumably that would only be satisfied by something like `zio-cli` once that reaches maturity. For this reason, I could drop the second commit that exposes underlying errors, as it's unrelated to the primary goal of providing a `cli` driver at the sbt console to aide in iteration.