### PR TITLE
Add missing directive rendering for derrived types

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -142,7 +142,7 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
           getDescription(ctx),
           subtypes.map { case (t, _) => fixEmptyUnionObject(t) },
           Some(ctx.typeName.full),
-          directives = Some(getDirectives(ctx.annotations))
+          Some(getDirectives(ctx.annotations))
         )
       else {
         val impl         = subtypes.map(_._1.copy(interfaces = () => Some(List(toType(isInput, isSubscription)))))

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -134,13 +134,15 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
           },
           Some(ctx.typeName.full)
         )
-      else if (!isInterface)
+      else if (!isInterface) {
         makeUnion(
           Some(getName(ctx)),
           getDescription(ctx),
           subtypes.map { case (t, _) => fixEmptyUnionObject(t) },
-          Some(ctx.typeName.full)
+          Some(ctx.typeName.full),
+          directives = Some(getDirectives(ctx.annotations))
         )
+      }
       else {
         val impl         = subtypes.map(_._1.copy(interfaces = () => Some(List(toType(isInput, isSubscription)))))
         val commonFields = () =>

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -136,7 +136,7 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
           Some(ctx.typeName.full),
           Some(getDirectives(ctx.annotations))
         )
-      else if (!isInterface) {
+      else if (!isInterface)
         makeUnion(
           Some(getName(ctx)),
           getDescription(ctx),
@@ -144,7 +144,7 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
           Some(ctx.typeName.full),
           directives = Some(getDirectives(ctx.annotations))
         )
-      } else {
+      else {
         val impl         = subtypes.map(_._1.copy(interfaces = () => Some(List(toType(isInput, isSubscription)))))
         val commonFields = () =>
           impl

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -144,8 +144,7 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
           Some(ctx.typeName.full),
           directives = Some(getDirectives(ctx.annotations))
         )
-      }
-      else {
+      } else {
         val impl         = subtypes.map(_._1.copy(interfaces = () => Some(List(toType(isInput, isSubscription)))))
         val commonFields = () =>
           impl

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -57,7 +57,8 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
               )
             )
             .toList,
-          Some(ctx.typeName.full)
+          Some(ctx.typeName.full),
+          Some(getDirectives(ctx))
         )
       else
         makeObject(
@@ -132,7 +133,8 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
               annotations.collectFirst { case GQLDeprecated(reason) => reason }
             )
           },
-          Some(ctx.typeName.full)
+          Some(ctx.typeName.full),
+          Some(getDirectives(ctx.annotations))
         )
       else if (!isInterface) {
         makeUnion(
@@ -159,7 +161,14 @@ trait SchemaDerivation[R] extends LowPriorityDerivedSchema {
             .flatten
             .toList
 
-        makeInterface(Some(getName(ctx)), getDescription(ctx), commonFields, impl, Some(ctx.typeName.full))
+        makeInterface(
+          Some(getName(ctx)),
+          getDescription(ctx),
+          commonFields,
+          impl,
+          Some(ctx.typeName.full),
+          Some(getDirectives(ctx.annotations))
+        )
       }
     }
 

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -81,14 +81,16 @@ trait SchemaDerivation[A] {
                     annotations.collectFirst { case GQLDeprecated(reason) => reason }
                   )
                 },
-                Some(info.full)
+                Some(info.full),
+                Some(getDirectives(annotations))
               )
             } else if (!isInterface)
               makeUnion(
                 Some(getName(annotations, info)),
                 getDescription(annotations),
                 subTypes.map { case (_, t, _) => fixEmptyUnionObject(t) },
-                Some(info.full)
+                Some(info.full),
+                Some(getDirectives(annotations))
               )
             else {
               val impl         = subTypes.map(_._2.copy(interfaces = () => Some(List(toType(isInput, isSubscription)))))
@@ -111,7 +113,8 @@ trait SchemaDerivation[A] {
                 getDescription(annotations),
                 commonFields,
                 impl,
-                Some(info.full)
+                Some(info.full),
+                Some(getDirectives(annotations))
               )
             }
 
@@ -147,7 +150,8 @@ trait SchemaDerivation[A] {
                     Some(fieldAnnotations.collect { case GQLDirective(dir) => dir }).filter(_.nonEmpty)
                   )
                 },
