### PR TITLE
Caliban settings directly to options

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
@@ -69,7 +69,7 @@ object CalibanCli {
 
   private val genClientHelpMsg =
     s"""
-       |calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--genView true|false]
+       |calibanGenClient schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--clientName name] [--genView true|false]
        |
        |This command will create a Scala file in `outputPath` containing client code for all the
        |typed defined in the provided GraphQL schema defined at `schemaPath`. Instead of a path,

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
@@ -22,20 +22,20 @@ sealed trait CalibanSettings {
   def append(other: Type): Type
 
   def toOptions(schemaPath: String, toPath: String) = Options(
-    schemaPath=schemaPath,
-    toPath=toPath,
-    fmtPath=scalafmtPath,
-    headers=Option(headers.map((Options.Header.apply _).tupled).toList).filter(_.nonEmpty),
-    packageName=packageName,
-    clientName=clientName,
-    genView=genView,
-    effect=Option.empty,
-    scalarMappings=Option(scalarMappings.toMap).filter(_.nonEmpty),
-    imports=Option(imports.toList).filter(_.nonEmpty),
-    abstractEffectType=Option.empty,
-    splitFiles=splitFiles,
-    enableFmt=enableFmt,
-    extensibleEnums=extensibleEnums
+    schemaPath = schemaPath,
+    toPath = toPath,
+    fmtPath = scalafmtPath,
+    headers = Option(headers.map((Options.Header.apply _).tupled).toList).filter(_.nonEmpty),
+    packageName = packageName,
+    clientName = clientName,
+    genView = genView,
+    effect = Option.empty,
+    scalarMappings = Option(scalarMappings.toMap).filter(_.nonEmpty),
+    imports = Option(imports.toList).filter(_.nonEmpty),
+    abstractEffectType = Option.empty,
+    splitFiles = splitFiles,
+    enableFmt = enableFmt,
+    extensibleEnums = extensibleEnums
   )
 }
 

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
@@ -1,5 +1,7 @@
 package caliban.codegen
 
+import caliban.tools.Options
+
 import java.io.File
 import java.net.URL
 
@@ -18,6 +20,23 @@ sealed trait CalibanSettings {
   def extensibleEnums: Option[Boolean]
 
   def append(other: Type): Type
+
+  def toOptions(schemaPath: String, toPath: String) = Options(
+    schemaPath=schemaPath,
+    toPath=toPath,
+    fmtPath=scalafmtPath,
+    headers=Option(headers.map((Options.Header.apply _).tupled).toList).filter(_.nonEmpty),
+    packageName=packageName,
+    clientName=clientName,
+    genView=genView,
+    effect=Option.empty,
+    scalarMappings=Option(scalarMappings.toMap).filter(_.nonEmpty),
+    imports=Option(imports.toList).filter(_.nonEmpty),
+    abstractEffectType=Option.empty,
+    splitFiles=splitFiles,
+    enableFmt=enableFmt,
+    extensibleEnums=extensibleEnums
+  )
 }
 
 case class CalibanFileSettings(

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
@@ -58,47 +58,6 @@ object CalibanSourceGenerator {
           }
       )
 
-  def renderArgs(settings: CalibanSettings): List[String] = {
-    def singleOpt(opt: String, value: Option[String]): List[String]        =
-      if (value.nonEmpty) {
-        opt :: value.toList
-      } else Nil
-    def pairList(opt: String, values: Seq[(String, String)]): List[String] =
-      if (values.nonEmpty) {
-        opt :: values.map({ case (fst, snd) => s"$fst:$snd" }).mkString(",") :: Nil
-      } else Nil
-    def list(opt: String, values: Seq[String]): List[String]               =
-      if (values.nonEmpty) {
-        opt :: values.mkString(",") :: Nil
-      } else Nil
-    val scalafmtPath                                                       = singleOpt("--scalafmtPath", settings.scalafmtPath)
-    val headers                                                            = pairList("--headers", settings.headers)
-    val packageName                                                        = singleOpt(
-      "--packageName",
-      settings.packageName
-    )
-
-    val genView = singleOpt(
-      "--genView",
-      settings.genView.map(_.toString())
-    ) // NB: Presuming zio-config can read toString'd booleans
-    val scalarMappings = pairList("--scalarMappings", settings.scalarMappings)
-    val imports        = list("--imports", settings.imports)
-    val splitFiles     = singleOpt(
-      "--splitFiles",
-      settings.splitFiles.map(_.toString())
-    ) // NB: Presuming zio-config can read toString'd booleans
-    val enableFmt = singleOpt(
-      "--enableFmt",
-      settings.enableFmt.map(_.toString())
-    ) // NB: Presuming zio-config can read toString'd booleans
-    val extensibleEnums = singleOpt(
-      "--extensibleEnums",
-      settings.extensibleEnums.map(_.toString())
-    ) // NB: Presuming zio-config can read toString'd booleans
-    scalafmtPath ++ headers ++ packageName ++ genView ++ scalarMappings ++ imports ++ splitFiles ++ enableFmt ++ extensibleEnums
-  }
-
   def apply(
     sourceRoot: File,
     sources: Seq[File],

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
@@ -13,7 +13,7 @@ object CalibanSourceGenerator {
 
   import sjsonnew.{ :*:, LList, LNil }
 
-  case class TrackedSettings(arguments: Seq[Seq[String]])
+  case class TrackedSettings(arguments: Seq[String])
   object TrackedSettings {
     import _root_.sbt.util.CacheImplicits._
 
@@ -23,10 +23,10 @@ object CalibanSourceGenerator {
       urlSettings: Seq[CalibanUrlSettings]
     ): TrackedSettings = {
       val allSettings: Seq[CalibanSettings] = sources.toList.map(collectSettingsFor(fileSettings, _)) ++ urlSettings
-      TrackedSettings(allSettings.map(renderArgs))
+      TrackedSettings(allSettings.map(_.toString))
     }
 
-    implicit val analysisIso = LList.iso[TrackedSettings, Seq[Seq[String]] :*: LNil](
+    implicit val analysisIso = LList.iso[TrackedSettings, Seq[String] :*: LNil](
       { case TrackedSettings(arguments) => ("args", arguments) :*: LNil },
       { case ((_, args) :*: LNil) => TrackedSettings(args) }
     )

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
@@ -113,7 +113,7 @@ object CalibanSourceGenerator {
       def generateFileSource(graphql: File, settings: CalibanSettings): IO[Option[Throwable], List[File]] = for {
         generatedSource <- ZIO.succeed(transformFile(sourceRoot, sourceManaged, settings)(graphql))
         _               <- Task(sbt.IO.createDirectory(generatedSource.toPath.getParent.toFile)).asSomeError
-        opts            <- ZIO.fromOption(Options.fromArgs(graphql.toString :: generatedSource.toString :: renderArgs(settings)))
+        opts            <- ZIO.fromOption(Some(settings.toOptions(graphql.toString, generatedSource.toString)))
         files           <- Codegen.generate(opts, GenType.Client).asSomeError
       } yield files
 
@@ -123,7 +123,7 @@ object CalibanSourceGenerator {
             transformFile(sourceRoot, sourceManaged, settings)(new java.io.File(graphql.getPath.stripPrefix("/")))
           )
         _               <- Task(sbt.IO.createDirectory(generatedSource.toPath.getParent.toFile)).asSomeError
-        opts            <- ZIO.fromOption(Options.fromArgs(graphql.toString :: generatedSource.toString :: renderArgs(settings)))
+        opts            <- ZIO.fromOption(Some(settings.toOptions(graphql.toString, generatedSource.toString)))
         files           <- Codegen.generate(opts, GenType.Client).asSomeError
       } yield files
 

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -21,7 +21,7 @@ object Codegen {
   ): Task[List[File]] = {
     val s                  = ".*/[scala|play.*|app][^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
     val packageName        = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
-    val objectName         = s.map(_.group(2)).getOrElse("Client")
+    val objectName         = arguments.clientName.orElse(s.map(_.group(2))).getOrElse("Client")
     val abstractEffectType = arguments.abstractEffectType.getOrElse(false)
     val effect             = arguments.effect.getOrElse {
       if (abstractEffectType) "F" else "zio.UIO"

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -9,6 +9,7 @@ final case class Options(
   fmtPath: Option[String],
   headers: Option[List[Options.Header]],
   packageName: Option[String],
+  clientName: Option[String],
   genView: Option[Boolean],
   effect: Option[String],
   scalarMappings: Option[Map[String, String]],
@@ -25,6 +26,7 @@ object Options {
     scalafmtPath: Option[String],
     headers: Option[List[String]],
     packageName: Option[String],
+    clientName: Option[String],
     genView: Option[Boolean],
     effect: Option[String],
     scalarMappings: Option[List[String]],
@@ -60,6 +62,7 @@ object Options {
               }
             },
             rawOpts.packageName,
+            rawOpts.clientName,
             rawOpts.genView,
             rawOpts.effect,
             rawOpts.scalarMappings.map {

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -137,7 +137,6 @@ object OptionsSpec extends DefaultRunnableSpec {
           )
         )
       },
-
       test("provide effect") {
         val input  = List("schema", "output", "--effect", "cats.effect.IO")
         val result = Options.fromArgs(input)

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -27,6 +27,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -52,6 +53,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -64,7 +66,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         assert(result)(
           equalTo(
             Some(
-              Options("schema", "output", None, None, None, None, None, None, None, None, None, None, None)
+              Options("schema", "output", None, None, None, None, None, None, None, None, None, None, None, None)
             )
           )
         )
@@ -102,12 +104,40 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
           )
         )
       },
+      test("provide client name") {
+        val input  = List("schema", "output", "--clientName", "GraphqlClient.scala")
+        val result = Options.fromArgs(input)
+        assert(result)(
+          equalTo(
+            Some(
+              Options(
+                "schema",
+                "output",
+                None,
+                None,
+                None,
+                Some("GraphqlClient.scala"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None
+              )
+            )
+          )
+        )
+      },
+
       test("provide effect") {
         val input  = List("schema", "output", "--effect", "cats.effect.IO")
         val result = Options.fromArgs(input)
@@ -117,6 +147,7 @@ object OptionsSpec extends DefaultRunnableSpec {
               Options(
                 "schema",
                 "output",
+                None,
                 None,
                 None,
                 None,
@@ -142,6 +173,7 @@ object OptionsSpec extends DefaultRunnableSpec {
               Options(
                 "schema",
                 "output",
+                None,
                 None,
                 None,
                 None,
@@ -177,6 +209,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 Some(true)
               )
             )
@@ -192,6 +225,7 @@ object OptionsSpec extends DefaultRunnableSpec {
               Options(
                 "schema",
                 "output",
+                None,
                 None,
                 None,
                 None,
@@ -223,6 +257,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 Some(List("a.b.Clazz", "b.c._")),
                 None,
                 None,
@@ -242,6 +277,7 @@ object OptionsSpec extends DefaultRunnableSpec {
               Options(
                 "schema",
                 "output",
+                None,
                 None,
                 None,
                 None,
@@ -269,6 +305,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 "output",
                 Some("fmtPath"),
                 Some(List(Header("aaa", "bbb:ccc"))),
+                None,
                 None,
                 None,
                 None,

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -103,6 +103,7 @@ If you provide a URL for `schemaPath`, you can provide request headers with `--h
 The package of the generated code is derived from the folder of `outputPath`.
 This can be overridden by providing an alternative package with the `--packageName`
 option.
+The generated object name is derived from `outputPath` file name but can be overridden with the `--clientName` option.
 Provide `--genView true` option if you want to generate a view for the GraphQL types. 
 If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
 `--scalarMappings` option. Also you can add imports for example for your ArgEncoder implicits by providing `--imports` option.


### PR DESCRIPTION
Basing this on #992 to reduce merge conflicts, but just implementing [my comment from that issue](https://github.com/ghostdogpr/caliban/pull/992#issuecomment-894833065) wherein it would be more ideal to just emit the `Options` direction out of `CalibanSettings` instead of round-tripping through the CLI parser unnecessarily.