### PR TITLE
Handle Long as String to be able to process all the range of values

### DIFF
--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -7,9 +7,9 @@ import caliban.parsing.Parser
 import caliban.uploads.Upload
 import zio.Chunk
 
+import java.time._
 import java.time.format.DateTimeFormatter
 import java.time.temporal.Temporal
-import java.time._
 import java.util.UUID
 import scala.annotation.implicitNotFound
 import scala.util.Try
@@ -85,8 +85,10 @@ object ArgBuilder extends ArgBuilderDerivation {
     case other           => Left(ExecutionError(s"Can't build an Int from input $other"))
   }
   implicit lazy val long: ArgBuilder[Long]             = {
-    case value: IntValue => Right(value.toLong)
-    case other           => Left(ExecutionError(s"Can't build a Long from input $other"))
+    case value: IntValue    => Right(value.toLong)
+    case StringValue(value) =>
+      Try(value.toLong).fold(_ => Left(ExecutionError(s"Can't build a Long from input $value")), Right(_))
+    case other              => Left(ExecutionError(s"Can't build a Long from input $other"))
   }
   implicit lazy val bigInt: ArgBuilder[BigInt]         = {
     case value: IntValue => Right(value.toBigInt)

--- a/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
+++ b/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
@@ -24,6 +24,15 @@ object ArgBuilderSpec extends DefaultRunnableSpec {
         )
       )
     ),
+    suite("long")(
+      testM("Long from string")(
+        check(Gen.anyLong) { value =>
+          assert(ArgBuilder.long.build(StringValue(s"$value")))(
+            isRight(equalTo(value))
+          )
+        }
+      )
+    ),
     suite("java.time")(
       test("Instant from epoch")(
         assert(ArgBuilder.instantEpoch.build(IntValue.LongNumber(100)))(


### PR DESCRIPTION
Handle the long values between 9007199254740991 and Long.MAX_VALUE 9223372036854775807 (and same for the negative ones)

Max Integer value in JS is 9007199254740991, and we need (in my project) to cover all the range of Scala Long.
One solution could be that Long ArgBuilder handle values as String, then JS can send us bigger values.

It's the behavior of Circe when you try to parse a long field from a String value.

This is the topic of my PR :)