### PR TITLE
Fix fields merging and improve performance

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -120,7 +120,7 @@ object Field {
           }
         case _                                                                                                      =>
       }
-      Field("", fieldType, None, fields = fieldList.result().toList)
+      Field("", fieldType, None, fields = fieldList.toList)
     }
 
     loop(selectionSet, fieldType).copy(directives = directives)

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -357,8 +357,8 @@ object ExecutionSpec extends DefaultRunnableSpec {
         for {
           interpreter <- api.interpreter
           result      <- interpreter.mapError(_ => "my custom error").execute(query)
-        } yield assert(result.errors)(equalTo(List("my custom error"))) &&
-          assert(result.asJson.noSpaces)(equalTo("""{"data":null,"errors":[{"message":"my custom error"}]}"""))
+        } yield assertTrue(result.errors == List("my custom error")) &&
+          assertTrue(result.asJson.noSpaces == """{"data":null,"errors":[{"message":"my custom error"}]}""")
       },
       testM("customErrorEffectSchema") {
         import io.circe.syntax._
@@ -689,11 +689,10 @@ object ExecutionSpec extends DefaultRunnableSpec {
         interpreter
           .flatMap(_.execute(query))
           .map(result =>
-            assert(result.data.toString)(
-              equalTo("""{"user1":{"name":"user","friends":["friend"]},"user2":null}""")
-            ) &&
-              assert(result.errors.collectFirst { case e: ExecutionError => e }.map(_.path))(
-                isSome(equalTo(List(Left("user2"), Left("friends"))))
+            assertTrue(result.data.toString == """{"user1":{"name":"user","friends":["friend"]},"user2":null}""") &&
+              assertTrue(
+                result.errors.collectFirst { case e: ExecutionError => e }.map(_.path).get ==
+                  List(Left("user2"), Left("friends"))
               )
           )
       },
@@ -715,7 +714,7 @@ object ExecutionSpec extends DefaultRunnableSpec {
             |}""".stripMargin
         interpreter
           .flatMap(_.execute(query))
-          .map(result => assert(result.data.toString)(equalTo("""{"user":null}""")))
+          .map(result => assertTrue(result.data.toString == """{"user":null}"""))
       },
       testM("failure in ArgBuilder, non optional field") {
         case class UserArgs(id: Int)
@@ -733,7 +732,7 @@ object ExecutionSpec extends DefaultRunnableSpec {
             |}""".stripMargin
         interpreter
           .flatMap(_.execute(query))
-          .map(result => assert(result.data.toString)(equalTo("""null""")))
+          .map(result => assertTrue(result.data.toString == """null"""))
       },
       testM("die inside a nullable list") {
         case class Queries(test: List[Task[String]])
@@ -867,6 +866,9 @@ object ExecutionSpec extends DefaultRunnableSpec {
             |    __typename
             |    ... on Character {
             |      name
+            |    }
+            |    ... on Human {
+            |      height
             |    }
             |    ... on Human {
             |      height


### PR DESCRIPTION
Fields were not properly merged during execution. I moved the merging to the validation phase and added some performance optimizations.

Before:
```
[info] Benchmark                               Mode  Cnt      Score      Error  Units
[info] GraphQLBenchmarks.fragmentsCaliban     thrpt    5     27.739 ±    2.741  ops/s
[info] GraphQLBenchmarks.fragmentsSangriaNew  thrpt    5     24.269 ±    4.216  ops/s
[info] GraphQLBenchmarks.fragmentsSangriaOld  thrpt    5      0.165 ±    0.011  ops/s
[info] GraphQLBenchmarks.introspectCaliban    thrpt    5   1585.284 ±  183.560  ops/s
[info] GraphQLBenchmarks.introspectSangria    thrpt    5    499.669 ±   19.512  ops/s
[info] GraphQLBenchmarks.simpleCaliban        thrpt    5  24539.809 ± 1188.386  ops/s
[info] GraphQLBenchmarks.simpleSangria        thrpt    5   7551.214 ± 1423.378  ops/s
```
After:
```
[info] Benchmark                               Mode  Cnt      Score     Error  Units
[info] GraphQLBenchmarks.fragmentsCaliban     thrpt    5     44.638 ±   1.523  ops/s
[info] GraphQLBenchmarks.fragmentsSangriaNew  thrpt    5     28.994 ±  16.953  ops/s
[info] GraphQLBenchmarks.fragmentsSangriaOld  thrpt    5      0.155 ±   0.039  ops/s
[info] GraphQLBenchmarks.introspectCaliban    thrpt    5   1782.754 ± 309.681  ops/s
[info] GraphQLBenchmarks.introspectSangria    thrpt    5    500.839 ±  15.303  ops/s
[info] GraphQLBenchmarks.simpleCaliban        thrpt    5  26091.734 ± 305.640  ops/s
[info] GraphQLBenchmarks.simpleSangria        thrpt    5   7831.910 ± 139.665  ops/s
```