### PR TITLE
Bug fix: adds the support for fields starting with capital letters

### DIFF
--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -597,7 +597,7 @@ object ClientWriter {
         """
 
   def safeUnapplyName(name: String): String =
-    if (reservedKeywords.contains(name) || name.endsWith("_")) s"$name$$"
+    if (reservedKeywords.contains(name) || name.endsWith("_") || name.charAt(0).isUpper) s"$$$name"
     else name
 
   def safeName(name: String): String =

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -597,8 +597,12 @@ object ClientWriter {
         """
 
   def safeUnapplyName(name: String): String =
-    if (reservedKeywords.contains(name) || name.endsWith("_") || name.charAt(0).isUpper) s"$$$name"
+    if (reservedKeywords.contains(name) || name.endsWith("_") || name.charAt(0).isUpper) s"${decapitalize(name)}$$"
     else name
+
+  private def decapitalize(name: String): String = if (name.length > 1 && name.charAt(0).isUpper)
+    name.charAt(0).toLower + name.substring(1)
+  else name
 
   def safeName(name: String): String =
     if (reservedKeywords.contains(name) || name.endsWith("_")) s"`$name`"

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -600,9 +600,13 @@ object ClientWriter {
     if (reservedKeywords.contains(name) || name.endsWith("_") || name.charAt(0).isUpper) s"${decapitalize(name)}$$"
     else name
 
-  private def decapitalize(name: String): String = if (name.length > 1 && name.charAt(0).isUpper)
-    name.charAt(0).toLower + name.substring(1)
-  else name
+  private def decapitalize(name: String): String = if (name.length > 1 && name.charAt(0).isUpper) {
+    val chars = name.toCharArray
+    chars(0) = chars(0).toLower
+    new String(chars)
+  } else {
+    name
+  }
 
   def safeName(name: String): String =
     if (reservedKeywords.contains(name) || name.endsWith("_")) s"`$name`"

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -597,10 +597,12 @@ object ClientWriter {
         """
 
   def safeUnapplyName(name: String): String =
-    if (reservedKeywords.contains(name) || name.endsWith("_") || name.charAt(0).isUpper) s"${decapitalize(name)}$$"
+    if (reservedKeywords.contains(name) || name.endsWith("_") || isCapital(name)) s"${decapitalize(name)}$$"
     else name
 
-  private def decapitalize(name: String): String = if (name.length > 1 && name.charAt(0).isUpper) {
+  private def isCapital(name: String): Boolean = name.nonEmpty && name.charAt(0).isUpper
+
+  private def decapitalize(name: String): String = if (isCapital(name)) {
     val chars = name.toCharArray
     chars(0) = chars(0).toLower
     new String(chars)

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -357,8 +357,8 @@ object Client {
 
     def view[PackageSelection](
       packageSelection: SelectionBuilder[`package`, PackageSelection]
-    ): ViewSelection[PackageSelection] = (`package`(packageSelection) ~ version).map { case ($package, version) =>
-      matchView($package, version)
+    ): ViewSelection[PackageSelection] = (`package`(packageSelection) ~ version).map { case (package$, version) =>
+      matchView(package$, version)
     }
 
     def `package`[A](innerSelection: SelectionBuilder[`package`, A]): SelectionBuilder[`match`, Option[A]] =
@@ -395,7 +395,7 @@ object Client {
 
     type ViewSelection = SelectionBuilder[TypeWithCapitalFields, TypeWithCapitalFieldsView]
 
-    def view: ViewSelection = (Name ~ Value).map { case ($Name, $Value) => TypeWithCapitalFieldsView($Name, $Value) }
+    def view: ViewSelection = (Name ~ Value).map { case (name$, value$) => TypeWithCapitalFieldsView(name$, value$) }
 
     def Name: SelectionBuilder[TypeWithCapitalFields, Option[String]]  =
       _root_.caliban.client.SelectionBuilder.Field("Name", OptionOf(Scalar()))

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -10,10 +10,10 @@ import zio.test.environment.TestEnvironment
 
 object ClientWriterViewSpec extends DefaultRunnableSpec {
 
-  val gen: String ⇒ RIO[Blocking, String] = (schema: String) ⇒
+  val gen: String => RIO[Blocking, String] = (schema: String) =>
     Parser
       .parseQuery(schema)
-      .flatMap(doc ⇒ Formatter.format(ClientWriter.write(doc, genView = true)(ScalarMappings(None)).head._2, None))
+      .flatMap(doc => Formatter.format(ClientWriter.write(doc, genView = true)(ScalarMappings(None)).head._2, None))
 
   override def spec: ZSpec[TestEnvironment, Any] =
     suite("ClientWriterViewSpec")(


### PR DESCRIPTION
The codegen generates semantically invalid scala code when Graphql fields types start with a capital letter. 

E.g., for a schema: 

```graphql
type Aspect {
    Name: String!
    Value: String!
}
```

Caliban codegen generates the following view: 

```scala
...

def view: ViewSelection = (Name, Value).map {
  case (Name, Value) ⇒ AspectView(Name, Value)
}
...
```

This code is invalid because Scala accepts only variable names starting with a lower case for pattern matching. 

This PR fixes this behavior by decapitalizing the variable name, so that the generated code is: 

```scala
...

def view: ViewSelection = (Name, Value).map {
  case (name$, value$) ⇒ AspectView(name$, value$)
}
...
```

The PR fixes the bug by adding the `$` symbol to the end of the variable name and decapitalizes for the following cases: 

- when a variable name is a keyword 
- when a variable name contains an underscore 
- (new case) when a variable name starts with a capital letter

Would appreciate any help reviewing this and pushing it whenever possible (currently, this bug prevents us from using **this excellent library**)!. 

Thanks
