### PR TITLE
Upgrade sbt in codegen test

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CompileTimeCalibanPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CompileTimeCalibanPlugin.scala
@@ -84,11 +84,13 @@ object CompileTimeCalibanServerPlugin extends AutoPlugin {
                        |import caliban.tools.compiletime.Config.ClientGenerationSettings
                        |import zio.{ExitCode, URIO}
                        |
-                       |private[generator] object $generatorName extends zio.App {
-                       |  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
-                       |    CompileTime.generateClient(args)(
-                       |      $ref,
-                       |      ${clientSettings.asScalaCode}
+                       |private[generator] object $generatorName {
+                       |  def main(args: Array[String]): Unit =
+                       |    zio.Runtime.default.unsafeRun(
+                       |      CompileTime.generateClient(args.toList)(
+                       |        $ref,
+                       |        ${clientSettings.asScalaCode}
+                       |      )
                        |    )
                        |}
                        |""".stripMargin.trim

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/project/build.properties
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.6.1


### PR DESCRIPTION
The compile time plugin stopped working with sbt 1.6.x. It seems that the code generator is running in the main sbt JVM and that `sys.exit` called in `zio.App` is making it stop.