### PR TITLE
Add mapType method to Schema

### DIFF
--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -86,6 +86,18 @@ trait Schema[-R, T] { self =>
   }
 
   /**
+   * Maps over this schema's [[__Type]], converting it to another [[__Type]].
+   *
+   * @param op The operation to run on this schemas [[__Type]]
+   */
+  def mapType(op: __Type => __Type): Schema[R, T] = new Schema[R, T] {
+    override def resolve(value: T): Step[R] = self.resolve(value)
+    override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
+      op(self.toType_(isInput, isSubscription))
+    }
+  }
+
+  /**
    * Changes the name of the generated graphql type.
    * @param name new name for the type
    * @param inputName new name for the type when it's an input type (by default "Input" is added after the name)

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -86,9 +86,9 @@ trait Schema[-R, T] { self =>
   }
 
   /**
-   * Maps over this schema's [[__Type]], converting it to another [[__Type]].
+   * Maps over this schema's type, converting it to another type.
    *
-   * @param op The operation to run on this schemas [[__Type]]
+   * @param op The operation to run on this schemas __Type.
    */
   def mapType(op: __Type => __Type): Schema[R, T] = new Schema[R, T] {
     override def resolve(value: T): Step[R]                                = self.resolve(value)

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -91,10 +91,9 @@ trait Schema[-R, T] { self =>
    * @param op The operation to run on this schemas [[__Type]]
    */
   def mapType(op: __Type => __Type): Schema[R, T] = new Schema[R, T] {
-    override def resolve(value: T): Step[R] = self.resolve(value)
-    override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
+    override def resolve(value: T): Step[R]                                = self.resolve(value)
+    override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
       op(self.toType_(isInput, isSubscription))
-    }
   }
 
   /**

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -129,6 +129,16 @@ object SchemaSpec extends DefaultRunnableSpec {
 
         assert(Types.innerType(introspectSubscription[Something]).name)(isSome(equalTo("SomethingElse")))
       },
+      test("mapType") {
+        case class Something(b: Int)
+        case class Query(something: Something)
+
+        implicit val somethingSchema: Schema[Any, Something] = Schema.gen[Any, Something].mapType { t =>
+          t.copy(description = Some("Changed description"))
+        }
+
+        assert(Types.innerType(introspectSubscription[Something]).description)(isSome(equalTo("Changed description")))
+      },
       test("union redirect") {
         case class Queries(union: RedirectingUnion)
 


### PR DESCRIPTION
Adds a new `Schema.mapType` method to support building a new schema by mapping over the current schema's `__Type`. I've found behavior like this handy by taking a base `Schema` produced by derivation, and then altering it slightly.