### PR TITLE
Fix package name extraction in code generation

### DIFF
--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -21,51 +21,49 @@ object Codegen {
     genType: GenType
   ): RIO[Blocking, List[File]] =
     for {
-      schema            <- loader.load
-      s                  = ".*/[scala|play.*|app][^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
-      packageName        = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
-      objectName         = arguments.clientName.orElse(s.map(_.group(2))).getOrElse("Client")
-      abstractEffectType = arguments.abstractEffectType.getOrElse(false)
-      effect             = arguments.effect.getOrElse {
-                             if (abstractEffectType) "F" else "zio.UIO"
-                           }
-      genView            = arguments.genView.getOrElse(false)
-      scalarMappings     = arguments.scalarMappings
-      splitFiles         = arguments.splitFiles.getOrElse(false)
-      enableFmt          = arguments.enableFmt.getOrElse(true)
-      extensibleEnums    = arguments.extensibleEnums.getOrElse(false)
-      code               = genType match {
-                             case GenType.Schema =>
-                               List(
-                                 objectName -> SchemaWriter.write(schema, packageName, effect, arguments.imports, abstractEffectType)(
-                                   ScalarMappings(scalarMappings)
-                                 )
-                               )
-                             case GenType.Client =>
-                               ClientWriter.write(
-                                 schema,
-                                 objectName,
-                                 packageName,
-                                 genView,
-                                 arguments.imports,
-                                 splitFiles,
-                                 extensibleEnums
-                               )(
-                                 ScalarMappings(scalarMappings)
-                               )
-                           }
-      formatted         <- if (enableFmt) Formatter.format(code, arguments.fmtPath) else Task.succeed(code)
-      paths             <- ZIO.foreach(formatted) { case (objectName, objectCode) =>
-                             val path =
-                               if (splitFiles) s"${arguments.toPath.reverse.dropWhile(_ != '/').reverse}$objectName.scala"
-                               else arguments.toPath
+      schema                   <- loader.load
+      (packageName, objectName) = getPackageAndObjectName(arguments)
+      abstractEffectType        = arguments.abstractEffectType.getOrElse(false)
+      effect                    = arguments.effect.getOrElse {
+                                    if (abstractEffectType) "F" else "zio.UIO"
+                                  }
+      genView                   = arguments.genView.getOrElse(false)
+      scalarMappings            = arguments.scalarMappings
+      splitFiles                = arguments.splitFiles.getOrElse(false)
+      enableFmt                 = arguments.enableFmt.getOrElse(true)
+      extensibleEnums           = arguments.extensibleEnums.getOrElse(false)
+      code                      = genType match {
+                                    case GenType.Schema =>
+                                      List(
+                                        objectName -> SchemaWriter.write(schema, packageName, effect, arguments.imports, abstractEffectType)(
+                                          ScalarMappings(scalarMappings)
+                                        )
+                                      )
+                                    case GenType.Client =>
+                                      ClientWriter.write(
+                                        schema,
+                                        objectName,
+                                        packageName,
+                                        genView,
+                                        arguments.imports,
+                                        splitFiles,
+                                        extensibleEnums
+                                      )(
+                                        ScalarMappings(scalarMappings)
+                                      )
+                                  }
+      formatted                <- if (enableFmt) Formatter.format(code, arguments.fmtPath) else Task.succeed(code)
+      paths                    <- ZIO.foreach(formatted) { case (objectName, objectCode) =>
+                                    val path =
+                                      if (splitFiles) s"${arguments.toPath.reverse.dropWhile(_ != '/').reverse}$objectName.scala"
+                                      else arguments.toPath
 
-                             blocking(
-                               Task(new PrintWriter(new File(path)))
-                                 .bracket(q => UIO(q.close()), pw => Task(pw.println(objectCode)))
-                                 .as(new File(path))
-                             )
-                           }
+                                    blocking(
+                                      Task(new PrintWriter(new File(path)))
+                                        .bracket(q => UIO(q.close()), pw => Task(pw.println(objectCode)))
+                                        .as(new File(path))
+                                    )
+                                  }
     } yield paths
 
   def generate(arguments: Options, genType: GenType): RIO[Blocking, List[File]] =
