### PR TITLE
Properly validate floating point numbers on input

### DIFF
--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -231,6 +231,7 @@ object VariablesCoercer {
       case __TypeKind.SCALAR if typ.name.contains("Float") =>
         value match {
           case NullValue                    => IO.succeed(NullValue)
+          case v: FloatValue                => IO.succeed(v)
           case IntValue.IntNumber(value)    => IO.succeed(Value.FloatValue(value.toDouble))
           case IntValue.LongNumber(value)   => IO.succeed(Value.FloatValue(value.toDouble))
           case IntValue.BigIntNumber(value) => IO.succeed(Value.FloatValue(BigDecimal(value)))


### PR DESCRIPTION
It looks like a change in the latest release to add input validation has a small bug for Float input types.  If you input an integer, it will properly coerce to a floating point, however if you enter a whole number with anything after the decimal point other than zero, it will fail on validation.  

For example, if you have a variable in a query alias named f of type `Float!` and provided an input of 99.1234, it would fail with `Variable 'f' with value 99.1324 cannot be coerced into Float`.  It seems when you enter a float, they are coming to the validation code as FloatValue.BigDecimalNumber, which is not checked in the pattern match for Float input validation.  This fix adds a check for any FloatValue and passes them on as is.