### PR TITLE
fix(zhttp): Allow authorization to finish running before accepting the request

### DIFF
--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -57,8 +57,26 @@ object ZHttpAdapter {
   object Callbacks {
     def empty[R, E] = Callbacks[R, E](None, None)
 
-    def init[R, E](f: io.circe.Json => ZIO[R, E, Any]): Callbacks[R, E]               = Callbacks(Some(f), None, None)
-    def afterInit[R, E](f: ZIO[R, E, Any]): Callbacks[R, E]                           = Callbacks(None, Some(f), None)
+    /**
+     * Specifies a callback that will be run before an incoming subscription
+     * request is accepted. Useful for e.g authorizing the incoming subscription
+     * before accepting it.
+     */
+    def init[R, E](f: io.circe.Json => ZIO[R, E, Any]): Callbacks[R, E] = Callbacks(Some(f), None, None)
+
+    /**
+     * Specifies a callback that will be run after an incoming subscription
+     * request has been accepted. Useful for e.g terminating a subscription
+     * after some time, such as authorization expiring.
+     */
+    def afterInit[R, E](f: ZIO[R, E, Any]): Callbacks[R, E] = Callbacks(None, Some(f), None)
+
+    /**
+     * Specifies a callback that will be run on the resulting `ZStream`
+     * for every active subscription. Useful to e.g modify the environment
+     * to inject session information into the `ZStream` handling the
+     * subscription.
+     */
     def message[R, E](f: ZStream[R, E, Text] => ZStream[R, E, Text]): Callbacks[R, E] = Callbacks(None, None, Some(f))
   }
 

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -27,15 +27,22 @@ object ZHttpAdapter {
   }
 
   case class Callbacks[R, E](
-    onInit: Option[io.circe.Json => ZIO[R, E, Any]] = None,
+    beforeInit: Option[io.circe.Json => ZIO[R, E, Any]] = None,
+    afterInit: Option[ZIO[R, E, Any]] = None,
     onMessage: Option[ZStream[R, E, Text] => ZStream[R, E, Text]] = None
   ) { self =>
     def ++(other: Callbacks[R, E]): Callbacks[R, E] =
       Callbacks(
-        onInit = (self.onInit, other.onInit) match {
+        beforeInit = (self.beforeInit, other.beforeInit) match {
           case (None, Some(f))      => Some(f)
           case (Some(f), None)      => Some(f)
           case (Some(f1), Some(f2)) => Some((x: io.circe.Json) => f1(x) *> f2(x))
+          case _                    => None
+        },
+        afterInit = (self.afterInit, other.afterInit) match {
+          case (None, Some(f))      => Some(f)
+          case (Some(f), None)      => Some(f)
+          case (Some(f1), Some(f2)) => Some(f1 &> f2)
           case _                    => None
         },
         onMessage = (self.onMessage, other.onMessage) match {
@@ -50,8 +57,9 @@ object ZHttpAdapter {
   object Callbacks {
     def empty[R, E] = Callbacks[R, E](None, None)
 
-    def init[R, E](f: io.circe.Json => ZIO[R, E, Any]): Callbacks[R, E]               = Callbacks(Some(f), None)
-    def message[R, E](f: ZStream[R, E, Text] => ZStream[R, E, Text]): Callbacks[R, E] = Callbacks(None, Some(f))
+    def init[R, E](f: io.circe.Json => ZIO[R, E, Any]): Callbacks[R, E]               = Callbacks(Some(f), None, None)
+    def afterInit[R, E](f: ZIO[R, E, Any]): Callbacks[R, E]                           = Callbacks(None, Some(f), None)
+    def message[R, E](f: ZStream[R, E, Text] => ZStream[R, E, Text]): Callbacks[R, E] = Callbacks(None, None, Some(f))
   }
 
   type Subscriptions = Ref[Map[String, Promise[Any, Unit]]]
@@ -155,13 +163,20 @@ object ZHttpAdapter {
         .fromEffect(ZIO.fromEither(decode[GraphQLWSRequest](text)))
         .collect({
           case GraphQLWSRequest("connection_init", id, payload) =>
-            val response = connectionAck ++ keepAlive(keepAliveTime)
-            val callback = (callbacks.onInit, payload) match {
-              case (Some(onInit), Some(payload)) =>
-                ZStream.fromEffect(onInit(payload)).drain.catchAll(toStreamError(id, _))
-              case _                             => Stream.empty
+            val before = (callbacks.beforeInit, payload) match {
+              case (Some(beforeInit), Some(payload)) =>
+                ZStream.fromEffect(beforeInit(payload)).drain.catchAll(toStreamError(id, _))
+              case _                                 => Stream.empty
             }
-            ZStream.mergeAllUnbounded()(response, callback)
+
+            val response = connectionAck ++ keepAlive(keepAliveTime)
+
+            val after = callbacks.afterInit match {
+              case Some(afterInit) => ZStream.fromEffect(afterInit).drain.catchAll(toStreamError(id, _))
+              case _               => Stream.empty
+            }
+
+            before ++ ZStream.mergeAllUnbounded()(response, after)
 
           case GraphQLWSRequest("connection_terminate", _, _) => close
           case GraphQLWSRequest("start", id, payload)         =>

--- a/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
@@ -35,15 +35,7 @@ object Auth {
   object WebSockets {
     val wsSession = Http.fromEffect(Ref.make[String]("unknown"))
 
-    // Simulate closing the socket after some time has passed due to e.g
-    // the session expiring.
-    def close(session: Ref[String]) = SocketApp.open(
-      Socket.fromFunction[SocketApp.Connection](_ =>
-        ZStream.fromEffect(ZIO.sleep(10.seconds)).drain ++ ZStream.halt(Cause.empty)
-      )
-    )
-
-    def live[R <: Has[Auth]](interpreter: GraphQLInterpreter[R, CalibanError]) =
+    def live[R <: Has[Auth] with Clock](interpreter: GraphQLInterpreter[R, CalibanError]) =
       wsSession.flatMap { session =>
         val auth = new Auth {
           def currentUser: ZIO[Any, Throwable, String]        = session.get
@@ -55,12 +47,14 @@ object Auth {
             .fromEither(payload.hcursor.downField("Authorization").as[String])
             .mapError(_ => CalibanError.ExecutionError("Unable to decode payload"))
             .flatMap(user => ZIO.service[Auth].flatMap(_.setUser(user).orDie))
-        ) ++ ZHttpAdapter.Callbacks.message(stream => stream.updateService[Auth](_ => auth))
+        ) ++
+          ZHttpAdapter.Callbacks.afterInit(ZIO.sleep(10.seconds) *> ZIO.halt(Cause.empty)) ++
+          ZHttpAdapter.Callbacks
+            .message(stream => stream.updateService[Auth](_ => auth))
 
         HttpApp.responseM(
           ZHttpAdapter
             .makeWebSocketHandler(interpreter, callbacks = callbacks)
-            .map(_ ++ close(session))
             .map(_.asResponse)
         )
       }


### PR DESCRIPTION
Sorry about all the PRs, you discover more things are you build on top of it incrementally...

There's an issue with the current implementation if authorizing a request takes a while (e.g happens asynchronously) that I missed in my previous PR. If auth is delayed, we need to delay accepting the request until it's finished running. Otherwise the user may start issuing requests without a proper session established (even though we told her that auth was successful).

I also realized that closing the connection very likely depends on the session being available since it's likely one needs to know when it expires.

This runs the first callback synchronously and adds an additional callback that can run after the connection has been authenticated, concurrently with the heartbeats.