-                Some(info.full)
+                Some(info.full),
+                Some(getDirectives(annotations))
               )
             else
               makeObject(

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -31,7 +31,7 @@ object Rendering {
                 .fold(List.empty[String])(_.flatMap(_.name))
                 .mkString(" | ")
             Some(
-              s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)} = $renderedTypes"""
+              s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderDirectives(t.directives)} = $renderedTypes"""
             )
           case _                   =>
             val renderedDirectives: String  = renderDirectives(t.directives)

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -31,7 +31,9 @@ object Rendering {
                 .fold(List.empty[String])(_.flatMap(_.name))
                 .mkString(" | ")
             Some(
-              s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderDirectives(t.directives)} = $renderedTypes"""
+              s"""${renderDescription(t.description)}${renderKind(t.kind)} ${renderTypeName(t)}${renderDirectives(
+                t.directives
+              )} = $renderedTypes"""
             )
           case _                   =>
             val renderedDirectives: String  = renderDirectives(t.directives)

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -65,9 +65,12 @@ object Types {
     name: Option[String],
     description: Option[String],
     subTypes: List[__Type],
-    origin: Option[String] = None
-  ): __Type =
-    __Type(__TypeKind.UNION, name, description, possibleTypes = Some(subTypes), origin = origin)
+    origin: Option[String] = None,
+    directives: Option[List[Directive]] = None
+  ): __Type = {
+    __Type(__TypeKind.UNION, name, description, possibleTypes = Some(subTypes), origin = origin, directives = directives)
+  }
+
 
   def makeInterface(
     name: Option[String],

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -24,7 +24,8 @@ object Types {
     name: Option[String],
     description: Option[String],
     values: List[__EnumValue],
-    origin: Option[String]
+    origin: Option[String],
+    directives: Option[List[Directive]] = None
   ): __Type =
     __Type(
       __TypeKind.ENUM,
@@ -32,7 +33,8 @@ object Types {
       description,
       enumValues =
         args => if (args.includeDeprecated.getOrElse(false)) Some(values) else Some(values.filter(!_.isDeprecated)),
-      origin = origin
+      origin = origin,
+      directives = directives
     )
 
   def makeObject(
@@ -57,9 +59,10 @@ object Types {
     name: Option[String],
     description: Option[String],
     fields: List[__InputValue],
-    origin: Option[String] = None
+    origin: Option[String] = None,
+    directives: Option[List[Directive]] = None
   ): __Type =
-    __Type(__TypeKind.INPUT_OBJECT, name, description, inputFields = Some(fields), origin = origin)
+    __Type(__TypeKind.INPUT_OBJECT, name, description, inputFields = Some(fields), origin = origin, directives = directives)
 
   def makeUnion(
     name: Option[String],
@@ -77,7 +80,8 @@ object Types {
     description: Option[String],
     fields: () => List[__Field],
     subTypes: List[__Type],
-    origin: Option[String] = None
+    origin: Option[String] = None,
+    directives: Option[List[Directive]] = None
   ): __Type =
     __Type(
       __TypeKind.INTERFACE,
@@ -86,7 +90,8 @@ object Types {
       fields =
         args => if (args.includeDeprecated.getOrElse(false)) Some(fields()) else Some(fields().filter(!_.isDeprecated)),
       possibleTypes = Some(subTypes),
-      origin = origin
+      origin = origin,
+      directives = directives
     )
 
   /**

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -62,7 +62,14 @@ object Types {
     origin: Option[String] = None,
     directives: Option[List[Directive]] = None
   ): __Type =
-    __Type(__TypeKind.INPUT_OBJECT, name, description, inputFields = Some(fields), origin = origin, directives = directives)
+    __Type(
+      __TypeKind.INPUT_OBJECT,
+      name,
+      description,
+      inputFields = Some(fields),
+      origin = origin,
+      directives = directives
+    )
 
   def makeUnion(
     name: Option[String],
@@ -70,10 +77,15 @@ object Types {
     subTypes: List[__Type],
     origin: Option[String] = None,
     directives: Option[List[Directive]] = None
-  ): __Type = {
-    __Type(__TypeKind.UNION, name, description, possibleTypes = Some(subTypes), origin = origin, directives = directives)
-  }
-
+  ): __Type =
+    __Type(
+      __TypeKind.UNION,
+      name,
+      description,
+      possibleTypes = Some(subTypes),
+      origin = origin,
+      directives = directives
+    )
 
   def makeInterface(
     name: Option[String],

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -34,11 +34,15 @@ object RenderingSpec extends DefaultRunnableSpec {
                     |  origin: Origin!
                     |}
                     |
+                    |interface Human {
+                    |  name: String! @external
+                    |}
+                    |
                     |type Captain {
                     |  shipName: CaptainShipName!
                     |}
                     |
-                    |type Character @key(name: "name") {
+                    |type Character implements Human @key(name: "name") {
                     |  name: String! @external
                     |  nicknames: [String!]! @required
                     |  origin: Origin!
@@ -53,6 +57,10 @@ object RenderingSpec extends DefaultRunnableSpec {
                     |  shipName: String!
                     |}
                     |
+                    |type Narrator implements Human {
+                    |  name: String!
+                    |}
+                    |
                     |type Pilot {
                     |  shipName: String!
                     |}
@@ -64,6 +72,7 @@ object RenderingSpec extends DefaultRunnableSpec {
                     |  character(name: String!): Character @deprecated(reason: "Use `characters`")
                     |  charactersIn(names: [String!]!): [Character!]!
                     |  exists(character: CharacterInput!): Boolean!
+                    |  human: Human!
                     |}""".stripMargin.trim)
         )
       },

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -19,7 +19,7 @@ object RenderingSpec extends DefaultRunnableSpec {
                     |"Description of custom scalar emphasizing proper captain ship names"
                     |scalar CaptainShipName @specifiedBy(url: "http://someUrl")
                     |
-                    |union Role = Captain | Engineer | Mechanic | Pilot
+                    |union Role @uniondirective = Captain | Engineer | Mechanic | Pilot
                     |
                     |enum Origin {
                     |  BELT

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -21,14 +21,14 @@ object RenderingSpec extends DefaultRunnableSpec {
                     |
                     |union Role @uniondirective = Captain | Engineer | Mechanic | Pilot
                     |
-                    |enum Origin {
+                    |enum Origin @enumdirective {
                     |  BELT
                     |  EARTH
                     |  MARS
                     |  MOON @deprecated(reason: "Use: EARTH | MARS | BELT")
                     |}
                     |
-                    |input CharacterInput {
+                    |input CharacterInput @inputobjdirective {
                     |  name: String! @external
                     |  nicknames: [String!]! @required
                     |  origin: Origin!

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -33,6 +33,7 @@ object TestUtils {
     case object MOON extends Origin
   }
 
+  @GQLDirective(Directive("uniondirective"))
   sealed trait Role
 
   case class CaptainShipName(value: String)

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -23,6 +23,7 @@ object TestUtils {
     case class C(id: String, blah: Boolean) extends Interface
   }
 
+  @GQLDirective(Directive("enumdirective"))
   sealed trait Origin
 
   object Origin {
@@ -68,6 +69,7 @@ object TestUtils {
   case class WrappedPainter(self: Painter) extends AnyVal
 
   @GQLInputName("CharacterInput")
+  @GQLDirective(Directive("inputobjdirective"))
   case class CharacterInput(
     @GQLDirective(Directive("external")) name: String,
     @GQLDirective(Directive("required")) nicknames: List[String],

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -54,13 +54,20 @@ object TestUtils {
     case class Mechanic(shipName: String)         extends Role
   }
 
+  @GQLInterface
+  sealed trait Human
+
   @GQLDirective(Directive("key", Map("name" -> StringValue("name"))))
   case class Character(
     @GQLDirective(Directive("external")) name: String,
     @GQLDirective(Directive("required")) nicknames: List[String],
     origin: Origin,
     role: Option[Role]
-  )
+  ) extends Human
+
+  case class Narrator(
+    name: String
+  ) extends Human
 
   case class OrganizationId(self: Long) extends AnyVal
   case class Event(organizationId: OrganizationId, title: String)
@@ -100,7 +107,8 @@ object TestUtils {
     @GQLDescription("Return all characters from a given origin") characters: CharactersArgs => List[Character],
     @GQLDeprecated("Use `characters`") character: CharacterArgs => Option[Character],
     charactersIn: CharacterInArgs => List[Character],
-    exists: CharacterObjectArgs => Boolean
+    exists: CharacterObjectArgs => Boolean,
+    human: Human
   )
 
   @GQLDescription("Queries")
@@ -124,7 +132,8 @@ object TestUtils {
       args => characters.filter(c => args.origin.forall(c.origin == _)),
       args => characters.find(c => c.name == args.name),
       args => characters.filter(c => args.names.contains(c.name)),
-      args => characters.exists(_.name == args.character.name)
+      args => characters.exists(_.name == args.character.name),
+      Narrator("narrator")
     )
   )
   val resolverIO               = RootResolver(


### PR DESCRIPTION
Adds rendering of directives for unions, enums, interfaces, and input objects whose schemas are automatically derived. Doing so required adding `directives` arguments to the various helper methods in `Types`, and the extracting the directives out inside the scala 2 and 3 `SchemaDerrivation` traits to pass in to those new arguments.

I also updated the test schema used in `RenderingSpec` to add directives to the various parts of the schema that were missing them.