### PR TITLE
fix: Object value formatting

### DIFF
--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -11,7 +11,7 @@ object InputValue extends ValueJsonCompat {
   }
   case class ObjectValue(fields: Map[String, InputValue]) extends InputValue {
     override def toString: String =
-      fields.map { case (name, value) => s""""$name":${value.toString}""" }.mkString("{", ",", "}")
+      fields.map { case (name, value) => s"""$name:${value.toString}""" }.mkString("{", ",", "}")
   }
   case class VariableValue(name: String)                  extends InputValue {
     override def toString: String = s"$$$name"

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -5,13 +5,13 @@ import caliban.Value.StringValue
 import caliban.client.IntrospectionClient._
 import caliban.client.Operations.RootQuery
 import caliban.client.{ CalibanClientError, SelectionBuilder }
+import caliban.parsing.Parser
 import caliban.parsing.SourceMapper
 import caliban.parsing.adt.Definition.TypeSystemDefinition.DirectiveLocation._
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
 import caliban.parsing.adt.Definition.TypeSystemDefinition.{ DirectiveDefinition, SchemaDefinition, TypeDefinition }
 import caliban.parsing.adt.Type.{ ListType, NamedType }
 import caliban.parsing.adt.{ Directive, Document, Type }
-import io.circe.parser.decode
 import sttp.client3._
 import sttp.client3.asynchttpclient.zio._
 import sttp.model.Uri
@@ -54,7 +54,7 @@ object IntrospectionClient {
     `type`: Type,
     defaultValue: Option[String]
   ): InputValueDefinition = {
-    val default = defaultValue.flatMap(v => decode[InputValue](v).toOption)
+    val default = defaultValue.flatMap(v => Parser.parseInputValue(v).toOption)
     InputValueDefinition(description, name, `type`, default, Nil)
   }
 


### PR DESCRIPTION
So I realized I got tricked [here](https://github.com/ghostdogpr/caliban/commit/03f12971c8f89b686bb3ea759afe5c2c5f2224c4#diff-bea012702f7958b3ed30e0075bcdae8b37763ba141bd7244365e3e946a131ba3L57) yesterday. The issue wasn't that the values are JSON (which they cannot be) but I got tripped up by the error I got.

From the spec:

> defaultValue may return a String encoding (using the GraphQL language) of the default value used by this input value in the condition a value is not provided at runtime. If this input value has no default value, returns null.

So our usage of `Parser` was correct. However, when we encode the `ObjectValue` we wrap fields in `"`, which [isn't allowed per the spec](https://spec.graphql.org/June2018/#sec-Input-Object-Values): 

> Input object literal values are unordered lists of keyed input values wrapped in curly‐braces { }. The values of an object literal may be any input value literal or variable (ex. { name: "Hello world", score: 1.0 }). We refer to literal representation of input objects as “object literals.”

So this reverts back to using the `Parser` as before but fixing `toString` on `ObjectValue`.

I'm not sure exactly where `toString` is used so this feels a tad scary, but all tests pass.