### PR TITLE
Root query: generate `{x}Option` method for fields with an optional interface type

### DIFF
--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -383,7 +383,7 @@ object ClientWriter {
               field,
               "_root_.caliban.client.Operations.RootMutation",
               optionalUnion = false,
-              optionalInterface = true,
+              optionalInterface = false,
               commonInterface = false
             )
           )

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -88,6 +88,15 @@ object ClientWriter {
       safeTypeName(name) -> op
     }.toMap
 
+    val knownInterfaceTypes = typesMap.collect { case (key, _: InterfaceTypeDefinition) => key }
+    val knownUnionTypes     = typesMap.collect { case (key, _: UnionTypeDefinition) => key }
+
+    def isOptionalInterfaceType(field: FieldDefinition): Boolean =
+      knownInterfaceTypes.exists(_.compareToIgnoreCase(Type.innerType(field.ofType)) == 0)
+
+    def isOptionalUnionType(field: FieldDefinition): Boolean =
+      knownUnionTypes.exists(_.compareToIgnoreCase(Type.innerType(field.ofType)) == 0)
+
     def writeFieldInfo(fieldInfo: FieldInfo): String = {
       val FieldInfo(
         name,
@@ -309,16 +318,36 @@ object ClientWriter {
 
     def writeRootQuery(typedef: ObjectTypeDefinition): String =
       s"""object ${typedef.name} {
-         |  ${typedef.fields
-        .map(
-          writeField(
-            _,
-            "_root_.caliban.client.Operations.RootQuery",
-            optionalUnion = false,
-            optionalInterface = false,
-            commonInterface = false
+         |  ${typedef.fields.flatMap { field =>
+        if (isOptionalInterfaceType(field)) {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootQuery",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
+            ),
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootQuery",
+              optionalUnion = false,
+              optionalInterface = true,
+              commonInterface = false
+            )
           )
-        )
+        } else {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootQuery",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
+            )
+          )
+        }
+      }
         .mkString("\n  ")}
          |}
          |""".stripMargin
@@ -376,10 +405,8 @@ object ClientWriter {
 
       val objectName: String = safeTypeName(typedef.name)
 
-      val unionTypes              = typesMap.collect { case (key, _: UnionTypeDefinition) => key }
       val optionalUnionTypeFields = typedef.fields.flatMap { field =>
-        val isOptionalUnionType = unionTypes.exists(_.compareToIgnoreCase(Type.innerType(field.ofType)) == 0)
-        if (isOptionalUnionType)
+        if (isOptionalUnionType(field))
           Some(
             collectFieldInfo(
               field,
@@ -392,10 +419,8 @@ object ClientWriter {
         else None
       }
 
-      val interfaceTypes              = typesMap.collect { case (key, _: InterfaceTypeDefinition) => key }
       val optionalInterfaceTypeFields = typedef.fields.flatMap { field =>
-        val isOptionalInterfaceType = interfaceTypes.exists(_.compareToIgnoreCase(Type.innerType(field.ofType)) == 0)
-        if (isOptionalInterfaceType)
+        if (isOptionalInterfaceType(field))
           Vector(
             collectFieldInfo(
               field,

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -359,16 +359,36 @@ object ClientWriter {
 
     def writeRootMutation(typedef: ObjectTypeDefinition): String =
       s"""object ${typedef.name} {
-         |  ${typedef.fields
-        .map(
-          writeField(
-            _,
-            "_root_.caliban.client.Operations.RootMutation",
-            optionalUnion = false,
-            optionalInterface = false,
-            commonInterface = false
+         |  ${typedef.fields.flatMap { field =>
+        if (isOptionalInterfaceType(field)) {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootMutation",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
+            ),
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootMutation",
+              optionalUnion = false,
+              optionalInterface = true,
+              commonInterface = false
+            )
           )
-        )
+        } else {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootMutation",
+              optionalUnion = false,
+              optionalInterface = true,
+              commonInterface = false
+            )
+          )
+        }
+      }
         .mkString("\n  ")}
          |}
          |""".stripMargin
@@ -380,16 +400,36 @@ object ClientWriter {
 
     def writeRootSubscription(typedef: ObjectTypeDefinition): String =
       s"""object ${typedef.name} {
-         |  ${typedef.fields
-        .map(
-          writeField(
-            _,
-            "_root_.caliban.client.Operations.RootSubscription",
-            optionalUnion = false,
-            optionalInterface = false,
-            commonInterface = false
+         |  ${typedef.fields.flatMap { field =>
+        if (isOptionalInterfaceType(field)) {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootSubscription",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
+            ),
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootSubscription",
+              optionalUnion = false,
+              optionalInterface = true,
+              commonInterface = false
+            )
           )
-        )
+        } else {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootSubscription",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
+            )
+          )
+        }
+      }
         .mkString("\n  ")}
          |}
          |""".stripMargin

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -1158,9 +1158,19 @@ object Client {
           """
           schema {
             query: Queries
+            mutation: Mutations
+            subscription: Subscriptions
           }
 
           type Queries {
+            node(id: ID!): Node
+          }
+
+          type Mutations {
+            updateNode(id: ID!, name: String): Node
+          }
+
+          type Subscriptions {
             node(id: ID!): Node
           }
 
@@ -1237,6 +1247,70 @@ object Client {
     )(onNodeA: Option[SelectionBuilder[NodeA, A]] = None, onNodeB: Option[SelectionBuilder[NodeB, A]] = None)(implicit
       encoder0: ArgEncoder[String]
     ): SelectionBuilder[_root_.caliban.client.Operations.RootQuery, Option[Option[A]]] =
+      _root_.caliban.client.SelectionBuilder.Field(
+        "node",
+        OptionOf(
+          ChoiceOf(
+            Map(
+              "NodeA" -> onNodeA.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "NodeB" -> onNodeB.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a)))
+            )
+          )
+        ),
+        arguments = List(Argument("id", id, "ID!")(encoder0))
+      )
+  }
+
+  type Mutations = _root_.caliban.client.Operations.RootMutation
+  object Mutations {
+    def updateNode[A](
+      id: String,
+      name: Option[String] = None
+    )(onNodeA: SelectionBuilder[NodeA, A], onNodeB: SelectionBuilder[NodeB, A])(implicit
+      encoder0: ArgEncoder[String],
+      encoder1: ArgEncoder[Option[String]]
+    ): SelectionBuilder[_root_.caliban.client.Operations.RootMutation, Option[A]] =
+      _root_.caliban.client.SelectionBuilder.Field(
+        "updateNode",
+        OptionOf(ChoiceOf(Map("NodeA" -> Obj(onNodeA), "NodeB" -> Obj(onNodeB)))),
+        arguments = List(Argument("id", id, "ID!")(encoder0), Argument("name", name, "String")(encoder1))
+      )
+    def updateNodeOption[A](
+      id: String,
+      name: Option[String] = None
+    )(onNodeA: Option[SelectionBuilder[NodeA, A]] = None, onNodeB: Option[SelectionBuilder[NodeB, A]] = None)(implicit
+      encoder0: ArgEncoder[String],
+      encoder1: ArgEncoder[Option[String]]
+    ): SelectionBuilder[_root_.caliban.client.Operations.RootMutation, Option[Option[A]]] =
+      _root_.caliban.client.SelectionBuilder.Field(
+        "updateNode",
+        OptionOf(
+          ChoiceOf(
+            Map(
+              "NodeA" -> onNodeA.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a))),
+              "NodeB" -> onNodeB.fold[FieldBuilder[Option[A]]](NullField)(a => OptionOf(Obj(a)))
+            )
+          )
+        ),
+        arguments = List(Argument("id", id, "ID!")(encoder0), Argument("name", name, "String")(encoder1))
+      )
+  }
+
+  type Subscriptions = _root_.caliban.client.Operations.RootSubscription
+  object Subscriptions {
+    def node[A](id: String)(onNodeA: SelectionBuilder[NodeA, A], onNodeB: SelectionBuilder[NodeB, A])(implicit
+      encoder0: ArgEncoder[String]
+    ): SelectionBuilder[_root_.caliban.client.Operations.RootSubscription, Option[A]] =
+      _root_.caliban.client.SelectionBuilder.Field(
+        "node",
+        OptionOf(ChoiceOf(Map("NodeA" -> Obj(onNodeA), "NodeB" -> Obj(onNodeB)))),
+        arguments = List(Argument("id", id, "ID!")(encoder0))
+      )
+    def nodeOption[A](
+      id: String
+    )(onNodeA: Option[SelectionBuilder[NodeA, A]] = None, onNodeB: Option[SelectionBuilder[NodeB, A]] = None)(implicit
+      encoder0: ArgEncoder[String]
+    ): SelectionBuilder[_root_.caliban.client.Operations.RootSubscription, Option[Option[A]]] =
       _root_.caliban.client.SelectionBuilder.Field(
         "node",
         OptionOf(


### PR DESCRIPTION
`ClientWriter` does not handle optional interfaces properly of the root query.  

I fixed the processing of the root query in the scope of the PR. If the output type of a field is an interface, the `ClientWriter` will generate two methods: `def {x}(...)` and `def {x}Option(...)`. 

### Schema 1 (without root schema)

```diff
type Queries {
  node(id: ID!): Node
}
interface Node {
  id: ID!
}
type NodeA implements Node {
  id: ID!
  a: String
}
type NodeB implements Node {
  id: ID!
  b: Int
}
```

`ClientWriter` generates two methods: `node(id: ID)(...)` and `nodeOption(id: ID)(...)`. 

### Schema 2 (with top-level `schema` definition)

```diff
+ schema {
+  query: Queries
+}
type Queries {
  node(id: ID!): Node
}
interface Node {
  id: ID!
}
type NodeA implements Node {
  id: ID!
  a: String
}
type NodeB implements Node {
  id: ID!
  b: Int
}
```

`ClientWriter` generates only one method: `node(id: ID)(...)`. 

