### PR TITLE
Fix "quantum execution"

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CompileTimeCalibanPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CompileTimeCalibanPlugin.scala
@@ -151,8 +151,7 @@ object CompileTimeCalibanServerPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Def.Setting[_]] =
     Seq(
       libraryDependencies += "com.github.ghostdogpr" %% "caliban-tools" % caliban.codegen.BuildInfo.version % Compile,
-      (Compile / sourceGenerators) += Compile / ctCalibanServer / ctCalibanServerGenerate,
-      (Test / sourceGenerators) += Test / ctCalibanServer / ctCalibanServerGenerate
+      (Compile / sourceGenerators) += Compile / ctCalibanServer / ctCalibanServerGenerate
     ) ++ inConfig(Compile)(pluginSettings) ++ inConfig(Test)(pluginSettings)
 }
 
@@ -343,8 +342,7 @@ object CompileTimeCalibanClientPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Def.Setting[_]] =
     Seq(
       libraryDependencies += "com.github.ghostdogpr" %% "caliban-client" % BuildInfo.version,
-      (Compile / sourceGenerators) += Compile / ctCalibanClient / ctCalibanClientGenerate,
-      (Test / sourceGenerators) += Test / ctCalibanClient / ctCalibanClientGenerate
+      (Compile / sourceGenerators) += Compile / ctCalibanClient / ctCalibanClientGenerate
     ) ++ inConfig(Compile)(pluginSettings) ++ inConfig(Test)(pluginSettings)
 
 }


### PR DESCRIPTION
When adding the plugin to a project and generating some code, **both** branches of the initial `if` of the `ctCalibanClientGenerate` task (ie. `if (clientsSettings.isEmpty)`) are executed.

Same problem for the `ctCalibanServerGenerate` task (ie. `if (pluginSettings.isEmpty)`).

You can see such "quantum execution" in this CI run for example: https://github.com/guizmaii/poc_compile_time_caliban_client_generation/runs/3787502945?check_suite_focus=true

I copy here the output of this CI task so you don't have to go see it there:
```scala
[success] Total time: 0 s, completed Oct 4, 2021, 6:51:20 AM
[error] Missing configuration for the "CompileTimeCalibanServerPlugin" plugin.
[error] 
[error] You need to configure the `Compile / ctCalibanServer / ctCalibanServerSettings` setting.
[error] 
[error] Here's an example of configuration:
[error] ```
[error] lazy val server =
[error]   project
[error]     .in(file("modules/server"))
[error]     .enablePlugins(CompileTimeCalibanServerPlugin)
[error]     .settings(
[error]       Compile / ctCalibanServer / ctCalibanServerSettings +=
[error]         "io.example.server.GraphQLApi.api" ->
[error]           ClientGenerationSettings(
[error]             packageName = "io.example.client.generated",
[error]             clientName = "CalibanClient",
[error]           )
[error]     )
[error] ```
[error] 
[error] See documentation for more details: (TODO Add link)
[info] compiling 3 Scala sources to /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/potatoes/target/scala-2.13/classes ...
[info] Non-compiled module 'compiler-bridge_2.13' for Scala 2.13.6. Compiling...
[error] Missing configuration for the "CompileTimeCalibanClientPlugin" plugin.
[error] 
[error] You need to configure the `Compile / ctCalibanClient / ctCalibanClientsSettings` setting.
[error] 
[error] Here's an example of configuration:
[error] ```
[error] lazy val server =
[error]   project
[error]     .in(file("modules/server"))
[error]     .enablePlugins(CompileTimeCalibanServerPlugin)
[error]     .settings(
[error]       Compile / ctCalibanServer / ctCalibanServerSettings +=
[error]         "io.example.server.GraphQLApi.api" ->
[error]           ClientGenerationSettings(
[error]             packageName = "io.example.client.generated",
[error]             clientName = "CalibanClient",
[error]           )
[error]     )
[error] 
[error] lazy val calibanClients =
[error]   project
[error]     .withId("caliban-clients")
[error]     .in(file("modules/caliban-clients"))
[error]     .enablePlugins(CompileTimeCalibanClientPlugin)
[error]     .settings(
[error]       Compile / ctCalibanClient / ctCalibanClientsSettings := Seq(server)
[error]     )
[error] ```
[error] 
[error] See documentation for more details: (TODO Add link)
[info] ctCalibanClient - Starting to generate...
[error] Missing configuration for the "CompileTimeCalibanServerPlugin" plugin.
[error] 
[error] You need to configure the `Compile / ctCalibanServer / ctCalibanServerSettings` setting.
[error] 
[error] Here's an example of configuration:
[error] ```
[error] lazy val server =
[error]   project
[error]     .in(file("modules/server"))
[error]     .enablePlugins(CompileTimeCalibanServerPlugin)
[error]     .settings(
[error]       Compile / ctCalibanServer / ctCalibanServerSettings +=
[error]         "io.example.server.GraphQLApi.api" ->
[error]           ClientGenerationSettings(
[error]             packageName = "io.example.client.generated",
[error]             clientName = "CalibanClient",
[error]           )
[error]     )
[error] ```
[error] 
[error] See documentation for more details: (TODO Add link)
[info] compiling 5 Scala sources to /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/posts/target/scala-2.13/classes ...
[info]   Compilation completed in 13.004s.
[info] done compiling
[info] done compiling
[warn] multiple main classes detected: run 'show discoveredMainClasses' to see the list
[info] compiling 1 Scala source to /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/app/target/scala-2.13/classes ...
[info] running caliban.generator.CalibanClientGenerator_1 /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/caliban-clients
[info] running caliban.generator.CalibanClientGenerator_0 /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/caliban-clients
[info] running caliban.generator.CalibanClientGenerator_2 /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/caliban-clients
[info] running caliban.generator.CalibanClientGenerator_0 /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/caliban-clients
[info] done compiling
parsed config (v2.7.5): .scalafmt.conf
parsed config (v2.7.5): .scalafmt.conf
parsed config (v2.7.5): .scalafmt.conf
parsed config (v2.7.5): .scalafmt.conf
[info] ctCalibanClient - Generation done!
[info] compiling 22 Scala sources to /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/caliban-clients/target/scala-2.13/classes ...
[info] done compiling
[info] compiling 2 Scala sources to /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/clients/target/scala-2.13/classes ...
[info] compiling 1 Scala source to /home/runner/work/poc_compile_time_caliban_client_generation/poc_compile_time_caliban_client_generation/modules/app/target/scala-2.13/test-classes ...
[info] done compiling
[info] done compiling
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[info] + Server Spec
[info]   + Caliban server Spec
[info]     + truthiness
[info]     + Create a post returns a 200
[info]     + Fetch a non existing post returns None
[info]     + Fetch an existing post returns Some(_)
[info] Ran 4 tests in 5 s 838 ms: 4 succeeded, 0 ignored, 0 failed
[info] No tests were executed
[success] Total time: 62 s (01:02), completed Oct 4, 2021, 6:52:22 AM
```

As you can see it prints the helper messages of the plugin AND succeed it execute the plugin. That shouldn't be possible.