### PR TITLE
add support for graphql-transport-ws

### DIFF
--- a/adapters/akka-http/src/test/scala/caliban/AkkaHttpAdapterSpec.scala
+++ b/adapters/akka-http/src/test/scala/caliban/AkkaHttpAdapterSpec.scala
@@ -42,7 +42,7 @@ object AkkaHttpAdapterSpec extends DefaultRunnableSpec {
                      }
       _           <- ZIO.fromFuture { _ =>
                        implicit val s: ActorSystem = system
-                       Http()(system).newServerAt("localhost", 8088).bind(route)
+                       Http().newServerAt("localhost", 8088).bind(route)
                      }
                        .toManaged(server => ZIO.fromFuture(_ => server.unbind()).ignore)
       _           <- clock.sleep(3 seconds).toManaged_

--- a/adapters/akka-http/src/test/scala/caliban/AkkaHttpAdapterSpec.scala
+++ b/adapters/akka-http/src/test/scala/caliban/AkkaHttpAdapterSpec.scala
@@ -3,6 +3,7 @@ package caliban
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
+import akka.stream.Materializer
 import caliban.interop.tapir.TestData.sampleCharacters
 import caliban.interop.tapir.TestService.TestService
 import caliban.interop.tapir.{ FakeAuthorizationInterceptor, TapirAdapterSpec, TestApi, TestService }
@@ -13,45 +14,44 @@ import zio._
 import zio.clock.Clock
 import zio.console.Console
 import zio.duration._
-import zio.internal.Platform
 import zio.random.Random
 import zio.test.{ DefaultRunnableSpec, TestFailure, ZSpec }
 
