### PR TITLE
Add calibanVersion setting

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanKeys.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanKeys.scala
@@ -19,6 +19,8 @@ trait CalibanKeys {
 
   @deprecated("CodegenPlugin has been renamed to CalibanPlugin", "1.1.0")
   val CodegenPlugin: CalibanPlugin.type = CalibanPlugin
+
+  val calibanVersion = settingKey[String]("Version of the Caliban sbt plugin")
 }
 
 object CalibanKeys extends CalibanKeys

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanPlugin.scala
@@ -12,6 +12,7 @@ object CalibanPlugin extends AutoPlugin {
 
   lazy val baseSettings = Seq(
     caliban                    := (caliban / calibanGenerator).value,
+    calibanVersion             := BuildInfo.version,
     (caliban / sourceManaged)  := {
       sourceManaged.value / "caliban-codegen-sbt"
     },


### PR DESCRIPTION
This will allow users of the plugin to use `% calibanVersion.value` for their dependencies instead of repeating the version from `plugins.sbt`.
