### PR TITLE
Escape quotes in description strings

### DIFF
--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -150,8 +150,9 @@ object Rendering {
 
   private def renderDescription(description: Option[String], newline: Boolean = true): String = description match {
     case None                   => ""
-    case Some(value) if newline => if (value.contains("\n")) s"""\"\"\"\n$value\"\"\"\n""" else s""""$value"\n"""
-    case Some(value)            => if (value.contains("\n")) s"""\"\"\"$value\"\"\" """ else s""""$value" """
+    case Some(value) if newline =>
+      if (value.contains("\n")) renderTripleQuotedString("\n" + value) + "\n" else renderString(value) + "\n"
+    case Some(value)            => if (value.contains("\n")) renderTripleQuotedString(value) else renderString(value) + " "
   }
 
   private def renderSpecifiedBy(specifiedBy: Option[String]): String =
@@ -219,4 +220,10 @@ object Rendering {
       case _                   => s"${fieldType.name.getOrElse("null")}"
     }
   }
+
+  private def renderTripleQuotedString(value: String) =
+    "\"\"\"" + value.replace("\"\"\"", "\\\"\"\"") + "\"\"\""
+
+  private def renderString(value: String) =
+    "\"" + value.replace("\"", "\\\"") + "\""
 }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -158,6 +158,26 @@ object RenderingSpec extends DefaultRunnableSpec {
         )
         val renderedType = Rendering.renderTypes(List(testType))
         assert(renderedType)(equalTo("type TestType @testdirective(object: {key1: \"value1\",key2: \"value2\"})"))
+      },
+      test("it should escape \" inside a normally quoted description string") {
+        val testType     = __Type(
+          __TypeKind.OBJECT,
+          name = Some("TestType"),
+          description = Some("A \"TestType\" description")
+        )
+        val renderedType = Rendering.renderTypes(List(testType))
+        assert(renderedType)(equalTo("\"A \\\"TestType\\\" description\"\ntype TestType"))
+      },
+      test("it should escape \"\"\" inside a triple-quoted description string") {
+        val testType     = __Type(
+          __TypeKind.OBJECT,
+          name = Some("TestType"),
+          description = Some("A multiline \"TestType\" description\ngiven inside \"\"\"-quotes\n")
+        )
+        val renderedType = Rendering.renderTypes(List(testType))
+        assert(renderedType)(
+          equalTo("\"\"\"\nA multiline \"TestType\" description\ngiven inside \\\"\"\"-quotes\n\"\"\"\ntype TestType")
+        )
       }
     )
 }


### PR DESCRIPTION
Escape `"` with `\"` in normally quoted strings and `"""`  with `\"""` in
triple-quoted strings. It previously rendered syntactically invalid GraphQL 
when a single-line description contained `"` or a multi-line description
contained `"""`.
https://spec.graphql.org/October2021/#sec-String-Value