### PR TITLE
Add cost estimation wrapper

### DIFF
--- a/core/src/main/scala/caliban/schema/Annotations.scala
+++ b/core/src/main/scala/caliban/schema/Annotations.scala
@@ -35,7 +35,12 @@ object Annotations {
   /**
    * Annotation used to provide directives to a schema type
    */
-  case class GQLDirective(directive: Directive) extends StaticAnnotation
+  class GQLDirective(val directive: Directive) extends StaticAnnotation
+
+  object GQLDirective {
+    def unapply(annotation: GQLDirective): Option[Directive] =
+      Some(annotation.directive)
+  }
 
   /**
    * Annotation to make a sealed trait an interface instead of a union type or an enum

--- a/core/src/main/scala/caliban/wrappers/CostEstimation.scala
+++ b/core/src/main/scala/caliban/wrappers/CostEstimation.scala
@@ -61,7 +61,7 @@ object CostEstimation {
               values.collect {
                 case StringValue(name) =>
                   f.arguments.get(name).collectFirst {
-                    case i: IntValue   => i.toInt
+                    case i: IntValue   => i.toInt.toDouble
                     case d: FloatValue => d.toDouble
                   }
                 case _                 => None

--- a/core/src/main/scala/caliban/wrappers/CostEstimation.scala
+++ b/core/src/main/scala/caliban/wrappers/CostEstimation.scala
@@ -1,0 +1,124 @@
+package caliban.wrappers
+
+import caliban.CalibanError.ValidationError
+import caliban.{ InputValue, Value }
+import caliban.InputValue.ListValue
+import caliban.Value.{ FloatValue, IntValue, StringValue }
+import caliban.execution.{ ExecutionRequest, Field }
+import caliban.parsing.adt.{ Directive, Document }
+import caliban.schema.Types
+import caliban.wrappers.Wrapper.ValidationWrapper
+import zio.{ IO, URIO, ZIO }
+
+import scala.annotation.tailrec
+
+object CostEstimation {
+
+  final val COST_DIRECTIVE_NAME = "cost"
+
+  object CostDirective {
+    def apply(cost: Double): Directive =
+      Directive(COST_DIRECTIVE_NAME, arguments = Map("weight" -> FloatValue(cost)))
+
+    def apply(cost: Double, multipliers: List[String]): Directive =
+      Directive(
+        COST_DIRECTIVE_NAME,
+        arguments = Map("weight" -> FloatValue(cost), "multipliers" -> ListValue(multipliers.map(StringValue)))
+      )
+  }
+
+  /**
+   * Computes field cost by examining the @cost directive
+   */
+  val costDirective = (f: Field) => {
+    def computeDirectiveCost(directives: List[Directive]) =
+      directives.collectFirst {
+        case d if d.name == COST_DIRECTIVE_NAME =>
+          // TODO should we support string backed formulas?
+          // TODO Support list arguments / multipliers
+          val weight = d.arguments
+            .get("weight")
+            .collect {
+              case i: IntValue   => i.toInt.toDouble
+              case f: FloatValue => f.toDouble
+            }
+            .getOrElse(1.0)
+
+          val multipliers = d.arguments
+            .get("multipliers")
+            .toList
+            .collect { case ListValue(values) =>
+              values.collect {
+                case StringValue(name) =>
+                  f.arguments.get(name).collectFirst {
+                    case i: IntValue   => i.toInt
+                    case d: FloatValue => d.toDouble
+                  }
+                case _                 => None
+              }.flatten
+            }
+            .flatten
+            .sum max 1.0
+
+          weight * multipliers
+      }
+
+    val directiveCost = computeDirectiveCost(f.directives).getOrElse(1.0)
+
+    val typeCost = Types
+      .innerType(f.fieldType)
+      .directives
+      .flatMap(computeDirectiveCost)
+      .getOrElse(0.0)
+
+    directiveCost + typeCost
+  }
+
+  private def computeComplexity(field: Field)(f: Field => Double): Double = {
+    @tailrec
+    def go(fields: List[Field], total: Double): Double = fields match {
+      case Nil          => total
+      case head :: tail => go(head.fields ++ tail, f(head) + total)
+    }
+
+    go(List(field), 0.0)
+  }
+
+  def maxComplexity(maxCost: Int)(f: Field => Double): ValidationWrapper[Any] =
+    new ValidationWrapper[Any] {
+      override def wrap[R1 <: Any](
+        process: Document => ZIO[R1, ValidationError, ExecutionRequest]
+      ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
+        (doc: Document) =>
+          for {
+            req <- process(doc)
+            cost = computeComplexity(req.field)(f)
+            _   <- IO.when(cost > maxCost)(
+                     IO.fail(ValidationError(s"Query costs too much: $cost. Max cost: $maxCost.", ""))
+                   )
+          } yield req
+    }
+
+  private def computeComplexityZIO[R](value: Field)(f: Field => URIO[R, Double]): URIO[R, Double] = {
+    def loop(field: Field, currentCost: Double): URIO[R, Double] =
+      URIO.foldLeft(field.fields)(currentCost)((acc, a) => f(a).map(_ + acc))
+
+    loop(value, 0.0)
+  }
+
+  def maxComplexityZIO[R](maxCost: Double)(f: Field => URIO[R, Double]): ValidationWrapper[R] =
+    new ValidationWrapper[R] {
+      override def wrap[R1 <: R](
+        process: Document => ZIO[R1, ValidationError, ExecutionRequest]
+      ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
+        (doc: Document) =>
+          for {
+            req  <- process(doc)
+            cost <- computeComplexityZIO(req.field)(f)
+            _    <- IO.when(cost > maxCost)(
+                      IO.fail(ValidationError(s"Query costs too much: $cost. Max cost: $maxCost.", ""))
+                    )
+          } yield req
+    }
+
+}

--- a/core/src/main/scala/caliban/wrappers/CostEstimation.scala
+++ b/core/src/main/scala/caliban/wrappers/CostEstimation.scala
@@ -43,7 +43,7 @@ object CostEstimation {
   }
 
   /**
-   * Computes field cost by examining the @cost directive. This can be used in conjunction with [[queryCost]] or [[maxCost]]
+   * Computes field cost by examining the @cost directive. This can be used in conjunction with `queryCost` or [[maxCost]]
    * In order to compute the estimated cost of executing a query.
    *
    * @note This will be executed *before* the actual resolvers are called, which allows you to stop potentially expensive queries
@@ -120,7 +120,7 @@ object CostEstimation {
     queryCostZIOWrapperState[R](costWrapper(_)(f))((cost, r) => p(cost).as(r))
 
   /**
-   * A more powerful version of [[queryCost]] which allows the field cost computation to return an effect instead of a plain value
+   * A more powerful version of `queryCost` which allows the field cost computation to return an effect instead of a plain value
    * when computing the cost estimate.
    * @param f The field cost estimate function
    *
@@ -139,7 +139,7 @@ object CostEstimation {
     queryCostZIOWrapperState(costWrapperZIO(_)(f))((cost, r) => p(cost) as r)
 
   /**
-   * The most powerful version of [[queryCost]] that allows maximum freedom in how the wrapper is defined. The function accepts
+   * The most powerful version of `queryCost` that allows maximum freedom in how the wrapper is defined. The function accepts
    * a function that will take a Ref that can be used for book keeping to track the current cost of the query, and returns a wrapper.
    * Normally this wrapper is a validation wrapper because it should be run before execution for the purposes of cost estimation.
    * However, the API provides the flexibility to redefine that. The second parameter of the function will receive the final cost estimate of the query

--- a/core/src/test/scala/caliban/wrappers/CostEstimationSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/CostEstimationSpec.scala
@@ -3,12 +3,15 @@ package caliban.wrappers
 import caliban.CalibanError.ValidationError
 import caliban.GraphQL.graphQL
 import caliban.Macros.gqldoc
+import caliban.ResponseValue.ObjectValue
 import caliban.RootResolver
-import caliban.Value.IntValue
+import caliban.Value.{ FloatValue, IntValue }
 import caliban.schema.Annotations.GQLDirective
 import caliban.wrappers.CostEstimation.CostDirective
-import zio.{ Ref, UIO }
+import zio.console.putStr
+import zio.test.environment.TestConsole
 import zio.test.{ assertTrue, DefaultRunnableSpec, ZSpec }
+import zio.{ Ref, UIO }
 
 object CostEstimationSpec extends DefaultRunnableSpec {
   case class WithArgs(limit: Int)
@@ -35,43 +38,48 @@ object CostEstimationSpec extends DefaultRunnableSpec {
 
   override def spec: ZSpec[_root_.zio.test.environment.TestEnvironment, Any] =
     suite("Cost Estimation")(
-      testM("Rejects queries that are too expensive") {
-        val wrapper = CostEstimation.maxComplexity(99)(CostEstimation.costDirective)
-        for {
-          interpreter <- (api @@ wrapper).interpreter
-          query        = gqldoc("""{ b }""")
-          response    <- interpreter.execute(query)
-        } yield assertTrue(response.errors == List(ValidationError("Query costs too much: 101.0. Max cost: 99.", "")))
-      },
-      testM("Allow queries below the limit") {
-        val wrapper = CostEstimation.maxComplexity(200)(CostEstimation.costDirective)
-        for {
-          interpreter <- (api @@ wrapper).interpreter
-          query        = gqldoc("{ a b }")
-          response    <- interpreter.execute(query)
-        } yield assertTrue(response.errors.isEmpty)
-      },
-      testM("Applies multipliers when computing cost") {
-        val wrapper = CostEstimation.maxComplexity(100)(CostEstimation.costDirective)
-        for {
-          interpreter <- (api @@ wrapper).interpreter
-          query        = gqldoc("{ c(limit: 50) }")
-          response    <- interpreter.execute(query)
-        } yield assertTrue(response.errors.nonEmpty)
-      },
-      testM("Applies multipliers from variables") {
-        val wrapper = CostEstimation.maxComplexity(100)(CostEstimation.costDirective)
-        for {
-          interpreter <- (api @@ wrapper).interpreter
-          query        = gqldoc("""query test($limit: Int!) { b c(limit: $limit) }""")
-          response    <- interpreter.execute(query, variables = Map("limit" -> IntValue(25)))
-        } yield assertTrue(response.errors == List(ValidationError("Query costs too much: 226.0. Max cost: 100.", "")))
-      },
-      testM("Max cost with fragments") {
-        val wrapper = CostEstimation.maxComplexity(5)(CostEstimation.costDirective)
-        for {
-          interpreter <- (api @@ wrapper).interpreter
-          query        = gqldoc("""
+      suite("maxCost")(
+        testM("Rejects queries that are too expensive") {
+          val wrapper = CostEstimation.maxCost(99)(CostEstimation.costDirective)
+          for {
+            interpreter <- (api @@ wrapper).interpreter
+            query        = gqldoc("""{ b }""")
+            response    <- interpreter.execute(query)
+          } yield assertTrue(
+            response.errors == List(ValidationError("Query costs too much: 101.0. Max cost: 99.0.", ""))
+          )
+        },
+        testM("Allow queries below the limit") {
+          val wrapper = CostEstimation.maxCost(200)(CostEstimation.costDirective)
+          for {
+            interpreter <- (api @@ wrapper).interpreter
+            query        = gqldoc("{ a b }")
+            response    <- interpreter.execute(query)
+          } yield assertTrue(response.errors.isEmpty)
+        },
+        testM("Applies multipliers when computing cost") {
+          val wrapper = CostEstimation.maxCost(100)(CostEstimation.costDirective)
+          for {
+            interpreter <- (api @@ wrapper).interpreter
+            query        = gqldoc("{ c(limit: 50) }")
+            response    <- interpreter.execute(query)
+          } yield assertTrue(response.errors.nonEmpty)
+        },
+        testM("Applies multipliers from variables") {
+          val wrapper = CostEstimation.maxCost(100)(CostEstimation.costDirective)
+          for {
+            interpreter <- (api @@ wrapper).interpreter
+            query        = gqldoc("""query test($limit: Int!) { b c(limit: $limit) }""")
+            response    <- interpreter.execute(query, variables = Map("limit" -> IntValue(25)))
+          } yield assertTrue(
+            response.errors == List(ValidationError("Query costs too much: 226.0. Max cost: 100.0.", ""))
+          )
+        },
+        testM("Max cost with fragments") {
+          val wrapper = CostEstimation.maxCost(5)(CostEstimation.costDirective)
+          for {
+            interpreter <- (api @@ wrapper).interpreter
+            query        = gqldoc("""
                query test { # cost: 1
                  d { # cost: 2
                    ...f
@@ -83,22 +91,65 @@ object CostEstimationSpec extends DefaultRunnableSpec {
                  f # cost: 1
                }
               """)
-          response    <- interpreter.execute(query)
-        } yield assertTrue(response.errors == List(ValidationError("Query costs too much: 16.0. Max cost: 5.", "")))
-      },
-      testM("Max cost with an effect") {
-        for {
-          ref         <- Ref.make(0.0)
-          count       <- Ref.make(0)
-          wrapper      = CostEstimation.maxComplexityZIO(100)(_ => ref.updateAndGet(_ + 10.0))
-          interpreter <- (api @@ wrapper).interpreter
-          query        = gqldoc("{ a }")
-          response    <- interpreter.execute(query).repeatUntilM(resp => count.update(_ + 1).as(resp.errors.nonEmpty))
-          c           <- count.get
-        } yield assertTrue(
-          response.errors == List(ValidationError("Query costs too much: 110.0. Max cost: 100.0.", ""))
-        ) &&
-          assertTrue(c == 11)
-      }
+            response    <- interpreter.execute(query)
+          } yield assertTrue(response.errors == List(ValidationError("Query costs too much: 6.0. Max cost: 5.0.", "")))
+        },
+        testM("Max cost with an effect") {
+          for {
+            ref         <- Ref.make(0.0)
+            count       <- Ref.make(0)
+            wrapper      = CostEstimation.maxCostZIO(500)(_ => ref.updateAndGet(_ + 10.0))
+            interpreter <- (api @@ wrapper).interpreter
+            query        = gqldoc("{ a d { e { value } f } }")
+            response    <- interpreter.execute(query).repeatUntilM(resp => count.update(_ + 1).as(resp.errors.nonEmpty))
+            c           <- count.get
+          } yield assertTrue(
+            response.errors == List(ValidationError("Query costs too much: 570.0. Max cost: 500.0.", ""))
+          ) &&
+            assertTrue(c == 2)
+        }
+      ),
+      suite("queryCost")(
+        testM("includes the cost as an extension") {
+          val wrapper = CostEstimation.queryCost(CostEstimation.costDirective)
+          for {
+            interpreter <- (api @@ wrapper).interpreter
+            query        = gqldoc("""
+               query test { # cost: 1
+                 d { # cost: 2
+                   ...f
+                 }
+               }
+               
+               fragment f on D { # type cost: 10
+                 e { value } # cost: 1 + 1
+                 f # cost: 1
+               }
+              """)
+            response    <- interpreter.execute(query)
+          } yield assertTrue(response.extensions.get == ObjectValue(List("queryCost" -> FloatValue(6.0))))
+        },
+        testM("execute arbitrary side-effect with query cost") {
+          val wrapper =
+            CostEstimation.queryCostWith(CostEstimation.costDirective)(total => putStr(s"Query cost $total").orDie)
+          for {
+            interpreter <- (api @@ wrapper).interpreter
+            query        = gqldoc("""
+               query test { # cost: 1
+                 d { # cost: 2
+                   ...f
+                 }
+               }
+               
+               fragment f on D { # type cost: 10 overridden by the field
+                 e { value } # cost: 1 + 1
+                 f # cost: 1
+               }
+              """)
+            _           <- interpreter.execute(query)
+            output      <- TestConsole.output
+          } yield assertTrue(output.head == "Query cost 6.0")
+        }
+      )
     )
 }

--- a/core/src/test/scala/caliban/wrappers/CostEstimationSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/CostEstimationSpec.scala
@@ -6,8 +6,7 @@ import caliban.Macros.gqldoc
 import caliban.ResponseValue.ObjectValue
 import caliban.RootResolver
 import caliban.Value.{ FloatValue, IntValue }
-import caliban.schema.Annotations.GQLDirective
-import caliban.wrappers.CostEstimation.CostDirective
+import caliban.wrappers.CostEstimation.GQLCost
 import zio.console.putStr
 import zio.test.environment.TestConsole
 import zio.test.{ assertTrue, DefaultRunnableSpec, ZSpec }
@@ -16,13 +15,13 @@ import zio.{ Ref, UIO }
 object CostEstimationSpec extends DefaultRunnableSpec {
   case class WithArgs(limit: Int)
   case class E(value: Int)
-  @GQLDirective(CostDirective(10))
-  case class D(e: E, @GQLDirective(CostDirective(1, List("limit"))) f: List[String])
+  @GQLCost(10)
+  case class D(e: E, @GQLCost(1, List("limit")) f: List[String])
   case class Test(
     a: Int,
-    @GQLDirective(CostDirective(100)) b: UIO[Int],
-    @GQLDirective(CostDirective(5, multipliers = List("limit"))) c: WithArgs => UIO[List[Int]],
-    @GQLDirective(CostDirective(2)) d: D
+    @GQLCost(100) b: UIO[Int],
+    @GQLCost(5, multipliers = List("limit")) c: WithArgs => UIO[List[Int]],
+    @GQLCost(2) d: D
   )
 
   val api = graphQL(

--- a/core/src/test/scala/caliban/wrappers/CostEstimationSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/CostEstimationSpec.scala
@@ -1,0 +1,104 @@
+package caliban.wrappers
+
+import caliban.CalibanError.ValidationError
+import caliban.GraphQL.graphQL
+import caliban.Macros.gqldoc
+import caliban.RootResolver
+import caliban.Value.IntValue
+import caliban.schema.Annotations.GQLDirective
+import caliban.wrappers.CostEstimation.CostDirective
+import zio.{ Ref, UIO }
+import zio.test.{ assertTrue, DefaultRunnableSpec, ZSpec }
+
+object CostEstimationSpec extends DefaultRunnableSpec {
+  case class WithArgs(limit: Int)
+  case class E(value: Int)
+  @GQLDirective(CostDirective(10))
+  case class D(e: E, @GQLDirective(CostDirective(1, List("limit"))) f: List[String])
+  case class Test(
+    a: Int,
+    @GQLDirective(CostDirective(100)) b: UIO[Int],
+    @GQLDirective(CostDirective(5, multipliers = List("limit"))) c: WithArgs => UIO[List[Int]],
+    @GQLDirective(CostDirective(2)) d: D
+  )
+
+  val api = graphQL(
+    RootResolver(
+      Test(
+        1,
+        UIO(2),
+        args => UIO(List.fill(args.limit)(42)),
+        D(E(99), List("Hello", "There"))
+      )
+    )
+  )
+
+  override def spec: ZSpec[_root_.zio.test.environment.TestEnvironment, Any] =
+    suite("Cost Estimation")(
+      testM("Rejects queries that are too expensive") {
+        val wrapper = CostEstimation.maxComplexity(99)(CostEstimation.costDirective)
+        for {
+          interpreter <- (api @@ wrapper).interpreter
+          query        = gqldoc("""{ b }""")
+          response    <- interpreter.execute(query)
+        } yield assertTrue(response.errors == List(ValidationError("Query costs too much: 101.0. Max cost: 99.", "")))
+      },
+      testM("Allow queries below the limit") {
+        val wrapper = CostEstimation.maxComplexity(200)(CostEstimation.costDirective)
+        for {
+          interpreter <- (api @@ wrapper).interpreter
+          query        = gqldoc("{ a b }")
+          response    <- interpreter.execute(query)
+        } yield assertTrue(response.errors.isEmpty)
+      },
+      testM("Applies multipliers when computing cost") {
+        val wrapper = CostEstimation.maxComplexity(100)(CostEstimation.costDirective)
+        for {
+          interpreter <- (api @@ wrapper).interpreter
+          query        = gqldoc("{ c(limit: 50) }")
+          response    <- interpreter.execute(query)
+        } yield assertTrue(response.errors.nonEmpty)
+      },
+      testM("Applies multipliers from variables") {
+        val wrapper = CostEstimation.maxComplexity(100)(CostEstimation.costDirective)
+        for {
+          interpreter <- (api @@ wrapper).interpreter
+          query        = gqldoc("""query test($limit: Int!) { b c(limit: $limit) }""")
+          response    <- interpreter.execute(query, variables = Map("limit" -> IntValue(25)))
+        } yield assertTrue(response.errors == List(ValidationError("Query costs too much: 226.0. Max cost: 100.", "")))
+      },
+      testM("Max cost with fragments") {
+        val wrapper = CostEstimation.maxComplexity(5)(CostEstimation.costDirective)
+        for {
+          interpreter <- (api @@ wrapper).interpreter
+          query        = gqldoc("""
+               query test { # cost: 1
+                 d { # cost: 2
+                   ...f
+                 }
+               }
+               
+               fragment f on D { # type cost: 10
+                 e { value } # cost: 1 + 1
+                 f # cost: 1
+               }
+              """)
+          response    <- interpreter.execute(query)
+        } yield assertTrue(response.errors == List(ValidationError("Query costs too much: 16.0. Max cost: 5.", "")))
+      },
+      testM("Max cost with an effect") {
+        for {
+          ref         <- Ref.make(0.0)
+          count       <- Ref.make(0)
+          wrapper      = CostEstimation.maxComplexityZIO(100)(_ => ref.updateAndGet(_ + 10.0))
+          interpreter <- (api @@ wrapper).interpreter
+          query        = gqldoc("{ a }")
+          response    <- interpreter.execute(query).repeatUntilM(resp => count.update(_ + 1).as(resp.errors.nonEmpty))
+          c           <- count.get
+        } yield assertTrue(
+          response.errors == List(ValidationError("Query costs too much: 110.0. Max cost: 100.0.", ""))
+        ) &&
+          assertTrue(c == 11)
+      }
+    )
+}


### PR DESCRIPTION
Adds a simple cost estimation wrapper for computing the effective cost of executing a query and rejecting it if it is too expensive. Different from `maxDepth` or `maxFields` because it supports an arbitrary function to determine the cost of the field. Out of the box it provides a simple `cost` directive that can be added to fields or types to specify their overall cost to execute. Note, because it is a "speculative" cost it can't take advantage of the actual return values meaning that it relies on the user to apply the correct multipliers and to determine a good metric for assessing a fields cost.