### PR TITLE
fix: UTF-8 handling for request bodies

### DIFF
--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -243,9 +243,15 @@ object ZHttpAdapter {
     if (req.url.queryParams.contains("query")) {
       queryFromQueryParams(req)
     } else if (req.headers.contains(contentTypeApplicationGraphQL)) {
-      ZIO.succeed(GraphQLRequest(query = req.getBodyAsString))
+      ZIO.succeed(GraphQLRequest(query = getBody(req)))
     } else {
-      ZIO.fromEither(decode[GraphQLRequest](req.getBodyAsString.getOrElse("")))
+      ZIO.fromEither(decode[GraphQLRequest](getBody(req).getOrElse("")))
+    }
+
+  private def getBody(r: Request) =
+    r.content match {
+      case HttpData.CompleteData(data) => Some(new String(data.toArray, "UTF-8"))
+      case _                           => None
     }
 
   private def generateGraphQLResponse[R, E](


### PR DESCRIPTION
`zio-http` just does `body.data.map(_.toChar)` which breaks for UTF-8 encoded bodies.

Not sure if treating everything as UTF-8 is the perfect fix, but at least it's better than breaking on UTF-8 :)