### PR TITLE
Add forward and backward pagination

### DIFF
--- a/core/src/test/scala/caliban/relay/ConnectionSpec.scala
+++ b/core/src/test/scala/caliban/relay/ConnectionSpec.scala
@@ -31,6 +31,16 @@ object ConnectionSpec extends DefaultRunnableSpec {
     after: Option[String]
   ) extends PaginationArgs[Base64Cursor]
 
+  case class ForwardArgs(
+    first: Option[Int],
+    after: Option[String]
+  ) extends ForwardPaginationArgs[Base64Cursor]
+
+  case class BackwardArgs(
+    last: Option[Int],
+    before: Option[String]
+  ) extends BackwardPaginationArgs[Base64Cursor]
+
   val conn = ItemConnection.fromList(
     List(Item("a"), Item("b"), Item("c")),
     Pagination(
@@ -259,6 +269,58 @@ object ConnectionSpec extends DefaultRunnableSpec {
         assertM(res)(
           fails(
             hasMessage(equalTo("first and last cannot both be empty"))
+          )
+        )
+      }
+    ),
+    suite("ForwardPagination")(
+      testM("must set first") {
+        val res = ForwardArgs(
+          first = None,
+          after = None
+        ).toPagination.run
+
+        assertM(res)(
+          fails(
+            hasMessage(equalTo("first cannot be empty"))
+          )
+        )
+      },
+      testM("first cannot be negative") {
+        val res = ForwardArgs(
+          first = Some(-1),
+          after = None
+        ).toPagination.run
+
+        assertM(res)(
+          fails(
+            hasMessage(equalTo("first cannot be negative"))
+          )
+        )
+      }
+    ),
+    suite("BackwardPagination")(
+      testM("must set last") {
+        val res = BackwardArgs(
+          last = None,
+          before = None
+        ).toPagination.run
+
+        assertM(res)(
+          fails(
+            hasMessage(equalTo("last cannot be empty"))
+          )
+        )
+      },
+      testM("last cannot be negative") {
+        val res = BackwardArgs(
+          last = Some(-1),
+          before = None
+        ).toPagination.run
+
+        assertM(res)(
+          fails(
+            hasMessage(equalTo("last cannot be negative"))
           )
         )
       }

--- a/core/src/test/scala/caliban/relay/ConnectionSpec.scala
+++ b/core/src/test/scala/caliban/relay/ConnectionSpec.scala
@@ -274,6 +274,21 @@ object ConnectionSpec extends DefaultRunnableSpec {
       }
     ),
     suite("ForwardPagination")(
+      testM("successfully returns a Pagination case class") {
+        val res = ForwardArgs(
+          first = Some(1),
+          after = Some(Cursor[Base64Cursor].encode(Base64Cursor(1)))
+        ).toPagination
+
+        assertM(res)(
+          equalTo(
+            Pagination(
+              count = PaginationCount.First(1),
+              cursor = PaginationCursor.After(Base64Cursor(1))
+            )
+          )
+        )
+      },
       testM("must set first") {
         val res = ForwardArgs(
           first = None,
@@ -300,6 +315,21 @@ object ConnectionSpec extends DefaultRunnableSpec {
       }
     ),
     suite("BackwardPagination")(
+      testM("successfully returns a Pagination case class") {
+        val res = BackwardArgs(
+          last = Some(1),
+          before = Some(Cursor[Base64Cursor].encode(Base64Cursor(1)))
+        ).toPagination
+
+        assertM(res)(
+          equalTo(
+            Pagination(
+              count = PaginationCount.Last(1),
+              cursor = PaginationCursor.Before(Base64Cursor(1))
+            )
+          )
+        )
+      },
       testM("must set last") {
         val res = BackwardArgs(
           last = None,


### PR DESCRIPTION
Often APIs support only one way of pagination for connections, either [forward or backward](https://relay.dev/graphql/connections.htm#sec-Forward-pagination-arguments). 

The proposed change is to introduce the aforementioned types of paginations, so APIs can easily support the desired pagination, avoiding clients to miss use their connection.

* ForwardPaginationArgs which accepts only `first` and `after`
* BackwardPaginationArgs which accepts only `last` and `before` 

