### PR TITLE
Coerce non-null values into lists of size one

### DIFF
--- a/core/src/test/scala-2/caliban/validation/InputArgumentSpecInterop.scala
+++ b/core/src/test/scala-2/caliban/validation/InputArgumentSpecInterop.scala
@@ -1,0 +1,19 @@
+package caliban.validation
+
+object InputArgumentSpecInterop {
+  import InputArgumentSpec._
+
+  case class Query(
+    bool: BoolArg => String = _ => "result",
+    boolNonNull: BoolArgNonNull => String = _ => "result",
+    float: FloatArg => String = _ => "result",
+    int: IntArg => String = _ => "result",
+    list: ListArg => String = _ => "result",
+    listInt: ListIntArg => Option[List[Option[Int]]] = _.input,
+    listListInt: ListListIntArg => Option[List[Option[List[Option[Int]]]]] = _.input,
+    string: StringArg => String = _ => "result",
+    `enum`: EnumArg => String = _ => "result",
+    input: InputArg => String = _ => "result",
+    exampleObject: ExampleObjectArg => Option[ExampleObject] = _.input
+  )
+}

--- a/core/src/test/scala-3/caliban/validation/InputArgumentSpecInterop.scala
+++ b/core/src/test/scala-3/caliban/validation/InputArgumentSpecInterop.scala
@@ -1,0 +1,20 @@
+package caliban.validation
+
+object InputArgumentSpecInterop {
+  import InputArgumentSpec._
+
+  case class Query(
+    bool: BoolArg => String = _ => "result",
+    boolNonNull: BoolArgNonNull => String = _ => "result",
+    float: FloatArg => String = _ => "result",
+    int: IntArg => String = _ => "result",
+    list: ListArg => String = _ => "result",
+    listInt: ListIntArg => Option[List[Option[Int]]] = _.input,
+    // does not compile on Scala 3
+    // listListInt: ListListIntArg => Option[List[Option[List[Option[Int]]]]] = _.input,
+    string: StringArg => String = _ => "result",
+    `enum`: EnumArg => String = _ => "result",
+    input: InputArg => String = _ => "result",
+    exampleObject: ExampleObjectArg => Option[ExampleObject] = _.input
+  )
+}

--- a/core/src/test/scala/caliban/TriState.scala
+++ b/core/src/test/scala/caliban/TriState.scala
@@ -1,0 +1,44 @@
+package caliban
+
+import caliban.schema.ArgBuilder
+import caliban.schema.Schema
+import caliban.schema.Step
+import caliban.schema.Step.PureStep
+
+sealed trait TriState[+A]
+object TriState {
+  case object Undefined     extends TriState[Nothing]
+  case object Null          extends TriState[Nothing]
+  case class Value[A](v: A) extends TriState[A]
+
+  def fromOption[A](o: Option[A]) = o.fold[TriState[A]](Null)(Value(_))
+
+  def schemaCustom[R, A](undefined: PureStep)(implicit ev: Schema[R, A]): Schema[R, TriState[A]] =
+    new Schema[R, TriState[A]] {
+      override val optional = true
+
+      override def toType(isInput: Boolean, isSubscription: Boolean) = ev.toType_(isInput, isSubscription)
+
+      override def resolve(value: TriState[A]) = {
+        println(("resolve", value))
+        value match {
+          case Undefined => undefined
+          case Null      => Step.NullStep
+          case Value(v)  => ev.resolve(v)
+        }
+      }
+    }
+
+  implicit def schema[R, A](implicit ev: Schema[R, A]): Schema[R, TriState[A]] = schemaCustom(Step.NullStep)
+
+  implicit def argBuilder[A](implicit ev: ArgBuilder[A]): ArgBuilder[TriState[A]] = new ArgBuilder[TriState[A]] {
+    private val base = ArgBuilder.option(ev)
+
+    override def build(input: InputValue) = base.build(input).map(fromOption(_))
+
+    override def buildMissing(default: Option[String]) = default match {
+      case None    => Right(Undefined)
+      case Some(v) => base.buildMissing(Some(v)).map(fromOption(_))
+    }
+  }
+}

--- a/core/src/test/scala/caliban/validation/InputArgumentSpec.scala
+++ b/core/src/test/scala/caliban/validation/InputArgumentSpec.scala
@@ -1,8 +1,9 @@
 package caliban.validation
 
