### PR TITLE
Adding parser logic for inputs and enums with empty bodies

### DIFF
--- a/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
@@ -87,11 +87,6 @@ private[caliban] object Parsers extends SelectionParsers {
         )
     }
 
-  def inputObjectTypeDefinitionWithoutBody(implicit ev: P[Any]): P[InputObjectTypeDefinition] =
-    P(stringValue.? ~ "input" ~/ name ~ directives.?).map { case (description, name, directives) =>
-      InputObjectTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil), fields = Nil)
-    }
-
   def enumValueDefinition(implicit ev: P[Any]): P[EnumValueDefinition] =
     P(stringValue.? ~ name ~ directives.?).map { case (description, enumValue, directives) =>
       EnumValueDefinition(description.map(_.value), enumValue, directives.getOrElse(Nil))

--- a/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
@@ -77,7 +77,7 @@ private[caliban] object Parsers extends SelectionParsers {
     }
 
   def inputObjectTypeDefinition(implicit ev: P[Any]): P[InputObjectTypeDefinition] =
-    P(inputObjectTypeDefinitionWithoutBody | inputObjectTypeDefinitionWithBody)
+    inputObjectTypeDefinitionWithBody | inputObjectTypeDefinitionWithoutBody
 
   def inputObjectTypeDefinitionWithBody(implicit ev: P[Any]): P[InputObjectTypeDefinition] =
     P(stringValue.? ~ "input" ~/ name ~ directives.? ~ "{" ~ argumentDefinition.rep ~ "}").map {
@@ -98,7 +98,7 @@ private[caliban] object Parsers extends SelectionParsers {
   def enumName(implicit ev: P[Any]): P[String] = name.filter(s => s != "true" && s != "false" && s != "null")
 
   def enumTypeDefinition(implicit ev: P[Any]): P[EnumTypeDefinition] =
-    P(enumTypeDefinitionWithoutBody | enumTypeDefinitionWithBody)
+    P(enumTypeDefinitionWithBody | enumTypeDefinitionWithoutBody)
 
   def enumTypeDefinitionWithBody(implicit ev: P[Any]): P[EnumTypeDefinition] =
     P(stringValue.? ~ "enum" ~/ enumName ~ directives.? ~ "{" ~ enumValueDefinition.rep ~ "}").map {
@@ -108,7 +108,12 @@ private[caliban] object Parsers extends SelectionParsers {
 
   def enumTypeDefinitionWithoutBody(implicit ev: P[Any]): P[EnumTypeDefinition] =
     P(stringValue.? ~ "enum" ~/ enumName ~ directives.?).map { case (description, name, directives) =>
-      EnumTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil), enumValuesDefinition = Nil)
+      EnumTypeDefinition(
+        description.map(_.value),
+        name,
+        directives.getOrElse(Nil),
+        enumValuesDefinition = Nil
+      )
     }
 
   def unionTypeDefinition(implicit ev: P[Any]): P[UnionTypeDefinition] =

--- a/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
@@ -77,9 +77,17 @@ private[caliban] object Parsers extends SelectionParsers {
     }
 
   def inputObjectTypeDefinition(implicit ev: P[Any]): P[InputObjectTypeDefinition] =
+    P(inputObjectTypeDefinitionWithoutBody | inputObjectTypeDefinitionWithBody)
+
+  def inputObjectTypeDefinitionWithBody(implicit ev: P[Any]): P[InputObjectTypeDefinition] =
     P(stringValue.? ~ "input" ~/ name ~ directives.? ~ "{" ~ argumentDefinition.rep ~ "}").map {
       case (description, name, directives, fields) =>
         InputObjectTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil), fields.toList)
+    }
+
+  def inputObjectTypeDefinitionWithoutBody(implicit ev: P[Any]): P[InputObjectTypeDefinition] =
+    P(stringValue.? ~ "input" ~/ name ~ directives.?).map { case (description, name, directives) =>
+      InputObjectTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil), fields = Nil)
     }
 
   def enumValueDefinition(implicit ev: P[Any]): P[EnumValueDefinition] =