@@ -79,4 +77,10 @@ object Codegen {
     if (path.startsWith("http")) SchemaLoader.fromIntrospection(path, schemaPathHeaders)
     else SchemaLoader.fromFile(path)
 
+  def getPackageAndObjectName(arguments: Options) = {
+    val s           = ".*(?:scala|play.*?|app)[^/]*/(?:(.*)/)?(.*).scala".r.findFirstMatchIn(arguments.toPath)
+    val packageName = arguments.packageName.orElse(s.flatMap(x => Option(x.group(1)).map(_.split("/").mkString("."))))
+    val objectName  = arguments.clientName.orElse(s.map(_.group(2))).getOrElse("Client")
+    packageName -> objectName
+  }
 }

--- a/tools/src/test/scala/caliban/tools/CodegenSpec.scala
+++ b/tools/src/test/scala/caliban/tools/CodegenSpec.scala
@@ -1,0 +1,89 @@
+package caliban.tools
+
+import Codegen.getPackageAndObjectName
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+object CodegenSpec extends DefaultRunnableSpec {
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("CodegenSpec")(
+      test("Package name is empty or default if path doesn't follow correct format") {
+        assert(packageAndObject("a/b/c", None, None))(
+          equalTo(None -> "Client")
+        ) &&
+        assert(packageAndObject("a/b/c", Some("package"), None))(
+          equalTo(Some("package") -> "Client")
+        )
+      },
+      test("Package name is extracted correctly when set") {
+        assert(packageAndObject("/a/b/c/src/main/scala/dirA/model.scala", Some("package"), None))(
+          equalTo(Some("package") -> "model")
+        )
+      },
+      test("Package name is extracted correctly absolute path") {
+        assert(packageAndObject("/a/b/c/src/main/scala/dirA/model.scala", None, None))(
+          equalTo(Some("dirA") -> "model")
+        )
+      },
+      test("Package name is extracted correctly single level") {
+        assert(packageAndObject("a/b/c/src/main/scala/dirA/model.scala", None, None))(
+          equalTo(Some("dirA") -> "model")
+        )
+      },
+      test("Package name is extracted correctly multiple levels") {
+        assert(packageAndObject("a/b/c/src/main/scala/dirA/dirB/model.scala", None, None))(
+          equalTo(Some("dirA.dirB") -> "model")
+        )
+      },
+      test("Package name is extracted correctly for play and app") {
+        assert(packageAndObject("app/dirA/dirB/model.scala", None, None))(
+          equalTo(Some("dirA.dirB") -> "model")
+        ) &&
+        assert(packageAndObject("play/dirA/dirB/model.scala", None, None))(
+          equalTo(Some("dirA.dirB") -> "model")
+        ) &&
+        assert(packageAndObject("play/src/main/scala/dirA/dirB/model.scala", None, None))(
+          equalTo(Some("dirA.dirB") -> "model")
+        )
+      },
+      test("Object name is extracted correctly when package is missing") {
+        assert(packageAndObject("a/b/c/src/main/scala/model.scala", None, None))(
+          equalTo(None -> "model")
+        ) &&
+        assert(packageAndObject("a/b/c/src/main/scala/model.scala", Some("package"), None))(
+          equalTo(Some("package") -> "model")
+        )
+      },
+      test("Object name is set to passed value") {
+        assert(packageAndObject("src/main/scala/client.scala", None, Some("model")))(
+          equalTo(None -> "model")
+        ) &&
+        assert(packageAndObject("", None, Some("model")))(
+          equalTo(None -> "model")
+        )
+      }
+    )
+
+  def packageAndObject(toPath: String, defaultPackageName: Option[String], defaultClientName: Option[String]) = {
+    val arguments = Options(
+      schemaPath = "schema.graphql",
+      toPath = toPath,
+      fmtPath = None,
+      headers = None,
+      packageName = defaultPackageName,
+      clientName = defaultClientName,
+      genView = None,
+      effect = None,
+      scalarMappings = None,
+      imports = None,
+      abstractEffectType = None,
+      splitFiles = None,
+      enableFmt = None,
+      extensibleEnums = None
+    )
+
+    getPackageAndObjectName(arguments)
+  }
+}


### PR DESCRIPTION
The old regex doesn't work properly on paths such as "src/main/scala/company/service/infra/graphql/model.scala". This returns "infra/graphql" as the package name. This is because of [] square brackets to match on one of scala, play or app. I replaced that with a non capturing regex group and that works as expected returning "company/service/infra/graphql" as the package name