### PR TITLE
Fix rendering of object arguments to directives

### DIFF
--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -162,7 +162,7 @@ object Rendering {
       Some(values.flatMap(renderDirectiveArgument).mkString("[", ",", "]"))
     case InputValue.ObjectValue(fields) =>
       Some(
-        fields.map { case (key, value) => renderDirectiveArgument(value).map(v => s"$key: $v") }.mkString("{", ",", "}")
+        fields.flatMap { case (key, value) => renderDirectiveArgument(value).map(v => s"$key: $v") }.mkString("{", ",", "}")
       )
     case NullValue                      => Some("null")
     case StringValue(value)             => Some("\"" + value + "\"")

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -162,7 +162,8 @@ object Rendering {
       Some(values.flatMap(renderDirectiveArgument).mkString("[", ",", "]"))
     case InputValue.ObjectValue(fields) =>
       Some(
-        fields.flatMap { case (key, value) => renderDirectiveArgument(value).map(v => s"$key: $v") }.mkString("{", ",", "}")
+        fields.flatMap { case (key, value) => renderDirectiveArgument(value).map(v => s"$key: $v") }
+          .mkString("{", ",", "}")
       )
     case NullValue                      => Some("null")
     case StringValue(value)             => Some("\"" + value + "\"")

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -2,7 +2,7 @@ package caliban
 
 import caliban.GraphQL._
 import caliban.TestUtils._
-import caliban.introspection.adt.{__Type, __TypeKind}
+import caliban.introspection.adt.{ __Type, __TypeKind }
 import caliban.parsing.adt.Directive
 import zio.test.Assertion._
 import zio.test._
@@ -137,15 +137,27 @@ object RenderingSpec extends DefaultRunnableSpec {
         )
       },
       test("it should render object arguments in type directives") {
-        val testType = __Type(__TypeKind.OBJECT, name = Some("TestType"), directives = Some(List(
-          Directive(name = "testdirective",
-            arguments = Map("object" -> InputValue.ObjectValue(Map(
-              "key1" -> Value.StringValue("value1"),
-              "key2" -> Value.StringValue("value2")
-            )))))))
+        val testType     = __Type(
+          __TypeKind.OBJECT,
+          name = Some("TestType"),
+          directives = Some(
+            List(
+              Directive(
+                name = "testdirective",
+                arguments = Map(
+                  "object" -> InputValue.ObjectValue(
+                    Map(
+                      "key1" -> Value.StringValue("value1"),
+                      "key2" -> Value.StringValue("value2")
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
         val renderedType = Rendering.renderTypes(List(testType))
-        assert(renderedType)(equalTo(
-          "type TestType @testdirective(object: {key1: \"value1\",key2: \"value2\"})"))
+        assert(renderedType)(equalTo("type TestType @testdirective(object: {key1: \"value1\",key2: \"value2\"})"))
       }
     )
 }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -2,6 +2,8 @@ package caliban
 
 import caliban.GraphQL._
 import caliban.TestUtils._
+import caliban.introspection.adt.{__Type, __TypeKind}
+import caliban.parsing.adt.Directive
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestEnvironment
@@ -133,6 +135,17 @@ object RenderingSpec extends DefaultRunnableSpec {
         assert(graphQL(InvalidSchemas.resolverEmpty).render.trim)(
           equalTo("")
         )
+      },
+      test("it should render object arguments in type directives") {
+        val testType = __Type(__TypeKind.OBJECT, name = Some("TestType"), directives = Some(List(
+          Directive(name = "testdirective",
+            arguments = Map("object" -> InputValue.ObjectValue(Map(
+              "key1" -> Value.StringValue("value1"),
+              "key2" -> Value.StringValue("value2")
+            )))))))
+        val renderedType = Rendering.renderTypes(List(testType))
+        assert(renderedType)(equalTo(
+          "type TestType @testdirective(object: {key1: \"value1\",key2: \"value2\"})"))
       }
     )
 }


### PR DESCRIPTION
Fixes issue with `Option` being stringified. E.g., the following directive
```scala
Directive(
  name="dir",
  arguments = Map(
    "object" -> InputValue.ObjectValue(Map(
      "key1" -> Value.StringValue("value1"),
      "key2" -> Value.StringValue("value2")))))
```       
was rendered as:
```graphql
@dir(object: {Some(key1: "value1"),Some(key2: "value2")})
```