### PR TITLE
Expose federation service schema

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -171,7 +171,7 @@ trait GraphQL[-R] { self =>
    */
   final def combine[R1 <: R](that: GraphQL[R1]): GraphQL[R1] =
     new GraphQL[R1] {
-      override private[caliban] val schemaBuilder: RootSchemaBuilder[R1]              = self.schemaBuilder |+| that.schemaBuilder
+      override private[caliban] val schemaBuilder: RootSchemaBuilder[R1]    = self.schemaBuilder |+| that.schemaBuilder
       override private[caliban] val wrappers: List[Wrapper[R1]]             = self.wrappers ++ that.wrappers
       override private[caliban] val additionalDirectives: List[__Directive] =
         self.additionalDirectives ++ that.additionalDirectives

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -22,9 +22,9 @@ import zio.{ IO, URIO }
  */
 trait GraphQL[-R] { self =>
 
-  protected val schemaBuilder: RootSchemaBuilder[R]
-  protected val wrappers: List[Wrapper[R]]
-  protected val additionalDirectives: List[__Directive]
+  private[caliban] val schemaBuilder: RootSchemaBuilder[R]
+  private[caliban] val wrappers: List[Wrapper[R]]
+  private[caliban] val additionalDirectives: List[__Directive]
 
   private[caliban] def validateRootSchema: IO[ValidationError, RootSchema[R]] =
     Validator.validateSchema(schemaBuilder)
@@ -171,9 +171,9 @@ trait GraphQL[-R] { self =>
    */
   final def combine[R1 <: R](that: GraphQL[R1]): GraphQL[R1] =
     new GraphQL[R1] {
-      override val schemaBuilder: RootSchemaBuilder[R1]              = self.schemaBuilder |+| that.schemaBuilder
-      override protected val wrappers: List[Wrapper[R1]]             = self.wrappers ++ that.wrappers
-      override protected val additionalDirectives: List[__Directive] =
+      override private[caliban] val schemaBuilder: RootSchemaBuilder[R1]              = self.schemaBuilder |+| that.schemaBuilder
+      override private[caliban] val wrappers: List[Wrapper[R1]]             = self.wrappers ++ that.wrappers
+      override private[caliban] val additionalDirectives: List[__Directive] =
         self.additionalDirectives ++ that.additionalDirectives
     }
 
@@ -194,7 +194,7 @@ trait GraphQL[-R] { self =>
     mutationsName: Option[String] = None,
     subscriptionsName: Option[String] = None
   ): GraphQL[R] = new GraphQL[R] {
-    override protected val schemaBuilder: RootSchemaBuilder[R]     = self.schemaBuilder.copy(
+    override private[caliban] val schemaBuilder: RootSchemaBuilder[R]     = self.schemaBuilder.copy(
       query = queriesName.fold(self.schemaBuilder.query)(name =>
         self.schemaBuilder.query.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
       ),
@@ -205,8 +205,8 @@ trait GraphQL[-R] { self =>
         self.schemaBuilder.subscription.map(m => m.copy(opType = m.opType.copy(name = Some(name))))
       )
     )
-    override protected val wrappers: List[Wrapper[R]]              = self.wrappers
-    override protected val additionalDirectives: List[__Directive] = self.additionalDirectives
+    override private[caliban] val wrappers: List[Wrapper[R]]              = self.wrappers
+    override private[caliban] val additionalDirectives: List[__Directive] = self.additionalDirectives
   }
 
   /**
@@ -216,10 +216,9 @@ trait GraphQL[-R] { self =>
    * @param types The type definitions to add.
    */
   final def withAdditionalTypes(types: List[__Type]): GraphQL[R] = new GraphQL[R] {
-    override protected val schemaBuilder: RootSchemaBuilder[R]     =
-      self.schemaBuilder.copy(additionalTypes = self.schemaBuilder.additionalTypes ++ types)
-    override protected val wrappers: List[Wrapper[R]]              = self.wrappers
-    override protected val additionalDirectives: List[__Directive] = self.additionalDirectives
+    override private[caliban] val schemaBuilder: RootSchemaBuilder[R]     = self.schemaBuilder.copy(additionalTypes = types)
+    override private[caliban] val wrappers: List[Wrapper[R]]              = self.wrappers
+    override private[caliban] val additionalDirectives: List[__Directive] = self.additionalDirectives
   }
 }
 

--- a/federation/src/main/scala/caliban/federation/FederatedGraphQL.scala
+++ b/federation/src/main/scala/caliban/federation/FederatedGraphQL.scala
@@ -3,6 +3,7 @@ package caliban.federation
 import caliban.GraphQL
 
 trait FederatedGraphQL[R] extends GraphQL[R] {
+
   /** The service schema for the federated subgraph. */
   val service: GraphQL[R]
 }

--- a/federation/src/main/scala/caliban/federation/FederatedGraphQL.scala
+++ b/federation/src/main/scala/caliban/federation/FederatedGraphQL.scala
@@ -1,0 +1,8 @@
+package caliban.federation
+
+import caliban.GraphQL
+
+trait FederatedGraphQL[R] extends GraphQL[R] {
+  /** The service schema for the federated subgraph. */
+  val service: GraphQL[R]
+}

--- a/federation/src/main/scala/caliban/federation/Federation.scala
+++ b/federation/src/main/scala/caliban/federation/Federation.scala
@@ -57,13 +57,13 @@ trait Federation {
       _fieldSet: FieldSet = FieldSet("")
     )
 
-
     new FederatedGraphQL[R] {
-      private val underlying = GraphQL.graphQL(RootResolver(Query(_service = _Service(original.render))), federationDirectives) |+| original
-      override val schemaBuilder: RootSchemaBuilder[R] = underlying.schemaBuilder
-      override val wrappers: List[Wrapper[R]] = underlying.wrappers
+      private val underlying                               =
+        GraphQL.graphQL(RootResolver(Query(_service = _Service(original.render))), federationDirectives) |+| original
+      override val schemaBuilder: RootSchemaBuilder[R]     = underlying.schemaBuilder
+      override val wrappers: List[Wrapper[R]]              = underlying.wrappers
       override val additionalDirectives: List[__Directive] = underlying.additionalDirectives
-      val service: GraphQL[R] = original
+      val service: GraphQL[R]                              = original
     }
   }
 
@@ -86,7 +86,11 @@ trait Federation {
    * @param resolver A type which can resolve a single type by a key which is provided per type using the @key directive
    * @param otherResolvers Additional resolvers to supply
    */
-  def federate[R](original: GraphQL[R], resolver: EntityResolver[R], otherResolvers: EntityResolver[R]*): FederatedGraphQL[R] = {
+  def federate[R](
+    original: GraphQL[R],
+    resolver: EntityResolver[R],
+    otherResolvers: EntityResolver[R]*
+  ): FederatedGraphQL[R] = {
 
     val resolvers = resolver +: otherResolvers.toList
 
@@ -127,7 +131,6 @@ trait Federation {
       _fieldSet: FieldSet = FieldSet("")
     )
 
-
     new FederatedGraphQL[R] {
       private val withSDL                                  = original.withAdditionalTypes(resolvers.map(_.toType).flatMap(Types.collectTypes(_)))
       private val underlying                               = GraphQL.graphQL[R, Query, Unit, Unit](
@@ -142,7 +145,7 @@ trait Federation {
       override val schemaBuilder: RootSchemaBuilder[R]     = underlying.schemaBuilder
       override val wrappers: List[Wrapper[R]]              = underlying.wrappers
       override val additionalDirectives: List[__Directive] = underlying.additionalDirectives
-      val service: GraphQL[R] = withSDL
+      val service: GraphQL[R]                              = withSDL
     }
   }
 }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -139,7 +139,7 @@ package object tapir {
         )
       )
 
-    override protected val schemaBuilder: RootSchemaBuilder[R] =
+    override private[caliban] val schemaBuilder: RootSchemaBuilder[R] =
       serverEndpoint.endpoint.method.getOrElse(Method.GET) match {
         case Method.PUT | Method.POST | Method.DELETE =>
           RootSchemaBuilder(None, Some(makeOperation("Mutation")), None)
@@ -147,8 +147,8 @@ package object tapir {
           RootSchemaBuilder(Some(makeOperation("Query")), None, None)
       }
 
-    override protected val wrappers: List[Wrapper[R]]              = Nil
-    override protected val additionalDirectives: List[__Directive] = Nil
+    override private[caliban] val wrappers: List[Wrapper[R]]              = Nil
+    override private[caliban] val additionalDirectives: List[__Directive] = Nil
   }
 
   private def extractPath[I](endpointName: Option[String], input: EndpointInput[I]): String =

--- a/tools/src/main/scala/caliban/tools/stitching/RemoteSchemaResolver.scala
+++ b/tools/src/main/scala/caliban/tools/stitching/RemoteSchemaResolver.scala
@@ -54,9 +54,9 @@ case class RemoteSchemaResolver(schema: __Schema, typeMap: Map[String, __Type]) 
     )
 
     new GraphQL[R] {
-      protected val additionalDirectives: List[__Directive]            = schema.directives
-      protected val schemaBuilder: caliban.schema.RootSchemaBuilder[R] = builder
-      protected val wrappers: List[caliban.wrappers.Wrapper[R]]        = List()
+      private[caliban] val additionalDirectives: List[__Directive]            = schema.directives
+      private[caliban] val schemaBuilder: caliban.schema.RootSchemaBuilder[R] = builder
+      private[caliban] val wrappers: List[caliban.wrappers.Wrapper[R]]        = List()
     }
   }
 }

--- a/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
+++ b/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
@@ -97,7 +97,7 @@ object RemoteSchemaSpec extends DefaultRunnableSpec {
 
   def fromRemoteSchema(s: __Schema): GraphQL[Any] =
     new GraphQL[Any] {
-      protected val schemaBuilder                                 =
+      private[caliban] val schemaBuilder                                 =
         RootSchemaBuilder(
           query = Some(
             Operation[Any](
@@ -108,8 +108,8 @@ object RemoteSchemaSpec extends DefaultRunnableSpec {
           mutation = None,
           subscription = None
         )
-      protected val additionalDirectives: List[__Directive]       = List()
-      protected val wrappers: List[caliban.wrappers.Wrapper[Any]] = List()
+      private[caliban] val additionalDirectives: List[__Directive]       = List()
+      private[caliban] val wrappers: List[caliban.wrappers.Wrapper[Any]] = List()
     }
 
 }


### PR DESCRIPTION
The Apollo federation spec requires a federated subgraph expose a `_service: _Service` field on the subgraph's query type. This [`_Service` type](https://www.apollographql.com/docs/federation/federation-spec/#type-_service) has a `sdl: String!` field, that is the SDL of the service's schema. This "service schema" is the schema of the subgraph + any entity types the subgraph resolves. It does _not_ include any of the extra federation types (i.e. `_Any`) or fields (i.e. `_service`, `_entities`). 

I needed to expose the service schema (to work with Apollo validation), but was unable to see a way to do that. Currently, the `federate` helper returns a `GraphQL` object, which only has a `render` method on it that renders the full graph schema, including the extra federation types.

This PR makes an attempt to expose that service schema by introducing a new `FederatedGraphQL` type that the `federate` helper returns. `FederatedGraphQL` has a `service: GraphQL` value on it, which is the "service schema."

The easiest way I saw to do this was to inline creation of the `FederatedGraphQL` instance for the two `federate` methods, delegating most methods to the underlying `GraphQL` object. I had to adjust the field visibility in order to access those underlying fields.

This was just my first stab at this, so happy to alter approach or make other changes.