### PR TITLE
Escape special characters in normally quoted strings

### DIFF
--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -225,5 +225,12 @@ object Rendering {
     "\"\"\"" + value.replace("\"\"\"", "\\\"\"\"") + "\"\"\""
 
   private def renderString(value: String) =
-    "\"" + value.replace("\"", "\\\"") + "\""
+    "\"" + value
+      .replace("\\", "\\\\")
+      .replace("\b", "\\b")
+      .replace("\f", "\\f")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+      .replace("\t", "\\t")
+      .replace("\"", "\\\"") + "\""
 }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -159,14 +159,18 @@ object RenderingSpec extends DefaultRunnableSpec {
         val renderedType = Rendering.renderTypes(List(testType))
         assert(renderedType)(equalTo("type TestType @testdirective(object: {key1: \"value1\",key2: \"value2\"})"))
       },
-      test("it should escape \" inside a normally quoted description string") {
+      test(
+        "it should escape \", \\, backspace, linefeed, carriage-return and tab inside a normally quoted description string"
+      ) {
         val testType     = __Type(
           __TypeKind.OBJECT,
           name = Some("TestType"),
-          description = Some("A \"TestType\" description")
+          description = Some("A \"TestType\" description with \\, \b, \f, \r and \t")
         )
         val renderedType = Rendering.renderTypes(List(testType))
-        assert(renderedType)(equalTo("\"A \\\"TestType\\\" description\"\ntype TestType"))
+        assert(renderedType)(
+          equalTo("\"A \\\"TestType\\\" description with \\\\, \\b, \\f, \\r and \\t\"\ntype TestType")
+        )
       },
       test("it should escape \"\"\" inside a triple-quoted description string") {
         val testType     = __Type(


### PR DESCRIPTION
Follow-up to #1372: also escape other special characters, since 
direct rendering of these (e.g. `\b`) may produce syntactically
incorrect GraphQL.