### PR TITLE
`CalibanPlugin` should only be active when explicitly enabled

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanPlugin.scala
@@ -1,10 +1,11 @@
 package caliban.codegen
 
-import sbt._
 import sbt.Keys._
+import sbt._
 
 object CalibanPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
+  override def trigger  = noTrigger
 
   object autoImport extends CalibanKeys
   import autoImport._


### PR DESCRIPTION
When I added the `addSbtPlugin("com.github.ghostdogpr"     % "caliban-codegen-sbt"  % "1.2.0")` dependency in my project, I had a name conflict in my sbt definition because I was having something named `caliban` and the `CalibanPlugin` was also bringing a key named like this while I'm not using this plugin.