### PR TITLE
fix: GQL syntax strings are incorrectly validated as enums

### DIFF
--- a/core/src/main/scala/caliban/parsing/VariablesUpdater.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesUpdater.scala
@@ -1,0 +1,53 @@
+package caliban.parsing
+
+import caliban.GraphQLRequest
+import caliban.introspection.adt._
+import caliban.parsing.adt.Definition.ExecutableDefinition.OperationDefinition
+import caliban.parsing.adt._
+import caliban.schema.RootType
+import caliban.{ InputValue, Value }
+import zio.{ IO, UIO }
+
+object VariablesUpdater {
+  def updateVariables(
+    req: GraphQLRequest,
+    doc: Document,
+    rootType: RootType
+  ): GraphQLRequest = {
+    val variableDefinitions = doc.operationDefinitions.flatMap(_.variableDefinitions)
+    val updated             = req.variables.getOrElse(Map.empty).map { case (key, value) =>
+      val v = variableDefinitions.find(_.name == key).map(resolveEnumValues(value, _, rootType)).getOrElse(value)
+      key -> v
+    }
+
+    req.copy(variables = Some(updated))
+  }
+
+  // Since we cannot separate a String from an Enum when variables
+  // are parsed, we need to translate from strings to enums here
+  // if we have a valid enum field.
+  private def resolveEnumValues(
+    value: InputValue,
+    definition: VariableDefinition,
+    rootType: RootType
+  ): InputValue = {
+    val t = Type
+      .innerType(definition.variableType)
+
+    rootType.types
+      .get(t)
+      .map(_.kind)
+      .flatMap { kind =>
+        (kind, value) match {
+          case (__TypeKind.ENUM, InputValue.ListValue(v)) =>
+            Some(
+              InputValue.ListValue(v.map(resolveEnumValues(_, definition, rootType)))
+            )
+          case (__TypeKind.ENUM, Value.StringValue(v))    =>
+            Some(Value.EnumValue(v))
+          case _                                          => None
+        }
+      }
+      .getOrElse(value)
+  }
+}

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -81,11 +81,9 @@ object ValueValidator {
             }
           case ENUM         =>
             argValue match {
-              case EnumValue(value)   =>
+              case EnumValue(value) =>
                 validateEnum(value, inputType, errorContext)
-              case StringValue(value) =>
-                validateEnum(value, inputType, errorContext)
-              case _                  =>
+              case _                =>
                 failValidation(
                   s"$errorContext has invalid type: $argValue",
                   "Input field was supposed to be an enum value."

--- a/core/src/test/scala/caliban/execution/FieldArgsSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldArgsSpec.scala
@@ -6,7 +6,7 @@ import caliban.Value.EnumValue
 import zio._
 import zio.test._
 import zio.test.environment.TestEnvironment
-import Assertion._
+import zio.test.Assertion._
 
 object FieldArgsSpec extends DefaultRunnableSpec {
   sealed trait COLOR

--- a/core/src/test/scala/caliban/execution/FieldArgsSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldArgsSpec.scala
@@ -176,7 +176,6 @@ object FieldArgsSpec extends DefaultRunnableSpec {
       for {
         interpreter <- api.interpreter
         res         <- interpreter.execute(query)
-        _           <- ZIO.debug(res)
       } yield assert(res.errors.headOption)(isSome(anything))
     }
   )


### PR DESCRIPTION
This was a bad consequence as a result of https://github.com/ghostdogpr/caliban/pull/1064

Instead of doing it during validation, we now rewrite the variables to be enums (if they should be) before running the validation, which I think is a more correct approach to it.