### PR TITLE
Entity resolvers should support partial responses and errors combined

### DIFF
--- a/federation/src/main/scala/caliban/federation/FederationSupport.scala
+++ b/federation/src/main/scala/caliban/federation/FederationSupport.scala
@@ -60,6 +60,7 @@ abstract class FederationSupport(
     import genericSchema._
 
     implicit val entitySchema: Schema[R, _Entity] = new Schema[R, _Entity] {
+      override def optional: Boolean                                         = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         __Type(
           __TypeKind.UNION,


### PR DESCRIPTION
Right now I can't find a way for entity resolvers to return both partial responses and the errors to the entities that wasn't resolved.

So either I get 
```
{
  "data": null,
  "errors": [
    {
      "message": "Not found James",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "_entities",
        1
      ]
    }
  ]
}
```
or I can get
```
{
  "data": {
    "_entities": [
      {
        "__typename": "Character",
        "name": "James Holden"
      },
      null
    ]
  }
}
```
by just capturing all errors.
I opened this PR just to get some guidance and to see if you have any input, thanks.