### PR TITLE
Fix cache poisoning

### DIFF
--- a/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
@@ -6,6 +6,9 @@ import caliban.wrappers.Wrapper.OverallWrapper
 import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, InputValue }
 import zio.{ Has, Layer, Ref, UIO, ZIO }
 
+import java.nio.charset.StandardCharsets
+import javax.xml.bind.DatatypeConverter
+
 object ApolloPersistedQueries {
 
   type ApolloPersistence = Has[Service]
@@ -44,8 +47,10 @@ object ApolloPersistedQueries {
                   case Some(query) => UIO(request.copy(query = Some(query)))
                   case None        =>
                     request.query match {
-                      case Some(value) => ZIO.accessM[ApolloPersistence](_.get.add(hash, value)).as(request)
-                      case None        => ZIO.fail(ValidationError("PersistedQueryNotFound", ""))
+                      case Some(value) if checkHash(hash, value) =>
+                        ZIO.accessM[ApolloPersistence](_.get.add(hash, value)).as(request)
+                      case Some(_)                               => ZIO.fail(ValidationError("Provided sha does not match any query", ""))
+                      case None                                  => ZIO.fail(ValidationError("PersistedQueryNotFound", ""))
                     }
 
                 }
@@ -65,4 +70,10 @@ object ApolloPersistedQueries {
           }
         case _                              => None
       }
+
+  private def checkHash(hash: String, query: String): Boolean = {
+    val sha256 = java.security.MessageDigest.getInstance("SHA-256")
+    val digest = sha256.digest(query.getBytes(StandardCharsets.UTF_8))
+    DatatypeConverter.printHexBinary(digest).toLowerCase == hash
+  }
 }

--- a/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
@@ -7,7 +7,7 @@ import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, InputValue }
 import zio.{ Has, Layer, Ref, UIO, ZIO }
 
 import java.nio.charset.StandardCharsets
-import javax.xml.bind.DatatypeConverter
+import scala.collection.mutable
 
 object ApolloPersistedQueries {
 
@@ -71,9 +71,15 @@ object ApolloPersistedQueries {
         case _                              => None
       }
 
+  private def hex(bytes: Array[Byte]): String = {
+    val builder = new mutable.StringBuilder(bytes.length * 2)
+    bytes.foreach(byte => builder.append(f"$byte%02x".toLowerCase))
+    builder.mkString
+  }
+
   private def checkHash(hash: String, query: String): Boolean = {
     val sha256 = java.security.MessageDigest.getInstance("SHA-256")
     val digest = sha256.digest(query.getBytes(StandardCharsets.UTF_8))
-    DatatypeConverter.printHexBinary(digest).toLowerCase == hash
+    hex(digest) == hash
   }
 }


### PR DESCRIPTION
Fixes a potential security vulnerability in the ApolloPersistedQuery wrapper that allowed for cache poisoning.