### PR TITLE
Do not render emplty field list

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -32,15 +32,23 @@ trait GraphQL[-R] { self =>
   /**
    * Returns a string that renders the API types into the GraphQL format.
    */
-  final def render: String =
-    s"""schema {
-       |${schemaBuilder.query.flatMap(_.opType.name).fold("")(n => s"  query: $n\n")}${schemaBuilder.mutation
-      .flatMap(_.opType.name)
-      .fold("")(n => s"  mutation: $n\n")}${schemaBuilder.subscription
-      .flatMap(_.opType.name)
-      .fold("")(n => s"  subscription: $n\n")}}
+  final def render: String = {
+    val parts  = Seq(
+      schemaBuilder.query.flatMap(_.opType.name).map(n => s"  query: $n"),
+      schemaBuilder.mutation.flatMap(_.opType.name).map(n => s"  mutation: $n"),
+      schemaBuilder.subscription.flatMap(_.opType.name).map(n => s"  subscription: $n")
+    )
+    val schema = parts.flatten.mkString("\n") match {
+      case ""        => ""
+      case something => s"""schema {
+                           |$something
+                           |}""".stripMargin
+    }
+
+    s"""$schema
        |
        |${renderTypes(schemaBuilder.types)}""".stripMargin
+  }
 
   /**
    * Converts the schema to a Document.

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -60,15 +60,17 @@ object Rendering {
               .fold(List.empty[String])(_.map(renderEnumValue))
               .mkString("\n  ")
 
-            val typedef = s"${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderInterfaces(t)}$renderedDirectives"
+            val typedef =
+              s"${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderInterfaces(t)}$renderedDirectives"
 
             s"$renderedFields$renderedInputFields$renderedEnumValues" match {
-              case "" => Some(typedef)
-              case interior => Some(
-                s"""$typedef {
-                   |  $interior
-                   |}""".stripMargin
-              )
+              case ""       => Some(typedef)
+              case interior =>
+                Some(
+                  s"""$typedef {
+                     |  $interior
+                     |}""".stripMargin
+                )
             }
         }
       }

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -59,11 +59,17 @@ object Rendering {
               .enumValues(__DeprecatedArgs(Some(true)))
               .fold(List.empty[String])(_.map(renderEnumValue))
               .mkString("\n  ")
-            Some(
-              s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderInterfaces(t)}$renderedDirectives {
-                 |  $renderedFields$renderedInputFields$renderedEnumValues
-                 |}""".stripMargin
-            )
+
+            val typedef = s"${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderInterfaces(t)}$renderedDirectives"
+
+            s"$renderedFields$renderedInputFields$renderedEnumValues" match {
+              case "" => Some(typedef)
+              case interior => Some(
+                s"""$typedef {
+                   |  $interior
+                   |}""".stripMargin
+              )
+            }
         }
       }
       .mkString("\n\n")

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -95,6 +95,19 @@ object RenderingSpec extends DefaultRunnableSpec {
                                      |  "field-description"
                                      |  age: Int!
                                      |}""".stripMargin.trim))
+      },
+      test("it should render empty objects without field list") {
+        assert(graphQL(InvalidSchemas.Object.resolverEmpty).render.trim)(
+          equalTo("""schema {
+                    |  query: TestEmptyObject
+                    |}
+                    |
+                    |type EmptyObject
+                    |
+                    |type TestEmptyObject {
+                    |  o: EmptyObject!
+                    |}""".stripMargin.trim)
+        )
       }
     )
 }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -108,6 +108,11 @@ object RenderingSpec extends DefaultRunnableSpec {
                     |  o: EmptyObject!
                     |}""".stripMargin.trim)
         )
+      },
+      test("it should not render a schema in no queries, mutations, or subscription") {
+        assert(graphQL(InvalidSchemas.resolverEmpty).render.trim)(
+          equalTo("")
+        )
       }
     )
 }

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -517,5 +517,6 @@ object TestUtils {
       TestWrongFieldArgDirectiveName(_ => UIO.unit)
     )
 
+    val resolverEmpty = new RootResolver(Option.empty[Unit], Option.empty[Unit], Option.empty[Unit])
   }
 }


### PR DESCRIPTION
According to [the GraphQL object spec](https://spec.graphql.org/June2018/#sec-Objects), for a given `type Foo` the fields definition for that type is optional. As far as I can tell, if you want to not specify a fields list, you need to also omit the wrapping `{...}`. i.e:

```graphql
// This is invalid
type Foo {
}

// This is valid
type Foo
```

Currently, Caliban always prints schema with the wrapping `{...}`, even if there are no fields for the type, which I believe is invalid. I tested this against our schema in Apollo and saw the below. Sensitive parts omitted, but the important part is the AST parse failure.

```
$ echo 'schema {query: Q} type Q {}' | rover subgraph check [...]
Checking the proposed schema for subgraph [...]
error: Could not parse partial schema as AST.

$ echo 'schema {query: Q} type Q' | rover subgraph check [...]
Checking the proposed schema for [...]
Compared 108 schema changes against 25 operations
```