-import scala.concurrent.ExecutionContextExecutor
 import scala.language.postfixOps
 
 object AkkaHttpAdapterSpec extends DefaultRunnableSpec {
 
-  implicit val system: ActorSystem                                                            = ActorSystem()
-  implicit val executionContext: ExecutionContextExecutor                                     = system.dispatcher
-  implicit val runtime: Runtime[TestService with Console with Clock with Random with Uploads] =
-    Runtime.unsafeFromLayer(
-      TestService.make(sampleCharacters) ++ Console.live ++ Clock.live ++ Random.live ++ Uploads.empty,
-      Platform.default
-    )
-
-  val apiLayer: ZLayer[zio.ZEnv, Throwable, Has[Unit]] =
+  val apiLayer: ZLayer[zio.ZEnv, Throwable, TestService] =
     (for {
+      runtime     <- ZManaged.runtime[TestService with Console with Clock with Random with Uploads]
+      system      <- ZManaged.make(Task.effectTotal(ActorSystem()))(sys => ZIO.fromFuture(_ => sys.terminate()).ignore)
+      ec           = system.dispatcher
+      mat          = Materializer(system)
+      service     <- ZManaged.service[TestService.Service]
       interpreter <- TestApi.api.interpreter.toManaged_
       route        = path("api" / "graphql") {
-                       AkkaHttpAdapter.makeHttpService(interpreter, requestInterceptor = FakeAuthorizationInterceptor.bearer)
-                     } ~ path("upload" / "graphql") {
-                       AkkaHttpAdapter.makeHttpUploadService(interpreter)
-                     } ~ path("ws" / "graphql") {
-                       AkkaHttpAdapter.makeWebSocketService(interpreter)
-                     }
-      _           <- ZIO
-                       .fromFuture(_ => Http().newServerAt("localhost", 8088).bind(route))
-                       .toManaged(server =>
-                         ZIO.fromFuture(_ => server.unbind()).ignore *> ZIO.fromFuture(_ => system.terminate()).ignore
+                       AkkaHttpAdapter.makeHttpService(interpreter, requestInterceptor = FakeAuthorizationInterceptor.bearer)(
+                         runtime,
+                         implicitly,
+                         implicitly
                        )
+                     } ~ path("upload" / "graphql") {
+                       AkkaHttpAdapter.makeHttpUploadService(interpreter)(runtime, implicitly, implicitly, implicitly)
+                     } ~ path("ws" / "graphql") {
+                       AkkaHttpAdapter.makeWebSocketService(interpreter)(ec, runtime, mat, implicitly, implicitly)
+                     }
+      _           <- ZIO.fromFuture { _ =>
+                       implicit val s: ActorSystem = system
+                       Http()(system).newServerAt("localhost", 8088).bind(route)
+                     }
+                       .toManaged(server => ZIO.fromFuture(_ => server.unbind()).ignore)
       _           <- clock.sleep(3 seconds).toManaged_
-    } yield ())
+    } yield service)
       .provideCustomLayer(TestService.make(sampleCharacters) ++ Uploads.empty ++ Clock.live)
       .toLayer
 
   def spec: ZSpec[ZEnv, Any] = {
-    val suite: ZSpec[Has[Unit], Throwable] =
+    val suite: ZSpec[TestService, Throwable] =
       TapirAdapterSpec.makeSuite(
         "AkkaHttpAdapterSpec",
         uri"http://localhost:8088/api/graphql",

--- a/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -218,7 +218,7 @@ object Http4sAdapter {
   def convertWebSocketEndpointToF[F[_], R, E](
     endpoint: ServerEndpoint[ZioWebSockets, RIO[R, *]]
   )(implicit interop: CatsInterop[F, R], runtime: Runtime[R]): ServerEndpoint[Fs2Streams[F] with WebSockets, F] = {
-    type Fs2Pipe = fs2.Pipe[F, GraphQLWSInput, GraphQLWSOutput]
+    type Fs2Pipe = fs2.Pipe[F, GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput]]
 
     val e = endpoint
       .asInstanceOf[

--- a/adapters/play/src/main/scala/caliban/PlayAdapter.scala
+++ b/adapters/play/src/main/scala/caliban/PlayAdapter.scala
@@ -88,7 +88,7 @@ class PlayAdapter private (private val options: Option[PlayServerOptions]) {
     playInterpreter.toRoutes(
       PlayAdapter.convertWebSocketEndpoint(
         endpoint.asInstanceOf[
-          ServerEndpoint.Full[Unit, Unit, ServerRequest, StatusCode, CalibanPipe, ZioWebSockets, RIO[R, *]]
+          ServerEndpoint.Full[Unit, Unit, (ServerRequest, String), StatusCode, CalibanPipe, ZioWebSockets, RIO[R, *]]
         ]
       )
     )
@@ -100,18 +100,28 @@ object PlayAdapter extends PlayAdapter(None) {
   def apply(options: PlayServerOptions) =
     new PlayAdapter(Some(options))
 
-  type AkkaPipe = Flow[GraphQLWSInput, GraphQLWSOutput, Any]
+  type AkkaPipe = Flow[GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput], Any]
 
   def convertWebSocketEndpoint[R](
-    endpoint: ServerEndpoint.Full[Unit, Unit, ServerRequest, StatusCode, CalibanPipe, ZioWebSockets, RIO[R, *]]
+    endpoint: ServerEndpoint.Full[Unit, Unit, (ServerRequest, String), StatusCode, CalibanPipe, ZioWebSockets, RIO[
+      R,
+      *
+    ]]
   )(implicit
     ec: ExecutionContext,
     runtime: Runtime[R],
     materializer: Materializer
   ): ServerEndpoint[AkkaStreams with WebSockets, Future] =
-    ServerEndpoint[Unit, Unit, ServerRequest, StatusCode, AkkaPipe, AkkaStreams with WebSockets, Future](
+    ServerEndpoint[Unit, Unit, (ServerRequest, String), StatusCode, AkkaPipe, AkkaStreams with WebSockets, Future](
       endpoint.endpoint
-        .asInstanceOf[PublicEndpoint[ServerRequest, StatusCode, Pipe[GraphQLWSInput, GraphQLWSOutput], Any]],
+        .asInstanceOf[
+          PublicEndpoint[
+            (ServerRequest, String),
+            StatusCode,
+            Pipe[GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput]],
+            Any
+          ]
+        ],
       _ => _ => Future.successful(Right(())),
       _ =>
         _ =>
@@ -128,7 +138,8 @@ object PlayAdapter extends PlayAdapter(None) {
                     sink            = Sink.foreachAsync[GraphQLWSInput](1)(input =>
                                         runtime.unsafeRunToFuture(inputQueue.offer(input).unit).future
                                       )
-                    (queue, source) = Source.queue[GraphQLWSOutput](0, OverflowStrategy.fail).preMaterialize()
+                    (queue, source) =
+                      Source.queue[Either[GraphQLWSClose, GraphQLWSOutput]](0, OverflowStrategy.fail).preMaterialize()
                     fiber          <- output.foreach(msg => ZIO.fromFuture(_ => queue.offer(msg))).forkDaemon
                     flow            = Flow.fromSinkAndSourceCoupled(sink, source).watchTermination() { (_, f) =>
                                         f.onComplete(_ => runtime.unsafeRun(fiber.interrupt))

--- a/core/src/main/scala/caliban/GraphQLWSClose.scala
+++ b/core/src/main/scala/caliban/GraphQLWSClose.scala
@@ -1,0 +1,3 @@
+package caliban
+
+case class GraphQLWSClose(code: Int, reason: String)

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -29,7 +29,26 @@ object InputValue extends ValueJsonCompat {
     caliban.interop.circe.json.ValueCirce.inputValueDecoder.asInstanceOf[F[InputValue]]
 }
 
-sealed trait ResponseValue
+sealed trait ResponseValue { self =>
+
+  /**
+   * Performs a deep merge of two response values. This currently means that the list values will be concatenated, and
+   * object values will be merged, incompatible types will assume the right-hand side of the merge.
+   */
+  def deepMerge(other: ResponseValue): ResponseValue = (this, other) match {
+    case (ResponseValue.ObjectValue(o1), ResponseValue.ObjectValue(o2)) =>
+      val otherMap = o2.toMap
+      ResponseValue.ObjectValue(o1.map { case (k, v) =>
+        otherMap.get(k) match {
+          case Some(otherValue) => (k, v.deepMerge(otherValue))
+          case None             => (k, v)
+        }
+      })
+    case (ResponseValue.ListValue(l1), ResponseValue.ListValue(l2))     =>
+      ResponseValue.ListValue(l1 ++ l2)
+    case _                                                              => other
+  }
+}
 object ResponseValue extends ValueJsonCompat {
   case class ListValue(values: List[ResponseValue])                extends ResponseValue {
     override def toString: String = values.mkString("[", ",", "]")

--- a/core/src/main/scala/caliban/interop/circe/circe.scala
+++ b/core/src/main/scala/caliban/interop/circe/circe.scala
@@ -226,10 +226,14 @@ object json {
 
     implicit val graphQLWSOutputEncoder: Encoder[GraphQLWSOutput] =
       Encoder.instance[GraphQLWSOutput](r =>
-        Json.obj(
-          "id"      -> r.id.asJson,
-          "type"    -> r.`type`.asJson,
-          "payload" -> r.payload.asJson
+        Json.fromJsonObject(
+          r.payload
+            .foldLeft(
+              JsonObject(
+                "id"   -> r.id.asJson,
+                "type" -> r.`type`.asJson
+              )
+            )((obj, v) => obj.add("payload", v.asJson))
         )
       )
 

--- a/examples/src/main/scala/example/play/ExampleApp.scala
+++ b/examples/src/main/scala/example/play/ExampleApp.scala
@@ -1,6 +1,7 @@
 package example.play
 
 import akka.actor.ActorSystem
+import akka.stream.Materializer
 import example.{ ExampleApi, ExampleService }
 import example.ExampleData.sampleCharacters
 import example.ExampleService.ExampleService
@@ -11,9 +12,9 @@ import play.api.routing.sird._
 import play.core.server.{ AkkaHttpServer, ServerConfig }
 import sttp.tapir.json.play._
 import zio.clock.Clock
-import zio.console.Console
+import zio.console.{ getStrLn, putStrLn, Console }
 import zio.internal.Platform
-import zio.Runtime
+import zio.{ ExitCode, Runtime, Task, URIO, ZIO, ZManaged }
 
 import scala.io.StdIn.readLine
 import zio.blocking.Blocking
@@ -21,33 +22,34 @@ import zio.random.Random
 
 import scala.concurrent.ExecutionContextExecutor
 
-object ExampleApp extends App {
+object ExampleApp extends zio.App {
 
-  implicit val system: ActorSystem                                                                = ActorSystem()
-  implicit val executionContext: ExecutionContextExecutor                                         = system.dispatcher
-  implicit val runtime: Runtime[ExampleService with Console with Clock with Blocking with Random] =
-    Runtime.unsafeFromLayer(
-      ExampleService.make(sampleCharacters) ++ Console.live ++ Clock.live ++ Random.live ++ Blocking.live,
-      Platform.default
-    )
-
-  val interpreter = runtime.unsafeRun(ExampleApi.api.interpreter)
-
-  val server = AkkaHttpServer.fromRouterWithComponents(
-    ServerConfig(
-      mode = Mode.Dev,
-      port = Some(8088),
-      address = "127.0.0.1"
-    )
-  ) { _ =>
-    Router.from {
-      case req @ POST(p"/api/graphql") => PlayAdapter.makeHttpService(interpreter).apply(req)
-      case req @ GET(p"/ws/graphql")   => PlayAdapter.makeWebSocketService(interpreter).apply(req)
-    }.routes
-  }
-
-  println("Server online at http://localhost:8088/\nPress RETURN to stop...")
-  readLine()
-  server.stop()
-
+  override def run(args: List[String]): ZIO[zio.ZEnv, Nothing, ExitCode] =
+    (for {
+      runtime     <- ZManaged.runtime[zio.ZEnv with ExampleService]
+      system      <- ZManaged.make(Task.effectTotal(ActorSystem()))(sys => ZIO.fromFuture(_ => sys.terminate()).ignore)
+      interpreter <- ExampleApi.api.interpreter.toManaged_
+      _           <- ZManaged.makeEffect(
+                       AkkaHttpServer.fromRouterWithComponents(
+                         ServerConfig(
+                           mode = Mode.Dev,
+                           port = Some(8088),
+                           address = "127.0.0.1"
+                         )
+                       ) { _ =>
+                         implicit val ec: ExecutionContextExecutor               = system.dispatcher
+                         implicit val mat: Materializer                          = Materializer(system)
+                         implicit val rts: Runtime[zio.ZEnv with ExampleService] = runtime
+                         Router.from {
+                           case req @ POST(p"/api/graphql") => PlayAdapter.makeHttpService(interpreter).apply(req)
+                           case req @ GET(p"/ws/graphql")   => PlayAdapter.makeWebSocketService(interpreter).apply(req)
+                         }.routes
+                       }
+                     )(server => server.stop())
+    } yield ())
+      .use_(
+        putStrLn("Server online at http://localhost:8088/\nPress RETURN to stop...") *> getStrLn
+      )
+      .exitCode
+      .provideCustomLayer(ExampleService.make(sampleCharacters))
 }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -277,10 +277,10 @@ object TapirAdapter {
     inputCodec: JsonCodec[GraphQLWSInput],
     outputCodec: JsonCodec[GraphQLWSOutput]
   ): ServerEndpoint[ZioWebSockets, RIO[R, *]] =
-    makeWebSocketEndpoint.serverLogic[RIO[R, *]](serverRequest =>
-      requestInterceptor(serverRequest._1)(
+    makeWebSocketEndpoint.serverLogic[RIO[R, *]] { case (serverRequest, protocol) =>
+      requestInterceptor(serverRequest)(
         Protocol
-          .fromName(serverRequest._2)
+          .fromName(protocol)
           .make(
             interpreter,
             skipValidation,
@@ -291,7 +291,7 @@ object TapirAdapter {
           )
           .map(Right(_))
       ).catchAll(ZIO.left(_))
-    )
+    }
 
   def convertHttpEndpointToFuture[E, R](
     endpoint: ServerEndpoint[Any, RIO[R, *]]

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -4,6 +4,7 @@ import caliban.ResponseValue.{ ObjectValue, StreamValue }
 import caliban.Value.StringValue
 import caliban._
 import caliban.execution.QueryExecution
+import caliban.interop.tapir.ws.Protocol
 import caliban.uploads.{ FileMeta, GraphQLUploadRequest, Uploads }
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
@@ -14,6 +15,7 @@ import sttp.tapir.Codec.JsonCodec
 import sttp.tapir._
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.ServerEndpoint
+import sttp.ws.WebSocketFrame
 import zio._
 import zio.clock.Clock
 import zio.duration.Duration
@@ -25,7 +27,7 @@ import scala.util.Try
 
 object TapirAdapter {
 
-  type CalibanPipe   = Pipe[GraphQLWSInput, GraphQLWSOutput]
+  type CalibanPipe   = Pipe[GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput]]
   type UploadRequest = (Seq[Part[Array[Byte]]], ServerRequest)
   type ZioWebSockets = ZioStreams with WebSockets
 
@@ -230,18 +232,38 @@ object TapirAdapter {
     makeHttpUploadEndpoint.serverLogic(logic)
   }
 
-  def makeWebSocketEndpoint[R, E](implicit
+  /**
+   * A codec which expects only text and close frames (all other frames cause a decoding error). Close frames correspond to a `Left`,
+   * while text frames are handled using the given `stringCodec` and wrapped with a `Right`
+   * @return
+   */
+  private implicit def textOrCloseWebSocketFrameEither[A, CF <: CodecFormat](implicit
+    stringCodec: Codec[String, A, CF]
+  ): Codec[WebSocketFrame, Either[GraphQLWSClose, A], CF] =
+    Codec
+      .id[WebSocketFrame, CF](stringCodec.format, Schema.string)
+      .mapDecode {
+        case WebSocketFrame.Text(s, _, _)       => stringCodec.decode(s).map(Right(_))
+        case WebSocketFrame.Close(code, reason) => DecodeResult.Value(Left(GraphQLWSClose(code, reason)))
+        case f                                  => DecodeResult.Error(f.toString, new UnsupportedWebSocketFrameException(f))
+      } {
+        case Left(value)  => WebSocketFrame.Close(value.code, value.reason)
+        case Right(value) => WebSocketFrame.text(stringCodec.encode(value))
+      }
+
+  def makeWebSocketEndpoint(implicit
     inputCodec: JsonCodec[GraphQLWSInput],
     outputCodec: JsonCodec[GraphQLWSOutput]
-  ): PublicEndpoint[ServerRequest, TapirResponse, CalibanPipe, ZioStreams with WebSockets] = {
-    val protocolHeader = Header("Sec-WebSocket-Protocol", "graphql-ws")
+  ): PublicEndpoint[(ServerRequest, String), TapirResponse, CalibanPipe, ZioStreams with WebSockets] =
     endpoint
-      .in(header(protocolHeader))
       .in(extractFromRequest(identity))
-      .out(header(protocolHeader))
-      .out(webSocketBody[GraphQLWSInput, CodecFormat.Json, GraphQLWSOutput, CodecFormat.Json](ZioStreams))
+      .in(header[String]("sec-websocket-protocol"))
+      .out(
+        webSocketBody[GraphQLWSInput, CodecFormat.Json, Either[GraphQLWSClose, GraphQLWSOutput], CodecFormat.Json](
+          ZioStreams
+        )
+      )
       .errorOut(errorBody)
-  }
 
   def makeWebSocketService[R, E](
     interpreter: GraphQLInterpreter[R, E],
@@ -254,77 +276,22 @@ object TapirAdapter {
   )(implicit
     inputCodec: JsonCodec[GraphQLWSInput],
     outputCodec: JsonCodec[GraphQLWSOutput]
-  ): ServerEndpoint[ZioWebSockets, RIO[R, *]] = {
-
-    val io: URIO[R, Either[Nothing, CalibanPipe]] =
-      for {
-        env           <- RIO.environment[R]
-        subscriptions <- Ref.make(Map.empty[String, Promise[Any, Unit]])
-        output        <- Queue.unbounded[GraphQLWSOutput]
-        pipe          <- UIO.right[CalibanPipe] { input =>
-                           ZStream
-                             .bracket(
-                               input.collectM {
-                                 case GraphQLWSInput("connection_init", id, payload) =>
-                                   val before   = ZIO.whenCase((webSocketHooks.beforeInit, payload)) {
-                                     case (Some(beforeInit), Some(payload)) =>
-                                       beforeInit(payload).catchAll(e => output.offer(makeError(id, e)))
-                                   }
-                                   val response = output.offer(connectionAck)
-                                   val ka       = keepAlive(keepAliveTime).mapM(output.offer).runDrain.fork
-                                   val after    = ZIO.whenCase(webSocketHooks.afterInit) { case Some(afterInit) =>
-                                     afterInit.catchAll(e => output.offer(makeError(id, e)))
-                                   }
-
-                                   before *> response *> ka *> after
-                                 case GraphQLWSInput("start", id, payload)           =>
-                                   val request = payload.collect { case InputValue.ObjectValue(fields) =>
-                                     val query         = fields.get("query").collect { case StringValue(v) => v }
-                                     val operationName = fields.get("operationName").collect { case StringValue(v) => v }
-                                     val variables     = fields.get("variables").collect { case InputValue.ObjectValue(v) => v }
-                                     val extensions    = fields.get("extensions").collect { case InputValue.ObjectValue(v) => v }
-                                     GraphQLRequest(query, operationName, variables, extensions)
-                                   }
-                                   request match {
-                                     case Some(req) =>
-                                       val stream = generateGraphQLResponse(
-                                         req,
-                                         id.getOrElse(""),
-                                         interpreter,
-                                         skipValidation,
-                                         enableIntrospection,
-                                         queryExecution,
-                                         subscriptions
-                                       )
-                                       webSocketHooks.onMessage
-                                         .map(_.transform(stream))
-                                         .getOrElse(stream)
-                                         .mapM(output.offer)
-                                         .runDrain
-                                         .catchAll(e => output.offer(makeError(id, e)))
-                                         .fork
-                                         .interruptible
-                                         .unit
-
-                                     case None => output.offer(connectionError)
-                                   }
-                                 case GraphQLWSInput("stop", id, _)                  =>
-                                   removeSubscription(id, subscriptions)
-                                 case GraphQLWSInput("connection_terminate", _, _)   =>
-                                   ZIO.interrupt
-                               }.runDrain.interruptible
-                                 .catchAll(_ => output.offer(connectionError))
-                                 .ensuring(subscriptions.get.flatMap(m => ZIO.foreach(m.values)(_.succeed(()))))
-                                 .provide(env)
-                                 .forkDaemon
-                             )(_.interrupt) *> ZStream.fromQueueWithShutdown(output)
-                         }
-      } yield pipe
-
+  ): ServerEndpoint[ZioWebSockets, RIO[R, *]] =
     makeWebSocketEndpoint.serverLogic[RIO[R, *]](serverRequest =>
-      requestInterceptor(serverRequest)(io).catchAll(ZIO.left(_))
+      requestInterceptor(serverRequest._1)(
+        Protocol
+          .fromName(serverRequest._2)
+          .make(
+            interpreter,
+            skipValidation,
+            enableIntrospection,
+            keepAliveTime,
+            queryExecution,
+            webSocketHooks
+          )
+          .map(Right(_))
+      ).catchAll(ZIO.left(_))
     )
-  }
 
   def convertHttpEndpointToFuture[E, R](
     endpoint: ServerEndpoint[Any, RIO[R, *]]
@@ -355,79 +322,6 @@ object TapirAdapter {
     override def flatten[T](ffa: RIO[R, RIO[R, T]]): RIO[R, T]                                                       = ffa.flatten
     override def ensure[T](f: RIO[R, T], e: => RIO[R, Unit]): RIO[R, T]                                              = f.ensuring(e.ignore)
   }
-
-  private[caliban] def keepAlive(keepAlive: Option[Duration]): UStream[GraphQLWSOutput] =
-    keepAlive match {
-      case None           => ZStream.empty
-      case Some(duration) =>
-        ZStream
-          .succeed(GraphQLWSOutput("ka", None, None))
-          .repeat(Schedule.spaced(duration))
-          .provideLayer(Clock.live)
-    }
-
-  private[caliban] val connectionError: GraphQLWSOutput = GraphQLWSOutput("connection_error", None, None)
-  private[caliban] val connectionAck: GraphQLWSOutput   = GraphQLWSOutput("connection_ack", None, None)
-
-  type Subscriptions = Ref[Map[String, Promise[Any, Unit]]]
-
-  private[caliban] def generateGraphQLResponse[R, E](
-    payload: GraphQLRequest,
-    id: String,
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean,
-    enableIntrospection: Boolean,
-    queryExecution: QueryExecution,
-    subscriptions: Subscriptions
-  ): ZStream[R, E, GraphQLWSOutput] = {
-    val resp =
-      ZStream
-        .fromEffect(interpreter.executeRequest(payload, skipValidation, enableIntrospection, queryExecution))
-        .flatMap(res =>
-          res.data match {
-            case ObjectValue((fieldName, StreamValue(stream)) :: Nil) =>
-              trackSubscription(id, subscriptions).flatMap { p =>
-                stream.map(toResponse(id, fieldName, _, res.errors)).interruptWhen(p)
-              }
-            case other                                                =>
-              ZStream.succeed(toResponse(id, GraphQLResponse(other, res.errors)))
-          }
-        )
-
-    (resp ++ complete(id)).catchAll(toStreamError(Option(id), _))
-  }
-
-  private def trackSubscription(id: String, subs: Subscriptions): UStream[Promise[Any, Unit]] =
-    ZStream.fromEffect(Promise.make[Any, Unit].tap(p => subs.update(_.updated(id, p))))
-
-  private[caliban] def removeSubscription(id: Option[String], subs: Subscriptions): UIO[Unit] =
-    IO.whenCase(id) { case Some(id) =>
-      subs.modify(map => (map.get(id), map - id)).flatMap { p =>
-        IO.whenCase(p) { case Some(p) => p.succeed(()) }
-      }
-    }
-
-  private[caliban] def toStreamError[E](id: Option[String], e: E): UStream[GraphQLWSOutput] =
-    ZStream.succeed(makeError(id, e))
-
-  private def makeError[E](id: Option[String], e: E): GraphQLWSOutput =
-    GraphQLWSOutput(
-      "error",
-      id,
-      Some(ResponseValue.ListValue(List(e match {
-        case e: CalibanError => e.toResponseValue
-        case e               => StringValue(e.toString)
-      })))
-    )
-
-  private def complete(id: String): UStream[GraphQLWSOutput] =
-    ZStream.succeed(GraphQLWSOutput("complete", Some(id), None))
-
-  private def toResponse[E](id: String, fieldName: String, r: ResponseValue, errors: List[E]): GraphQLWSOutput =
-    toResponse(id, GraphQLResponse(ObjectValue(List(fieldName -> r)), errors))
-
-  private def toResponse[E](id: String, r: GraphQLResponse[E]): GraphQLWSOutput =
-    GraphQLWSOutput("data", Some(id), Some(r.toResponseValue))
 
   private def parsePath(path: String): List[Either[String, Int]] =
     path.split('.').map(c => Try(c.toInt).toEither.left.map(_ => c)).toList

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
@@ -1,0 +1,362 @@
+package caliban.interop.tapir.ws
+
+import caliban.ResponseValue.{ ObjectValue, StreamValue }
+import caliban.Value.StringValue
+import caliban._
+import caliban.execution.QueryExecution
+import caliban.interop.tapir.TapirAdapter.CalibanPipe
+import caliban.interop.tapir.WebSocketHooks
+import sttp.tapir.model.ServerRequest
+import zio.clock.Clock
+import zio.duration.Duration
+import zio.stm.TMap
+import zio.stream.{ UStream, ZStream }
+import zio.{ Promise, Queue, RIO, Ref, Schedule, UIO, URIO, ZIO }
+
+sealed trait Protocol {
+  def name: String
+
+  def make[R, E](
+    interpreter: GraphQLInterpreter[R, E],
+    skipValidation: Boolean,
+    enableIntrospection: Boolean,
+    keepAliveTime: Option[Duration],
+    queryExecution: QueryExecution,
+    webSocketHooks: WebSocketHooks[R, E]
+  ): URIO[R, CalibanPipe]
+
+}
+
+object Protocol {
+
+  def fromName(name: String): Protocol = name match {
+    case "graphql-transport-ws" => GraphQLWS
+    case _                      => Legacy
+  }
+
+  def fromRequest(serverRequest: ServerRequest): Protocol =
+    serverRequest
+      .header("Sec-WebSocket-Protocol")
+      .fold[Protocol](GraphQLWS)(fromName)
+
+  object GraphQLWS extends Protocol {
+    object Ops {
+      final val Next           = "next"
+      final val Error          = "error"
+      final val Complete       = "complete"
+      final val Pong           = "pong"
+      final val Ping           = "ping"
+      final val Subscribe      = "subscribe"
+      final val ConnectionInit = "connection_init"
+      final val ConnectionAck  = "connection_ack"
+    }
+
+    val name = "graphql-transport-ws"
+
+    val handler = new ResponseHandler {
+      override def toResponse[E](id: String, r: GraphQLResponse[E]): GraphQLWSOutput =
+        GraphQLWSOutput(Ops.Next, Some(id), Some(r.toResponseValue))
+
+      override def complete(id: String): GraphQLWSOutput =
+        GraphQLWSOutput(Ops.Complete, Some(id), None)
+
+      override def error[E](id: Option[String], e: E): GraphQLWSOutput =
+        GraphQLWSOutput(
+          Ops.Error,
+          id,
+          Some(ResponseValue.ListValue(List(e match {
+            case e: CalibanError => e.toResponseValue
+            case e               => StringValue(e.toString)
+          })))
+        )
+    }
+
+    override def make[R, E](
+      interpreter: GraphQLInterpreter[R, E],
+      skipValidation: Boolean,
+      enableIntrospection: Boolean,
+      keepAliveTime: Option[Duration],
+      queryExecution: QueryExecution,
+      webSocketHooks: WebSocketHooks[R, E]
+    ): URIO[R, CalibanPipe] =
+      for {
+        env           <- RIO.environment[R]
+        subscriptions <- SubscriptionManager.make
+        ack           <- Ref.make(false)
+        output        <- Queue.unbounded[Either[GraphQLWSClose, GraphQLWSOutput]]
+        pipe          <- UIO.succeed[CalibanPipe] { input =>
+                           ZStream.managed(
+                             input.mapM {
+                               case GraphQLWSInput(Ops.ConnectionInit, id, payload)  =>
+                                 val before     = ZIO.whenCase((webSocketHooks.beforeInit, payload)) {
+                                   case (Some(beforeInit), Some(payload)) =>
+                                     beforeInit(payload).catchAll(e => output.offer(Right(handler.error(id, e))))
+                                 }
+                                 val ackPayload = webSocketHooks.onAck.fold[URIO[R, Option[ResponseValue]]](ZIO.none)(_.option)
+                                 val response   =
+                                   ack.set(true) *> ackPayload.flatMap(payload => output.offer(Right(connectionAck(payload))))
+                                 val ka         = ping(keepAliveTime).mapM(output.offer).runDrain.fork
+                                 val after      = ZIO.whenCase(webSocketHooks.afterInit) { case Some(afterInit) =>
+                                   afterInit.catchAll(e => output.offer(Right(handler.error(id, e))))
+                                 }
+
+                                 before *> response *> ka *> after
+                               case GraphQLWSInput(Ops.Pong, id, payload)            =>
+                                 ZIO.whenCase(webSocketHooks.onPong -> payload) { case (Some(onPong), Some(payload)) =>
+                                   onPong(payload).catchAll(e => output.offer(Right(handler.error(id, e))))
+                                 }
+                               case GraphQLWSInput(Ops.Subscribe, Some(id), payload) =>
+                                 val request = payload.collect { case InputValue.ObjectValue(fields) =>
+                                   val query         = fields.get("query").collect { case StringValue(v) => v }
+                                   val operationName = fields.get("operationName").collect { case StringValue(v) => v }
+                                   val variables     = fields.get("variables").collect { case InputValue.ObjectValue(v) => v }
+                                   val extensions    = fields.get("extensions").collect { case InputValue.ObjectValue(v) => v }
+                                   GraphQLRequest(query, operationName, variables, extensions)
+                                 }
+
+                                 val continue = request match {
+                                   case Some(req) =>
+                                     val stream = handler.generateGraphQLResponse(
+                                       req,
+                                       id,
+                                       interpreter,
+                                       skipValidation,
+                                       enableIntrospection,
+                                       queryExecution,
+                                       subscriptions
+                                     )
+
+                                     ZIO.ifM(subscriptions.isTracking(id))(
+                                       output.offer(Left(GraphQLWSClose(4409, s"Subscriber for $id already exists"))).unit,
+                                       webSocketHooks.onMessage
+                                         .map(_.transform(stream))
+                                         .getOrElse(stream)
+                                         .map(Right(_))
+                                         .foreachChunk(output.offerAll)
+                                         .catchAll(e => output.offer(Right(handler.error(Some(id), e))))
+                                         .fork
+                                         .interruptible
+                                         .unit
+                                     )
+
+                                   case None => output.offer(Right(connectionError))
+                                 }
+
+                                 ZIO.ifM(ack.get)(continue, output.offer(Left(GraphQLWSClose(4401, "Unauthorized"))))
+                               case GraphQLWSInput(Ops.Complete, Some(id), _)        =>
+                                 subscriptions.untrack(id)
+                               case GraphQLWSInput(unsupported, _, _)                =>
+                                 output.offer(Left(GraphQLWSClose(4400, s"Unsupported operation: $unsupported")))
+                             }.runDrain.interruptible
+                               .catchAll(_ => output.offer(Right(connectionError)))
+                               .ensuring(subscriptions.untrackAll)
+                               .provide(env)
+                               .forkManaged
+                           ) *> ZStream.fromQueueWithShutdown(output)
+                         }
+      } yield pipe
+
+    private val connectionError: GraphQLWSOutput                               = GraphQLWSOutput(Ops.Error, None, None)
+    private def connectionAck(payload: Option[ResponseValue]): GraphQLWSOutput =
+      GraphQLWSOutput(Ops.ConnectionAck, None, payload)
+
+    private def ping(keepAlive: Option[Duration]): UStream[Either[Nothing, GraphQLWSOutput]] =
+      keepAlive match {
+        case None           => ZStream.empty
+        case Some(duration) =>
+          ZStream
+            .repeatWith(Right(GraphQLWSOutput(Ops.Ping, None, None)), Schedule.spaced(duration))
+            .provideLayer(Clock.live)
+      }
+
+  }
+
+  object Legacy extends Protocol {
+    object Ops {
+      final val ConnectionInit      = "connection_init"
+      final val ConnectionAck       = "connection_ack"
+      final val ConnectionKeepAlive = "ka"
+      final val ConnectionTerminate = "connection_terminate"
+      final val Start               = "start"
+      final val Stop                = "stop"
+      final val Error               = "error"
+      final val ConnectionError     = "connection_error"
+      final val Complete            = "complete"
+      final val Data                = "data"
+    }
+
+    val name = "graphql-ws"
+
+    val handler: ResponseHandler = new ResponseHandler {
+      override def toResponse[E](id: String, r: GraphQLResponse[E]): GraphQLWSOutput =
+        GraphQLWSOutput(Ops.Data, Some(id), Some(r.toResponseValue))
+
+      override def complete(id: String): GraphQLWSOutput =
+        GraphQLWSOutput(Ops.Complete, Some(id), None)
+
+      override def error[E](id: Option[String], e: E): GraphQLWSOutput =
+        GraphQLWSOutput(
+          Ops.Error,
+          id,
+          Some(ResponseValue.ListValue(List(e match {
+            case e: CalibanError => e.toResponseValue
+            case e               => StringValue(e.toString)
+          })))
+        )
+    }
+
+    override def make[R, E](
+      interpreter: GraphQLInterpreter[R, E],
+      skipValidation: Boolean,
+      enableIntrospection: Boolean,
+      keepAliveTime: Option[Duration],
+      queryExecution: QueryExecution,
+      webSocketHooks: WebSocketHooks[R, E]
+    ): URIO[R, CalibanPipe] =
+      for {
+        env           <- RIO.environment[R]
+        ack           <- Ref.make(false)
+        subscriptions <- SubscriptionManager.make
+        output        <- Queue.unbounded[Either[GraphQLWSClose, GraphQLWSOutput]]
+        pipe          <- UIO.succeed[CalibanPipe] { input =>
+                           ZStream
+                             .bracket(
+                               input.collectM {
+                                 case GraphQLWSInput(Ops.ConnectionInit, id, payload) =>
+                                   val before     = ZIO.whenCase((webSocketHooks.beforeInit, payload)) {
+                                     case (Some(beforeInit), Some(payload)) =>
+                                       beforeInit(payload).catchAll(e => output.offer(Right(handler.error(id, e))))
+                                   }
+                                   val ackPayload = webSocketHooks.onAck.fold[URIO[R, Option[ResponseValue]]](ZIO.none)(_.option)
+
+                                   val response =
+                                     ack.set(true) *> ackPayload.flatMap(payload => output.offer(Right(connectionAck(payload))))
+                                   val ka       = keepAlive(keepAliveTime).mapM(o => output.offer(Right(o))).runDrain.fork
+                                   val after    = ZIO.whenCase(webSocketHooks.afterInit) { case Some(afterInit) =>
+                                     afterInit.catchAll(e => output.offer(Right(handler.error(id, e))))
+                                   }
+
+                                   before *> response *> ka *> after
+                                 case GraphQLWSInput(Ops.Start, id, payload)          =>
+                                   val request  = payload.collect { case InputValue.ObjectValue(fields) =>
+                                     val query         = fields.get("query").collect { case StringValue(v) => v }
+                                     val operationName = fields.get("operationName").collect { case StringValue(v) => v }
+                                     val variables     = fields.get("variables").collect { case InputValue.ObjectValue(v) => v }
+                                     val extensions    = fields.get("extensions").collect { case InputValue.ObjectValue(v) => v }
+                                     GraphQLRequest(query, operationName, variables, extensions)
+                                   }
+                                   val continue = request match {
+                                     case Some(req) =>
+                                       val stream = handler.generateGraphQLResponse(
+                                         req,
+                                         id.getOrElse(""),
+                                         interpreter,
+                                         skipValidation,
+                                         enableIntrospection,
+                                         queryExecution,
+                                         subscriptions
+                                       )
+                                       webSocketHooks.onMessage
+                                         .map(_.transform(stream))
+                                         .getOrElse(stream)
+                                         .foreachChunk(o => output.offerAll(o.map(Right(_))))
+                                         .catchAll(e => output.offer(Right(handler.error(id, e))))
+                                         .fork
+                                         .interruptible
+                                         .unit
+
+                                     case None => output.offer(Right(connectionError))
+                                   }
+
+                                   ZIO.ifM(ack.get)(continue, output.offer(Left(GraphQLWSClose(4401, "Unauthorized"))))
+                                 case GraphQLWSInput(Ops.Stop, Some(id), _)           =>
+                                   subscriptions.untrack(id)
+                                 case GraphQLWSInput(Ops.ConnectionTerminate, _, _)   =>
+                                   ZIO.interrupt
+                               }.runDrain.interruptible
+                                 .catchAll(_ => output.offer(Right(connectionError)))
+                                 .ensuring(subscriptions.untrackAll)
+                                 .provide(env)
+                                 .forkDaemon
+                             )(_.interrupt) *> ZStream.fromQueueWithShutdown(output)
+                         }
+      } yield pipe
+
+    private def keepAlive(keepAlive: Option[Duration]): UStream[GraphQLWSOutput] =
+      keepAlive match {
+        case None           => ZStream.empty
+        case Some(duration) =>
+          ZStream
+            .repeatWith(GraphQLWSOutput(Ops.ConnectionKeepAlive, None, None), Schedule.spaced(duration))
+            .provideLayer(Clock.live)
+      }
+
+    private val connectionError: GraphQLWSOutput                               = GraphQLWSOutput(Ops.ConnectionError, None, None)
+    private def connectionAck(payload: Option[ResponseValue]): GraphQLWSOutput =
+      GraphQLWSOutput(Ops.ConnectionAck, None, payload)
+  }
+
+  private[ws] trait ResponseHandler {
+    self =>
+    def toResponse[E](id: String, fieldName: String, r: ResponseValue, errors: List[E]): GraphQLWSOutput =
+      toResponse(id, GraphQLResponse(ObjectValue(List(fieldName -> r)), errors))
+
+    def toResponse[E](id: String, r: GraphQLResponse[E]): GraphQLWSOutput
+
+    def complete(id: String): GraphQLWSOutput
+
+    def error[E](id: Option[String], e: E): GraphQLWSOutput
+
+    def toStreamComplete(id: String): UStream[GraphQLWSOutput] =
+      ZStream.succeed(complete(id))
+
+    def toStreamError[E](id: Option[String], e: E): UStream[GraphQLWSOutput] =
+      ZStream.succeed(error(id, e))
+
+    final def generateGraphQLResponse[R, E](
+      payload: GraphQLRequest,
+      id: String,
+      interpreter: GraphQLInterpreter[R, E],
+      skipValidation: Boolean,
+      enableIntrospection: Boolean,
+      queryExecution: QueryExecution,
+      subscriptions: SubscriptionManager
+    ): ZStream[R, E, GraphQLWSOutput] = {
+      val resp =
+        ZStream
+          .fromEffect(interpreter.executeRequest(payload, skipValidation, enableIntrospection, queryExecution))
+          .flatMap(res =>
+            res.data match {
+              case ObjectValue((fieldName, StreamValue(stream)) :: Nil) =>
+                subscriptions.track(id).flatMap { p =>
+                  stream.map(self.toResponse(id, fieldName, _, res.errors)).interruptWhen(p)
+                }
+              case other                                                =>
+                ZStream.succeed(self.toResponse(id, GraphQLResponse(other, res.errors)))
+            }
+          )
+
+      (resp ++ self.toStreamComplete(id)).catchAll(self.toStreamError(Option(id), _))
+    }
+  }
+
+  private[ws] class SubscriptionManager private (private val tracked: TMap[String, Promise[Any, Unit]]) {
+    def track(id: String): UStream[Promise[Any, Unit]] =
+      ZStream.fromEffect(Promise.make[Any, Unit].tap(tracked.put(id, _).commit))
+
+    def untrack(id: String): UIO[Unit] =
+      (tracked.get(id) <* tracked.delete(id)).commit.flatMap {
+        UIO.whenCase(_) { case Some(p) => p.succeed(()) }
+      }
+
+    def untrackAll: UIO[Unit] =
+      tracked.keys.map(ids => ZIO.foreach_(ids)(untrack)).commit.flatten
+
+    def isTracking(id: String): UIO[Boolean] = tracked.contains(id).commit
+  }
+
+  private object SubscriptionManager {
+    val make = TMap.make[String, Promise[Any, Unit]]().map(new SubscriptionManager(_)).commit
+  }
+
+}

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
@@ -30,14 +30,9 @@ sealed trait Protocol {
 object Protocol {
 
   def fromName(name: String): Protocol = name match {
-    case "graphql-transport-ws" => GraphQLWS
-    case _                      => Legacy
+    case GraphQLWS.name => GraphQLWS
+    case _              => Legacy
   }
-
-  def fromRequest(serverRequest: ServerRequest): Protocol =
-    serverRequest
-      .header("Sec-WebSocket-Protocol")
-      .fold[Protocol](GraphQLWS)(fromName)
 
   object GraphQLWS extends Protocol {
     object Ops {

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -260,7 +260,7 @@ object TapirAdapterSpec {
               assertTrue(messages(2).map(_.`type`) == Right(Ops.Complete))
             }
           }
-        ) @@ TestAspect.sequential
+        )
       )
     )
 

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestService.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestService.scala
@@ -95,7 +95,7 @@ object TestService {
       def deletedEvents: ZStream[Any, Nothing, String] =
         ZStream.unwrapManaged(subscribers.subscribe.map(ZStream.fromQueue(_)))
 
-      override def reset: UIO[Unit] = characters.set(initial)
+      def reset: UIO[Unit] = characters.set(initial)
     }).toLayer
 
   private def sha256(b: Array[Byte]): Array[Byte] =

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestService.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestService.scala
@@ -21,7 +21,12 @@ object TestService {
     def deleteCharacter(name: String): UIO[Boolean]
 
     def deletedEvents: ZStream[Any, Nothing, String]
+
+    def reset: UIO[Unit]
   }
+
+  def reset: URIO[TestService, Unit] =
+    URIO.serviceWith(_.reset)
 
   def getCharacters(origin: Option[Origin]): URIO[TestService, List[Character]] =
     URIO.serviceWith(_.getCharacters(origin))
@@ -89,6 +94,8 @@ object TestService {
 
       def deletedEvents: ZStream[Any, Nothing, String] =
         ZStream.unwrapManaged(subscribers.subscribe.map(ZStream.fromQueue(_)))
+
+      override def reset: UIO[Unit] = characters.set(initial)
     }).toLayer
 
   private def sha256(b: Array[Byte]): Array[Byte] =


### PR DESCRIPTION
Adds support for the new graphql subscription [variant](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md). Splits the handling of the protocol into a separate type so that it can be implemented in a single place rather than in the adapters + zio-http.

There is probably even more refactoring that can be done here to get a smaller LOC profile, but I got as far as the weekend would allow so figured this would be a good checkin that we can continue to enhance.