-import caliban.{ CalibanError, GraphQLRequest, InputValue, RootResolver, TestUtils, Value }
+import caliban.{ CalibanError, GraphQLRequest, InputValue, ResponseValue, RootResolver, TriState, Value }
 import caliban.GraphQL._
-import zio.test.Assertion._
+import caliban.schema.Schema
+import caliban.schema.Step
 import zio.test._
 import zio.test.environment.TestEnvironment
 
@@ -17,24 +18,40 @@ object InputArgumentSpec extends DefaultRunnableSpec {
   case class FloatArg(input: Option[Float])
   case class IntArg(input: Option[Int])
   case class ListArg(input: Option[List[String]])
+  case class ListIntArg(input: Option[List[Option[Int]]])
+  case class ListListIntArg(input: Option[List[Option[List[Option[Int]]]]])
   case class StringArg(input: Option[String])
   case class EnumArg(input: Option[Enum])
   case class InputArg(input: Option[InputObject])
 
-  // TODO: INPUT_OBJECT
+  case class ExampleObject(a: TriState[String], b: Int)
+  object ExampleObject {
+    implicit val schemaTriState: Schema[Any, TriState[String]] =
+      TriState.schemaCustom(Step.PureStep(Value.StringValue("__undefined__")))
 
-  case class TestOutput(value: String)
+    implicit val schema: Schema[Any, ExampleObject] = Schema.genMacro[ExampleObject].schema
+  }
+  case class ExampleObjectArg(input: Option[ExampleObject])
+
   case class Query(
     bool: BoolArg => String = _ => "result",
     boolNonNull: BoolArgNonNull => String = _ => "result",
     float: FloatArg => String = _ => "result",
     int: IntArg => String = _ => "result",
     list: ListArg => String = _ => "result",
+    listInt: ListIntArg => Option[List[Option[Int]]] = _.input,
+    listListInt: ListListIntArg => Option[List[Option[List[Option[Int]]]]] = _.input,
     string: StringArg => String = _ => "result",
     `enum`: EnumArg => String = _ => "result",
-    input: InputArg => String = _ => "result"
+    input: InputArg => String = _ => "result",
+    exampleObject: ExampleObjectArg => Option[ExampleObject] = _.input
   )
   val gql = graphQL(RootResolver(Query()))
+
+  private def execute(query: String, variables: Map[String, InputValue] = Map.empty) = for {
+    int <- gql.interpreter
+    res <- int.executeRequest(GraphQLRequest(query = Some(query), variables = Some(variables)))
+  } yield res
 
   override def spec: ZSpec[TestEnvironment, Any] =
     suite("InputArgumentSpec")(
@@ -339,7 +356,7 @@ object InputArgumentSpec extends DefaultRunnableSpec {
           } yield assertTrue(
             res.errors == List(
               CalibanError.ValidationError(
-                "Variable 'list' with value 2 cannot be coerced into into [String].",
+                "Variable 'list' with value 2 cannot be coerced into String.",
                 "Variable values need to follow GraphQL's coercion rules."
               )
             )
@@ -360,7 +377,181 @@ object InputArgumentSpec extends DefaultRunnableSpec {
                      )
                    )
           } yield assertTrue(res.errors == List())
-        }
+        },
+        // test cases from http://spec.graphql.org/October2021/#sec-List.Input-Coercion
+        suite("[Int]")(
+          testM("[1, 2, 3] -> [1, 2, 3]") {
+            val query = """
+              query QueryName($input: [Int!]!) {
+                listInt(input: $input)
+              }
+            """
+            val list  = List(Value.IntValue(1), Value.IntValue(2), Value.IntValue(3))
+            val vars  = Map("input" -> InputValue.ListValue(list))
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(res.data == ResponseValue.ObjectValue(List("listInt" -> ResponseValue.ListValue(list))))
+          },
+          testM("""[1, "b", true, 4] -> errors""") {
+            val query = """
+              query QueryName($input: [Int!]!) {
+                listInt(input: $input)
+              }
+            """
+            val list  = List(Value.IntValue(1), Value.StringValue("b"), Value.BooleanValue(true), Value.IntValue(4))
+            val vars  = Map("input" -> InputValue.ListValue(list))
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(
+              res.errors == List(
+                CalibanError.ValidationError(
+                  "Variable 'input' at index '1' with value \"b\" cannot be coerced into Int.",
+                  "Variable values need to follow GraphQL's coercion rules."
+                )
+              )
+            )
+          },
+          testM("1 -> [1]") {
+            val query = """
+              query QueryName($input: [Int!]!) {
+                listInt(input: $input)
+              }
+            """
+            val input = Value.IntValue(1)
+            val vars  = Map("input" -> input)
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(
+              res.data == ResponseValue.ObjectValue(List("listInt" -> ResponseValue.ListValue(List(input))))
+            )
+          },
+          testM("null -> null") {
+            val query = """
+              query QueryName($input: [Int]) {
+                listInt(input: $input)
+              }
+            """
+            val input = Value.NullValue
+            val vars  = Map("input" -> input)
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(res.data == ResponseValue.ObjectValue(List("listInt" -> input)))
+          }
+        ),
+        suite("[[Int]]")(
+          testM("[[1], [2, 3]] -> [[1], [2, 3]]") {
+            val query = """
+              query QueryName($input: [[Int!]!]!) {
+                listListInt(input: $input)
+              }
+            """
+            val list  = List(
+              InputValue.ListValue(List(Value.IntValue(1))),
+              InputValue.ListValue(List(Value.IntValue(2), Value.IntValue(3)))
+            )
+            val vars  = Map("input" -> InputValue.ListValue(list))
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(
+              res.data == ResponseValue.ObjectValue(
+                List(
+                  "listListInt" -> ResponseValue.ListValue(
+                    List(
+                      ResponseValue.ListValue(List(Value.IntValue(1))),
+                      ResponseValue.ListValue(List(Value.IntValue(2), Value.IntValue(3)))
+                    )
+                  )
+                )
+              )
+            )
+          },
+          // note that the spec says this should be an error, but the reference implementation allows it
+          testM("[1, 2, 3] -> [[1], [2], [3]]") {
+            val query = """
+              query QueryName($input: [[Int!]!]!) {
+                listListInt(input: $input)
+              }
+            """
+            val list  = List(Value.IntValue(1), Value.IntValue(2), Value.IntValue(3))
+            val vars  = Map("input" -> InputValue.ListValue(list))
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(
+              res.data == ResponseValue.ObjectValue(
+                List(
+                  "listListInt" -> ResponseValue.ListValue(
+                    List(
+                      ResponseValue.ListValue(List(Value.IntValue(1))),
+                      ResponseValue.ListValue(List(Value.IntValue(2))),
+                      ResponseValue.ListValue(List(Value.IntValue(3)))
+                    )
+                  )
+                )
+              )
+            )
+          },
+          testM("1 -> [[1]]") {
+            val query = """
+              query QueryName($input: [[Int!]!]!) {
+                listListInt(input: $input)
+              }
+            """
+            val input = Value.IntValue(1)
+            val vars  = Map("input" -> input)
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(
+              res.data == ResponseValue.ObjectValue(
+                List("listListInt" -> ResponseValue.ListValue(List(ResponseValue.ListValue(List(input)))))
+              )
+            )
+          },
+          testM("null -> null") {
+            val query = """
+              query QueryName($input: [[Int]]) {
+                listListInt(input: $input)
+              }
+            """
+            val input = Value.NullValue
+            val vars  = Map("input" -> input)
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(res.data == ResponseValue.ObjectValue(List("listListInt" -> input)))
+          },
+          testM("[1, [null], null] -> [[1], [null], null]") {
+            val query = """
+              query QueryName($input: [[Int]]) {
+                listListInt(input: $input)
+              }
+            """
+            val list  = List(Value.IntValue(1), InputValue.ListValue(List(Value.NullValue)), Value.NullValue)
+            val vars  = Map("input" -> InputValue.ListValue(list))
+
+            for {
+              res <- execute(query, vars)
+            } yield assertTrue(
+              res.data == ResponseValue.ObjectValue(
+                List(
+                  "listListInt" -> ResponseValue.ListValue(
+                    List(
+                      ResponseValue.ListValue(List(Value.IntValue(1))),
+                      ResponseValue.ListValue(List(Value.NullValue)),
+                      Value.NullValue
+                    )
+                  )
+                )
+              )
+            )
+          }
+        )
       ),
       suite("input objects")(
         testM("invalid coercion") {
@@ -417,6 +608,329 @@ object InputArgumentSpec extends DefaultRunnableSpec {
                      )
                    )
           } yield assertTrue(res.errors == List())
