### PR TITLE
Add missing `final` in generated case classes

### DIFF
--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -509,7 +509,7 @@ object ClientWriter {
     typedef: InputObjectTypeDefinition
   )(implicit mappingClashedTypeNames: MappingClashedTypeNames, scalarMappings: ScalarMappings): String = {
     val inputObjectName = safeTypeName(typedef.name)
-    s"""case class $inputObjectName(${writeArgumentFields(typedef.fields)})
+    s"""final case class $inputObjectName(${writeArgumentFields(typedef.fields)})
        |object $inputObjectName {
        |  implicit val encoder: ArgEncoder[$inputObjectName] = new ArgEncoder[$inputObjectName] {
        |    override def encode(value: $inputObjectName): __Value =
@@ -560,7 +560,7 @@ object ClientWriter {
       .map(v =>
         s"case object ${safeEnumValue(v.enumValue)} extends $enumName { val value: String = ${"\"" + safeEnumValue(v.enumValue) + "\""} }"
       ) ++
-      (if (extensibleEnums) Some(s"case class __Unknown(value: String) extends $enumName") else None)
+      (if (extensibleEnums) Some(s"final case class __Unknown(value: String) extends $enumName") else None)
 
     val decoderCases = typedef.enumValuesDefinition
       .map(v => s"""case __StringValue ("${v.enumValue}") => Right($enumName.${safeEnumValue(v.enumValue)})""") ++

--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -109,7 +109,7 @@ object SchemaWriter {
   ): String = {
     val typeParamOrEmpty = if (isEffectTypeAbstract) s"[$effect[_]]" else ""
     s"""
-       |${writeDescription(op.description)}case class ${op.name}$typeParamOrEmpty(
+       |${writeDescription(op.description)}final case class ${op.name}$typeParamOrEmpty(
        |${op.fields.map(c => writeRootField(c, op, effect)).mkString(",\n")}
        |)""".stripMargin
 
@@ -125,17 +125,17 @@ object SchemaWriter {
 
   def writeRootSubscriptionDef(op: ObjectTypeDefinition)(implicit scalarMappings: ScalarMappings): String =
     s"""
-       |${writeDescription(op.description)}case class ${op.name}(
+       |${writeDescription(op.description)}final case class ${op.name}(
        |${op.fields.map(c => writeSubscriptionField(c, op)).mkString(",\n")}
        |)""".stripMargin
 
   def writeObject(typedef: ObjectTypeDefinition)(implicit scalarMappings: ScalarMappings): String =
-    s"""${writeDescription(typedef.description)}case class ${typedef.name}(${typedef.fields
+    s"""${writeDescription(typedef.description)}final case class ${typedef.name}(${typedef.fields
       .map(writeField(_, typedef))
       .mkString(", ")})"""
 
   def writeInputObject(typedef: InputObjectTypeDefinition)(implicit scalarMappings: ScalarMappings): String =
-    s"""${writeDescription(typedef.description)}case class ${typedef.name}(${typedef.fields
+    s"""${writeDescription(typedef.description)}final case class ${typedef.name}(${typedef.fields
       .map(writeInputValue)
       .mkString(", ")})"""
 
@@ -237,7 +237,7 @@ object SchemaWriter {
       s"${args.map(arg => s"${safeName(arg.name)} : ${writeType(arg.ofType)}").mkString(", ")}"
 
     if (field.args.nonEmpty) {
-      s"case class ${argsName(field, of)}(${fields(field.args)})"
+      s"final case class ${argsName(field, of)}(${fields(field.args)})"
     } else {
       ""
     }

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -314,7 +314,7 @@ object Client {
     val values: Vector[Origin] = Vector(EARTH, MARS, BELT)
   }
 
-  case class Routes(origin: Origin, destinations: List[com.example.Destination] = Nil)
+  final case class Routes(origin: Origin, destinations: List[com.example.Destination] = Nil)
   object Routes {
     implicit val encoder: ArgEncoder[Routes] = new ArgEncoder[Routes] {
       override def encode(value: Routes): __Value =
@@ -354,10 +354,10 @@ object Client {
 
   sealed trait Origin extends scala.Product with scala.Serializable { def value: String }
   object Origin {
-    case object EARTH                   extends Origin { val value: String = "EARTH" }
-    case object MARS                    extends Origin { val value: String = "MARS"  }
-    case object BELT                    extends Origin { val value: String = "BELT"  }
-    case class __Unknown(value: String) extends Origin
+    case object EARTH                         extends Origin { val value: String = "EARTH" }
+    case object MARS                          extends Origin { val value: String = "MARS"  }
+    case object BELT                          extends Origin { val value: String = "BELT"  }
+    final case class __Unknown(value: String) extends Origin
 
     implicit val decoder: ScalarDecoder[Origin] = {
       case __StringValue("EARTH") => Right(Origin.EARTH)
@@ -397,7 +397,7 @@ import caliban.client.__Value._
 
 object Client {
 
-  case class CharacterInput(name: String, nicknames: List[String] = Nil)
+  final case class CharacterInput(name: String, nicknames: List[String] = Nil)
   object CharacterInput {
     implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
       override def encode(value: CharacterInput): __Value =
@@ -430,7 +430,7 @@ import caliban.client.__Value._
 
 object Client {
 
-  case class CharacterInput(wait$ : String)
+  final case class CharacterInput(wait$ : String)
   object CharacterInput {
     implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
       override def encode(value: CharacterInput): __Value =

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -55,13 +55,13 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
 
         val a = assertM(typeCaseClass)(
           equalTo(
-            "case class Hero(name: HeroNameArgs => String, nick: String, bday: Option[Int])"
+            "final case class Hero(name: HeroNameArgs => String, nick: String, bday: Option[Int])"
           )
         )
 
         val b = assertM(typeCaseClassArgs)(
           equalTo(
-            "case class HeroNameArgs(pad: Int)"
+            "final case class HeroNameArgs(pad: Int)"
           )
         )
 
@@ -91,7 +91,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
 
         assertM(result)(
           equalTo(
-            """case class Query(
+            """final case class Query(
   user: QueryUserArgs => zio.UIO[Option[User]],
   userList: zio.UIO[List[Option[User]]]
 )""".stripMargin
@@ -116,7 +116,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
 
         assertM(result)(
           equalTo(
-            """case class Mutation(
+            """final case class Mutation(
               |  setMessage: MutationSetMessageArgs => zio.UIO[Option[String]]
               |)""".stripMargin
           )
@@ -137,7 +137,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
         assertM(result)(
           equalTo(
             """
-              |case class Subscription(
+              |final case class Subscription(
               |UserWatch: SubscriptionUserWatchArgs => ZStream[Any, Nothing, String]
               |)""".stripMargin
           )
@@ -165,7 +165,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
 
         assertM(result)(
           equalTo(
-            """case class Query[F[_]](
+            """final case class Query[F[_]](
   user: QueryUserArgs => F[Option[User]],
   userList: F[List[Option[User]]]
 )""".stripMargin
@@ -190,7 +190,7 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
 
         assertM(result)(
           equalTo(
-            """case class Mutation[F[_]](
+            """final case class Mutation[F[_]](
               |  setMessage: MutationSetMessageArgs => F[Option[String]]
               |)""".stripMargin
           )
@@ -221,22 +221,22 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
               |import zio.stream.ZStream
               |
               |object Types {
-              |  case class MutationAddPostArgs(author: Option[String], comment: Option[String])
-              |  case class Post(author: Option[String], comment: Option[String])
+              |  final case class MutationAddPostArgs(author: Option[String], comment: Option[String])
+              |  final case class Post(author: Option[String], comment: Option[String])
               |
               |}
               |
               |object Operations {
               |
-              |  case class Query(
+              |  final case class Query(
               |    posts: zio.UIO[Option[List[Option[Post]]]]
               |  )
               |
-              |  case class Mutation(
+              |  final case class Mutation(
               |    addPost: MutationAddPostArgs => zio.UIO[Option[Post]]
               |  )
               |
-              |  case class Subscription(
+              |  final case class Subscription(
               |    postAdded: ZStream[Any, Nothing, Option[Post]]
               |  )
               |
@@ -328,15 +328,15 @@ object Types {
   sealed trait Role2 extends scala.Product with scala.Serializable
 
   object Role2 {
-    case class Stewart(shipName: String) extends Role2
+    final case class Stewart(shipName: String) extends Role2
   }
 
-  case class Captain(
+  final case class Captain(
     @GQLDescription("ship")
     shipName: String
-  )                                  extends Role
+  )                                        extends Role
       with Role2
-  case class Pilot(shipName: String) extends Role with Role2
+  final case class Pilot(shipName: String) extends Role with Role2
 
 }
 """
@@ -357,7 +357,7 @@ object Types {
 
 object Types {
 
-  case class Captain(
+  final case class Captain(
     @GQLDescription("foo \\"quotes\\" bar")
     shipName: String
   )
@@ -383,7 +383,7 @@ object Types {
           equalTo(
             """object Operations {
 
-  case class Queries(
+  final case class Queries(
     characters: zio.UIO[Int]
   )
 
@@ -408,8 +408,8 @@ object Types {
           equalTo(
             """object Types {
 
-  case class Character(name: String)
-  case class CharacterArgs(name: String)
+  final case class Character(name: String)
+  final case class CharacterArgs(name: String)
 
 }
 """
@@ -430,14 +430,14 @@ object Types {
           equalTo(
             """object Types {
 
-  case class Character(`private`: String, `object`: String, `type`: String)
+  final case class Character(`private`: String, `object`: String, `type`: String)
 
 }
 """
           )
         )
       },
-      testM("case class reserved field name used") {
+      testM("final case class reserved field name used") {
         val schema =
           """
              type Character {
@@ -449,7 +449,7 @@ object Types {
           equalTo(
             """object Types {
 
-  case class Character(wait$ : String)
+  final case class Character(wait$ : String)
 
 }
 """
@@ -471,10 +471,10 @@ object Types {
         assertM(gen(schema))(
           equalTo(
             """object Types {
-              |  case class HeroCallAlliesArgs(number: Int)
-              |  case class VillainCallAlliesArgs(number: Int, w: String)
-              |  case class Hero(callAllies: HeroCallAlliesArgs => List[Hero])
-              |  case class Villain(callAllies: VillainCallAlliesArgs => List[Villain])
+              |  final case class HeroCallAlliesArgs(number: Int)
+              |  final case class VillainCallAlliesArgs(number: Int, w: String)
+              |  final case class Hero(callAllies: HeroCallAlliesArgs => List[Hero])
+              |  final case class Villain(callAllies: VillainCallAlliesArgs => List[Villain])
               |
               |}
               |""".stripMargin
@@ -509,19 +509,19 @@ object Types {
               |import zio.stream.ZStream
               |
               |object Types {
-              |  case class QueryCharactersArgs(p: Params)
-              |  case class SubscriptionCharactersArgs(p: Params)
-              |  case class Params(p: Int)
+              |  final case class QueryCharactersArgs(p: Params)
+              |  final case class SubscriptionCharactersArgs(p: Params)
+              |  final case class Params(p: Int)
               |
               |}
               |
               |object Operations {
               |
-              |  case class Query(
+              |  final case class Query(
               |    characters: QueryCharactersArgs => zio.UIO[Int]
               |  )
               |
-              |  case class Subscription(
+              |  final case class Subscription(
               |    characters: SubscriptionCharactersArgs => ZStream[Any, Nothing, Int]
               |  )
               |
@@ -561,22 +561,22 @@ object Types {
               |import a.b._
               |
               |object Types {
-              |  case class MutationAddPostArgs(author: Option[String], comment: Option[String])
-              |  case class Post(date: java.time.OffsetDateTime, author: Option[String], comment: Option[String])
+              |  final case class MutationAddPostArgs(author: Option[String], comment: Option[String])
+              |  final case class Post(date: java.time.OffsetDateTime, author: Option[String], comment: Option[String])
               |
               |}
               |
               |object Operations {
               |
-              |  case class Query(
+              |  final case class Query(
               |    posts: zio.UIO[Option[List[Option[Post]]]]
               |  )
               |
-              |  case class Mutation(
+              |  final case class Mutation(
               |    addPost: MutationAddPostArgs => zio.UIO[Option[Post]]
               |  )
               |
-              |  case class Subscription(
+              |  final case class Subscription(
               |    postAdded: ZStream[Any, Nothing, Option[Post]]
               |  )
               |


### PR DESCRIPTION
Before: https://github.com/guizmaii/poc_compile_time_caliban_client_generation/pull/23/checks?check_run_id=3857963687
After: https://github.com/guizmaii/poc_compile_time_caliban_client_generation/pull/24/checks?check_run_id=3858016758

(The scalafix rule checking that all the case classes are final fail in the "before" run and pass in the "after" run)