### PR TITLE
add http linking to an example of Caliban using play's route file

### DIFF
--- a/vuepress/docs/docs/examples.md
+++ b/vuepress/docs/docs/examples.md
@@ -3,6 +3,7 @@ The [examples](https://github.com/ghostdogpr/caliban/tree/master/examples/) proj
 - [GraphQL API exposed with http4s](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/http4s)
 - [GraphQL API exposed with Akka HTTP](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/akkahttp)
 - [GraphQL API exposed with play](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/play)
+- [GraphQL API exposed with play's route file](https://github.com/rlavolee/caliban-play-with-route-file)
 - [GraphQL API exposed with zio-http](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/ziohttp)
 - [GraphQL Client usage](https://github.com/ghostdogpr/caliban/tree/master/examples/src/main/scala/example/client)
 - [GraphQL Client integration with Laminext](https://github.com/ghostdogpr/caliban/tree/master/client-laminext/src/test/scala/caliban/client/laminext)


### PR DESCRIPTION
You'll find in the following example how to use Caliban with Play's route file.
I hope it helps in any ways.