### PR TITLE
Entity resolvers should support partial responses and errors combined

### DIFF
--- a/federation/src/main/scala/caliban/federation/FederationSupport.scala
+++ b/federation/src/main/scala/caliban/federation/FederationSupport.scala
@@ -60,6 +60,8 @@ abstract class FederationSupport(
     import genericSchema._
 
     implicit val entitySchema: Schema[R, _Entity] = new Schema[R, _Entity] {
+      override def optional: Boolean = true
+
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         __Type(
           __TypeKind.UNION,


### PR DESCRIPTION
I added this change to the series/1.x branch as well since we're not using zio2 yet internally