### PR TITLE
fix ping/pong handler in tapir websocket protocol

### DIFF
--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
@@ -9,12 +9,12 @@ trait StreamTransformer[-R, +E] {
 }
 
 trait WebSocketHooks[-R, +E] { self =>
-  def beforeInit: Option[InputValue => ZIO[R, E, Any]]     = None
-  def afterInit: Option[ZIO[R, E, Any]]                    = None
-  def onMessage: Option[StreamTransformer[R, E]]           = None
-  def onPong: Option[InputValue => ZIO[R, E, Any]]         = None
-  def onPing: Option[Option[InputValue] => ZIO[R, E, Any]] = None
-  def onAck: Option[ZIO[R, E, ResponseValue]]              = None
+  def beforeInit: Option[InputValue => ZIO[R, E, Any]]                       = None
+  def afterInit: Option[ZIO[R, E, Any]]                                      = None
+  def onMessage: Option[StreamTransformer[R, E]]                             = None
+  def onPong: Option[InputValue => ZIO[R, E, Any]]                           = None
+  def onPing: Option[Option[InputValue] => ZIO[R, E, Option[ResponseValue]]] = None
+  def onAck: Option[ZIO[R, E, ResponseValue]]                                = None
 
   def ++[R2 <: R, E2 >: E](other: WebSocketHooks[R2, E2]): WebSocketHooks[R2, E2] =
     new WebSocketHooks[R2, E2] {
@@ -51,12 +51,21 @@ trait WebSocketHooks[-R, +E] { self =>
         case _                    => None
       }
 
-      override def onPing: Option[Option[InputValue] => ZIO[R2, E2, Any]] = (self.onPing, other.onPing) match {
-        case (None, Some(f))      => Some(f)
-        case (Some(f), None)      => Some(f)
-        case (Some(f1), Some(f2)) => Some((x: Option[InputValue]) => f1(x) &> f2(x))
-        case _                    => None
-      }
+      override def onPing: Option[Option[InputValue] => ZIO[R2, E2, Option[ResponseValue]]] =
+        (self.onPing, other.onPing) match {
+          case (None, Some(f))      => Some(f)
+          case (Some(f), None)      => Some(f)
+          case (Some(f1), Some(f2)) =>
+            Some { (x: Option[InputValue]) =>
+              f1(x).zipWithPar(f2(x)) {
+                case (a @ Some(_), None) => a
+                case (None, b @ Some(_)) => b
+                case (Some(a), Some(b))  => Some(a.deepMerge(b))
+                case _                   => None
+              }
+            }
+          case _                    => None
+        }
 
       override def onAck: Option[ZIO[R2, E2, ResponseValue]] = (self.onAck, other.onAck) match {
         case (None, Some(f))      => Some(f)

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
@@ -9,12 +9,12 @@ trait StreamTransformer[-R, +E] {
 }
 
 trait WebSocketHooks[-R, +E] { self =>
-  def beforeInit: Option[InputValue => ZIO[R, E, Any]] = None
-  def afterInit: Option[ZIO[R, E, Any]]                = None
-  def onMessage: Option[StreamTransformer[R, E]]       = None
-  def onPong: Option[InputValue => ZIO[R, E, Any]]     = None
-  def onPing: Option[InputValue => ZIO[R, E, Any]]     = None
-  def onAck: Option[ZIO[R, E, ResponseValue]]          = None
+  def beforeInit: Option[InputValue => ZIO[R, E, Any]]     = None
+  def afterInit: Option[ZIO[R, E, Any]]                    = None
+  def onMessage: Option[StreamTransformer[R, E]]           = None
+  def onPong: Option[InputValue => ZIO[R, E, Any]]         = None
+  def onPing: Option[Option[InputValue] => ZIO[R, E, Any]] = None
+  def onAck: Option[ZIO[R, E, ResponseValue]]              = None
 
   def ++[R2 <: R, E2 >: E](other: WebSocketHooks[R2, E2]): WebSocketHooks[R2, E2] =
     new WebSocketHooks[R2, E2] {
@@ -51,10 +51,10 @@ trait WebSocketHooks[-R, +E] { self =>
         case _                    => None
       }
 
-      override def onPing: Option[InputValue => ZIO[R2, E2, Any]] = (self.onPing, other.onPing) match {
+      override def onPing: Option[Option[InputValue] => ZIO[R2, E2, Any]] = (self.onPing, other.onPing) match {
         case (None, Some(f))      => Some(f)
         case (Some(f), None)      => Some(f)
-        case (Some(f1), Some(f2)) => Some((x: InputValue) => f1(x) &> f2(x))
+        case (Some(f1), Some(f2)) => Some((x: Option[InputValue]) => f1(x) &> f2(x))
         case _                    => None
       }
 

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
@@ -93,13 +93,12 @@ object Protocol {
                                  }
 
                                  before *> response *> ka *> after
-                               case GraphQLWSInput(Ops.Ping, id, payload)            =>
-                                 val sendPong = output.offer(Right(GraphQLWSOutput(Ops.Pong, id, None)))
-                                 webSocketHooks.onPong -> payload match {
-                                   case (Some(onPong), Some(payload)) =>
-                                     (onPong(payload) *> sendPong).catchAll(e => output.offer(Right(handler.error(id, e))))
-                                   case _                             => sendPong
+                               case GraphQLWSInput(Ops.Pong, id, payload)            =>
+                                 ZIO.whenCase(webSocketHooks.onPong -> payload) { case (Some(onPong), Some(payload)) =>
+                                   onPong(payload).catchAll(e => output.offer(Right(handler.error(id, e))))
                                  }
+                               case GraphQLWSInput(Ops.Ping, id, _)                  =>
+                                 output.offer(Right(GraphQLWSOutput(Ops.Pong, id, None)))
                                case GraphQLWSInput(Ops.Subscribe, Some(id), payload) =>
                                  val request = payload.collect { case InputValue.ObjectValue(fields) =>
                                    val query         = fields.get("query").collect { case StringValue(v) => v }


### PR DESCRIPTION
Hi, I believe I found a bug in the protocol while investigating an issue we have with our websocket server using the [graphql-ws](https://github.com/enisdenjo/graphql-ws) client with [keepAlive](https://github.com/enisdenjo/graphql-ws/blob/6358a8fd794edba24e676a33e01c740170243006/docs/interfaces/client.ClientOptions.md#keepalive) config (see config description). Currently It causes the server to close the websocket after it receives a ping message instead of responding with pong.

This update would make it respond with a "pong" message to "ping" by default, or after a successfully executed "onPing" hook if defined.