@@ -90,9 +98,17 @@ private[caliban] object Parsers extends SelectionParsers {
   def enumName(implicit ev: P[Any]): P[String] = name.filter(s => s != "true" && s != "false" && s != "null")
 
   def enumTypeDefinition(implicit ev: P[Any]): P[EnumTypeDefinition] =
+    P(enumTypeDefinitionWithoutBody | enumTypeDefinitionWithBody)
+
+  def enumTypeDefinitionWithBody(implicit ev: P[Any]): P[EnumTypeDefinition] =
     P(stringValue.? ~ "enum" ~/ enumName ~ directives.? ~ "{" ~ enumValueDefinition.rep ~ "}").map {
       case (description, name, directives, enumValuesDefinition) =>
         EnumTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil), enumValuesDefinition.toList)
+    }
+
+  def enumTypeDefinitionWithoutBody(implicit ev: P[Any]): P[EnumTypeDefinition] =
+    P(stringValue.? ~ "enum" ~/ enumName ~ directives.?).map { case (description, name, directives) =>
+      EnumTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil), enumValuesDefinition = Nil)
     }
 
   def unionTypeDefinition(implicit ev: P[Any]): P[UnionTypeDefinition] =

--- a/core/src/main/scala-3/caliban/parsing/Parser.scala
+++ b/core/src/main/scala-3/caliban/parsing/Parser.scala
@@ -362,8 +362,13 @@ object Parser {
     ((P.string(
       "input"
     ) *> whitespaceWithComment1 *> name <* whitespaceWithComment) ~ (directives <* whitespaceWithComment).? ~
-      wrapBrackets(argumentDefinition.repSep0(whitespaceWithComment))).map { case ((name, directives), fields) =>
-      InputObjectTypeDefinition(description, name, directives.getOrElse(Nil), fields)
+      wrapBrackets(argumentDefinition.repSep0(whitespaceWithComment)).?).map { case ((name, directives), fields) =>
+      InputObjectTypeDefinition(
+        description,
+        name,
+        directives.getOrElse(Nil),
+        fields.fold(List[InputValueDefinition]())(_.toList)
+      )
     }
 
   private val enumValueDefinition: P[EnumValueDefinition] =
@@ -378,8 +383,13 @@ object Parser {
     ((P.string("enum") *> whitespaceWithComment1 *> enumName <* whitespaceWithComment) ~
       (directives <* whitespaceWithComment).? ~ wrapBrackets(
         enumValueDefinition.repSep0(whitespaceWithComment)
-      )).map { case ((name, directives), enumValuesDefinition) =>
-      EnumTypeDefinition(description, name, directives.getOrElse(Nil), enumValuesDefinition)
+      ).?).map { case ((name, directives), enumValuesDefinition) =>
+      EnumTypeDefinition(
+        description,
+        name,
+        directives.getOrElse(Nil),
+        enumValuesDefinition.fold(List[EnumValueDefinition]())(_.toList)
+      )
     }
 
   private def unionTypeDefinition(description: Option[String]): P[UnionTypeDefinition] =

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -229,7 +229,7 @@ object ParserSpec extends DefaultRunnableSpec {
                   index = 39
                 )
               ),
-              sourceMapper = SourceMapper(query)
+              sourceMapper = SourceMapper.apply(query)
             )
           )
         )
