### PR TITLE
feat: Add @GQLExcluded

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -64,7 +64,7 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
           Some(getName(ctx)),
           getDescription(ctx),
           ctx.parameters
-            .filter(p => !p.annotations.exists(_ == GQLExcluded()))
+            .filterNot(p => p.annotations.exists(_ == GQLExcluded()))
             .map(p =>
               __Field(
                 getName(p),

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -64,6 +64,7 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
           Some(getName(ctx)),
           getDescription(ctx),
           ctx.parameters
+            .filter(p => !p.annotations.exists(_ == GQLExcluded()))
             .map(p =>
               __Field(
                 getName(p),

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -64,7 +64,7 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
           Some(getName(ctx)),
           getDescription(ctx),
           ctx.parameters
-            .filterNot(p => p.annotations.exists(_ == GQLExcluded()))
+            .filterNot(_.annotations.exists(_ == GQLExcluded()))
             .map(p =>
               __Field(
                 getName(p),

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -143,7 +143,9 @@ trait SchemaDerivation[R] {
               makeObject(
                 Some(getName(annotations, info)),
                 getDescription(annotations),
-                fields.map { case (label, _, schema, _) =>
+                fields.filter { case (label, _, _, _) =>
+                  !paramAnnotations.getOrElse(label, Nil).exists(_ == GQLExcluded())
+                }.map { case (label, _, schema, _) =>
                   val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
                   __Field(
                     getName(fieldAnnotations, label),

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -143,8 +143,8 @@ trait SchemaDerivation[R] {
               makeObject(
                 Some(getName(annotations, info)),
                 getDescription(annotations),
-                fields.filter { case (label, _, _, _) =>
-                  !paramAnnotations.getOrElse(label, Nil).exists(_ == GQLExcluded())
+                fields.filterNot { case (label, _, _, _) =>
+                  paramAnnotations.getOrElse(label, Nil).exists(_ == GQLExcluded())
                 }.map { case (label, _, schema, _) =>
                   val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
                   __Field(

--- a/core/src/main/scala/caliban/schema/Annotations.scala
+++ b/core/src/main/scala/caliban/schema/Annotations.scala
@@ -17,6 +17,11 @@ object Annotations {
   case class GQLDescription(value: String) extends StaticAnnotation
 
   /**
+   * Annotation used to exlucde a field from a type.
+   */
+  case class GQLExcluded() extends StaticAnnotation
+
+  /**
    * Annotation used to customize the name of an input type.
    * This is usually needed to avoid a name clash when a type is used both as an input and an output.
    */

--- a/core/src/main/scala/caliban/schema/Annotations.scala
+++ b/core/src/main/scala/caliban/schema/Annotations.scala
@@ -17,7 +17,7 @@ object Annotations {
   case class GQLDescription(value: String) extends StaticAnnotation
 
   /**
-   * Annotation used to exlucde a field from a type.
+   * Annotation used to exclude a field from a type.
    */
   case class GQLExcluded() extends StaticAnnotation
 


### PR DESCRIPTION
Closes #1040.

Didn't add support to exclude an enum member since it felt like it'd need special handling (what are we supposed to output as result if we were to get back a value that's `GQLExcluded`?).