### PR TITLE
Serve graphiql.html with text/html Content-Type

### DIFF
--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -4,6 +4,7 @@ import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
 
 import caliban.ZHttpAdapter
+import io.netty.handler.codec.http.{HttpHeaderNames, HttpHeaderValues}
 import zio._
 import zio.stream._
 import zhttp.http._
@@ -11,8 +12,13 @@ import zhttp.service.Server
 
 object ExampleApp extends App {
   private val graphiql =
-    Http.succeed(Response.http(content = HttpData.fromStream(ZStream.fromResource("graphiql.html"))))
-
+    Http.succeed(
+      Response.http(
+        content = HttpData.fromStream(ZStream.fromResource("graphiql.html")),
+        headers = List(Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_HTML))
+      )
+    )
+  
   override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
     (for {
       interpreter <- ExampleApi.api.interpreter


### PR DESCRIPTION
Currently it serves without any Content-Type, which does not always work.