### PR TITLE
support uuid as arg encoder

### DIFF
--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,9 +1,18 @@
 package caliban.client
 
-import caliban.client.__Value.{ __BooleanValue, __ListValue, __NullValue, __NumberValue, __ObjectValue, __StringValue }
+import caliban.client.__Value.{
+  __BooleanValue,
+  __ListValue,
+  __NullValue,
+  __NumberValue,
+  __ObjectValue,
+  __StringValue,
+  __UUIDValue
+}
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
+import java.util.UUID
 
 /**
  * Typeclass that defines how to encode an argument of type `A` into a valid [[caliban.client.__Value]].
@@ -41,6 +50,8 @@ object ArgEncoder {
   implicit val boolean: ArgEncoder[Boolean] = (value: Boolean) => __BooleanValue(value)
 
   implicit val unit: ArgEncoder[Unit] = (_: Unit) => __ObjectValue(Nil)
+
+  implicit val uuid: ArgEncoder[UUID] = (value: UUID) => __UUIDValue(value)
 
   implicit def option[A](implicit ev: ArgEncoder[A]): ArgEncoder[Option[A]] = (value: Option[A]) =>
     value.fold(__NullValue: __Value)(ev.encode)

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,14 +1,6 @@
 package caliban.client
 
-import caliban.client.__Value.{
-  __BooleanValue,
-  __ListValue,
-  __NullValue,
-  __NumberValue,
-  __ObjectValue,
-  __StringValue,
-  __UUIDValue
-}
+import caliban.client.__Value.{ __BooleanValue, __ListValue, __NullValue, __NumberValue, __ObjectValue, __StringValue }
 import io.circe.Json
 
 import scala.annotation.implicitNotFound
@@ -51,7 +43,7 @@ object ArgEncoder {
 
   implicit val unit: ArgEncoder[Unit] = (_: Unit) => __ObjectValue(Nil)
 
-  implicit val uuid: ArgEncoder[UUID] = (value: UUID) => __UUIDValue(value)
+  implicit val uuid: ArgEncoder[UUID] = (value: UUID) => __StringValue(value.toString())
 
   implicit def option[A](implicit ev: ArgEncoder[A]): ArgEncoder[Option[A]] = (value: Option[A]) =>
     value.fold(__NullValue: __Value)(ev.encode)

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -36,8 +36,8 @@ object __Value {
   case class __BooleanValue(value: Boolean)   extends __Value {
     override def toString: String = value.toString
   }
-  case class __UUIDValue(value: UUID) extends __Value {
-    override def toString: String = value.toString
+  case class __UUIDValue(value: UUID)         extends __Value {
+    override def toString: String = Json.fromString(value.toString()).toString
 
   }
   case class __ListValue(values: List[__Value])             extends __Value {

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -1,6 +1,7 @@
 package caliban.client
 
 import io.circe.{ Decoder, Encoder, Json }
+import java.util.UUID
 
 /**
  * Value that can be returned by the server or sent as an argument.
@@ -20,20 +21,24 @@ sealed trait __Value { self =>
 }
 
 object __Value {
-  case object __NullValue                                   extends __Value {
+  case object __NullValue                     extends __Value {
     override def toString: String = "null"
   }
-  case class __NumberValue(value: BigDecimal)               extends __Value {
+  case class __NumberValue(value: BigDecimal) extends __Value {
     override def toString: String = s"$value"
   }
-  case class __EnumValue(value: String)                     extends __Value {
+  case class __EnumValue(value: String)       extends __Value {
     override def toString: String = value
   }
-  case class __StringValue(value: String)                   extends __Value {
+  case class __StringValue(value: String)     extends __Value {
     override def toString: String = Json.fromString(value).toString
   }
-  case class __BooleanValue(value: Boolean)                 extends __Value {
+  case class __BooleanValue(value: Boolean)   extends __Value {
     override def toString: String = value.toString
+  }
+  case class __UUIDValue(value: UUID) extends __Value {
+    override def toString: String = value.toString
+
   }
   case class __ListValue(values: List[__Value])             extends __Value {
     override def toString: String = values.map(_.toString).mkString("[", ",", "]")
@@ -59,6 +64,7 @@ object __Value {
     case __StringValue(value)  => Json.fromString(value)
     case __EnumValue(value)    => Json.fromString(value)
     case __BooleanValue(value) => Json.fromBoolean(value)
+    case __UUIDValue(value)    => Json.fromString(value.toString())
     case __ListValue(values)   => Json.fromValues(values.map(valueToJson))
     case __ObjectValue(fields) => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
   }

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -1,7 +1,6 @@
 package caliban.client
 
 import io.circe.{ Decoder, Encoder, Json }
-import java.util.UUID
 
 /**
  * Value that can be returned by the server or sent as an argument.
@@ -21,24 +20,20 @@ sealed trait __Value { self =>
 }
 
 object __Value {
-  case object __NullValue                     extends __Value {
+  case object __NullValue                                   extends __Value {
     override def toString: String = "null"
   }
-  case class __NumberValue(value: BigDecimal) extends __Value {
+  case class __NumberValue(value: BigDecimal)               extends __Value {
     override def toString: String = s"$value"
   }
-  case class __EnumValue(value: String)       extends __Value {
+  case class __EnumValue(value: String)                     extends __Value {
     override def toString: String = value
   }
-  case class __StringValue(value: String)     extends __Value {
+  case class __StringValue(value: String)                   extends __Value {
     override def toString: String = Json.fromString(value).toString
   }
-  case class __BooleanValue(value: Boolean)   extends __Value {
+  case class __BooleanValue(value: Boolean)                 extends __Value {
     override def toString: String = value.toString
-  }
-  case class __UUIDValue(value: UUID)         extends __Value {
-    override def toString: String = Json.fromString(value.toString()).toString
-
   }
   case class __ListValue(values: List[__Value])             extends __Value {
     override def toString: String = values.map(_.toString).mkString("[", ",", "]")
@@ -64,7 +59,6 @@ object __Value {
     case __StringValue(value)  => Json.fromString(value)
     case __EnumValue(value)    => Json.fromString(value)
     case __BooleanValue(value) => Json.fromBoolean(value)
-    case __UUIDValue(value)    => Json.fromString(value.toString())
     case __ListValue(values)   => Json.fromValues(values.map(valueToJson))
     case __ObjectValue(fields) => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
   }

--- a/client/src/test/scala/caliban/client/ArgEncoderSpec.scala
+++ b/client/src/test/scala/caliban/client/ArgEncoderSpec.scala
@@ -3,6 +3,7 @@ package caliban.client
 import zio.test.Assertion.equalTo
 import zio.test._
 import zio.test.environment.TestEnvironment
+import java.util.UUID
 
 object ArgEncoderSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[TestEnvironment, Any] =
@@ -19,6 +20,13 @@ object ArgEncoderSpec extends DefaultRunnableSpec {
         },
         test("string with null characters") {
           assert(ArgEncoder.string.encode("abcde who am i\u0000").toString)(equalTo("\"abcde who am i\\u0000\""))
+        }
+      ),
+      suite("__UUIDValue")(
+        test("regular uuid") {
+          assert(ArgEncoder.uuid.encode(UUID.fromString("20a69d87-6d68-4779-a4da-601f4c04ebf3")).toString)(
+            equalTo(""""20a69d87-6d68-4779-a4da-601f4c04ebf3"""")
+          )
         }
       )
     )


### PR DESCRIPTION
Added support for UUID to the ArgEncoder typeclass hierarchy. 

With this clients don't need to turn their UUID to String and can use UUID values directly