### PR TITLE
Support Short schemas and args

### DIFF
--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -11,7 +11,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound(
   """Cannot find an ArgEncoder for type ${A}.
-     
+
 Caliban needs it to know how to encode arguments of type ${A}.
 """
 )
@@ -22,6 +22,8 @@ trait ArgEncoder[-A] { self =>
 }
 
 object ArgEncoder {
+
+  implicit val short: ArgEncoder[Short] = (value: Short) => __NumberValue(value)
 
   implicit val int: ArgEncoder[Int] = (value: Int) => __NumberValue(value)
 

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -23,7 +23,8 @@ trait ArgEncoder[-A] { self =>
 
 object ArgEncoder {
 
-  implicit val short: ArgEncoder[Short] = (value: Short) => __NumberValue(value)
+  // In Scala3 there does not appear to be a short2bigDecimal implicit conversion.
+  implicit val short: ArgEncoder[Short] = (value: Short) => __NumberValue(value.toInt)
 
   implicit val int: ArgEncoder[Int] = (value: Int) => __NumberValue(value)
 

--- a/client/src/main/scala/caliban/client/ScalarDecoder.scala
+++ b/client/src/main/scala/caliban/client/ScalarDecoder.scala
@@ -14,7 +14,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound(
   """Cannot find a ScalarDecoder for type ${A}.
-     
+
 Caliban needs it to know how to decode a scalar of type ${A}.
 """
 )
@@ -23,6 +23,10 @@ trait ScalarDecoder[+A] {
 }
 
 object ScalarDecoder {
+  implicit val short: ScalarDecoder[Short]           = {
+    case __NumberValue(value) => Right(value.toShort)
+    case other                => Left(DecodingError(s"Can't build a Short from input $other"))
+  }
   implicit val int: ScalarDecoder[Int]               = {
     case __NumberValue(value) =>
       Try(value.toIntExact).toEither.left.map(ex => DecodingError(s"Can't build an Int from input $value", Some(ex)))

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -243,6 +243,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
   implicit val booleanSchema: Schema[Any, Boolean]       = scalarSchema("Boolean", None, BooleanValue.apply)
   implicit val stringSchema: Schema[Any, String]         = scalarSchema("String", None, StringValue.apply)
   implicit val uuidSchema: Schema[Any, UUID]             = scalarSchema("ID", None, uuid => StringValue(uuid.toString))
+  implicit val shortSchema: Schema[Any, Short]           = scalarSchema("Short", None, IntValue(_))
   implicit val intSchema: Schema[Any, Int]               = scalarSchema("Int", None, IntValue(_))
   implicit val longSchema: Schema[Any, Long]             = scalarSchema("Long", None, IntValue(_))
   implicit val bigIntSchema: Schema[Any, BigInt]         = scalarSchema("BigInt", None, IntValue(_))


### PR DESCRIPTION
I ran into a situation where I had a `Short` type that I needed a schema for, but Caliban didn't have one. This PR adds one which is implemented as a Scalar, along with an `ArgBuilder` for it. Few notes:

* My editor automatically trims training whitespace on save, so there are some whitespace changes. I am happy to remove them if you would like.
* I didn't see any specific tests for schemas so I didn't add any, but if you point me in the right direction I can add them.
* Let me know how to update docs. I think I only need to add the row to the table on [the schema page](https://ghostdogpr.github.io/caliban/docs/schema.html#enums-unions-interfaces), but I wasn't sure if the docs HTML checked in was automatically generated or not.