### PR TITLE
Deferred execution

### DIFF
--- a/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -74,7 +74,7 @@ class AkkaHttpAdapter private (private val options: AkkaHttpServerOptions) {
     materializer: Materializer,
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
+    responseCodec: JsonCodec[ResponseValue]
   ): Route = {
     val endpoint = TapirAdapter.makeHttpUploadService[R, E](
       interpreter,

--- a/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -39,7 +39,7 @@ class AkkaHttpAdapter private (private val options: AkkaHttpServerOptions) {
     runtime: Runtime[R],
     materializer: Materializer,
     requestCodec: JsonCodec[GraphQLRequest],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
+    responseCodec: JsonCodec[ResponseValue]
   ): Route = {
     val endpoints: List[ServerEndpoint[ZioStreams, RIO[R, *]]] = TapirAdapter.makeHttpService[R, E](
       interpreter,

--- a/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -50,15 +50,16 @@ object Http4sAdapter {
     queryExecution: QueryExecution = QueryExecution.Parallel,
     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
   )(implicit interop: ToEffect[F, R]): HttpRoutes[F] = {
-    val endpoints                                       = TapirAdapter.makeHttpService[R, E](
+    val endpoints = TapirAdapter.makeHttpService[R, E](
       interpreter,
       skipValidation,
       enableIntrospection,
       queryExecution,
       requestInterceptor
     )
-    val endpointsF: List[ServerEndpoint[ZioStreams, F]] = endpoints.map(convertHttpEndpointToF[F, R, E])
-    Http4sServerInterpreter().toRoutes(endpointsF)
+//    val endpointsF: List[ServerEndpoint[ZioStreams, F]] = endpoints.map(convertHttpEndpointToF[F, R, E])
+//    Http4sServerInterpreter().toRoutes(endpointsF)
+    ???
   }
 
   def makeHttpUploadService[R <: Has[_] with Random, E](
@@ -197,20 +198,20 @@ object Http4sAdapter {
    */
   def convertHttpEndpointToF[F[_], R, E](
     endpoint: ServerEndpoint[ZioStreams, RIO[R, *]]
-  )(implicit interop: ToEffect[F, R]): ServerEndpoint[Fs2Streams[F], F] =
-    ServerEndpoint[
-      endpoint.SECURITY_INPUT,
-      endpoint.PRINCIPAL,
-      endpoint.INPUT,
-      endpoint.ERROR_OUTPUT,
-      endpoint.OUTPUT,
-      Fs2Streams[F],
-      F
-    ](
-      endpoint.endpoint,
-      _ => a => interop.toEffect(endpoint.securityLogic(zioMonadError)(a)),
-      _ => u => req => interop.toEffect(endpoint.logic(zioMonadError)(u)(req))
-    )
+  )(implicit interop: ToEffect[F, R]): ServerEndpoint[Fs2Streams[F], F] = ???
+//    ServerEndpoint[
+//      endpoint.SECURITY_INPUT,
+//      endpoint.PRINCIPAL,
+//      endpoint.INPUT,
+//      endpoint.ERROR_OUTPUT,
+//      endpoint.OUTPUT,
+//      Fs2Streams[F],
+//      F
+//    ](
+//      endpoint.endpoint,
+//      _ => a => interop.toEffect(endpoint.securityLogic(zioMonadError)(a)),
+//      _ => u => req => interop.toEffect(endpoint.logic(zioMonadError)(u)(req))
+//    )
 
   /**
    * If you wish to use `Http4sServerInterpreter` with cats-effect IO instead of `ZHttp4sServerInterpreter`,

--- a/core/src/main/scala-2/caliban/interop/zio/zio.scala
+++ b/core/src/main/scala-2/caliban/interop/zio/zio.scala
@@ -414,9 +414,10 @@ private[caliban] object GraphQLResponseZioJson {
     implicit val decoder: JsonDecoder[GQLResponse]            = DeriveJsonDecoder.gen[GQLResponse]
   }
 
-  implicit val errorValueDecoder: JsonDecoder[CalibanError]                 = ErrorZioJson.errorValueDecoder
-  implicit val responseValueDecoder: JsonDecoder[ResponseValue.ObjectValue] = ValueZIOJson.Obj.responseDecoder
-  val graphQLResponseDecoder: JsonDecoder[GraphQLResponse[CalibanError]]    =
+  implicit val errorValueDecoder: JsonDecoder[CalibanError]               = ErrorZioJson.errorValueDecoder
+  implicit val objectValueDecoder: JsonDecoder[ResponseValue.ObjectValue] = ValueZIOJson.Obj.responseDecoder
+  implicit val listValueDecoder: JsonDecoder[ResponseValue.ListValue]     = ValueZIOJson.Arr.responseDecoder
+  val graphQLResponseDecoder: JsonDecoder[GraphQLResponse[CalibanError]]  =
     DeriveJsonDecoder.gen[GraphQLResponse[CalibanError]]
 }
 

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -2,7 +2,7 @@ package caliban
 
 import caliban.CalibanError.ValidationError
 import caliban.Rendering.{ renderDirectives, renderSchemaDirectives, renderTypes }
-import caliban.execution.{ ExecutionRequest, Executor, QueryExecution }
+import caliban.execution.{ ExecutionRequest, Executor, Feature, QueryExecution }
 import caliban.introspection.Introspector
 import caliban.introspection.adt._
 import caliban.parsing.adt.Definition.TypeSystemDefinition.SchemaDefinition
@@ -25,6 +25,7 @@ trait GraphQL[-R] { self =>
   protected val schemaBuilder: RootSchemaBuilder[R]
   protected val wrappers: List[Wrapper[R]]
   protected val additionalDirectives: List[__Directive]
+  protected val features: Set[Feature]
 
   private[caliban] def validateRootSchema: IO[ValidationError, RootSchema[R]] =
     Validator.validateSchema(schemaBuilder)
@@ -139,7 +140,7 @@ trait GraphQL[-R] { self =>
                   execute           =
                     (req: ExecutionRequest) =>
                       Executor
-                        .executeRequest(req, op.plan, fieldWrappers, queryExecution)
+                        .executeRequest(req, op.plan, fieldWrappers, queryExecution, features)
                   result           <- wrap(execute)(executionWrappers, executionRequest)
                 } yield result).catchAll(Executor.fail)
               )(overallWrappers, request)
@@ -158,6 +159,7 @@ trait GraphQL[-R] { self =>
       override val schemaBuilder: RootSchemaBuilder[R2]    = self.schemaBuilder
       override val wrappers: List[Wrapper[R2]]             = wrapper :: self.wrappers
       override val additionalDirectives: List[__Directive] = self.additionalDirectives
+      override val features: Set[Feature]                  = self.features
     }
 
   /**
@@ -182,6 +184,8 @@ trait GraphQL[-R] { self =>
       override protected val wrappers: List[Wrapper[R1]]             = self.wrappers ++ that.wrappers
       override protected val additionalDirectives: List[__Directive] =
         self.additionalDirectives ++ that.additionalDirectives
+
+      override protected val features: Set[Feature] = self.features ++ that.features
     }
 
   /**
@@ -214,6 +218,7 @@ trait GraphQL[-R] { self =>
     )
     override protected val wrappers: List[Wrapper[R]]              = self.wrappers
     override protected val additionalDirectives: List[__Directive] = self.additionalDirectives
+    override protected val features: Set[Feature]                  = self.features
   }
 
   /**
@@ -227,6 +232,7 @@ trait GraphQL[-R] { self =>
       self.schemaBuilder.copy(additionalTypes = self.schemaBuilder.additionalTypes ++ types)
     override protected val wrappers: List[Wrapper[R]]              = self.wrappers
     override protected val additionalDirectives: List[__Directive] = self.additionalDirectives
+    override protected val features: Set[Feature]                  = self.features
   }
 
   final def withSchemaDirectives(directives: List[Directive]): GraphQL[R] = new GraphQL[R] {
@@ -234,6 +240,21 @@ trait GraphQL[-R] { self =>
       self.schemaBuilder.copy(schemaDirectives = self.schemaBuilder.schemaDirectives ++ directives)
     override protected val wrappers: List[Wrapper[R]]              = self.wrappers
     override protected val additionalDirectives: List[__Directive] = self.additionalDirectives
+    override protected val features: Set[Feature]                  = self.features
+  }
+
+  final def withAdditionalDirectives(directives: List[__Directive]): GraphQL[R] = new GraphQL[R] {
+    override protected val schemaBuilder: RootSchemaBuilder[R]     = self.schemaBuilder
+    override protected val wrappers: List[Wrapper[R]]              = self.wrappers
+    override protected val additionalDirectives: List[__Directive] = self.additionalDirectives ++ directives
+    override protected val features: Set[Feature]                  = self.features
+  }
+
+  final def enable(feature: Feature): GraphQL[R] = new GraphQL[R] {
+    override protected val schemaBuilder: RootSchemaBuilder[R]     = self.schemaBuilder
+    override protected val wrappers: List[Wrapper[R]]              = self.wrappers
+    override protected val additionalDirectives: List[__Directive] = self.additionalDirectives
+    override protected val features: Set[Feature]                  = self.features + feature
   }
 }
 
@@ -264,5 +285,6 @@ object GraphQL {
     )
     val wrappers: List[Wrapper[R]]              = Nil
     val additionalDirectives: List[__Directive] = directives
+    val features                                = Set.empty
   }
 }

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -2,6 +2,7 @@ package caliban
 
 import scala.util.Try
 import caliban.interop.circe._
+import caliban.interop.tapir.IsTapirSchema
 import zio.stream.Stream
 
 sealed trait InputValue {
@@ -53,6 +54,8 @@ object ResponseValue extends ValueJsonCompat {
     caliban.interop.circe.json.ValueCirce.responseValueEncoder.asInstanceOf[F[ResponseValue]]
   implicit def circeDecoder[F[_]: IsCirceDecoder]: F[ResponseValue] =
     caliban.interop.circe.json.ValueCirce.responseValueDecoder.asInstanceOf[F[ResponseValue]]
+  implicit def tapirSchema[F[_]: IsTapirSchema]: F[ResponseValue]   =
+    caliban.interop.tapir.schema.responseValueSchema.asInstanceOf[F[ResponseValue]]
 }
 
 sealed trait Value extends InputValue with ResponseValue

--- a/core/src/main/scala/caliban/execution/Deferred.scala
+++ b/core/src/main/scala/caliban/execution/Deferred.scala
@@ -1,0 +1,9 @@
+package caliban.execution
+
+import caliban.schema.ReducedStep
+
+case class Deferred[-R](
+  path: List[Either[String, Int]],
+  step: ReducedStep[R],
+  label: Option[String]
+)

--- a/core/src/main/scala/caliban/execution/DeferredGraphQLResponse.scala
+++ b/core/src/main/scala/caliban/execution/DeferredGraphQLResponse.scala
@@ -10,6 +10,11 @@ case class DeferredGraphQLResponse[+E] private (
 )
 
 object DeferredGraphQLResponse {
+  def unapply[E](response: GraphQLResponse[E]): Option[(GraphQLResponse[E], ZStream[Any, Throwable, ResponseValue])] =
+    response.extensions.flatMap(_.fields.collectFirst { case ("__defer", StreamValue(stream)) =>
+      response -> stream
+    })
+
   def apply[E](response: GraphQLResponse[E]): DeferredGraphQLResponse[E] =
     DeferredGraphQLResponse(
       response,

--- a/core/src/main/scala/caliban/execution/DeferredGraphQLResponse.scala
+++ b/core/src/main/scala/caliban/execution/DeferredGraphQLResponse.scala
@@ -1,0 +1,22 @@
+package caliban.execution
+
+import caliban.ResponseValue.StreamValue
+import caliban.{ GraphQLResponse, ResponseValue }
+import zio.stream.ZStream
+
+case class DeferredGraphQLResponse[+E] private (
+  head: GraphQLResponse[E],
+  tail: ZStream[Any, Throwable, ResponseValue]
+)
+
+object DeferredGraphQLResponse {
+  def apply[E](response: GraphQLResponse[E]): DeferredGraphQLResponse[E] =
+    DeferredGraphQLResponse(
+      response,
+      ZStream
+        .fromIterable(response.extensions.flatMap(_.fields.collectFirst { case ("__defer", StreamValue(stream)) =>
+          stream
+        }))
+        .flatten
+    )
+}

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -5,6 +5,7 @@ import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue._
 import caliban.Value._
 import caliban._
+import caliban.execution.Executor.{ effectfulExecutionError, fieldInfo, mergeFields, reduceList, reduceObject }
 import caliban.execution.Fragment.IsDeferred
 import caliban.parsing.adt._
 import caliban.schema.ReducedStep.DeferStep
@@ -242,9 +243,9 @@ object Executor {
       responseAndDefers <- runQuery(reduced, cache, None, None)
       (response, defers) = responseAndDefers
       remaining         <- Ref.make(defers.size)
-      deferStream        = makeDeferStream(defers, remaining, cache).provide(env)
     } yield
-      if (defers.nonEmpty) response.withExtension("__defer", StreamValue(deferStream))
+      if (defers.nonEmpty)
+        response.withExtension("__defer", StreamValue(makeDeferStream(defers, remaining, cache).provide(env)))
       else response
   }
 
@@ -319,3 +320,5 @@ object Executor {
     }
   }
 }
+
+object Reducer {}

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -216,7 +216,8 @@ object Executor {
             case Left(value)  => StringValue(value)
             case Right(value) => IntValue(value)
           }.reverse)
-        )
+        ),
+        hasNext = if (defers.nonEmpty) Some(true) else None
       ) -> defers)
 
     def makeDeferStream(

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -217,7 +217,7 @@ object Executor {
           ListValue(path.map {
             case Left(value)  => StringValue(value)
             case Right(value) => IntValue(value)
-          })
+          }.reverse)
         )
       ) -> defers)
 
@@ -233,7 +233,9 @@ object Executor {
               remaining.updateAndGet(_ - 1).map(more => resp.copy(hasNext = Some(more > 0))).map(_.toResponseValue)
             )
           case (resp, more) =>
-            ZStream.fromEffect(remaining.updateAndGet(_ - 1 + more.size).as(resp.toResponseValue)) ++
+            ZStream.fromEffect(
+              remaining.updateAndGet(_ - 1 + more.size).as(resp.copy(hasNext = Some(true)).toResponseValue)
+            ) ++
               makeDeferStream(more, remaining, cache)
         })
 

--- a/core/src/main/scala/caliban/execution/Feature.scala
+++ b/core/src/main/scala/caliban/execution/Feature.scala
@@ -1,0 +1,8 @@
+package caliban.execution
+
+sealed trait Feature
+
+object Feature {
+  case object Defer  extends Feature
+  case object Stream extends Feature
+}

--- a/core/src/main/scala/caliban/execution/Fragment.scala
+++ b/core/src/main/scala/caliban/execution/Fragment.scala
@@ -1,5 +1,19 @@
 package caliban.execution
 
+import caliban.Value.{ BooleanValue, StringValue }
 import caliban.parsing.adt.Directive
 
-case class Fragment(name: Option[String], directives: List[Directive])
+case class Fragment(name: Option[String], directives: List[Directive]) {}
+
+object Fragment {
+  object IsDeferred {
+    def unapply(fragment: Fragment): Option[Option[String]] =
+      fragment.directives.collectFirst {
+        case Directive("defer", args, _) if args.get("if").forall {
+              case BooleanValue(v) => v
+              case _               => true
+            } =>
+          args.get("name").collect { case StringValue(v) => v }
+      }
+  }
+}

--- a/core/src/main/scala/caliban/execution/Fragment.scala
+++ b/core/src/main/scala/caliban/execution/Fragment.scala
@@ -1,6 +1,6 @@
 package caliban.execution
 
-import caliban.Value.{ BooleanValue, StringValue }
+import caliban.Value.{ BooleanValue, IntValue, StringValue }
 import caliban.parsing.adt.Directive
 
 case class Fragment(name: Option[String], directives: List[Directive]) {}
@@ -16,4 +16,14 @@ object Fragment {
           args.get("label").collect { case StringValue(v) => v }
       }
   }
+}
+
+object IsStream {
+  def unapply(field: Field): Option[(Option[String], Option[Int])] =
+    field.directives.collectFirst { case Directive("stream", args, _) =>
+      (
+        args.get("label").collect { case StringValue(v) => v },
+        args.get("initialCount").collect { case v: IntValue => v.toInt }
+      )
+    }
 }

--- a/core/src/main/scala/caliban/execution/Fragment.scala
+++ b/core/src/main/scala/caliban/execution/Fragment.scala
@@ -1,0 +1,5 @@
+package caliban.execution
+
+import caliban.parsing.adt.Directive
+
+case class Fragment(name: Option[String], directives: List[Directive])

--- a/core/src/main/scala/caliban/execution/Fragment.scala
+++ b/core/src/main/scala/caliban/execution/Fragment.scala
@@ -13,7 +13,7 @@ object Fragment {
               case BooleanValue(v) => v
               case _               => true
             } =>
-          args.get("name").collect { case StringValue(v) => v }
+          args.get("label").collect { case StringValue(v) => v }
       }
   }
 }

--- a/core/src/main/scala/caliban/interop/tapir/tapir.scala
+++ b/core/src/main/scala/caliban/interop/tapir/tapir.scala
@@ -13,12 +13,14 @@ private[caliban] object IsTapirSchema {
 }
 
 object schema {
-  implicit lazy val requestSchema: Schema[GraphQLRequest]    =
+  implicit lazy val requestSchema: Schema[GraphQLRequest]      =
     sttp.tapir.Schema[GraphQLRequest](SchemaType.SString[GraphQLRequest]())
-  implicit def responseSchema[E]: Schema[GraphQLResponse[E]] =
+  implicit def responseSchema[E]: Schema[GraphQLResponse[E]]   =
     sttp.tapir.Schema[GraphQLResponse[E]](SchemaType.SString[GraphQLResponse[E]]())
-  implicit lazy val wsInputSchema: Schema[GraphQLWSInput]    =
+  implicit lazy val wsInputSchema: Schema[GraphQLWSInput]      =
     sttp.tapir.Schema[GraphQLWSInput](SchemaType.SString[GraphQLWSInput]())
-  implicit lazy val wsOutputSchema: Schema[GraphQLWSOutput]  =
+  implicit lazy val wsOutputSchema: Schema[GraphQLWSOutput]    =
     sttp.tapir.Schema[GraphQLWSOutput](SchemaType.SString[GraphQLWSOutput]())
+  implicit lazy val responseValueSchema: Schema[ResponseValue] =
+    sttp.tapir.Schema[ResponseValue](SchemaType.SString[ResponseValue]())
 }

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -38,12 +38,6 @@ object Introspector extends IntrospectionDerivation {
       ),
       Set(__DirectiveLocation.SCALAR),
       List(__InputValue("url", None, () => Types.string.nonNull, None))
-    ),
-    __Directive(
-      "defer",
-      Some(""),
-      Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
-      List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None))
     )
   )
 

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -38,6 +38,12 @@ object Introspector extends IntrospectionDerivation {
       ),
       Set(__DirectiveLocation.SCALAR),
       List(__InputValue("url", None, () => Types.string.nonNull, None))
+    ),
+    __Directive(
+      "defer",
+      Some(""),
+      Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
+      List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None))
     )
   )
 

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -48,6 +48,11 @@ object ReducedStep {
   case class ObjectStep[-R](fields: List[(String, ReducedStep[R], FieldInfo)])    extends ReducedStep[R]
   case class QueryStep[-R](query: ZQuery[R, ExecutionError, ReducedStep[R]])      extends ReducedStep[R]
   case class StreamStep[-R](inner: ZStream[R, ExecutionError, ReducedStep[R]])    extends ReducedStep[R]
+  case class DeferStep[-R](
+    obj: ReducedStep[R],
+    deferred: List[(ReducedStep[R], Option[String])],
+    path: List[Either[String, Int]]
+  ) extends ReducedStep[R]
 
   // PureStep is both a Step and a ReducedStep so it is defined outside this object
   // This is to avoid boxing/unboxing pure values during step reduction

--- a/core/src/main/scala/caliban/wrappers/DeferSupport.scala
+++ b/core/src/main/scala/caliban/wrappers/DeferSupport.scala
@@ -1,3 +1,37 @@
 package caliban.wrappers
 
-object DeferSupport {}
+import caliban.execution.Feature
+import caliban.introspection.adt.{ __Directive, __DirectiveLocation, __InputValue }
+import caliban.schema.Types
+import caliban.{ GraphQL, GraphQLAspect }
+
+object DeferSupport {
+  private[caliban] val defer = __Directive(
+    "defer",
+    Some(""),
+    Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
+    List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None))
+  )
+
+  private[caliban] val stream = __Directive(
+    "stream",
+    Some(""),
+    Set(__DirectiveLocation.FIELD),
+    List(
+      __InputValue("if", None, () => Types.boolean, None),
+      __InputValue("label", None, () => Types.string, None),
+      __InputValue("initialCount", None, () => Types.int, None)
+    )
+  )
+
+  val deferSupport = new GraphQLAspect[Nothing, Any] {
+    override def apply[R](gql: GraphQL[R]): GraphQL[R] =
+      gql.withAdditionalDirectives(List(defer)).enable(Feature.Defer)
+  }
+
+  val streamSupport = new GraphQLAspect[Nothing, Any] {
+    override def apply[R >: Nothing <: Any](gql: GraphQL[R]): GraphQL[R] =
+      gql.withAdditionalDirectives(List(stream)).enable(Feature.Stream)
+  }
+
+}

--- a/core/src/main/scala/caliban/wrappers/DeferSupport.scala
+++ b/core/src/main/scala/caliban/wrappers/DeferSupport.scala
@@ -1,0 +1,3 @@
+package caliban.wrappers
+
+object DeferSupport {}

--- a/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
@@ -1,0 +1,109 @@
+package caliban.execution
+
+import caliban.GraphQL.graphQL
+import caliban.Macros.gqldoc
+import caliban.{ ResponseValue, RootResolver }
+import caliban.TestUtils.Origin.{ BELT, EARTH, MARS }
+import caliban.TestUtils.Role.{ Captain, Engineer, Mechanic, Pilot }
+import caliban.TestUtils.{ characters, resolverIO, CaptainShipName, Character, CharacterArgs, Origin, Role }
+import caliban.schema.Annotations.GQLName
+import caliban.schema.GenericSchema
+import zio.{ Has, UIO, URIO, ZIO, ZLayer }
+import zio.stream.ZStream
+import zio.test.Assertion.equalTo
+import zio.test.{ assertM, assertTrue, DefaultRunnableSpec, ZSpec }
+
+trait CharacterService {
+  def characterBy(pred: Character => Boolean): UIO[List[Character]]
+}
+
+object CharacterService {
+  val test = ZLayer.succeed(new CharacterService {
+    override def characterBy(pred: Character => Boolean): UIO[List[Character]] =
+      UIO.succeed(characters.filter(pred))
+  })
+}
+
+object DeferredExecutionSpec extends DefaultRunnableSpec {
+
+  object schema extends GenericSchema[Has[CharacterService]]
+  import schema._
+
+  case class ConnectionArgs(
+    withOrigin: List[Origin] = Nil,
+    withName: Option[String] = None
+  )
+
+  @GQLName("Character")
+  case class CharacterZIO(
+    name: String,
+    nicknames: List[String],
+    origin: Origin,
+    role: Option[Role],
+    connections: ConnectionArgs => URIO[Has[CharacterService], List[CharacterZIO]]
+  )
+
+  case class Query(
+    character: CharacterArgs => URIO[Has[CharacterService], Option[CharacterZIO]]
+  )
+
+  def character2CharacterZIO(ch: Character): CharacterZIO =
+    CharacterZIO(
+      name = ch.name,
+      nicknames = ch.nicknames,
+      origin = ch.origin,
+      role = ch.role,
+      connections = { case ConnectionArgs(withOrigin, withName) =>
+        ZIO
+          .mapParN(
+            ZIO.serviceWith[CharacterService](_.characterBy(c => withOrigin.contains(c.origin))),
+            ZIO.serviceWith[CharacterService](_.characterBy(c => withName.contains(c.name)))
+          )(_ ++ _)
+          .map(_.distinct.filter(_.name != ch.name))
+          .map(_.map(character2CharacterZIO))
+      }
+    )
+
+  val resolver =
+    RootResolver(
+      Query(
+        character = args =>
+          ZIO
+            .serviceWith[CharacterService](_.characterBy(_.name == args.name))
+            .map(_.headOption.map(character2CharacterZIO))
+      )
+    )
+
+  override def spec: ZSpec[_root_.zio.test.environment.TestEnvironment, Any] = suite("Defer Execution")(
+    testM("sanity") {
+      val interpreter = graphQL(resolver).interpreter
+      val query       = gqldoc("""
+           query test {
+             character(name: "Roberta Draper") {
+               name
+               ... @defer(label: "human") { 
+                  nicknames
+                  connections(withOrigin: [MARS, EARTH]) {
+                    ...FragmentHuman @defer(label: "human")
+                  }
+               }
+             }
+           }
+           
+           fragment FragmentHuman on Character {
+             name
+             nicknames
+           }
+          """)
+
+      for {
+        first <- interpreter.flatMap(_.execute(query))
+        rest  <- DeferredGraphQLResponse(first).tail.runCollect
+      } yield assertTrue(first.data.toString == """{"character":{"name":"Roberta Draper"}}""") && assertTrue(
+        rest.toList.map(_.toString) == List(
+          """{"data":{"nicknames":["Bobbie","Gunny"]},"hasNext":false,"path":["character"]}"""
+        )
+      )
+    }
+  ).provideCustomLayer(CharacterService.test)
+}

--- a/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
@@ -2,17 +2,15 @@ package caliban.execution
 
 import caliban.GraphQL.graphQL
 import caliban.Macros.gqldoc
-import caliban.{ ResponseValue, RootResolver }
-import caliban.TestUtils.Origin.{ BELT, EARTH, MARS }
+import caliban.RootResolver
 import caliban.TestUtils.Role.{ Captain, Engineer, Mechanic, Pilot }
-import caliban.TestUtils.{ characters, resolverIO, CaptainShipName, Character, CharacterArgs, Origin, Role }
+import caliban.TestUtils.{ characters, CaptainShipName, Character, CharacterArgs, Origin, Role }
 import caliban.schema.Annotations.GQLName
 import caliban.schema.GenericSchema
 import caliban.wrappers.DeferSupport
+import zio.test.Assertion.hasSameElements
+import zio.test.{ assert, assertTrue, DefaultRunnableSpec, ZSpec }
 import zio.{ Has, UIO, URIO, ZIO, ZLayer }
-import zio.stream.ZStream
-import zio.test.Assertion.{ equalTo, hasSameElements }
-import zio.test.{ assert, assertCompletesM, assertM, assertTrue, DefaultRunnableSpec, ZSpec }
 
 trait CharacterService {
   def characterBy(pred: Character => Boolean): UIO[List[Character]]

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -5,11 +5,11 @@ import example.ExampleService.ExampleService
 import caliban.GraphQL
 import caliban.GraphQL.graphQL
 import caliban.RootResolver
-import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
+import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLName }
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.wrappers.ApolloTracing.apolloTracing
 import caliban.wrappers.Wrappers._
-import zio.URIO
+import zio.{ URIO, ZIO }
 import zio.clock.Clock
 import zio.console.Console
 import zio.duration._
@@ -19,26 +19,75 @@ import scala.language.postfixOps
 
 object ExampleApi extends GenericSchema[ExampleService] {
 
+  sealed trait ConnectedBy
+
+  object ConnectedBy {
+    case object Origin extends ConnectedBy
+    case object Ship   extends ConnectedBy
+  }
+
+  case class ConnectionArgs(by: ConnectedBy)
+
+  @GQLName("Character")
+  case class CharacterZIO(
+    name: String,
+    nicknames: List[String],
+    origin: Origin,
+    role: Option[Role],
+    connections: ConnectionArgs => URIO[ExampleService, List[CharacterZIO]]
+  )
+
+  def character2CharacterZIO(ch: Character): CharacterZIO =
+    CharacterZIO(
+      name = ch.name,
+      nicknames = ch.nicknames,
+      origin = ch.origin,
+      role = ch.role,
+      connections = args =>
+        (args.by match {
+          case ConnectedBy.Origin => ExampleService.getCharacters(Some(ch.origin))
+          case ConnectedBy.Ship   =>
+            ExampleService.getCharacters(None).map { characters =>
+              val maybeShip = ch.role.collectFirst {
+                case Role.Captain(shipName)  => shipName
+                case Role.Pilot(shipName)    => shipName
+                case Role.Engineer(shipName) => shipName
+                case Role.Mechanic(shipName) => shipName
+              }
+              characters
+                .filter(_.role.exists {
+                  case Role.Captain(shipName)  => maybeShip.contains(shipName)
+                  case Role.Pilot(shipName)    => maybeShip.contains(shipName)
+                  case Role.Engineer(shipName) => maybeShip.contains(shipName)
+                  case Role.Mechanic(shipName) => maybeShip.contains(shipName)
+                })
+
+            }
+        }).map(_.filter(_.name == ch.name).map(character2CharacterZIO))
+    )
+
   case class Queries(
     @GQLDescription("Return all characters from a given origin")
-    characters: CharactersArgs => URIO[ExampleService, List[Character]],
+    characters: CharactersArgs => URIO[ExampleService, List[CharacterZIO]],
     @GQLDeprecated("Use `characters`")
-    character: CharacterArgs => URIO[ExampleService, Option[Character]]
+    character: CharacterArgs => URIO[ExampleService, Option[CharacterZIO]]
   )
   case class Mutations(deleteCharacter: CharacterArgs => URIO[ExampleService, Boolean])
   case class Subscriptions(characterDeleted: ZStream[ExampleService, Nothing, String])
 
-  implicit val roleSchema: Schema[Any, Role]                     = Schema.gen
-  implicit val characterSchema: Schema[Any, Character]           = Schema.gen
-  implicit val characterArgsSchema: Schema[Any, CharacterArgs]   = Schema.gen
-  implicit val charactersArgsSchema: Schema[Any, CharactersArgs] = Schema.gen
+  implicit val connectedBySchema: Schema[Any, ConnectedBy]                   = Schema.gen
+  implicit val roleSchema: Schema[Any, Role]                                 = Schema.gen
+  implicit val characterArgsSchema: Schema[Any, CharacterArgs]               = Schema.gen
+  implicit val charactersArgsSchema: Schema[Any, CharactersArgs]             = Schema.gen
+  implicit lazy val characterZIOSchema: Schema[ExampleService, CharacterZIO] = gen
+  implicit val queriesSchema: Schema[ExampleService, Queries]                = gen
 
   val api: GraphQL[Console with Clock with ExampleService] =
     graphQL(
       RootResolver(
         Queries(
-          args => ExampleService.getCharacters(args.origin),
-          args => ExampleService.findCharacter(args.name)
+          args => ExampleService.getCharacters(args.origin).map(_.map(character2CharacterZIO)),
+          args => ExampleService.findCharacter(args.name).map(_.map(character2CharacterZIO))
         ),
         Mutations(args => ExampleService.deleteCharacter(args.name)),
         Subscriptions(ExampleService.deletedEvents)

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -2,12 +2,12 @@ package example.ziohttp
 
 import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
-
 import caliban.ZHttpAdapter
-import io.netty.handler.codec.http.{ HttpHeaderNames, HttpHeaderValues }
+import zhttp.http.Middleware.cors
 import zio._
 import zio.stream._
 import zhttp.http._
+import zhttp.http.middleware.Cors.CorsConfig
 import zhttp.service.Server
 import zio.console._
 
@@ -24,7 +24,7 @@ object ExampleApp extends App {
                            case _ -> !! / "api" / "graphql" => ZHttpAdapter.makeHttpService(interpreter)
                            case _ -> !! / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
                            case _ -> !! / "graphiql"        => graphiql
-                         }
+                         } @@ cors(CorsConfig())
                        )
                        .forever
                        .fork

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -9,6 +9,7 @@ import zio._
 import zio.stream._
 import zhttp.http._
 import zhttp.service.Server
+import zio.console._
 
 object ExampleApp extends App {
   private val graphiql = Http.fromStream(ZStream.fromResource("graphiql.html"))
@@ -26,6 +27,8 @@ object ExampleApp extends App {
                          }
                        )
                        .forever
+                       .fork
+      _           <- getStrLn
     } yield ())
       .provideCustomLayer(ExampleService.make(sampleCharacters))
       .exitCode

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -149,6 +149,7 @@ package object tapir {
 
     override protected val wrappers: List[Wrapper[R]]              = Nil
     override protected val additionalDirectives: List[__Directive] = Nil
+    override protected val features                                = Set.empty
   }
 
   private def extractPath[I](endpointName: Option[String], input: EndpointInput[I]): String =

--- a/tools/src/main/scala/caliban/tools/stitching/RemoteSchemaResolver.scala
+++ b/tools/src/main/scala/caliban/tools/stitching/RemoteSchemaResolver.scala
@@ -1,7 +1,7 @@
 package caliban.tools.stitching
 
 import caliban.CalibanError.ExecutionError
-import caliban.execution.Field
+import caliban.execution.{ Feature, Field }
 import caliban.introspection.adt._
 import caliban.schema._
 import caliban.{ CalibanError, GraphQL, ResponseValue }
@@ -57,6 +57,7 @@ case class RemoteSchemaResolver(schema: __Schema, typeMap: Map[String, __Type]) 
       protected val additionalDirectives: List[__Directive]            = schema.directives
       protected val schemaBuilder: caliban.schema.RootSchemaBuilder[R] = builder
       protected val wrappers: List[caliban.wrappers.Wrapper[R]]        = List()
+      protected val features: Set[Feature]                             = Set.empty
     }
   }
 }


### PR DESCRIPTION
Adds experimental support for the `@defer` and the `@stream` based on the current [RFC](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md) and supercedes #1148  

You can read more at the provided links but the tldr for it is that when enabled the client can make requests such as

```graphql
{
  characters {
    name
    ... @defer(label:"moreinfo") {
    	nicknames @stream(initialCount:1)
        connections(by:Origin) {
          name
        }
    }
  }
}
```

And the executor will move deferred and streaming components into a separate execution chain that will be delivered _after_ the primary payload. To do this the server adapter needs to detect the presence of deferred fields and switch the response from `application/json` to `multipart/mixed` (optionally we could also look at supporting `text/eventstream` or via websockets). The primary payload is then sent with the deferred fields not included, but has a couple extra top-level fields indicating that there is more data coming. The subsequent payloads contain data as well as a `path` which tells the client how to patch in the data.

Because this behavior is still experimental (very few clients support it) it is still opt-in, and because using it requires the transport to be changed it is much safer to force servers to opt-in to this behavior, especially if they roll their own adapters.

For testing I forked this lib: https://github.com/n1ru4l/graphql-bleeding-edge-playground and modified some values locally so I could test against a running server, though I still have a task to fix all the adapters because in order to support the streaming behavior the response types needed to be updated to use binary streams directly instead of the higher level `GraphQLResponse`.

- [ ] Fix Http4s encoding
- [ ] Test all the adapters
- [ ] Update the docs

Further reading:

The working group repository for the defer/stream specification
https://github.com/robrichard/defer-stream-wg
