### PR TITLE
Make sure relay validation errors gets propagated to the user

### DIFF
--- a/core/src/main/scala/caliban/relay/PaginationArgs.scala
+++ b/core/src/main/scala/caliban/relay/PaginationArgs.scala
@@ -24,7 +24,7 @@ object Pagination {
       )
       .map { case (count, cursor) => new Pagination[C](count, cursor) }
       .parallelErrors
-      .mapError((errors: ::[String]) => CalibanError.ValidationError(msg = errors.mkString(", "), explanatoryText = ""))
+      .mapError((errors: ::[String]) => CalibanError.ExecutionError(msg = errors.mkString(", ")))
 
   private def validateCursors[C: Cursor](
     before: Option[String],


### PR DESCRIPTION
If this connection is used right now and a user doesn't pass in any args or invalid args the only error we get back is:
```
"errors": [
    {
      "message": "Effect failure",
      "locations": [
        ...
      ],
      "path": [
       ...
      ]
    }
  ]

```
With this we make sure to propagate the actual error to the user so they understand what they're doing wrong