### PR TITLE
Schema Gen: Add Option for Preserving Input Names

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanCli.scala
@@ -52,7 +52,7 @@ object CalibanCli {
 
   private val genSchemaHelpMsg =
     s"""
-       |calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--abstractEffectType true|false]
+       |calibanGenSchema schemaPath outputPath [--scalafmtPath path] [--headers name:value,name2:value2] [--packageName name] [--effect fqdn.Effect] [--abstractEffectType true|false] [--preserveInputNames true|false]
        |
        |This command will create a Scala file in `outputPath` containing all the types
        |defined in the provided GraphQL schema defined at `schemaPath`. Instead of a path,
@@ -66,6 +66,8 @@ object CalibanCli {
        |type is abstract, so that it will be added as a type parameter to the generated
        |Query and Mutation classes (if applicable).  In such cases `F` will be used by
        |as the type parameter unless the `--effect` option is explicitly given.
+       |By default all input types will have 'Input' appended to their names in the
+       |derived schema.  Use the --preserveInputNames flag to disable this.
        |""".stripMargin
 
   private val genClientHelpMsg =

--- a/tools/src/main/scala/caliban/tools/CalibanCommonSettings.scala
+++ b/tools/src/main/scala/caliban/tools/CalibanCommonSettings.scala
@@ -15,7 +15,8 @@ final case class CalibanCommonSettings(
   extensibleEnums: Option[Boolean],
   genType: GenType,
   effect: Option[String],
-  abstractEffectType: Option[Boolean]
+  abstractEffectType: Option[Boolean],
+  preserveInputNames: Option[Boolean]
 ) {
 
   private[caliban] def toOptions(schemaPath: String, toPath: String): Options =
@@ -33,7 +34,8 @@ final case class CalibanCommonSettings(
       abstractEffectType = abstractEffectType,
       splitFiles = splitFiles,
       enableFmt = enableFmt,
-      extensibleEnums = extensibleEnums
+      extensibleEnums = extensibleEnums,
+      preserveInputNames = preserveInputNames
     )
 
   private[caliban] def combine(r: => CalibanCommonSettings): CalibanCommonSettings =
@@ -50,7 +52,8 @@ final case class CalibanCommonSettings(
       extensibleEnums = r.extensibleEnums.orElse(this.extensibleEnums),
       genType = r.genType,
       effect = r.effect.orElse(this.effect),
-      abstractEffectType = r.abstractEffectType.orElse(this.abstractEffectType)
+      abstractEffectType = r.abstractEffectType.orElse(this.abstractEffectType),
+      preserveInputNames = r.preserveInputNames.orElse(this.preserveInputNames)
     )
 
   def clientName(value: String): CalibanCommonSettings                       = this.copy(clientName = Some(value))
@@ -68,6 +71,8 @@ final case class CalibanCommonSettings(
   def effect(effect: String): CalibanCommonSettings                          = this.copy(effect = Some(effect))
   def abstractEffectType(abstractEffectType: Boolean): CalibanCommonSettings =
     this.copy(abstractEffectType = Some(abstractEffectType))
+  def preserveInputNames(preserveInputNames: Boolean): CalibanCommonSettings =
+    this.copy(preserveInputNames = Some(preserveInputNames))
 }
 
 object CalibanCommonSettings {
@@ -85,6 +90,7 @@ object CalibanCommonSettings {
       extensibleEnums = None,
       genType = GenType.Client,
       effect = None,
-      abstractEffectType = None
+      abstractEffectType = None,
+      preserveInputNames = None
     )
 }

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -27,6 +27,7 @@ object Codegen {
       effect                    = arguments.effect.getOrElse {
                                     if (abstractEffectType) "F" else "zio.UIO"
                                   }
+      preserveInputNames        = arguments.preserveInputNames.getOrElse(false)
       genView                   = arguments.genView.getOrElse(false)
       scalarMappings            = arguments.scalarMappings
       splitFiles                = arguments.splitFiles.getOrElse(false)
@@ -41,7 +42,8 @@ object Codegen {
                                           effect,
                                           arguments.imports,
                                           scalarMappings,
-                                          abstractEffectType
+                                          abstractEffectType,
+                                          preserveInputNames
                                         )
                                       )
                                     case GenType.Client =>

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -17,7 +17,8 @@ final case class Options(
   abstractEffectType: Option[Boolean],
   splitFiles: Option[Boolean],
   enableFmt: Option[Boolean],
-  extensibleEnums: Option[Boolean]
+  extensibleEnums: Option[Boolean],
+  preserveInputNames: Option[Boolean]
 )
 
 object Options {
@@ -34,7 +35,8 @@ object Options {
     abstractEffectType: Option[Boolean],
     splitFiles: Option[Boolean],
     enableFmt: Option[Boolean],
-    extensibleEnums: Option[Boolean]
+    extensibleEnums: Option[Boolean],
+    preserveInputNames: Option[Boolean]
   )
 
   def fromArgs(args: List[String]): Option[Options] =
@@ -77,7 +79,8 @@ object Options {
             rawOpts.abstractEffectType,
             rawOpts.splitFiles,
             rawOpts.enableFmt,
-            rawOpts.extensibleEnums
+            rawOpts.extensibleEnums,
+            rawOpts.preserveInputNames
           )
         }
       case _                             => None

--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -12,7 +12,8 @@ object SchemaWriter {
     effect: String = "zio.UIO",
     imports: Option[List[String]] = None,
     scalarMappings: Option[Map[String, String]],
-    isEffectTypeAbstract: Boolean = false
+    isEffectTypeAbstract: Boolean = false,
+    preserveInputNames: Boolean = false
   ): String = {
 
     val interfaceImplementationsMap = (for {
@@ -62,10 +63,13 @@ object SchemaWriter {
         .map(writeField(_, typedef))
         .mkString(", ")})"""
 
-    def writeInputObject(typedef: InputObjectTypeDefinition): String =
-      s"""${writeDescription(typedef.description)}final case class ${typedef.name}(${typedef.fields
+    def writeInputObject(typedef: InputObjectTypeDefinition): String = {
+      val name            = typedef.name
+      val maybeAnnotation = if (preserveInputNames) s"""@GQLInputName("$name")\n""" else ""
+      s"""${maybeAnnotation}${writeDescription(typedef.description)}final case class $name(${typedef.fields
         .map(writeInputValue)
         .mkString(", ")})"""
+    }
 
     def writeEnum(typedef: EnumTypeDefinition): String =
       s"""${writeDescription(typedef.description)}sealed trait ${typedef.name} extends scala.Product with scala.Serializable

--- a/tools/src/main/scala/caliban/tools/compiletime/Config.scala
+++ b/tools/src/main/scala/caliban/tools/compiletime/Config.scala
@@ -29,7 +29,8 @@ trait Config {
         extensibleEnums = Some(extensibleEnums),
         GenType.Client,
         effect = None,
-        abstractEffectType = None
+        abstractEffectType = None,
+        preserveInputNames = None
       )
 
     private[caliban] def asScalaCode: String = {

--- a/tools/src/test/scala/caliban/tools/CodegenSpec.scala
+++ b/tools/src/test/scala/caliban/tools/CodegenSpec.scala
@@ -81,7 +81,8 @@ object CodegenSpec extends DefaultRunnableSpec {
       abstractEffectType = None,
       splitFiles = None,
       enableFmt = None,
-      extensibleEnums = None
+      extensibleEnums = None,
+      preserveInputNames = None
     )
 
     getPackageAndObjectName(arguments)

--- a/tools/src/test/scala/caliban/tools/OptionsSpec.scala
+++ b/tools/src/test/scala/caliban/tools/OptionsSpec.scala
@@ -28,6 +28,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -54,6 +55,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -66,7 +68,7 @@ object OptionsSpec extends DefaultRunnableSpec {
         assert(result)(
           equalTo(
             Some(
-              Options("schema", "output", None, None, None, None, None, None, None, None, None, None, None, None)
+              Options("schema", "output", None, None, None, None, None, None, None, None, None, None, None, None, None)
             )
           )
         )
@@ -105,6 +107,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -124,6 +127,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some("GraphqlClient.scala"),
+                None,
                 None,
                 None,
                 None,
@@ -157,6 +161,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -177,6 +182,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some(true),
+                None,
                 None,
                 None,
                 None,
@@ -209,7 +215,8 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
-                Some(true)
+                Some(true),
+                None
               )
             )
           )
@@ -231,6 +238,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 Some(Map("Long" -> "scala.Long")),
+                None,
                 None,
                 None,
                 None,
@@ -261,6 +269,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -287,7 +296,35 @@ object OptionsSpec extends DefaultRunnableSpec {
                 Some(true),
                 None,
                 None,
+                None,
                 None
+              )
+            )
+          )
+        )
+      },
+      test("provide preserveInputNames") {
+        val input  = List("schema", "output", "--preserveInputNames", "true")
+        val result = Options.fromArgs(input)
+        assert(result)(
+          equalTo(
+            Some(
+              Options(
+                "schema",
+                "output",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(true)
               )
             )
           )
@@ -304,6 +341,7 @@ object OptionsSpec extends DefaultRunnableSpec {
                 "output",
                 Some("fmtPath"),
                 Some(List(Header("aaa", "bbb:ccc"))),
+                None,
                 None,
                 None,
                 None,

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -15,7 +15,8 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
     effect: String = "zio.UIO",
     imports: List[String] = List.empty,
     scalarMappings: Map[String, String] = Map.empty,
-    isEffectTypeAbstract: Boolean = false
+    isEffectTypeAbstract: Boolean = false,
+    preserveInputNames: Boolean = false
   ): RIO[Blocking, String] = Parser
     .parseQuery(schema.stripMargin)
     .flatMap(doc =>
@@ -27,7 +28,8 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
             effect,
             Some(imports),
             Some(scalarMappings),
-            isEffectTypeAbstract
+            isEffectTypeAbstract,
+            preserveInputNames
           ),
           None
         )
@@ -350,6 +352,30 @@ object SchemaWriterSpec extends DefaultRunnableSpec {
         |
         |  final case class Character(name: String)
         |  final case class CharacterArgs(name: String)
+        |
+        |}"""
+    ),
+    (
+      "input type with preserved input",
+      gen(
+        """
+             type Character {
+                name: String!
+             }
+
+             input CharacterInput {
+               name: String!
+             }
+            """,
+        preserveInputNames = true
+      ),
+      """import caliban.schema.Annotations._
+        |
+        |object Types {
+        |
+        |  final case class Character(name: String)
+        |  @GQLInputName("CharacterInput")
+        |  final case class CharacterInput(name: String)
         |
         |}"""
     ),

--- a/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
+++ b/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
@@ -39,7 +39,8 @@ object ConfigSpec extends DefaultRunnableSpec {
               enableFmt = Some(false),
               extensibleEnums = Some(true),
               effect = None,
-              abstractEffectType = None
+              abstractEffectType = None,
+              preserveInputNames = None
             )
         )
       )

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -299,6 +299,8 @@ By default, each Query and Mutation will be wrapped into a `zio.UIO` effect. Thi
 
 You can also indicate that the effect type is abstract via `--abstractEffectType true`, in which case `Query` will be replaced by `Query[F[_]]` and so on (note `F` will be used unless `--effect <effect>` is explicitly given in which case `<effect>` would be used in place of `F`).
 
+By default the suffix `Input` is appended to the type name of input types in the derived schema.  Use the `--preserveInputNames` flag to disable this. 
+
 If you want to force a mapping between a GraphQL type and a Scala class (such as scalars), you can use the
 `--scalarMappings` option. Also you can add additional imports by providing `--imports` option.
 


### PR DESCRIPTION
Hi!  This PR adds the `--preserveInputNames` option to the schema gen cli which will prompt the case classes of Input types to be generated with the `@GQLInputName("$name")` where `name` is the name of the Input type.

The motivation is that I would like the derived schema to be as close as possible to the `.gql` file used as input to the schema gen, so I will often name my input types like `FooInput`, but then this is changed in the derived schema to `FooInputInput` :slightly_smiling_face:

Thanks