### PR TITLE
Adding a new required param to an input field is not considered a breaking change

### DIFF
--- a/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
@@ -142,6 +142,28 @@ object SchemaComparisonSpec extends DefaultRunnableSpec {
 
         compare(schema1, schema2, expected)
       },
+      testM("considers adding a required arg to an input field as breaking") {
+        val schema1: String =
+          """
+          input HeroInput {
+            test: String
+          }
+            |""".stripMargin
+
+        val schema2: String =
+          """
+          input HeroInput {
+            test: String
+            test2: String!
+          }
+            |""".stripMargin
+
+        assertM(for {
+          s1  <- Parser.parseQuery(schema1)
+          s2  <- Parser.parseQuery(schema2)
+          diff = compareDocuments(s1, s2)
+        } yield diff)(hasFirst(hasField("breaking", _.breaking, equalTo(true))))
+      },
       testM("deprecated") {
         val schema1: String =
           """


### PR DESCRIPTION
I do not wish to merge this code. It is just a demonstration of an issue I came across when trying to use the schema comparison functionality in caliban-tools.