### PR TITLE
support lower-case content-type header

### DIFF
--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -81,7 +81,7 @@ object TapirAdapter {
                 queryFromQueryParams(params)
               else if (
                 headers.exists(header =>
-                  header.name == HeaderNames.ContentType &&
+                  header.name.equalsIgnoreCase(HeaderNames.ContentType) &&
                     MediaType
                       .parse(header.value)
                       .exists(mediaType => mediaType.mainType == "application" && mediaType.subType == "graphql")


### PR DESCRIPTION
I couldn't really figure out to write a test that used `application/graphql` :/