### PR TITLE
Fix relay connection from list

### DIFF
--- a/core/src/test/scala/caliban/relay/ConnectionSpec.scala
+++ b/core/src/test/scala/caliban/relay/ConnectionSpec.scala
@@ -69,6 +69,56 @@ object ConnectionSpec extends DefaultRunnableSpec {
           )
       )
     },
+    test("it correctly calculates hasNextPage") {
+      val list = List(Item("a"), Item("b"), Item("c"))
+
+      val calcHasNextPage = (cursor: PaginationCursor[Base64Cursor], count: PaginationCount) =>
+        ItemConnection
+          .fromList(
+            list,
+            Pagination(cursor = cursor, count = count)
+          )
+          .pageInfo
+          .hasNextPage
+
+      // when first is set
+      assert(calcHasNextPage(PaginationCursor.NoCursor, PaginationCount.First(2)))(isTrue) &&
+      assert(calcHasNextPage(PaginationCursor.NoCursor, PaginationCount.First(3)))(isFalse) &&
+      assert(calcHasNextPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.First(1)))(isTrue) &&
+      assert(calcHasNextPage(PaginationCursor.After(Base64Cursor(1)), PaginationCount.First(1)))(isFalse) &&
+      // when before is set
+      assert(calcHasNextPage(PaginationCursor.Before(Base64Cursor(2)), PaginationCount.First(1)))(isTrue) &&
+      assert(calcHasNextPage(PaginationCursor.Before(Base64Cursor(2)), PaginationCount.First(2)))(isFalse)
+      // when last is set, the result is always false
+      assert(calcHasNextPage(PaginationCursor.NoCursor, PaginationCount.Last(3)))(isFalse)
+      assert(calcHasNextPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(3)))(isFalse)
+      assert(calcHasNextPage(PaginationCursor.Before(Base64Cursor(1)), PaginationCount.Last(3)))(isFalse)
+    },
+    test("it correctly calculates hasPreviousPage") {
+      val list = List(Item("a"), Item("b"), Item("c"))
+
+      val calcHasPreviousPage = (cursor: PaginationCursor[Base64Cursor], count: PaginationCount) =>
+        ItemConnection
+          .fromList(
+            list,
+            Pagination(cursor = cursor, count = count)
+          )
+          .pageInfo
+          .hasPreviousPage
+
+      // when last is set
+      assert(calcHasPreviousPage(PaginationCursor.NoCursor, PaginationCount.Last(2)))(isTrue) &&
+      assert(calcHasPreviousPage(PaginationCursor.NoCursor, PaginationCount.Last(3)))(isFalse) &&
+      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(1)))(isTrue) &&
+      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(1)), PaginationCount.Last(1)))(isFalse) &&
+      // when after is set
+      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(1)))(isTrue) &&
+      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(2)))(isFalse)
+      // when first is set, the result is always false
+      assert(calcHasPreviousPage(PaginationCursor.NoCursor, PaginationCount.First(3)))(isFalse)
+      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.First(3)))(isFalse)
+      assert(calcHasPreviousPage(PaginationCursor.Before(Base64Cursor(1)), PaginationCount.First(3)))(isFalse)
+    },
     testM("it paginates the response forwards") {
       for {
         int <- api.interpreter

--- a/core/src/test/scala/caliban/relay/ConnectionSpec.scala
+++ b/core/src/test/scala/caliban/relay/ConnectionSpec.scala
@@ -101,10 +101,10 @@ object ConnectionSpec extends DefaultRunnableSpec {
       assert(calcHasNextPage(PaginationCursor.After(Base64Cursor(1)), PaginationCount.First(1)))(isFalse) &&
       // when before is set
       assert(calcHasNextPage(PaginationCursor.Before(Base64Cursor(2)), PaginationCount.First(1)))(isTrue) &&
-      assert(calcHasNextPage(PaginationCursor.Before(Base64Cursor(2)), PaginationCount.First(2)))(isFalse)
+      assert(calcHasNextPage(PaginationCursor.Before(Base64Cursor(2)), PaginationCount.First(2)))(isFalse) &&
       // when last is set, the result is always false
-      assert(calcHasNextPage(PaginationCursor.NoCursor, PaginationCount.Last(3)))(isFalse)
-      assert(calcHasNextPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(3)))(isFalse)
+      assert(calcHasNextPage(PaginationCursor.NoCursor, PaginationCount.Last(3)))(isFalse) &&
+      assert(calcHasNextPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(3)))(isFalse) &&
       assert(calcHasNextPage(PaginationCursor.Before(Base64Cursor(1)), PaginationCount.Last(3)))(isFalse)
     },
     test("it correctly calculates hasPreviousPage") {
@@ -126,10 +126,10 @@ object ConnectionSpec extends DefaultRunnableSpec {
       assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(1)), PaginationCount.Last(1)))(isFalse) &&
       // when after is set
       assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(1)))(isTrue) &&
-      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(2)))(isFalse)
+      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.Last(2)))(isFalse) &&
       // when first is set, the result is always false
-      assert(calcHasPreviousPage(PaginationCursor.NoCursor, PaginationCount.First(3)))(isFalse)
-      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.First(3)))(isFalse)
+      assert(calcHasPreviousPage(PaginationCursor.NoCursor, PaginationCount.First(3)))(isFalse) &&
+      assert(calcHasPreviousPage(PaginationCursor.After(Base64Cursor(0)), PaginationCount.First(3)))(isFalse) &&
       assert(calcHasPreviousPage(PaginationCursor.Before(Base64Cursor(1)), PaginationCount.First(3)))(isFalse)
     },
     testM("it paginates the response forwards") {

--- a/core/src/test/scala/caliban/relay/ConnectionSpec.scala
+++ b/core/src/test/scala/caliban/relay/ConnectionSpec.scala
@@ -69,6 +69,19 @@ object ConnectionSpec extends DefaultRunnableSpec {
           )
       )
     },
+    test("it correctly slices the list when before is set") {
+      assertTrue(
+        ItemConnection
+          .fromList(
+            List(Item("a"), Item("b"), Item("c")),
+            Pagination(cursor = PaginationCursor.Before(Base64Cursor(2)), count = PaginationCount.First(3))
+          )
+          .edges == List(
+          ItemEdge(Base64Cursor(0), Item("a")),
+          ItemEdge(Base64Cursor(1), Item("b"))
+        )
+      )
+    },
     test("it correctly calculates hasNextPage") {
       val list = List(Item("a"), Item("b"), Item("c"))
 


### PR DESCRIPTION
Noticed two inconsistencies when creating a relay connection from a list. The fixes:
* fix connection slice when using `before`
* fix hasNextPage & hasPreviousPage [to follow the spec](https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo.Fields)