+        },
+        // test cases from http://spec.graphql.org/October2021/#sec-Input-Objects.Input-Coercion
+        testM("""{ a: "abc", b: 123 } + {} -> { a: "abc", b: 123 }""") {
+          val query = """
+            query QueryName {
+              exampleObject(input: { a: "abc", b: 123 }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.data == ResponseValue.ObjectValue(
+              List(
+                "exampleObject" -> ResponseValue.ObjectValue(
+                  List(
+                    "a" -> Value.StringValue("abc"),
+                    "b" -> Value.IntValue(123)
+                  )
+                )
+              )
+            )
+          )
+        },
+        testM("""{ a: null, b: 123 } + {} -> { a: null, b: 123 }""") {
+          val query = """
+            query QueryName {
+              exampleObject(input: { a: null, b: 123 }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.data == ResponseValue.ObjectValue(
+              List(
+                "exampleObject" -> ResponseValue.ObjectValue(
+                  List(
+                    "a" -> Value.NullValue,
+                    "b" -> Value.IntValue(123)
+                  )
+                )
+              )
+            )
+          )
+        },
+        testM("""{ b: 123 } + {} -> { b: 123 }""") {
+          val query = """
+            query QueryName {
+              exampleObject(input: { b: 123 }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.data == ResponseValue.ObjectValue(
+              List(
+                "exampleObject" -> ResponseValue.ObjectValue(
+                  List(
+                    "a" -> Value.StringValue("__undefined__"),
+                    "b" -> Value.IntValue(123)
+                  )
+                )
+              )
+            )
+          )
+        },
+        testM("""{ a: $var, b: 123 } + { var: null } -> { a: null, b: 123 }""") {
+          val query = """
+            query QueryName($var: String) {
+              exampleObject(input: { a: $var, b: 123 }) { a, b }
+            }
+          """
+          val vars  = Map("var" -> Value.NullValue)
+
+          for {
+            res <- execute(query, vars)
+          } yield assertTrue(
+            res.data == ResponseValue.ObjectValue(
+              List(
+                "exampleObject" -> ResponseValue.ObjectValue(
+                  List(
+                    "a" -> Value.NullValue,
+                    "b" -> Value.IntValue(123)
+                  )
+                )
+              )
+            )
+          )
+        },
+        testM("""{ a: $var, b: 123 } + {} -> { a: null, b: 123 }""") {
+          val query = """
+            query QueryName($var: String) {
+              exampleObject(input: { a: $var, b: 123 }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.data == ResponseValue.ObjectValue(
+              List(
+                "exampleObject" -> ResponseValue.ObjectValue(
+                  List(
+                    "a" -> Value.StringValue("__undefined__"),
+                    "b" -> Value.IntValue(123)
+                  )
+                )
+              )
+            )
+          )
+        },
+        testM("""{ b: $var } + { var: 123 } -> { b: 123 }""") {
+          val query = """
+            query QueryName($var: Int!) {
+              exampleObject(input: { b: $var }) { a, b }
+            }
+          """
+          val vars  = Map("var" -> Value.IntValue(123))
+
+          for {
+            res <- execute(query, vars)
+          } yield assertTrue(
+            res.data == ResponseValue.ObjectValue(
+              List(
+                "exampleObject" -> ResponseValue.ObjectValue(
+                  List(
+                    "a" -> Value.StringValue("__undefined__"),
+                    "b" -> Value.IntValue(123)
+                  )
+                )
+              )
+            )
+          )
+        },
+        testM("""$var + { var: { b: 123 } } -> { b: 123 }""") {
+          val query = """
+            query QueryName($var: ExampleObjectInput!) {
+              exampleObject(input: $var) { a, b }
+            }
+          """
+          val vars  = Map("var" -> InputValue.ObjectValue(Map("b" -> Value.IntValue(123))))
+
+          for {
+            res <- execute(query, vars)
+          } yield assertTrue(
+            res.data == ResponseValue.ObjectValue(
+              List(
+                "exampleObject" -> ResponseValue.ObjectValue(
+                  List(
+                    "a" -> Value.StringValue("__undefined__"),
+                    "b" -> Value.IntValue(123)
+                  )
+                )
+              )
+            )
+          )
+        },
+        testM(""""abc123" + {} -> errors""") {
+          val query = """
+            query QueryName {
+              exampleObject(input: "abc123") { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "InputValue 'input' of Field 'exampleObject' has invalid type: \"abc123\"",
+                "Input field was supposed to be an input object."
+              )
+            )
+          )
+        },
+        testM("""$var + { var: "abc123" } -> errors""") {
+          val query = """
+            query QueryName($var: ExampleObjectInput!) {
+              exampleObject(input: $var) { a, b }
+            }
+          """
+          val vars  = Map("var" -> Value.StringValue("abc123"))
+
+          for {
+            res <- execute(query, vars)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "Variable 'var' cannot coerce \"abc123\" to ExampleObjectInput",
+                "Variable values need to follow GraphQL's coercion rules."
+              )
+            )
+          )
+        },
+        testM("""{ a: "abc", b: "123" } + {} -> errors""") {
+          val query = """
+            query QueryName {
+              exampleObject(input: { a: "abc", b: "123" }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "InputValue 'input' of Field 'b' of InputObject 'ExampleObjectInput' has invalid type \"123\"",
+                "Expected 'Int'"
+              )
+            )
+          )
+        },
+        testM("""{ a: "abc" } + {} -> errors""") {
+          val query = """
+            query QueryName {
+              exampleObject(input: { a: "abc" }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "Required field 'b' on object 'ExampleObjectInput' was not provided.",
+                "Input object fields may be required. Much like a field may have required arguments, an input object may have required fields. An input field is required if it has a non‐null type and does not have a default value. Otherwise, the input object field is optional."
+              )
+            )
+          )
+        },
+        testM("""{ b: $var } + {} -> errors""") {
+          val query = """
+            query QueryName($var: Int!) {
+              exampleObject(input: { b: $var }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "Variable 'var' is null but is specified to be non-null.",
+                "The value of a variable must be compatible with its type."
+              )
+            )
+          )
+        },
+        testM("""$var + { var: { a: "abc" } } -> errors""") {
+          val query = """
+            query QueryName($var: ExampleObjectInput) {
+              exampleObject(input: $var) { a, b }
+            }
+          """
+          val vars  = Map("var" -> InputValue.ObjectValue(Map("a" -> Value.StringValue("abc"))))
+
+          for {
+            res <- execute(query, vars)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "Field b in InputValue 'input' of Field 'exampleObject' is null",
+                "Input field was null but was supposed to be non-null."
+              )
+            )
+          )
+        },
+        testM("""{ a: "abc", b: null } + {} -> errors""") {
+          val query = """
+            query QueryName {
+              exampleObject(input: { a: "abc", b: null }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "InputValue 'input' of Field 'b' of InputObject 'ExampleObjectInput' is null",
+                "Input field was null but was supposed to be non-null."
+              )
+            )
+          )
+        },
+        testM("""{ b: $var } + { var: null } -> errors""") {
+          val query = """
+            query QueryName($var: Int!) {
+              exampleObject(input: { b: $var }) { a, b }
+            }
+          """
+          val vars  = Map("var" -> Value.NullValue)
+
+          for {
+            res <- execute(query, vars)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "InputValue 'input' of Field 'b' of InputObject 'ExampleObjectInput' is null",
+                "Input field was null but was supposed to be non-null."
+              )
+            )
+          )
+        },
+        testM("""{ b: 123, c: "xyz" } + {} -> errors""") {
+          val query = """
+            query QueryName {
+              exampleObject(input: { b: 123, c: "xyz" }) { a, b }
+            }
+          """
+
+          for {
+            res <- execute(query)
+          } yield assertTrue(
+            res.errors == List(
+              CalibanError.ValidationError(
+                "Input field 'c' is not defined on type 'ExampleObjectInput'.",
+                "Every input field provided in an input object value must be defined in the set of possible fields of that input object’s expected type."
+              )
+            )
+          )
         }
       )
     )


### PR DESCRIPTION
As per the specification, if a value passed as an input to a list type is
not a list and is not null then it should be coerced into a list of size
one.