### PR TITLE
Include VARIABLE_DEFINITION in IntrospectionClient

### DIFF
--- a/client/src/main/scala/caliban/client/IntrospectionClient.scala
+++ b/client/src/main/scala/caliban/client/IntrospectionClient.scala
@@ -62,6 +62,7 @@ object IntrospectionClient {
     case object ENUM_VALUE             extends __DirectiveLocation
     case object INPUT_OBJECT           extends __DirectiveLocation
     case object INPUT_FIELD_DEFINITION extends __DirectiveLocation
+    case object VARIABLE_DEFINITION    extends __DirectiveLocation
 
     implicit val decoder: ScalarDecoder[__DirectiveLocation] = {
       case __StringValue("QUERY")                  => Right(__DirectiveLocation.QUERY)
@@ -82,6 +83,7 @@ object IntrospectionClient {
       case __StringValue("ENUM_VALUE")             => Right(__DirectiveLocation.ENUM_VALUE)
       case __StringValue("INPUT_OBJECT")           => Right(__DirectiveLocation.INPUT_OBJECT)
       case __StringValue("INPUT_FIELD_DEFINITION") => Right(__DirectiveLocation.INPUT_FIELD_DEFINITION)
+      case __StringValue("VARIABLE_DEFINITION")    => Right(__DirectiveLocation.VARIABLE_DEFINITION)
       case other                                   => Left(DecodingError(s"Can't build __DirectiveLocation from input $other"))
     }
     implicit val encoder: ArgEncoder[__DirectiveLocation]    = {
@@ -103,6 +105,7 @@ object IntrospectionClient {
       case __DirectiveLocation.ENUM_VALUE             => EnumValue("ENUM_VALUE")
       case __DirectiveLocation.INPUT_OBJECT           => EnumValue("INPUT_OBJECT")
       case __DirectiveLocation.INPUT_FIELD_DEFINITION => EnumValue("INPUT_FIELD_DEFINITION")
+      case __DirectiveLocation.VARIABLE_DEFINITION    => EnumValue("VARIABLE_DEFINITION")
     }
   }
 

--- a/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
@@ -300,6 +300,7 @@ private[caliban] object Parsers extends SelectionParsers {
       case "ENUM_VALUE"             => TypeSystemDirectiveLocation.ENUM_VALUE
       case "INPUT_OBJECT"           => TypeSystemDirectiveLocation.INPUT_OBJECT
       case "INPUT_FIELD_DEFINITION" => TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION
+      case "VARIABLE_DEFINITION"    => TypeSystemDirectiveLocation.VARIABLE_DEFINITION
     }
 
   def directiveDefinition(implicit ev: P[Any]): P[DirectiveDefinition] =

--- a/core/src/main/scala-3/caliban/parsing/Parser.scala
+++ b/core/src/main/scala-3/caliban/parsing/Parser.scala
@@ -523,7 +523,8 @@ object Parser {
         P.string("ENUM_VALUE").as(TypeSystemDirectiveLocation.ENUM_VALUE),
         P.string("ENUM").as(TypeSystemDirectiveLocation.ENUM),
         P.string("INPUT_OBJECT").as(TypeSystemDirectiveLocation.INPUT_OBJECT),
-        P.string("INPUT_FIELD_DEFINITION").as(TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION)
+        P.string("INPUT_FIELD_DEFINITION").as(TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION),
+        P.string("VARIABLE_DEFINITION").as(TypeSystemDirectiveLocation.VARIABLE_DEFINITION)
       )
     )
 

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -120,6 +120,7 @@ object Rendering {
       case __DirectiveLocation.ENUM_VALUE             => "ENUM_VALUE"
       case __DirectiveLocation.INPUT_OBJECT           => "INPUT_OBJECT"
       case __DirectiveLocation.INPUT_FIELD_DEFINITION => "INPUT_FIELD_DEFINITION"
+      case __DirectiveLocation.VARIABLE_DEFINITION    => "VARIABLE_DEFINITION"
     }
     val directiveLocations = locationStrings.mkString(" | ")
 

--- a/core/src/main/scala/caliban/introspection/adt/__DirectiveLocation.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__DirectiveLocation.scala
@@ -24,6 +24,7 @@ sealed trait __DirectiveLocation { self =>
       case __DirectiveLocation.ENUM_VALUE             => TypeSystemDirectiveLocation.ENUM_VALUE
       case __DirectiveLocation.INPUT_OBJECT           => TypeSystemDirectiveLocation.INPUT_OBJECT
       case __DirectiveLocation.INPUT_FIELD_DEFINITION => TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION
+      case __DirectiveLocation.VARIABLE_DEFINITION    => TypeSystemDirectiveLocation.VARIABLE_DEFINITION
     }
 }
 
@@ -46,4 +47,5 @@ object __DirectiveLocation {
   case object ENUM_VALUE             extends __DirectiveLocation
   case object INPUT_OBJECT           extends __DirectiveLocation
   case object INPUT_FIELD_DEFINITION extends __DirectiveLocation
+  case object VARIABLE_DEFINITION    extends __DirectiveLocation
 }

--- a/core/src/main/scala/caliban/parsing/adt/Definition.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Definition.scala
@@ -71,6 +71,7 @@ object Definition {
         case object ENUM_VALUE             extends TypeSystemDirectiveLocation
         case object INPUT_OBJECT           extends TypeSystemDirectiveLocation
         case object INPUT_FIELD_DEFINITION extends TypeSystemDirectiveLocation
+        case object VARIABLE_DEFINITION    extends TypeSystemDirectiveLocation
       }
     }
 

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -162,6 +162,7 @@ object IntrospectionClient {
         case __DirectiveLocation.ENUM_VALUE             => TypeSystemDirectiveLocation.ENUM_VALUE
         case __DirectiveLocation.INPUT_OBJECT           => TypeSystemDirectiveLocation.INPUT_OBJECT
         case __DirectiveLocation.INPUT_FIELD_DEFINITION => TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION
+        case __DirectiveLocation.VARIABLE_DEFINITION    => TypeSystemDirectiveLocation.VARIABLE_DEFINITION
       }.toSet
     )
 

--- a/tools/src/main/scala/caliban/tools/RemoteSchema.scala
+++ b/tools/src/main/scala/caliban/tools/RemoteSchema.scala
@@ -296,6 +296,7 @@ object RemoteSchema {
       case DirectiveLocation.TypeSystemDirectiveLocation.INPUT_OBJECT           => __DirectiveLocation.INPUT_OBJECT
       case DirectiveLocation.TypeSystemDirectiveLocation.INPUT_FIELD_DEFINITION =>
         __DirectiveLocation.INPUT_FIELD_DEFINITION
+      case DirectiveLocation.TypeSystemDirectiveLocation.VARIABLE_DEFINITION    => __DirectiveLocation.VARIABLE_DEFINITION
     }
 
   private def filterDeprecated(x: __Field, deprecated: __DeprecatedArgs): Boolean =


### PR DESCRIPTION
The newest GraphQL spec includes `VARIABLE_DEFINITION` as a possible directive location. Any introspection query with an up to date schema spec will fail with:

```Decoding Error: Can't build __DirectiveLocation from input "VARIABLE_DEFINITION"```