### PR TITLE
Improve persisted query performance by caching the document

### DIFF
--- a/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
@@ -62,7 +62,7 @@ object ApolloPersistedQueries {
                   case Some(doc) => docVar.set(Some(Right(doc))) as request
                   case None      =>
                     request.query match {
-                      case Some(value) if checkHash(hash, value) => docVar.set(Some(Left(hash))) as request
+                      case Some(value) if checkHash(hash, value) => docVar.set(Some(Left(hash))).as(request)
                       case Some(_)                               => ZIO.fail(ValidationError("Provided sha does not match any query", ""))
                       case None                                  => ZIO.fail(ValidationError("PersistedQueryNotFound", ""))
                     }


### PR DESCRIPTION
This PR improves the performance of the `ApolloPersistedQuery` wrapper by caching the parsed `Document` instead of the unparsed string. The advantage of this approach is that in the happy path we get to skip subsequent parsing steps and simply return the `Document`