### PR TITLE
Adding aspects and annotations

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -142,6 +142,13 @@ trait GraphQL[-R] { self =>
       override val additionalDirectives: List[__Directive] = self.additionalDirectives
     }
 
+  /**
+   * Attaches an aspect that will wrap the entire GraphQL so that it can be manipulated.
+   * This method is a higher-level abstraction of [[withWrapper]] which allows the caller to
+   * completely replace or change all aspects of the schema.
+   * @param aspect A wrapper type that will be applied to this GraphQL
+   * @return A new GraphQL API
+   */
   final def @@[LowerR <: UpperR, UpperR <: R](aspect: GraphQLAspect[LowerR, UpperR]): GraphQL[UpperR] =
     aspect(self)
 

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -142,10 +142,8 @@ trait GraphQL[-R] { self =>
       override val additionalDirectives: List[__Directive] = self.additionalDirectives
     }
 
-  /**
-   * A symbolic alias for `withWrapper`.
-   */
-  final def @@[R2 <: R](wrapper: Wrapper[R2]): GraphQL[R2] = withWrapper(wrapper)
+  final def @@[LowerR <: UpperR, UpperR <: R](aspect: GraphQLAspect[LowerR, UpperR]): GraphQL[UpperR] =
+    aspect(self)
 
   /**
    * Merges this GraphQL API with another GraphQL API.

--- a/core/src/main/scala/caliban/GraphQLAspect.scala
+++ b/core/src/main/scala/caliban/GraphQLAspect.scala
@@ -1,5 +1,10 @@
 package caliban
 
+/**
+ * A `GraphQLAspect` is wrapping type similar to a polymorphic function, which is capable
+ * of transforming a GraphQL into another while possibly enlarging the required environment type.
+ * It allows a flexible way to augment an existing GraphQL with new capabilities or features.
+ */
 trait GraphQLAspect[+LowerR, -UpperR] { self =>
   def apply[R >: LowerR <: UpperR](gql: GraphQL[R]): GraphQL[R]
 

--- a/core/src/main/scala/caliban/GraphQLAspect.scala
+++ b/core/src/main/scala/caliban/GraphQLAspect.scala
@@ -1,0 +1,13 @@
+package caliban
+
+trait GraphQLAspect[+LowerR, -UpperR] { self =>
+  def apply[R >: LowerR <: UpperR](gql: GraphQL[R]): GraphQL[R]
+
+  def @@[LowerR1 >: LowerR, UpperR1 <: UpperR](
+    other: GraphQLAspect[LowerR1, UpperR1]
+  ): GraphQLAspect[LowerR1, UpperR1] =
+    new GraphQLAspect[LowerR1, UpperR1] {
+      def apply[R >: LowerR1 <: UpperR1](gql: GraphQL[R]): GraphQL[R] =
+        other(self(gql))
+    }
+}

--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -1,15 +1,15 @@
 package caliban.wrappers
 
-import scala.annotation.tailrec
 import caliban.CalibanError.{ ExecutionError, ParsingError, ValidationError }
 import caliban.execution.{ ExecutionRequest, FieldInfo }
 import caliban.introspection.adt.__Introspection
 import caliban.parsing.adt.Document
 import caliban.wrappers.Wrapper.CombinedWrapper
-import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, ResponseValue }
-import zio.{ UIO, ZIO }
+import caliban._
 import zio.query.ZQuery
-import caliban.{ GraphQL, GraphQLAspect }
+import zio.{ UIO, ZIO }
+
+import scala.annotation.tailrec
 
 /**
  * A `Wrapper[-R]` represents an extra layer of computation that can be applied on top of Caliban's query handling.

--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -9,6 +9,7 @@ import caliban.wrappers.Wrapper.CombinedWrapper
 import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, ResponseValue }
 import zio.{ UIO, ZIO }
 import zio.query.ZQuery
+import caliban.{ GraphQL, GraphQLAspect }
 
 /**
  * A `Wrapper[-R]` represents an extra layer of computation that can be applied on top of Caliban's query handling.
@@ -21,8 +22,11 @@ import zio.query.ZQuery
  *
  * It is also possible to combine wrappers using `|+|` and to build a wrapper effectfully with `EffectfulWrapper`.
  */
-sealed trait Wrapper[-R] { self =>
+sealed trait Wrapper[-R] extends GraphQLAspect[Nothing, R] { self =>
   def |+|[R1 <: R](that: Wrapper[R1]): Wrapper[R1] = CombinedWrapper(List(self, that))
+
+  def apply[R1 <: R](that: GraphQL[R1]): GraphQL[R1] =
+    that.withWrapper(self)
 }
 
 object Wrapper {

--- a/federation/src/test/scala/caliban/federation/FederationSpec.scala
+++ b/federation/src/test/scala/caliban/federation/FederationSpec.scala
@@ -52,7 +52,7 @@ object FederationSpec extends DefaultRunnableSpec {
 
   override def spec = suite("FederationSpec")(
     testM("should resolve federated types") {
-      val interpreter = federate(graphQL(resolver), entityResolver).interpreter
+      val interpreter = (graphQL(resolver) @@ federated(entityResolver)).interpreter
 
       val query = gqldoc("""
             query test {
@@ -69,7 +69,7 @@ object FederationSpec extends DefaultRunnableSpec {
       )
     },
     testM("should not include _entities if not resolvers provided") {
-      val interpreter = federate(graphQL(resolver)).interpreter
+      val interpreter = (graphQL(resolver) @@ federated).interpreter
 
       val query = gqldoc("""
             query test {
@@ -93,7 +93,7 @@ object FederationSpec extends DefaultRunnableSpec {
       )
     },
     testM("should include orphan entities in sdl") {
-      val interpreter = federate(graphQL(resolver), orphanResolver).interpreter
+      val interpreter = (graphQL(resolver) @@ federated(orphanResolver)).interpreter
 
       val query = gqldoc("""{ _service { sdl } }""")
       assertM(interpreter.flatMap(_.execute(query)).map(d => d.data.toString))(
@@ -106,7 +106,7 @@ object FederationSpec extends DefaultRunnableSpec {
       )
     },
     testM("should include field metadata") {
-      val interpreter = federate(graphQL(resolver), functionEntityResolver).interpreter
+      val interpreter = (graphQL(resolver) @@ federated(functionEntityResolver)).interpreter
       val query       = gqldoc("""
            query Entities($withNicknames: Boolean = false) {
             _entities(representations: [{__typename: "Character", name: "Amos Burton"}]) {


### PR DESCRIPTION
Unifies the `Wrapper` capabilities into a higher-level abstraction of `GraphQLAspect` the idea being that many of the existing specification capabilities require changes not just to the execution of the request but also to the underlying schema (adding directives, manipulating the underlying graphql).
As a demonstration I refactored the `federate` function into a wrapper (though still kept the existing function for backward compatibility).