### PR TITLE
Fix custom directive parsing in Scala 3 impl

### DIFF
--- a/core/src/main/scala-3/caliban/parsing/Parser.scala
+++ b/core/src/main/scala-3/caliban/parsing/Parser.scala
@@ -509,6 +509,7 @@ object Parser {
         P.string("QUERY").as(ExecutableDirectiveLocation.QUERY),
         P.string("MUTATION").as(ExecutableDirectiveLocation.MUTATION),
         P.string("SUBSCRIPTION").as(ExecutableDirectiveLocation.SUBSCRIPTION),
+        P.string("FIELD_DEFINITION").as(TypeSystemDirectiveLocation.FIELD_DEFINITION),
         P.string("FIELD").as(ExecutableDirectiveLocation.FIELD),
         P.string("FRAGMENT_DEFINITION").as(ExecutableDirectiveLocation.FRAGMENT_DEFINITION),
         P.string("FRAGMENT_SPREAD").as(ExecutableDirectiveLocation.FRAGMENT_SPREAD),
@@ -516,12 +517,11 @@ object Parser {
         P.string("SCHEMA").as(TypeSystemDirectiveLocation.SCHEMA),
         P.string("SCALAR").as(TypeSystemDirectiveLocation.SCALAR),
         P.string("OBJECT").as(TypeSystemDirectiveLocation.OBJECT),
-        P.string("FIELD_DEFINITION").as(TypeSystemDirectiveLocation.FIELD_DEFINITION),
         P.string("ARGUMENT_DEFINITION").as(TypeSystemDirectiveLocation.ARGUMENT_DEFINITION),
         P.string("INTERFACE").as(TypeSystemDirectiveLocation.INTERFACE),
         P.string("UNION").as(TypeSystemDirectiveLocation.UNION),
-        P.string("ENUM").as(TypeSystemDirectiveLocation.ENUM),
         P.string("ENUM_VALUE").as(TypeSystemDirectiveLocation.ENUM_VALUE),
+        P.string("ENUM").as(TypeSystemDirectiveLocation.ENUM),
         P.string("INPUT_OBJECT").as(TypeSystemDirectiveLocation.INPUT_OBJECT),
         P.string("INPUT_FIELD_DEFINITION").as(TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION)
       )
@@ -532,7 +532,7 @@ object Parser {
       (P.string("directive @") *> name <* whitespaceWithComment) ~
       ((argumentDefinitions <* whitespaceWithComment).? <* P.string("on") <* whitespaceWithComment1) ~
       ((P.char('|') <* whitespaceWithComment).? *> directiveLocation <* whitespaceWithComment) ~
-      (P.char('|') *> whitespaceWithComment *> directiveLocation).repSep(whitespaceWithComment)).map {
+      (P.char('|') *> whitespaceWithComment *> directiveLocation).repSep0(whitespaceWithComment)).map {
       case ((((description, name), args), firstLoc), otherLoc) =>
         DirectiveDefinition(description.map(_.value), name, args.getOrElse(Nil), otherLoc.toList.toSet + firstLoc)
     }

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -5,6 +5,8 @@ import caliban.InputValue
 import caliban.InputValue._
 import caliban.Value._
 import caliban.parsing.adt.Definition.ExecutableDefinition.{ FragmentDefinition, OperationDefinition }
+import caliban.parsing.adt.Definition.TypeSystemDefinition
+import caliban.parsing.adt.Definition.TypeSystemDefinition.DirectiveDefinition
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
 import caliban.parsing.adt.Definition.TypeSystemExtension.SchemaExtension
 import caliban.parsing.adt.Definition.TypeSystemExtension.TypeExtension._
@@ -1086,6 +1088,26 @@ object ParserSpec extends DefaultRunnableSpec {
                   Nil,
                   List(
                     InputValueDefinition(None, "z", NamedType("Int", nonNull = true), None, Nil)
+                  )
+                )
+              ),
+              sourceMapper = SourceMapper.apply(gqlInputExtension)
+            )
+          )
+        )
+      },
+      testM("parse custom directives") {
+        val gqlInputExtension = "directive @test on FIELD_DEFINITION"
+        assertM(Parser.parseQuery(gqlInputExtension))(
+          equalTo(
+            Document(
+              List(
+                DirectiveDefinition(
+                  None,
+                  "test",
+                  List.empty,
+                  Set(
+                    TypeSystemDefinition.DirectiveLocation.TypeSystemDirectiveLocation.FIELD_DEFINITION
                   )
                 )
               ),


### PR DESCRIPTION
Closes #1312 

Test is rather minimalistic. To properly cover it all one would have to write round-trip property tests `Document -> String -> Parser -> Document`