@@ -493,7 +493,7 @@ object ParserSpec extends DefaultRunnableSpec {
         )
       },
       testM("input with no body") {
-        val inputWithNoBody = "input BarBaz"
+        val inputWithNoBody = "input BarBaz".stripMargin
         assertM(Parser.parseQuery(inputWithNoBody))(
           equalTo(
             Document(
@@ -511,8 +511,8 @@ object ParserSpec extends DefaultRunnableSpec {
         )
       },
       testM("input with empty body") {
-        val inputWithNoBody = "input BarBaz { }"
-        assertM(Parser.parseQuery(inputWithNoBody))(
+        val inputWithEmptyBody = "input BarBaz { }"
+        assertM(Parser.parseQuery(inputWithEmptyBody))(
           equalTo(
             Document(
               List(
@@ -523,7 +523,7 @@ object ParserSpec extends DefaultRunnableSpec {
                   fields = Nil
                 )
               ),
-              sourceMapper = SourceMapper.apply(inputWithNoBody)
+              sourceMapper = SourceMapper.apply(inputWithEmptyBody)
             )
           )
         )

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -492,6 +492,55 @@ object ParserSpec extends DefaultRunnableSpec {
           )
         )
       },
+      testM("input with no body") {
+        val inputWithNoBody = "input BarBaz"
+        assertM(Parser.parseQuery(inputWithNoBody))(
+          equalTo(
+            Document(
+              List(
+                InputObjectTypeDefinition(
+                  description = None,
+                  name = "BarBaz",
+                  directives = Nil,
+                  fields = Nil
+                )
+              ),
+              sourceMapper = SourceMapper.apply(inputWithNoBody)
+            )
+          )
+        )
+      },
+      testM("input with no body") {
+        val inputWithNoBody = "input BarBaz { }"
+        assertM(Parser.parseQuery(inputWithNoBody))(
+          equalTo(
+            Document(
+              List(
+                InputObjectTypeDefinition(
+                  description = None,
+                  name = "BarBaz",
+                  directives = Nil,
+                  fields = Nil
+                )
+              ),
+              sourceMapper = SourceMapper.apply(inputWithNoBody)
+            )
+          )
+        )
+      },
+      testM("enum with no body") {
+        val enumWithNoBody = "enum BarBaz"
+        assertM(Parser.parseQuery(enumWithNoBody))(
+          equalTo(
+            Document(
+              List(
+                EnumTypeDefinition(description = None, name = "BarBaz", directives = Nil, enumValuesDefinition = Nil)
+              ),
+              sourceMapper = SourceMapper.apply(enumWithNoBody)
+            )
+          )
+        )
+      },
       testM("extend schema with directives") {
         val gqlSchemaExtension = "extend schema @addedDirective"
         assertM(Parser.parseQuery(gqlSchemaExtension))(

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -493,7 +493,7 @@ object ParserSpec extends DefaultRunnableSpec {
         )
       },
       testM("input with no body") {
-        val inputWithNoBody = "input BarBaz".stripMargin
+        val inputWithNoBody = "input BarBaz"
         assertM(Parser.parseQuery(inputWithNoBody))(
           equalTo(
             Document(

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -541,6 +541,19 @@ object ParserSpec extends DefaultRunnableSpec {
           )
         )
       },
+      testM("enum with empty body") {
+        val enumWithNoBody = "enum BarBaz { }"
+        assertM(Parser.parseQuery(enumWithNoBody))(
+          equalTo(
+            Document(
+              List(
+                EnumTypeDefinition(description = None, name = "BarBaz", directives = Nil, enumValuesDefinition = Nil)
+              ),
+              sourceMapper = SourceMapper.apply(enumWithNoBody)
+            )
+          )
+        )
+      },
       testM("extend schema with directives") {
         val gqlSchemaExtension = "extend schema @addedDirective"
         assertM(Parser.parseQuery(gqlSchemaExtension))(

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -229,7 +229,7 @@ object ParserSpec extends DefaultRunnableSpec {
                   index = 39
                 )
               ),
-              sourceMapper = SourceMapper.apply(query)
+              sourceMapper = SourceMapper(query)
             )
           )
         )

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -510,7 +510,7 @@ object ParserSpec extends DefaultRunnableSpec {
           )
         )
       },
-      testM("input with no body") {
+      testM("input with empty body") {
         val inputWithNoBody = "input BarBaz { }"
         assertM(Parser.parseQuery(inputWithNoBody))(
           equalTo(


### PR DESCRIPTION
Closes #1252 

  * The parser now accepts strings of the following form:
    * `input FooBar`
    * `enum FooBar`
  * There does remain a question, do the following forms parse to an identical
    AST?
      * `input FooBar` and `input FooBar { }`