### PR TITLE
fix: Run onInit concurrently with the regular response

### DIFF
--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -161,7 +161,7 @@ object ZHttpAdapter {
                 ZStream.fromEffect(onInit(payload)).drain.catchAll(toStreamError(id, _))
               case _                             => Stream.empty
             }
-            callback ++ response
+            ZStream.mergeAllUnbounded()(response, callback)
 
           case GraphQLWSRequest("connection_terminate", _, _) => close
           case GraphQLWSRequest("start", id, payload)         =>


### PR DESCRIPTION
This was an oversight on my part, otherwise it becomes problematic to do things like delayed shutdowns since we'll delay the sending of the heartbeats until we're supposed to shut down (i.e via `ZIO.halt(Cause.empty)`).