### PR TITLE
[2.x] Update Scala 2.12 to `2.12.17`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.16 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test
+      - run: sbt ++2.12.17 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test
       - save_cache:
           key: sbtcache
           paths:
@@ -36,7 +36,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.16 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test
+      - run: sbt ++2.12.17 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test
       - save_cache:
           key: sbtcache
           paths:
@@ -50,7 +50,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.16 codegenSbt/scripted
+      - run: sbt ++2.12.17 codegenSbt/scripted
       - save_cache:
           key: sbtcache
           paths:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 
-val scala212 = "2.12.16"
+val scala212 = "2.12.17"
 val scala213 = "2.13.8"
 val scala3   = "3.2.0"
 val allScala = Seq(scala212, scala213, scala3)
@@ -51,7 +51,12 @@ inThisBuild(
         url("https://github.com/ghostdogpr")
       )
     ),
-    ConsoleHelper.welcomeMessage
+    ConsoleHelper.welcomeMessage,
+    // See https://github.com/playframework/playframework/issues/11461#issuecomment-1276028512
+    // Can be removed when the entire Scala ecosystem has migrated to Scala 2.12.17+, sbt 1.8.x, and moved away from scala-xml v1 in general.
+    libraryDependencySchemes ++= Seq(
+      "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+    )
   )
 )
 

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Def.spaceDelimited
 import sbt.librarymanagement.Resolver
 
-val scala212 = "2.12.16"
+val scala212 = "2.12.17"
 val scala213 = "2.13.8"
 val scala3   = "3.2.0"
 val allScala = Seq(scala212, scala213, scala3)

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/project/build.properties
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.7.1
+sbt.version = 1.7.2

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -4,7 +4,7 @@ import caliban.Value._
 import caliban.introspection.adt._
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations._
-import caliban.schema.Step._
+import caliban.schema.Step.{ PureStep => _, _ }
 import caliban.schema.Types._
 import magnolia._
 

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -6,7 +6,7 @@ import caliban.Value._
 import caliban.execution.Field
 import caliban.introspection.adt._
 import caliban.parsing.adt.{ Directive, Directives }
-import caliban.schema.Step._
+import caliban.schema.Step.{ PureStep => _, _ }
 import caliban.schema.Types._
 import caliban.uploads.Upload
 import caliban.{ InputValue, ResponseValue }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.7.1
+sbt.version = 1.7.2


### PR DESCRIPTION
Fixes scala-xml bincompat issues
See 
- https://github.com/scala/bug/issues/12632
- https://github.com/playframework/twirl/pull/548
- https://github.com/sbt/sbt/pull/7050