### PR TITLE
fix: Handle additional default value edge cases

### DIFF
--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -12,6 +12,7 @@ import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
 import caliban.parsing.adt.Definition.TypeSystemDefinition.{ DirectiveDefinition, SchemaDefinition, TypeDefinition }
 import caliban.parsing.adt.Type.{ ListType, NamedType }
 import caliban.parsing.adt.{ Directive, Document, Type }
+import io.circe.parser.decode
 import sttp.client3._
 import sttp.client3.asynchttpclient.zio._
 import sttp.model.Uri
@@ -54,7 +55,7 @@ object IntrospectionClient {
     `type`: Type,
     defaultValue: Option[String]
   ): InputValueDefinition = {
-    val default = defaultValue.flatMap(v => Parser.parseInputValue(v).toOption)
+    val default = defaultValue.flatMap(v => decode[InputValue](v).toOption)
     InputValueDefinition(description, name, `type`, default, Nil)
   }
 


### PR DESCRIPTION
Realized adding default values broke the stitching example since there were a couple of edge cases we didn't properly handle.

1. When we get an enum value from introspection it'll be a string so we need to accept string values
2. `null` is a valid value for any scalar since the `NON_NULL` is handled before dealing with the scalar itself.

I've verified that we now support the full GitHub API again, which is quite comprehensive.