### PR TITLE
Deferred execution

### DIFF
--- a/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -6,15 +6,7 @@ import akka.stream.{ Materializer, OverflowStrategy }
 import akka.util.ByteString
 import caliban.AkkaHttpAdapter.{ convertHttpStreamingEndpoint, convertWebSocketEndpoint }
 import caliban.execution.QueryExecution
-import caliban.interop.tapir.TapirAdapter.{
-  zioMonadError,
-  CalibanBody,
-  CalibanEndpoint,
-  CalibanPipe,
-  CalibanResponse,
-  TapirResponse,
-  ZioWebSockets
-}
+import caliban.interop.tapir.TapirAdapter._
 import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks }
 import sttp.capabilities.WebSockets
 import sttp.capabilities.akka.AkkaStreams

--- a/adapters/akka-http/src/test/scala/caliban/AkkaHttpAdapterSpec.scala
+++ b/adapters/akka-http/src/test/scala/caliban/AkkaHttpAdapterSpec.scala
@@ -29,13 +29,14 @@ object AkkaHttpAdapterSpec extends ZIOSpecDefault {
       route        = path("api" / "graphql") {
                        adapter.makeHttpService(interpreter, requestInterceptor = FakeAuthorizationInterceptor.bearer)(
                          runtime,
+                         mat,
                          implicitly,
                          implicitly
                        )
                      } ~ path("upload" / "graphql") {
-                       adapter.makeHttpUploadService(interpreter)(runtime, implicitly, implicitly, implicitly)
+                       adapter.makeHttpUploadService(interpreter)(runtime, mat, implicitly, implicitly, implicitly)
                      } ~ path("ws" / "graphql") {
-                       adapter.makeWebSocketService(interpreter)(ec, runtime, mat, implicitly, implicitly)
+                       adapter.makeWebSocketService(interpreter)(runtime, mat, implicitly, implicitly)
                      }
       _           <- ZIO.fromFuture { _ =>
                        implicit val s: ActorSystem = system

--- a/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -11,6 +11,7 @@ import org.http4s._
 import org.http4s.server.websocket.WebSocketBuilder2
 import sttp.capabilities.WebSockets
 import sttp.capabilities.fs2.Fs2Streams
+import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.Endpoint
 import sttp.tapir.server.ServerEndpoint
@@ -52,14 +53,14 @@ object Http4sAdapter {
     requestCodec: JsonCodec[GraphQLRequest],
     responseCodec: JsonCodec[GraphQLResponse[E]]
   ): HttpRoutes[F] = {
-    val endpoints  = TapirAdapter.makeHttpService[R, E](
+    val endpoints                                          = TapirAdapter.makeHttpService[R, E](
       interpreter,
       skipValidation,
       enableIntrospection,
       queryExecution,
       requestInterceptor
     )
-    val endpointsF = endpoints.map(convertHttpEndpointToF[F, R])
+    val endpointsF: List[ServerEndpoint[Fs2Streams[F], F]] = endpoints.map(convertHttpEndpointToF[F, R])
     Http4sServerInterpreter().toRoutes(endpointsF)
   }
 
@@ -215,18 +216,19 @@ object Http4sAdapter {
    * you can use this function to convert the tapir endpoints to their cats-effect counterpart.
    */
   def convertHttpEndpointToF[F[_], R](
-    endpoint: ServerEndpoint[Any, RIO[R, *]]
-  )(implicit interop: ToEffect[F, R]): ServerEndpoint[Any, F] =
+    endpoint: ServerEndpoint[ZioStreams, RIO[R, *]]
+  )(implicit interop: ToEffect[F, R]): ServerEndpoint[Fs2Streams[F], F] =
     ServerEndpoint[
       endpoint.SECURITY_INPUT,
       endpoint.PRINCIPAL,
       endpoint.INPUT,
       endpoint.ERROR_OUTPUT,
       endpoint.OUTPUT,
-      Any,
+      Fs2Streams[F],
       F
     ](
-      endpoint.endpoint,
+      endpoint.endpoint
+        .asInstanceOf[Endpoint[endpoint.SECURITY_INPUT, endpoint.INPUT, endpoint.ERROR_OUTPUT, endpoint.OUTPUT, Any]],
       _ => a => interop.toEffect(endpoint.securityLogic(zioMonadError)(a)),
       _ => u => req => interop.toEffect(endpoint.logic(zioMonadError)(u)(req))
     )

--- a/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -30,8 +30,7 @@ object Http4sAdapter {
     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
-    responseValueCodec: JsonCodec[ResponseValue],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
+    responseValueCodec: JsonCodec[ResponseValue]
   ): HttpRoutes[RIO[R, *]] = {
     val endpoints = TapirAdapter.makeHttpService[R, E](
       interpreter,
@@ -52,8 +51,7 @@ object Http4sAdapter {
   )(implicit
     interop: ToEffect[F, R],
     requestCodec: JsonCodec[GraphQLRequest],
-    responseValueCodec: JsonCodec[ResponseValue],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
+    responseValueCodec: JsonCodec[ResponseValue]
   ): HttpRoutes[F] = {
     val endpoints                                          = TapirAdapter.makeHttpService[R, E](
       interpreter,
@@ -75,8 +73,7 @@ object Http4sAdapter {
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseValueCodec: JsonCodec[ResponseValue],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
+    responseValueCodec: JsonCodec[ResponseValue]
   ): HttpRoutes[RIO[R, *]] = {
     val endpoint = TapirAdapter.makeHttpUploadService[R, E](
       interpreter,
@@ -98,8 +95,7 @@ object Http4sAdapter {
     interop: ToEffect[F, R],
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseValueCodec: JsonCodec[ResponseValue],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
+    responseValueCodec: JsonCodec[ResponseValue]
   ): HttpRoutes[F] = {
     val endpoint  = TapirAdapter.makeHttpUploadService[R, E](
       interpreter,

--- a/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -30,6 +30,7 @@ object Http4sAdapter {
     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
+    responseValueCodec: JsonCodec[ResponseValue],
     responseCodec: JsonCodec[GraphQLResponse[E]]
   ): HttpRoutes[RIO[R, *]] = {
     val endpoints = TapirAdapter.makeHttpService[R, E](
@@ -51,6 +52,7 @@ object Http4sAdapter {
   )(implicit
     interop: ToEffect[F, R],
     requestCodec: JsonCodec[GraphQLRequest],
+    responseValueCodec: JsonCodec[ResponseValue],
     responseCodec: JsonCodec[GraphQLResponse[E]]
   ): HttpRoutes[F] = {
     val endpoints                                          = TapirAdapter.makeHttpService[R, E](
@@ -73,6 +75,7 @@ object Http4sAdapter {
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
+    responseValueCodec: JsonCodec[ResponseValue],
     responseCodec: JsonCodec[GraphQLResponse[E]]
   ): HttpRoutes[RIO[R, *]] = {
     val endpoint = TapirAdapter.makeHttpUploadService[R, E](
@@ -95,6 +98,7 @@ object Http4sAdapter {
     interop: ToEffect[F, R],
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
+    responseValueCodec: JsonCodec[ResponseValue],
     responseCodec: JsonCodec[GraphQLResponse[E]]
   ): HttpRoutes[F] = {
     val endpoint  = TapirAdapter.makeHttpUploadService[R, E](

--- a/adapters/http4s/src/test/scala/caliban/Http4sAdapterSpec.scala
+++ b/adapters/http4s/src/test/scala/caliban/Http4sAdapterSpec.scala
@@ -27,7 +27,6 @@ object Http4sAdapterSpec extends ZIOSpecDefault {
   private def apiLayer(implicit
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseCodec: JsonCodec[GraphQLResponse[CalibanError]],
     responseValueCodec: JsonCodec[ResponseValue],
     wsInputCodec: JsonCodec[GraphQLWSInput],
     wsOutputCodec: JsonCodec[GraphQLWSOutput]

--- a/adapters/http4s/src/test/scala/caliban/Http4sAdapterSpec.scala
+++ b/adapters/http4s/src/test/scala/caliban/Http4sAdapterSpec.scala
@@ -28,6 +28,7 @@ object Http4sAdapterSpec extends ZIOSpecDefault {
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
     responseCodec: JsonCodec[GraphQLResponse[CalibanError]],
+    responseValueCodec: JsonCodec[ResponseValue],
     wsInputCodec: JsonCodec[GraphQLWSInput],
     wsOutputCodec: JsonCodec[GraphQLWSOutput]
   ) = envLayer >>> ZLayer.scoped {

--- a/adapters/play/src/main/scala/caliban/PlayAdapter.scala
+++ b/adapters/play/src/main/scala/caliban/PlayAdapter.scala
@@ -5,17 +5,9 @@ import akka.stream.scaladsl.{ Flow, Sink, Source }
 import akka.util.ByteString
 import caliban.PlayAdapter.convertHttpStreamingEndpoint
 import caliban.execution.QueryExecution
-import caliban.interop.tapir.TapirAdapter.{
-  zioMonadError,
-  CalibanBody,
-  CalibanPipe,
-  CalibanResponse,
-  TapirResponse,
-  ZioWebSockets
-}
-import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks }
+import caliban.interop.tapir.TapirAdapter.{ zioMonadError, CalibanPipe, CalibanResponse, TapirResponse, ZioWebSockets }
+import caliban.interop.tapir._
 import play.api.routing.Router.Routes
-import sttp.{ capabilities, model }
 import sttp.capabilities.WebSockets
 import sttp.capabilities.akka.AkkaStreams
 import sttp.capabilities.akka.AkkaStreams.Pipe
@@ -29,7 +21,7 @@ import sttp.tapir.server.play.{ PlayServerInterpreter, PlayServerOptions }
 import zio._
 import zio.stream.ZStream
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 class PlayAdapter private (private val options: Option[PlayServerOptions]) {
   private def playInterpreter(implicit mat: Materializer) =

--- a/adapters/play/src/main/scala/caliban/PlayAdapter.scala
+++ b/adapters/play/src/main/scala/caliban/PlayAdapter.scala
@@ -37,7 +37,6 @@ class PlayAdapter private (private val options: Option[PlayServerOptions]) {
     runtime: Runtime[R],
     materializer: Materializer,
     requestCodec: JsonCodec[GraphQLRequest],
-    responseCodec: JsonCodec[GraphQLResponse[E]],
     responseValueCodec: JsonCodec[ResponseValue]
   ): Routes = {
     val endpoints = TapirAdapter.makeHttpService[R, E](

--- a/adapters/play/src/main/scala/caliban/PlayAdapter.scala
+++ b/adapters/play/src/main/scala/caliban/PlayAdapter.scala
@@ -38,7 +38,8 @@ class PlayAdapter private (private val options: Option[PlayServerOptions]) {
     runtime: Runtime[R],
     materializer: Materializer,
     requestCodec: JsonCodec[GraphQLRequest],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
+    responseCodec: JsonCodec[GraphQLResponse[E]],
+    responseValueCodec: JsonCodec[ResponseValue]
   ): Routes = {
     val endpoints = TapirAdapter.makeHttpService[R, E](
       interpreter,
@@ -80,7 +81,8 @@ class PlayAdapter private (private val options: Option[PlayServerOptions]) {
     materializer: Materializer,
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
+    responseCodec: JsonCodec[GraphQLResponse[E]],
+    responseValueCodec: JsonCodec[ResponseValue]
   ): Routes = {
     val endpoint = TapirAdapter.makeHttpUploadService[R, E](
       interpreter,

--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -25,7 +25,6 @@ object PlayAdapterSpec extends ZIOSpecDefault {
   private val apiLayer = envLayer >>> ZLayer.scoped {
     for {
       system      <- ZIO.succeed(ActorSystem()).withFinalizer(sys => ZIO.fromFuture(_ => sys.terminate()).ignore)
-      ec           = system.dispatcher
       mat          = Materializer(system)
       runtime     <- ZIO.runtime[TestService with Uploads]
       interpreter <- TestApi.api.interpreter
@@ -44,7 +43,7 @@ object PlayAdapterSpec extends ZIOSpecDefault {
                            .makeHttpUploadService(interpreter)(runtime, mat, implicitly, implicitly, implicitly)
                            .apply(req)
                        case req @ GET(p"/ws/graphql")      =>
-                         PlayAdapter.makeWebSocketService(interpreter)(ec, runtime, mat, implicitly, implicitly).apply(req)
+                         PlayAdapter.makeWebSocketService(interpreter)(runtime, mat, implicitly, implicitly).apply(req)
                      }
       _           <- ZIO
                        .attempt(

--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -35,12 +35,13 @@ object PlayAdapterSpec extends ZIOSpecDefault {
                              runtime,
                              mat,
                              implicitly,
+                             implicitly,
                              implicitly
                            )
                            .apply(req)
                        case req @ POST(p"/upload/graphql") =>
                          PlayAdapter
-                           .makeHttpUploadService(interpreter)(runtime, mat, implicitly, implicitly, implicitly)
+                           .makeHttpUploadService(interpreter)(runtime, mat, implicitly, implicitly, implicitly, implicitly)
                            .apply(req)
                        case req @ GET(p"/ws/graphql")      =>
                          PlayAdapter.makeWebSocketService(interpreter)(runtime, mat, implicitly, implicitly).apply(req)

--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -41,7 +41,7 @@ object PlayAdapterSpec extends ZIOSpecDefault {
                            .apply(req)
                        case req @ POST(p"/upload/graphql") =>
                          PlayAdapter
-                           .makeHttpUploadService(interpreter)(runtime, mat, implicitly, implicitly, implicitly, implicitly)
+                           .makeHttpUploadService(interpreter)(runtime, mat, implicitly, implicitly, implicitly)
                            .apply(req)
                        case req @ GET(p"/ws/graphql")      =>
                          PlayAdapter.makeWebSocketService(interpreter)(runtime, mat, implicitly, implicitly).apply(req)

--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -35,7 +35,6 @@ object PlayAdapterSpec extends ZIOSpecDefault {
                              runtime,
                              mat,
                              implicitly,
-                             implicitly,
                              implicitly
                            )
                            .apply(req)

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -23,7 +23,6 @@ object ZHttpAdapter {
     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
-    responseCodec: JsonCodec[GraphQLResponse[E]],
     responseValueCodec: JsonCodec[ResponseValue],
     serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
   ): HttpApp[R, Throwable] = {

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -24,6 +24,7 @@ object ZHttpAdapter {
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
     responseCodec: JsonCodec[GraphQLResponse[E]],
+    responseValueCodec: JsonCodec[ResponseValue],
     serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
   ): HttpApp[R, Throwable] = {
     val endpoints = TapirAdapter.makeHttpService[R, E](

--- a/build.sbt
+++ b/build.sbt
@@ -431,7 +431,7 @@ lazy val examples = project
   .settings(commonSettings)
   .settings(
     publish / skip     := true,
-//    run / fork         := true,
+    run / fork         := true,
     run / connectInput := true
   )
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -282,10 +282,11 @@ lazy val tapirInterop = project
       Seq(
         "com.softwaremill.sttp.tapir"   %% "tapir-core"                    % tapirVersion,
         "com.softwaremill.sttp.tapir"   %% "tapir-zio"                     % tapirVersion,
-        "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"             % tapirVersion % Test,
-        "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % sttpVersion  % Test,
-        "dev.zio"                       %% "zio-test"                      % zioVersion   % Test,
-        "dev.zio"                       %% "zio-test-sbt"                  % zioVersion   % Test
+        "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"             % tapirVersion   % Test,
+        "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % sttpVersion    % Test,
+        "dev.zio"                       %% "zio-json"                      % zioJsonVersion % Test,
+        "dev.zio"                       %% "zio-test"                      % zioVersion     % Test,
+        "dev.zio"                       %% "zio-test-sbt"                  % zioVersion     % Test
       )
   )
   .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -430,7 +430,7 @@ lazy val examples = project
   .settings(commonSettings)
   .settings(
     publish / skip     := true,
-    run / fork         := true,
+//    run / fork         := true,
     run / connectInput := true
   )
   .settings(

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -10,7 +10,8 @@ import caliban.parsing.adt.{ Directive, Document, OperationType }
 import caliban.parsing.{ Parser, SourceMapper, VariablesCoercer }
 import caliban.schema._
 import caliban.validation.Validator
-import caliban.wrappers.Wrapper
+import caliban.wrappers.Wrapper.{ decompose, IntrospectionWrapper }
+import caliban.wrappers.{ Wrapper, Wrappers }
 import caliban.wrappers.Wrapper._
 import zio.{ IO, Trace, URIO, ZIO }
 

--- a/core/src/main/scala/caliban/Incremental.scala
+++ b/core/src/main/scala/caliban/Incremental.scala
@@ -14,32 +14,6 @@ sealed trait Incremental[+E] extends Product with Serializable {
 
 object Incremental {
 
-  case class Stream[+E](
-    items: List[ResponseValue],
-    path: ListValue,
-    errors: List[E],
-    label: Option[String],
-    extensions: Option[ObjectValue] = None
-  ) extends Incremental[E] {
-
-    def toResponseValue: ResponseValue =
-      ObjectValue(
-        List(
-          "items"      -> Some(ListValue(items)),
-          "errors"     -> (if (errors.nonEmpty)
-                         Some(ListValue(errors.map {
-                           case e: CalibanError => e.toResponseValue
-                           case e               => ObjectValue(List("message" -> StringValue(e.toString)))
-                         }))
-                       else None),
-          "extensions" -> extensions,
-          "path"       -> Some(path),
-          "label"      -> label.map(StringValue.apply)
-        ).collect { case (name, Some(v)) => name -> v }
-      )
-
-  }
-
   case class Defer[+E](
     data: ResponseValue,
     path: ListValue,

--- a/core/src/main/scala/caliban/Incremental.scala
+++ b/core/src/main/scala/caliban/Incremental.scala
@@ -1,0 +1,50 @@
+package caliban
+
+import caliban.ResponseValue.{ ListValue, ObjectValue }
+import caliban.Value.{ BooleanValue, StringValue }
+
+case class Incremental[+E](
+  data: ResponseValue,
+  errors: List[E],
+  path: ListValue,
+  label: Option[String],
+  extensions: Option[ObjectValue] = None
+) {
+
+  def toResponseValue: ResponseValue =
+    ObjectValue(
+      List(
+        "data"       -> Some(data),
+        "errors"     -> (if (errors.nonEmpty)
+                       Some(ListValue(errors.map {
+                         case e: CalibanError => e.toResponseValue
+                         case e               => ObjectValue(List("message" -> StringValue(e.toString)))
+                       }))
+                     else None),
+        "extensions" -> extensions,
+        "path"       -> Some(path),
+        "label"      -> label.map(StringValue.apply)
+      ).collect { case (name, Some(v)) => name -> v }
+    )
+
+}
+
+case class GraphQLIncrementalResponse[+E](
+  incremental: List[Incremental[E]],
+  hasNext: Boolean
+) {
+
+  def toResponseValue: ResponseValue =
+    ObjectValue(
+      List(
+        "incremental" -> (if (incremental.nonEmpty)
+                            Some(ListValue(incremental.map(_.toResponseValue)))
+                          else None),
+        "hasNext"     -> Some(BooleanValue(hasNext))
+      ).collect { case (name, Some(v)) => name -> v }
+    )
+}
+
+object GraphQLIncrementalResponse {
+  val empty: GraphQLIncrementalResponse[Nothing] = GraphQLIncrementalResponse(Nil, hasNext = false)
+}

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -2,6 +2,7 @@ package caliban
 
 import scala.util.Try
 import caliban.interop.circe._
+import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 import zio.stream.Stream
@@ -80,6 +81,8 @@ object ResponseValue extends ValueJsonCompat {
     caliban.interop.circe.json.ValueCirce.responseValueEncoder.asInstanceOf[F[ResponseValue]]
   implicit def circeDecoder[F[_]: IsCirceDecoder]: F[ResponseValue]                  =
     caliban.interop.circe.json.ValueCirce.responseValueDecoder.asInstanceOf[F[ResponseValue]]
+  implicit def tapirSchema[F[_]: IsTapirSchema]: F[ResponseValue]                    =
+    caliban.interop.tapir.schema.responseValueSchema.asInstanceOf[F[ResponseValue]]
   implicit def responseValueZioJsonEncoder[F[_]: IsZIOJsonEncoder]: F[ResponseValue] =
     caliban.interop.zio.ValueZIOJson.responseValueEncoder.asInstanceOf[F[ResponseValue]]
   implicit def responseValueZioJsonDecoder[F[_]: IsZIOJsonDecoder]: F[ResponseValue] =

--- a/core/src/main/scala/caliban/execution/Deferred.scala
+++ b/core/src/main/scala/caliban/execution/Deferred.scala
@@ -1,0 +1,9 @@
+package caliban.execution
+
+import caliban.schema.ReducedStep
+
+case class Deferred[-R](
+  path: List[Either[String, Int]],
+  step: ReducedStep[R],
+  label: Option[String]
+)

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -1,17 +1,20 @@
 package caliban.execution
 
-import scala.annotation.tailrec
 import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue._
 import caliban.Value._
 import caliban._
+import caliban.execution.Fragment.IsDeferred
 import caliban.parsing.adt._
+import caliban.schema.ReducedStep.DeferStep
 import caliban.schema.Step._
 import caliban.schema.{ ReducedStep, Step, Types }
 import caliban.wrappers.Wrapper.FieldWrapper
 import zio._
-import zio.query.ZQuery
+import zio.query.{ Cache, ZQuery }
+import zio.stream.ZStream
 
+import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
 object Executor {
@@ -27,7 +30,8 @@ object Executor {
     request: ExecutionRequest,
     plan: Step[R],
     fieldWrappers: List[FieldWrapper[R]] = Nil,
-    queryExecution: QueryExecution = QueryExecution.Parallel
+    queryExecution: QueryExecution = QueryExecution.Parallel,
+    featureSet: Set[Feature] = Set.empty
   )(implicit trace: Trace): URIO[R, GraphQLResponse[CalibanError]] = {
 
     val execution                                                          = request.operationType match {
@@ -72,20 +76,38 @@ object Executor {
             Types.listOf(currentField.fieldType).fold(false)(_.isNullable)
           )
         case ObjectStep(objectName, fields) =>
-          val filteredFields = mergeFields(currentField, objectName)
-          val items          = filteredFields.map {
-            case f @ Field(name @ "__typename", _, _, alias, _, _, _, directives, _, _) =>
-              (alias.getOrElse(name), PureStep(StringValue(objectName)), fieldInfo(f, path, directives))
-            case f @ Field(name, _, _, alias, _, _, args, directives, _, _)             =>
-              (
-                alias.getOrElse(name),
-                fields
-                  .get(name)
-                  .fold(NullStep: ReducedStep[R])(reduceStep(_, f, args, Left(alias.getOrElse(name)) :: path)),
-                fieldInfo(f, path, directives)
+          val filteredFields    = mergeFields(currentField, objectName)
+          val (deferred, eager) = filteredFields.partitionMap {
+            case f @ Field(name @ "__typename", _, _, alias, _, _, _, directives, _, _, _) =>
+              Right((alias.getOrElse(name), PureStep(StringValue(objectName)), fieldInfo(f, path, directives)))
+            case f @ Field(name, _, _, alias, _, _, args, directives, _, _, fragment)      =>
+              val aliasedName = alias.getOrElse(name)
+              val field       = fields
+                .get(name)
+                .fold(NullStep: ReducedStep[R])(reduceStep(_, f, args, Left(alias.getOrElse(name)) :: path))
+
+              val info = fieldInfo(f, path, directives)
+
+              fragment.collectFirst {
+                // The defer spec provides some latitude on how we handle responses. Since it is more performant to return
+                // pure fields rather than spin up the defer machinery we return pure fields immediately to the caller.
+                case IsDeferred(label) if featureSet(Feature.Defer) && !field.isPure =>
+                  (label, (aliasedName, field, info))
+              }.toLeft((aliasedName, field, info))
+          }
+
+          deferred match {
+            case Nil => reduceObject(eager, fieldWrappers)
+            case d   =>
+              DeferStep(
+                reduceObject(eager, fieldWrappers),
+                d.groupBy(_._1).toList.map { case (label, labelAndFields) =>
+                  val (_, fields) = labelAndFields.unzip
+                  reduceObject(fields, fieldWrappers) -> label
+                },
+                path
               )
           }
-          reduceObject(items, fieldWrappers)
         case QueryStep(inner)               =>
           ReducedStep.QueryStep(
             inner.foldCauseQuery(
@@ -110,7 +132,11 @@ object Executor {
           }
       }
 
-    def makeQuery(step: ReducedStep[R], errors: Ref[List[CalibanError]]): ZQuery[R, Nothing, ResponseValue] = {
+    def makeQuery(
+      step: ReducedStep[R],
+      errors: Ref[List[CalibanError]],
+      deferred: Ref[List[Deferred[R]]]
+    ): ZQuery[R, Nothing, ResponseValue] = {
 
       def handleError(error: ExecutionError, isNullable: Boolean): ZQuery[Any, ExecutionError, ResponseValue] =
         if (isNullable) ZQuery.fromZIO(errors.update(error :: _)).as(NullValue)
@@ -158,17 +184,82 @@ object Executor {
                   )
                 )
               )
+          case ReducedStep.DeferStep(obj, nextSteps, path)   =>
+            val deferredSteps = nextSteps.map { case (step, label) =>
+              Deferred(path, step, label)
+            }
+            ZQuery.fromZIO(deferred.update(deferredSteps ::: _)) *> loop(obj)
         }
       loop(step).flatMap(_.fold(error => ZQuery.fromZIO(errors.update(error :: _)).as(NullValue), ZQuery.succeed(_)))
     }
 
+    def runQuery(step: ReducedStep[R], cache: Cache) =
+      for {
+        env          <- ZIO.environment[R]
+        deferred     <- Ref.make(List.empty[Deferred[R]])
+        errors       <- Ref.make(List.empty[CalibanError])
+        query         = makeQuery(step, errors, deferred)
+        result       <- query.runCache(cache)
+        resultErrors <- errors.get
+        defers       <- deferred.get
+        stream        =
+          (makeDeferStream(defers, cache)
+            .mapChunks(chunk => Chunk.single(GraphQLIncrementalResponse(chunk.toList, hasNext = true))) ++ ZStream
+            .succeed(GraphQLIncrementalResponse.empty))
+            .map(_.toResponseValue)
+            .provideEnvironment(env)
+      } yield
+        if (defers.nonEmpty)
+          GraphQLResponse(
+            StreamValue(ZStream.succeed(result) ++ stream),
+            resultErrors.reverse,
+            hasNext = Some(true)
+          )
+        else GraphQLResponse(result, resultErrors.reverse, hasNext = None)
+
+    def makeDeferStream(
+      defers: List[Deferred[R]],
+      cache: Cache
+    ): ZStream[R, Nothing, Incremental[CalibanError]] = {
+      def run(d: Deferred[R]) =
+        ZStream.unwrap(runIncrementalQuery(d.step, cache, d.path, d.label).map {
+          case (resp, Nil)  =>
+            ZStream.succeed(resp)
+          case (resp, more) =>
+            ZStream.succeed(resp) ++ makeDeferStream(more, cache)
+        })
+
+      ZStream.mergeAllUnbounded()(defers.map(run): _*)
+    }
+
+    def runIncrementalQuery(
+      step: ReducedStep[R],
+      cache: Cache,
+      path: List[Either[String, Int]],
+      label: Option[String]
+    ) =
+      for {
+        deferred     <- Ref.make(List.empty[Deferred[R]])
+        errors       <- Ref.make(List.empty[CalibanError])
+        query         = makeQuery(step, errors, deferred)
+        result       <- query.runCache(cache)
+        resultErrors <- errors.get
+        defers       <- deferred.get
+      } yield (Incremental(
+        result,
+        resultErrors.reverse,
+        label = label,
+        path = ListValue(path.map {
+          case Left(s)  => StringValue(s)
+          case Right(i) => IntValue(i)
+        }.reverse)
+      ) -> defers)
+
     for {
-      errors       <- Ref.make(List.empty[CalibanError])
-      reduced       = reduceStep(plan, request.field, Map(), Nil)
-      query         = makeQuery(reduced, errors)
-      result       <- query.run
-      resultErrors <- errors.get
-    } yield GraphQLResponse(result, resultErrors.reverse)
+      cache    <- Cache.empty
+      reduced   = reduceStep(plan, request.field, Map(), Nil)
+      response <- runQuery(reduced, cache)
+    } yield response
   }
 
   private[caliban] def fail(error: CalibanError): UIO[GraphQLResponse[CalibanError]] =
@@ -227,4 +318,18 @@ object Executor {
       case Some(e: ExecutionError) => Cause.fail(e.copy(path = path.reverse, locationInfo = locationInfo))
       case other                   => Cause.fail(ExecutionError("Effect failure", path.reverse, locationInfo, other))
     }
+
+  private implicit class EnrichedListOps[+A](val list: List[A]) extends AnyVal {
+    def partitionMap[A1, A2](f: A => Either[A1, A2]): (List[A1], List[A2]) = {
+      val l = List.newBuilder[A1]
+      val r = List.newBuilder[A2]
+      list.foreach { x =>
+        f(x) match {
+          case Left(x1)  => l += x1
+          case Right(x2) => r += x2
+        }
+      }
+      (l.result(), r.result())
+    }
+  }
 }

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -245,15 +245,16 @@ object Executor {
         result       <- query.runCache(cache)
         resultErrors <- errors.get
         defers       <- deferred.get
-      } yield (Incremental(
+      } yield (Incremental.Defer(
         result,
-        resultErrors.reverse,
-        label = label,
+        errors = resultErrors.reverse,
         path = ListValue(path.map {
           case Left(s)  => StringValue(s)
           case Right(i) => IntValue(i)
-        }.reverse)
-      ) -> defers)
+        }.reverse),
+        label = label
+      )
+        -> defers)
 
     for {
       cache    <- Cache.empty

--- a/core/src/main/scala/caliban/execution/Feature.scala
+++ b/core/src/main/scala/caliban/execution/Feature.scala
@@ -1,0 +1,8 @@
+package caliban.execution
+
+sealed trait Feature
+
+object Feature {
+  case object Defer  extends Feature
+  case object Stream extends Feature
+}

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -95,7 +95,9 @@ object Field {
           if (checkDirectives(resolvedDirectives)) {
             val t = selected.fold(Types.string)(_.`type`()) // default only case where it's not found is __typename
 
-            val fields = if (selectionSet.nonEmpty) loop(selectionSet, t, None) else Nil // Fragments apply on to the direct children of the fragment spread
+            val fields =
+              if (selectionSet.nonEmpty) loop(selectionSet, t, None)
+              else Nil // Fragments apply on to the direct children of the fragment spread
 
             addField(
               Field(

--- a/core/src/main/scala/caliban/execution/Fragment.scala
+++ b/core/src/main/scala/caliban/execution/Fragment.scala
@@ -1,0 +1,29 @@
+package caliban.execution
+
+import caliban.Value.{ BooleanValue, IntValue, StringValue }
+import caliban.parsing.adt.Directive
+
+case class Fragment(name: Option[String], directives: List[Directive]) {}
+
+object Fragment {
+  object IsDeferred {
+    def unapply(fragment: Fragment): Option[Option[String]] =
+      fragment.directives.collectFirst {
+        case Directive("defer", args, _) if args.get("if").forall {
+              case BooleanValue(v) => v
+              case _               => true
+            } =>
+          args.get("label").collect { case StringValue(v) => v }
+      }
+  }
+}
+
+object IsStream {
+  def unapply(field: Field): Option[(Option[String], Option[Int])] =
+    field.directives.collectFirst { case Directive("stream", args, _) =>
+      (
+        args.get("label").collect { case StringValue(v) => v },
+        args.get("initialCount").collect { case v: IntValue => v.toInt }
+      )
+    }
+}

--- a/core/src/main/scala/caliban/interop/tapir/tapir.scala
+++ b/core/src/main/scala/caliban/interop/tapir/tapir.scala
@@ -13,12 +13,14 @@ private[caliban] object IsTapirSchema {
 }
 
 object schema {
-  implicit lazy val requestSchema: Schema[GraphQLRequest]    =
+  implicit lazy val requestSchema: Schema[GraphQLRequest]      =
     sttp.tapir.Schema[GraphQLRequest](SchemaType.SString[GraphQLRequest]())
-  implicit def responseSchema[E]: Schema[GraphQLResponse[E]] =
+  implicit def responseSchema[E]: Schema[GraphQLResponse[E]]   =
     sttp.tapir.Schema[GraphQLResponse[E]](SchemaType.SString[GraphQLResponse[E]]())
-  implicit lazy val wsInputSchema: Schema[GraphQLWSInput]    =
+  implicit lazy val wsInputSchema: Schema[GraphQLWSInput]      =
     sttp.tapir.Schema[GraphQLWSInput](SchemaType.SString[GraphQLWSInput]())
-  implicit lazy val wsOutputSchema: Schema[GraphQLWSOutput]  =
+  implicit lazy val wsOutputSchema: Schema[GraphQLWSOutput]    =
     sttp.tapir.Schema[GraphQLWSOutput](SchemaType.SString[GraphQLWSOutput]())
+  implicit lazy val responseValueSchema: Schema[ResponseValue] =
+    sttp.tapir.Schema[ResponseValue](SchemaType.SString[ResponseValue]())
 }

--- a/core/src/main/scala/caliban/interop/zio/zio.scala
+++ b/core/src/main/scala/caliban/interop/zio/zio.scala
@@ -412,10 +412,10 @@ private[caliban] object GraphQLResponseZioJson {
     implicit val decoder: JsonDecoder[GQLResponse]            = DeriveJsonDecoder.gen[GQLResponse]
   }
 
-  implicit val errorValueDecoder: JsonDecoder[CalibanError]               = ErrorZioJson.errorValueDecoder
-  implicit val objectValueDecoder: JsonDecoder[ResponseValue.ObjectValue] = ValueZIOJson.Obj.responseDecoder
-  implicit val listValueDecoder: JsonDecoder[ResponseValue.ListValue]     = ValueZIOJson.Arr.responseDecoder
-  implicit val graphQLResponseDecoder: JsonDecoder[GraphQLResponse[CalibanError]]  =
+  implicit val errorValueDecoder: JsonDecoder[CalibanError]                       = ErrorZioJson.errorValueDecoder
+  implicit val objectValueDecoder: JsonDecoder[ResponseValue.ObjectValue]         = ValueZIOJson.Obj.responseDecoder
+  implicit val listValueDecoder: JsonDecoder[ResponseValue.ListValue]             = ValueZIOJson.Arr.responseDecoder
+  implicit val graphQLResponseDecoder: JsonDecoder[GraphQLResponse[CalibanError]] =
     GQLResponse.decoder.map { resp =>
       GraphQLResponse[CalibanError](
         data = resp.data,

--- a/core/src/main/scala/caliban/interop/zio/zio.scala
+++ b/core/src/main/scala/caliban/interop/zio/zio.scala
@@ -412,9 +412,10 @@ private[caliban] object GraphQLResponseZioJson {
     implicit val decoder: JsonDecoder[GQLResponse]            = DeriveJsonDecoder.gen[GQLResponse]
   }
 
-  implicit val errorValueDecoder: JsonDecoder[CalibanError]                       = ErrorZioJson.errorValueDecoder
-  implicit val responseValueDecoder: JsonDecoder[ResponseValue.ObjectValue]       = ValueZIOJson.Obj.responseDecoder
-  implicit val graphQLResponseDecoder: JsonDecoder[GraphQLResponse[CalibanError]] =
+  implicit val errorValueDecoder: JsonDecoder[CalibanError]               = ErrorZioJson.errorValueDecoder
+  implicit val objectValueDecoder: JsonDecoder[ResponseValue.ObjectValue] = ValueZIOJson.Obj.responseDecoder
+  implicit val listValueDecoder: JsonDecoder[ResponseValue.ListValue]     = ValueZIOJson.Arr.responseDecoder
+  implicit val graphQLResponseDecoder: JsonDecoder[GraphQLResponse[CalibanError]]  =
     GQLResponse.decoder.map { resp =>
       GraphQLResponse[CalibanError](
         data = resp.data,

--- a/core/src/main/scala/caliban/package.scala
+++ b/core/src/main/scala/caliban/package.scala
@@ -30,5 +30,6 @@ package object caliban {
     )
     val wrappers: List[Wrapper[R]]              = Nil
     val additionalDirectives: List[__Directive] = directives
+    val features                                = Set.empty
   }
 }

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -48,6 +48,11 @@ object ReducedStep {
   case class ObjectStep[-R](fields: List[(String, ReducedStep[R], FieldInfo)])    extends ReducedStep[R]
   case class QueryStep[-R](query: ZQuery[R, ExecutionError, ReducedStep[R]])      extends ReducedStep[R]
   case class StreamStep[-R](inner: ZStream[R, ExecutionError, ReducedStep[R]])    extends ReducedStep[R]
+  case class DeferStep[-R](
+    obj: ReducedStep[R],
+    deferred: List[(ReducedStep[R], Option[String])],
+    path: List[Either[String, Int]]
+  ) extends ReducedStep[R]
 
   // PureStep is both a Step and a ReducedStep so it is defined outside this object
   // This is to avoid boxing/unboxing pure values during step reduction

--- a/core/src/main/scala/caliban/wrappers/DeferSupport.scala
+++ b/core/src/main/scala/caliban/wrappers/DeferSupport.scala
@@ -1,0 +1,37 @@
+package caliban.wrappers
+
+import caliban.execution.Feature
+import caliban.introspection.adt.{ __Directive, __DirectiveLocation, __InputValue }
+import caliban.schema.Types
+import caliban.{ GraphQL, GraphQLAspect }
+
+object DeferSupport {
+  private[caliban] val defer = __Directive(
+    "defer",
+    Some(""),
+    Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
+    List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None))
+  )
+
+  private[caliban] val stream = __Directive(
+    "stream",
+    Some(""),
+    Set(__DirectiveLocation.FIELD),
+    List(
+      __InputValue("if", None, () => Types.boolean, None),
+      __InputValue("label", None, () => Types.string, None),
+      __InputValue("initialCount", None, () => Types.int, None)
+    )
+  )
+
+  val deferSupport = new GraphQLAspect[Nothing, Any] {
+    override def apply[R](gql: GraphQL[R]): GraphQL[R] =
+      gql.withAdditionalDirectives(List(defer)).enable(Feature.Defer)
+  }
+
+  val streamSupport = new GraphQLAspect[Nothing, Any] {
+    override def apply[R](gql: GraphQL[R]): GraphQL[R] =
+      gql.withAdditionalDirectives(List(stream)).enable(Feature.Stream)
+  }
+
+}

--- a/core/src/main/scala/caliban/wrappers/DeferSupport.scala
+++ b/core/src/main/scala/caliban/wrappers/DeferSupport.scala
@@ -14,26 +14,8 @@ object DeferSupport {
     repeatable = false
   )
 
-  private[caliban] val streamDirective = __Directive(
-    "stream",
-    Some(""),
-    Set(__DirectiveLocation.FIELD),
-    List(
-      __InputValue("if", None, () => Types.boolean, None),
-      __InputValue("label", None, () => Types.string, None),
-      __InputValue("initialCount", None, () => Types.int, None)
-    ),
-    repeatable = false
-  )
-
   val defer = new GraphQLAspect[Nothing, Any] {
     override def apply[R](gql: GraphQL[R]): GraphQL[R] =
       gql.withAdditionalDirectives(List(deferDirective)).enable(Feature.Defer)
   }
-
-  val stream = new GraphQLAspect[Nothing, Any] {
-    override def apply[R](gql: GraphQL[R]): GraphQL[R] =
-      gql.withAdditionalDirectives(List(streamDirective)).enable(Feature.Stream)
-  }
-
 }

--- a/core/src/main/scala/caliban/wrappers/DeferSupport.scala
+++ b/core/src/main/scala/caliban/wrappers/DeferSupport.scala
@@ -6,14 +6,15 @@ import caliban.schema.Types
 import caliban.{ GraphQL, GraphQLAspect }
 
 object DeferSupport {
-  private[caliban] val defer = __Directive(
+  private[caliban] val deferDirective = __Directive(
     "defer",
     Some(""),
     Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
-    List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None))
+    List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None)),
+    repeatable = false
   )
 
-  private[caliban] val stream = __Directive(
+  private[caliban] val streamDirective = __Directive(
     "stream",
     Some(""),
     Set(__DirectiveLocation.FIELD),
@@ -21,17 +22,18 @@ object DeferSupport {
       __InputValue("if", None, () => Types.boolean, None),
       __InputValue("label", None, () => Types.string, None),
       __InputValue("initialCount", None, () => Types.int, None)
-    )
+    ),
+    repeatable = false
   )
 
-  val deferSupport = new GraphQLAspect[Nothing, Any] {
+  val defer = new GraphQLAspect[Nothing, Any] {
     override def apply[R](gql: GraphQL[R]): GraphQL[R] =
-      gql.withAdditionalDirectives(List(defer)).enable(Feature.Defer)
+      gql.withAdditionalDirectives(List(deferDirective)).enable(Feature.Defer)
   }
 
-  val streamSupport = new GraphQLAspect[Nothing, Any] {
+  val stream = new GraphQLAspect[Nothing, Any] {
     override def apply[R](gql: GraphQL[R]): GraphQL[R] =
-      gql.withAdditionalDirectives(List(stream)).enable(Feature.Stream)
+      gql.withAdditionalDirectives(List(streamDirective)).enable(Feature.Stream)
   }
 
 }

--- a/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
@@ -1,17 +1,12 @@
 package caliban.execution
 
-import caliban.GraphQL.graphQL
 import caliban.Macros.gqldoc
 import caliban.ResponseValue.StreamValue
-import caliban.{ CalibanError, GraphQLResponse, ResponseValue, RootResolver, Value }
-import caliban.TestUtils.Role.{ Captain, Engineer, Mechanic, Pilot }
-import caliban.TestUtils.{ characters, CaptainShipName, Character, CharacterArgs, Origin, Role }
-import caliban.schema.Annotations.GQLName
-import caliban.schema.{ GenericSchema, Schema }
-import caliban.wrappers.DeferSupport
+import caliban.TestUtils.{ characters, Character }
+import caliban.{ CalibanError, GraphQLResponse, ResponseValue, Value }
 import zio.test.Assertion.hasSameElements
 import zio.test.{ assert, assertTrue, TestAspect, ZIOSpecDefault }
-import zio.{ Chunk, UIO, URIO, ZIO, ZLayer }
+import zio.{ Chunk, UIO, ZIO, ZLayer }
 
 trait CharacterService {
   def characterBy(pred: Character => Boolean): UIO[List[Character]]

--- a/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
@@ -188,28 +188,7 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
           """{"hasNext":false}"""
         )
       )
-    },
-    test("streaming values") {
-      val query = gqldoc("""
-           query test {
-            character(name: "Roberta Draper") {
-               name
-               nicknames @stream(label: "nicknames", initialCount: 1)
-            }
-           }
-          """)
-
-      for {
-        response <- interpreter.flatMap(_.execute(query))
-        rest     <- runIncrementalResponses(response)
-      } yield assertTrue(
-        rest.head.toString == """{"character":{"name":"Roberta Draper","nicknames":["Bobbie","Gunny"]}}""",
-        rest.tail.toList.map(_.toString) == List(
-          """{"incremental":[{"data":"Gunny","path":["character","nicknames",1]}],"label":"nicknames","hasNext":true}""",
-          """{"hasNext":false}"""
-        )
-      )
-    } @@ TestAspect.ignore
+    }
   ).provide(CharacterService.test)
 
   def runIncrementalResponses(response: GraphQLResponse[CalibanError]) =

--- a/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
@@ -1,0 +1,201 @@
+package caliban.execution
+
+import caliban.GraphQL.graphQL
+import caliban.Macros.gqldoc
+import caliban.ResponseValue.StreamValue
+import caliban.{ CalibanError, GraphQLResponse, RootResolver }
+import caliban.TestUtils.Role.{ Captain, Engineer, Mechanic, Pilot }
+import caliban.TestUtils.{ characters, CaptainShipName, Character, CharacterArgs, Origin, Role }
+import caliban.schema.Annotations.GQLName
+import caliban.schema.{ GenericSchema, Schema }
+import caliban.wrappers.DeferSupport
+import zio.test.Assertion.hasSameElements
+import zio.test.{ assert, assertTrue, TestAspect, ZIOSpecDefault }
+import zio.{ Chunk, UIO, URIO, ZIO, ZLayer }
+
+trait CharacterService {
+  def characterBy(pred: Character => Boolean): UIO[List[Character]]
+}
+
+object CharacterService {
+  val test = ZLayer.succeed(new CharacterService {
+    override def characterBy(pred: Character => Boolean): UIO[List[Character]] =
+      ZIO.succeed(characters.filter(pred))
+  })
+}
+
+object DeferredExecutionSpec extends ZIOSpecDefault {
+
+  import TestDeferredSchema._
+
+  override def spec = suite("Defer Execution")(
+    test("don't defer pure fields") {
+
+      val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             ... @defer {
+               name
+             }
+           }
+        }
+          """)
+
+      for {
+        response <- interpreter.flatMap(_.execute(query))
+        data     <- runIncrementalResponses(response)
+      } yield assertTrue(data.size == 1) && assertTrue(
+        data.head.toString == """{"character":{"name":"Roberta Draper"}}"""
+      )
+    },
+    test("inline fragments") {
+      val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             ... @defer {
+               name
+               nicknames
+             }
+           }
+        }
+          """)
+
+      for {
+        resp <- interpreter.flatMap(_.execute(query))
+        rest <- runIncrementalResponses(resp)
+      } yield assertTrue(
+        rest.head.toString == """{"character":{"name":"Roberta Draper"}}"""
+      ) && assertTrue(
+        rest.tail.toList.map(_.toString) == List(
+          """{"incremental":[{"data":{"nicknames":["Bobbie","Gunny"]},"path":["character"]}],"hasNext":true}""",
+          """{"hasNext":false}"""
+        )
+      )
+    },
+    test("named fragments") {
+      val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             ...Fragment @defer
+           }
+        }
+        
+        fragment Fragment on Character {
+          name
+          nicknames
+        }
+          """)
+
+      for {
+        resp <- interpreter.flatMap(_.execute(query))
+        rest <- runIncrementalResponses(resp)
+      } yield assertTrue(
+        rest.head.toString == """{"character":{"name":"Roberta Draper"}}"""
+      ) && assertTrue(
+        rest.tail.toList.map(_.toString) == List(
+          """{"incremental":[{"data":{"nicknames":["Bobbie","Gunny"]},"path":["character"]}],"hasNext":true}""",
+          """{"hasNext":false}"""
+        )
+      )
+    },
+    test("disable") {
+      val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             ... @defer(if: false, label: "first") { nicknames }
+           }
+        }
+          """)
+
+      for {
+        resp <- interpreter.flatMap(_.execute(query))
+        rest <- runIncrementalResponses(resp)
+      } yield assertTrue(
+        rest.head.toString == """{"character":{"nicknames":["Bobbie","Gunny"]}}"""
+      ) && assertTrue(rest.tail.isEmpty)
+    },
+    test("different labels") {
+      val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             ... @defer(label: "first") { n1: nicknames }
+             ... @defer(label: "second") { n2: nicknames }
+           }
+        }
+          """)
+
+      for {
+        resp <- interpreter.flatMap(_.execute(query))
+        rest <- runIncrementalResponses(resp)
+      } yield assertTrue(
+        rest.head.toString == """{"character":{}}"""
+      ) && assert(rest.tail.toList.map(_.toString))(
+        hasSameElements(
+          List(
+            """{"incremental":[{"data":{"n1":["Bobbie","Gunny"]},"path":["character"],"label":"first"}],"hasNext":true}""",
+            """{"incremental":[{"data":{"n2":["Bobbie","Gunny"]},"path":["character"],"label":"second"}],"hasNext":true}""",
+            """{"hasNext":false}"""
+          )
+        )
+      )
+    },
+    test("nested defers") {
+      val query = gqldoc("""
+           query test {
+             character(name: "Roberta Draper") {
+               name
+               ... @defer(label: "outer") { 
+                  connections(by: Origin) {
+                    ...FragmentHuman @defer(label: "inner")
+                  }
+               }
+             }
+           }
+           
+           fragment FragmentHuman on Character {
+             name
+             nicknames
+           }
+          """)
+
+      for {
+        first <- interpreter.flatMap(_.execute(query))
+        rest  <- runIncrementalResponses(first)
+      } yield assertTrue(rest.head.toString == """{"character":{"name":"Roberta Draper"}}""") && assertTrue(
+        rest.tail.toList.map(_.toString) == List(
+          """{"incremental":[{"data":{"connections":[{"name":"Alex Kamal"}]},"path":["character"],"label":"outer"}],"hasNext":true}""",
+          """{"incremental":[{"data":{"nicknames":[]},"path":["character","connections",0],"label":"inner"}],"hasNext":true}""",
+          """{"hasNext":false}"""
+        )
+      )
+    },
+    test("streaming values") {
+      val query = gqldoc("""
+           query test {
+            character(name: "Roberta Draper") {
+               name
+               nicknames @stream(label: "nicknames", initialCount: 1)
+            }
+           }
+          """)
+
+      for {
+        response <- interpreter.flatMap(_.execute(query))
+        rest     <- runIncrementalResponses(response)
+      } yield assertTrue(
+        rest.head.toString == """{"character":{"name":"Roberta Draper","nicknames":["Bobbie","Gunny"]}}"""
+      ) && assertTrue(
+        rest.tail.toList.map(_.toString) == List(
+          """{"incremental":[{"data":"Gunny","path":["character","nicknames",1]}],"label":"nicknames","hasNext":true}""",
+          """{"hasNext":false}"""
+        )
+      )
+    } @@ TestAspect.ignore
+  ).provide(CharacterService.test)
+
+  def runIncrementalResponses(response: GraphQLResponse[CalibanError]) =
+    response.data match {
+      case StreamValue(stream) => stream.runCollect
+      case value               => ZIO.succeed(Chunk.single(value))
+    }
+}

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -62,7 +62,7 @@ object TestDeferredSchema extends GenericSchema[CharacterService] {
       }
     )
 
-  implicit lazy val characterSchema: Schema[CharacterService, CharacterZIO] = gen[CharacterService, CharacterZIO]
+  implicit lazy val characterSchema: Schema[CharacterService, CharacterZIO] = genAll[CharacterService, CharacterZIO]
   implicit val querySchema: Schema[CharacterService, Query]                 = gen[CharacterService, Query]
 
   val resolver =

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -1,15 +1,16 @@
 package caliban.execution
 
-import caliban.GraphQL.graphQL
-import caliban.RootResolver
 import caliban.TestUtils.Role.{ Captain, Engineer, Mechanic, Pilot }
 import caliban.TestUtils.{ CaptainShipName, Character, CharacterArgs, Origin, Role }
+import caliban.{ graphQL, RootResolver }
 import caliban.schema.Annotations.GQLName
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.wrappers.DeferSupport
 import zio.{ UIO, URIO, ZIO }
 
 object TestDeferredSchema extends GenericSchema[CharacterService] {
+  import auto._
+  import caliban.schema.ArgBuilder.auto._
 
   sealed trait By
 
@@ -74,5 +75,5 @@ object TestDeferredSchema extends GenericSchema[CharacterService] {
       )
     )
 
-  val interpreter = (graphQL(resolver) @@ DeferSupport.deferSupport @@ DeferSupport.streamSupport).interpreter
+  val interpreter = (graphQL(resolver) @@ DeferSupport.defer @@ DeferSupport.stream).interpreter
 }

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -75,5 +75,5 @@ object TestDeferredSchema extends GenericSchema[CharacterService] {
       )
     )
 
-  val interpreter = (graphQL(resolver) @@ DeferSupport.defer @@ DeferSupport.stream).interpreter
+  val interpreter = (graphQL(resolver) @@ DeferSupport.defer).interpreter
 }

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -1,0 +1,78 @@
+package caliban.execution
+
+import caliban.GraphQL.graphQL
+import caliban.RootResolver
+import caliban.TestUtils.Role.{ Captain, Engineer, Mechanic, Pilot }
+import caliban.TestUtils.{ CaptainShipName, Character, CharacterArgs, Origin, Role }
+import caliban.schema.Annotations.GQLName
+import caliban.schema.{ GenericSchema, Schema }
+import caliban.wrappers.DeferSupport
+import zio.{ UIO, URIO, ZIO }
+
+object TestDeferredSchema extends GenericSchema[CharacterService] {
+
+  sealed trait By
+
+  object By {
+    case object Origin extends By
+
+    case object Ship extends By
+  }
+
+  case class ConnectionArgs(by: By)
+
+  @GQLName("Character")
+  case class CharacterZIO(
+    name: String,
+    nicknames: UIO[List[UIO[String]]],
+    origin: Origin,
+    role: Option[Role],
+    connections: ConnectionArgs => URIO[CharacterService, List[CharacterZIO]]
+  )
+
+  case class Query(
+    character: CharacterArgs => URIO[CharacterService, Option[CharacterZIO]]
+  )
+
+  def character2CharacterZIO(ch: Character): CharacterZIO =
+    CharacterZIO(
+      name = ch.name,
+      nicknames = ZIO.succeed(ch.nicknames.map(ZIO.succeed(_))),
+      origin = ch.origin,
+      role = ch.role,
+      connections = {
+        case ConnectionArgs(By.Origin) =>
+          ZIO
+            .serviceWithZIO[CharacterService](_.characterBy(_.origin == ch.origin))
+            .map(_.filter(_ != ch).map(character2CharacterZIO))
+        case ConnectionArgs(By.Ship)   =>
+          val maybeShip = ch.role.collect {
+            case Captain(CaptainShipName(shipName)) => shipName
+            case Pilot(shipName)                    => shipName
+            case Engineer(shipName)                 => shipName
+            case Mechanic(shipName)                 => shipName
+          }
+          ZIO.serviceWithZIO[CharacterService](_.characterBy(_.role.exists {
+            case Captain(CaptainShipName(shipName)) => maybeShip.contains(shipName)
+            case Pilot(shipName)                    => maybeShip.contains(shipName)
+            case Engineer(shipName)                 => maybeShip.contains(shipName)
+            case Mechanic(shipName)                 => maybeShip.contains(shipName)
+          }).map(_.filter(_ != ch).map(character2CharacterZIO)))
+      }
+    )
+
+  implicit lazy val characterSchema: Schema[CharacterService, CharacterZIO] = gen[CharacterService, CharacterZIO]
+  implicit val querySchema: Schema[CharacterService, Query]                 = gen[CharacterService, Query]
+
+  val resolver =
+    RootResolver(
+      Query(
+        character = args =>
+          ZIO
+            .serviceWithZIO[CharacterService](_.characterBy(_.name == args.name))
+            .map(_.headOption.map(character2CharacterZIO))
+      )
+    )
+
+  val interpreter = (graphQL(resolver) @@ DeferSupport.deferSupport @@ DeferSupport.streamSupport).interpreter
+}

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -3,10 +3,11 @@ package example
 import example.ExampleData._
 import example.ExampleService.ExampleService
 import caliban._
-import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
+import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLName }
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._
 import caliban.wrappers.ApolloTracing.apolloTracing
+import caliban.wrappers.DeferSupport
 import caliban.wrappers.Wrappers._
 import zio._
 import zio.stream.ZStream
@@ -15,39 +16,89 @@ import scala.language.postfixOps
 
 object ExampleApi extends GenericSchema[ExampleService] {
 
+  sealed trait ConnectedBy
+
+  object ConnectedBy {
+    case object Origin extends ConnectedBy
+    case object Ship   extends ConnectedBy
+  }
+
+  case class ConnectionArgs(by: ConnectedBy)
+
+  @GQLName("Character")
+  case class CharacterZIO(
+    name: String,
+    nicknames: UIO[List[UIO[String]]],
+    origin: Origin,
+    role: UIO[Option[Role]],
+    connections: ConnectionArgs => URIO[ExampleService, List[CharacterZIO]]
+  )
+
+  def character2CharacterZIO(ch: Character): CharacterZIO =
+    CharacterZIO(
+      name = ch.name,
+      nicknames = ZIO.succeed(ch.nicknames.map(ZIO.succeed(_))),
+      origin = ch.origin,
+      role = ZIO.succeed(ch.role),
+      connections = args =>
+        ZIO.sleep(5.seconds) *> (args.by match {
+          case ConnectedBy.Origin => ExampleService.getCharacters(Some(ch.origin))
+          case ConnectedBy.Ship   =>
+            ExampleService.getCharacters(None).map { characters =>
+              val maybeShip = ch.role.collectFirst {
+                case Role.Captain(shipName)  => shipName
+                case Role.Pilot(shipName)    => shipName
+                case Role.Engineer(shipName) => shipName
+                case Role.Mechanic(shipName) => shipName
+              }
+              characters
+                .filter(_.role.exists {
+                  case Role.Captain(shipName)  => maybeShip.contains(shipName)
+                  case Role.Pilot(shipName)    => maybeShip.contains(shipName)
+                  case Role.Engineer(shipName) => maybeShip.contains(shipName)
+                  case Role.Mechanic(shipName) => maybeShip.contains(shipName)
+                })
+
+            }
+        }).map(_.filter(_.name != ch.name).map(character2CharacterZIO))
+    )
+
   import auto._
 
   case class Queries(
     @GQLDescription("Return all characters from a given origin")
-    characters: CharactersArgs => URIO[ExampleService, List[Character]],
+    characters: CharactersArgs => URIO[ExampleService, List[CharacterZIO]],
     @GQLDeprecated("Use `characters`")
-    character: CharacterArgs => URIO[ExampleService, Option[Character]]
+    character: CharacterArgs => URIO[ExampleService, Option[CharacterZIO]]
   )
   case class Mutations(deleteCharacter: CharacterArgs => URIO[ExampleService, Boolean])
   case class Subscriptions(characterDeleted: ZStream[ExampleService, Nothing, String])
 
   implicit val originSchema: Schema[Any, Origin]                 = Schema.gen
-  implicit val roleSchema: Schema[Any, Role]                     = Schema.gen
-  implicit val characterSchema: Schema[Any, Character]           = Schema.gen
-  implicit val characterArgsSchema: Schema[Any, CharacterArgs]   = Schema.gen
-  implicit val charactersArgsSchema: Schema[Any, CharactersArgs] = Schema.gen
+  implicit val connectedBySchema: Schema[Any, ConnectedBy]                   = Schema.gen
+  implicit val roleSchema: Schema[Any, Role]                                 = Schema.gen
+  implicit val characterArgsSchema: Schema[Any, CharacterArgs]               = Schema.gen
+  implicit val charactersArgsSchema: Schema[Any, CharactersArgs]             = Schema.gen
+  implicit lazy val characterZIOSchema: Schema[ExampleService, CharacterZIO] = gen
+  implicit val queriesSchema: Schema[ExampleService, Queries]                = gen
 
   val api: GraphQL[ExampleService] =
     graphQL(
       RootResolver(
         Queries(
-          args => ExampleService.getCharacters(args.origin),
-          args => ExampleService.findCharacter(args.name)
+          args => ExampleService.getCharacters(args.origin).map(_.map(character2CharacterZIO)),
+          args => ExampleService.findCharacter(args.name).map(_.map(character2CharacterZIO))
         ),
         Mutations(args => ExampleService.deleteCharacter(args.name)),
         Subscriptions(ExampleService.deletedEvents)
       )
     ) @@
-      maxFields(200) @@               // query analyzer that limit query fields
+      maxFields(300) @@               // query analyzer that limit query fields
       maxDepth(30) @@                 // query analyzer that limit query depth
       timeout(3 seconds) @@           // wrapper that fails slow queries
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
-      apolloTracing                   // wrapper for https://github.com/apollographql/apollo-tracing
-
+      apolloTracing @@                // wrapper for https://github.com/apollographql/apollo-tracing
+      DeferSupport.deferSupport @@    // wrapper that enables @defer directive support
+      DeferSupport.streamSupport      // wrapper that enables @stream directive support
 }

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -99,6 +99,6 @@ object ExampleApi extends GenericSchema[ExampleService] {
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
       apolloTracing @@                // wrapper for https://github.com/apollographql/apollo-tracing
-      DeferSupport.deferSupport @@    // wrapper that enables @defer directive support
-      DeferSupport.streamSupport      // wrapper that enables @stream directive support
+      DeferSupport.defer @@    // wrapper that enables @defer directive support
+      DeferSupport.stream      // wrapper that enables @stream directive support
 }

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -74,7 +74,7 @@ object ExampleApi extends GenericSchema[ExampleService] {
   case class Mutations(deleteCharacter: CharacterArgs => URIO[ExampleService, Boolean])
   case class Subscriptions(characterDeleted: ZStream[ExampleService, Nothing, String])
 
-  implicit val originSchema: Schema[Any, Origin]                 = Schema.gen
+  implicit val originSchema: Schema[Any, Origin]                             = Schema.gen
   implicit val connectedBySchema: Schema[Any, ConnectedBy]                   = Schema.gen
   implicit val roleSchema: Schema[Any, Role]                                 = Schema.gen
   implicit val characterArgsSchema: Schema[Any, CharacterArgs]               = Schema.gen
@@ -99,6 +99,5 @@ object ExampleApi extends GenericSchema[ExampleService] {
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
       apolloTracing @@                // wrapper for https://github.com/apollographql/apollo-tracing
-      DeferSupport.defer @@    // wrapper that enables @defer directive support
-      DeferSupport.stream      // wrapper that enables @stream directive support
+      DeferSupport.defer              // wrapper that enables @defer directive support
 }

--- a/examples/src/main/scala/example/http4s/ExampleApp.scala
+++ b/examples/src/main/scala/example/http4s/ExampleApp.scala
@@ -37,7 +37,9 @@ object ExampleApp extends ZIOAppDefault {
                              ).orNotFound
                            )
                            .build
-                           .toScopedZIO *> ZIO.never
+                           .toScopedZIO
+          _           <- Console.printLine("Server online at http://localhost:8088/\nPress RETURN to stop...")
+          _           <- Console.readLine
         } yield ()
       )
       .provideSomeLayer[Scope](ExampleService.make(sampleCharacters))

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -3,7 +3,6 @@ package example.ziohttp
 import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
 import caliban.ZHttpAdapter
-import zhttp.http.Middleware.cors
 import zio._
 import zio.stream._
 import zio.http._

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -2,11 +2,12 @@ package example.ziohttp
 
 import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
-
 import caliban.ZHttpAdapter
+import zhttp.http.Middleware.cors
 import zio._
 import zio.stream._
 import zio.http._
+import zio.Console
 
 object ExampleApp extends ZIOAppDefault {
   import sttp.tapir.json.circe._
@@ -26,6 +27,8 @@ object ExampleApp extends ZIOAppDefault {
                            }
                            .withDefaultErrorResponse
                        )
+      _           <- Console.printLine("Server online at http://localhost:8088/")
+      _           <- Console.printLine("Press RETURN to stop...") *> Console.readLine
     } yield ())
       .provide(ExampleService.make(sampleCharacters), Server.default)
       .exitCode

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -2,6 +2,7 @@ package example.ziohttp
 
 import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
+
 import caliban.ZHttpAdapter
 import zio._
 import zio.stream._
@@ -30,5 +31,4 @@ object ExampleApp extends ZIOAppDefault {
       _           <- Console.printLine("Press RETURN to stop...") *> Console.readLine
     } yield ())
       .provide(ExampleService.make(sampleCharacters), Server.default)
-      .exitCode
 }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -34,7 +34,7 @@ object TapirAdapter {
     type Stream = Right[Nothing, ZStream[Any, Throwable, Byte]]
 
   }
-  type CalibanBody = Either[ResponseValue, ZStream[Any, Throwable, Byte]]
+  type CalibanBody     = Either[ResponseValue, ZStream[Any, Throwable, Byte]]
   type CalibanResponse = (MediaType, CalibanBody)
 
   case class TapirResponse(

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -185,7 +185,7 @@ object TapirAdapter {
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseCodec: JsonCodec[ResponseValue]
+    responseValueCodec: JsonCodec[ResponseValue],
   ): ServerEndpoint[ZioStreams, RIO[R, *]] = {
     def logic(
       request: UploadRequest

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -34,8 +34,19 @@ object TapirAdapter {
     type Stream = Right[Nothing, ZStream[Any, Throwable, Byte]]
 
   }
-  type CalibanBody     = Either[ResponseValue, ZStream[Any, Throwable, Byte]]
-  type CalibanResponse = (MediaType, CalibanBody)
+  type CalibanBody        = Either[ResponseValue, ZStream[Any, Throwable, Byte]]
+  type CalibanResponse    = (MediaType, CalibanBody)
+  type CalibanEndpoint[R] =
+    ServerEndpoint.Full[Unit, Unit, (GraphQLRequest, ServerRequest), TapirResponse, CalibanResponse, ZioStreams, RIO[
+      R,
+      *
+    ]]
+
+  type CalibanUploadsEndpoint[R] =
+    ServerEndpoint.Full[Unit, Unit, UploadRequest, TapirResponse, CalibanResponse, ZioStreams, RIO[
+      R,
+      *
+    ]]
 
   case class TapirResponse(
     code: StatusCode,
@@ -161,7 +172,7 @@ object TapirAdapter {
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
     responseCodec: JsonCodec[ResponseValue]
-  ): List[ServerEndpoint[ZioStreams, RIO[R, *]]] = {
+  ): List[CalibanEndpoint[R]] = {
     def logic(
       request: (GraphQLRequest, ServerRequest)
     ): RIO[R, Either[TapirResponse, CalibanResponse]] = {
@@ -204,7 +215,7 @@ object TapirAdapter {
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
     responseValueCodec: JsonCodec[ResponseValue]
-  ): ServerEndpoint[ZioStreams, RIO[R, *]] = {
+  ): CalibanUploadsEndpoint[R] = {
     def logic(
       request: UploadRequest
     ): RIO[R, Either[TapirResponse, CalibanResponse]] = {

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -147,6 +147,7 @@ package object tapir {
 
     override protected val wrappers: List[Wrapper[R]]              = Nil
     override protected val additionalDirectives: List[__Directive] = Nil
+    override protected val features                                = Set.empty
   }
 
   private def extractPath[I](endpointName: Option[String], input: EndpointInput[I]): String =

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -2,23 +2,25 @@ package caliban.interop.tapir
 
 import caliban.InputValue.ObjectValue
 import caliban.Value.StringValue
-import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, GraphQLWSInput, GraphQLWSOutput, ResponseValue }
-import sttp.capabilities.WebSockets
+import caliban._
+import caliban.interop.tapir.TapirAdapter.CalibanBody
 import sttp.capabilities.zio.ZioStreams
-import sttp.client3.SttpBackend
+import sttp.capabilities.{ Effect, WebSockets }
+import sttp.client3.{ BasicRequestBody, DeserializationException, HttpError, ResponseException, SttpBackend }
 import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
 import sttp.model._
-import sttp.tapir.AttributeKey
-import sttp.tapir.Codec.JsonCodec
+import sttp.tapir.Codec.{ multipart, JsonCodec }
 import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.tapir.client.sttp.ws.zio._
 import sttp.tapir.model.{ ConnectionInfo, ServerRequest }
+import sttp.tapir.{ AttributeKey, DecodeResult }
 import zio.json._
 import zio.stream.{ ZPipeline, ZSink, ZStream }
 import zio.test.TestAspect.before
 import zio.test._
-import zio.{ test => _, _ }
+import zio.{ test => _, ZIO, _ }
 
+import scala.collection.immutable
 import scala.language.postfixOps
 
 object TapirAdapterSpec {
@@ -40,6 +42,11 @@ object TapirAdapterSpec {
     override def withUnderlying(underlying: Any): ServerRequest = this
   }
 
+  private def customError: CustomAssertion[ResponseException[String, String], String] = CustomAssertion.make {
+    case HttpError(body, statusCode)           => Right(body)
+    case DeserializationException(body, error) => Right(error)
+  }
+
   def makeSuite(
     label: String,
     httpUri: Uri,
@@ -53,30 +60,30 @@ object TapirAdapterSpec {
     wsInputCodec: JsonCodec[GraphQLWSInput],
     wsOutputCodec: JsonCodec[GraphQLWSOutput]
   ): Spec[TestService, Throwable] = suite(label) {
-    val run       =
-      SttpClientInterpreter()
-        .toRequestThrowDecodeFailures(TapirAdapter.makeHttpEndpoints[CalibanError].head, Some(httpUri))
-    val runUpload = uploadUri.map(uploadUri =>
-      SttpClientInterpreter()
-        .toRequestThrowDecodeFailures(TapirAdapter.makeHttpUploadEndpoint, Some(uploadUri))
-    )
-    val runWS     = wsUri.map(wsUri =>
+    val httpClient   = new TapirClient(httpUri)
+    val uploadClient = uploadUri.map(new TapirClient(_))
+    val run          = (request: GraphQLRequest) => httpClient.runPost(request)
+    val runUpload    = uploadClient.map(client => (request: List[Part[BasicRequestBody]]) => client.runUpload(request))
+    val runWS        = wsUri.map(wsUri =>
       SttpClientInterpreter()
         .toRequestThrowDecodeFailures(TapirAdapter.makeWebSocketEndpoint, Some(wsUri))
     )
 
-    def readAsResponse(stream: ZStream[Any, Throwable, Byte]): ZIO[Any, Throwable, GraphQLResponse[CalibanError]] =
-      stream
-        .via(ZPipeline.utfDecode)
-        .mkString
-        .flatMap(json =>
-          json
-            .fromJson[GraphQLResponse[CalibanError]]
-            .fold(
-              err => ZIO.fail(new Throwable(s"Failed to parse response: $err")),
-              ZIO.succeed(_)
-            )
-        )
+    def readAsResponse(
+      body: CalibanBody
+    ): ZIO[Any, Throwable, Either[GraphQLResponse[CalibanError], Chunk[GraphQLResponse[CalibanError]]]] = body match {
+      case Right(stream) =>
+        readMultipartResponse(stream).map(Right(_))
+      case Left(value)   =>
+        responseCodec.decode(responseValueCodec.encode(value)) match {
+          case DecodeResult.Value(v)                   => ZIO.left(v)
+          case DecodeResult.Error(_, throwable)        => ZIO.fail(throwable)
+          case DecodeResult.Missing                    => ZIO.fail(new Throwable("Missing value"))
+          case DecodeResult.Multiple(values)           => ZIO.fail(new Throwable(s"Multiple values: $values"))
+          case DecodeResult.Mismatch(expected, actual) => ZIO.fail(new Throwable(s"Expected $expected, got $actual"))
+          case DecodeResult.InvalidValue(errors)       => ZIO.fail(new Throwable(s"Invalid value: $errors"))
+        }
+    }
 
     def readMultipartResponse(
       stream: ZStream[Any, Throwable, Byte]
@@ -96,13 +103,13 @@ object TapirAdapterSpec {
           test("test http endpoint") {
 
             for {
-              res         <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](
-                               run((GraphQLRequest(Some("{ characters { name }  }")), null)).send(_)
-                             )
-              binResponse <- ZIO.fromEither(res.body).orElseFail(new Throwable("Failed to parse result"))
-              response    <- readAsResponse(binResponse._2)
+              res      <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](
+                            run(GraphQLRequest(Some("{ characters { name }  }"))).send(_)
+                          )
+              response <- ZIO.fromEither(res.body).orElseFail(new Throwable("Failed to parse result"))
             } yield assertTrue(
-              response.data.toString ==
+              res.contentType.contains(MediaType.ApplicationJson.toString()),
+              response.is(_.left).data.toString ==
                 """{"characters":[{"name":"James Holden"},{"name":"Naomi Nagata"},{"name":"Amos Burton"},{"name":"Alex Kamal"},{"name":"Chrisjen Avasarala"},{"name":"Josephus Miller"},{"name":"Roberta Draper"}]}"""
             )
 
@@ -110,44 +117,42 @@ object TapirAdapterSpec {
           test("test interceptor failure") {
             for {
               res      <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](
-                            run((GraphQLRequest(Some("{ characters { name }  }")), null)).header("X-Invalid", "1").send(_)
+                            run(GraphQLRequest(Some("{ characters { name }  }"))).header("X-Invalid", "1").send(_)
                           )
               response <- ZIO.fromEither(res.body).flip.orElseFail(new Throwable("Failed to parse result"))
-            } yield assertTrue(response.code == StatusCode.Unauthorized) &&
-              assertTrue(
-                response.body == "You are unauthorized!"
-              )
+            } yield assertTrue(
+              res.code == StatusCode.Unauthorized,
+              response.is(_.custom(customError)) == "You are unauthorized!"
+            )
           },
           test("lower-case content-type header") {
             val q = "{ characters { name }  }"
-            val r = run((GraphQLRequest(), null))
+            val r = run(GraphQLRequest())
               .header(Header("content-type", "application/graphql; charset=utf-8"), replaceExisting = true)
               .body(q)
               // if we don't set content-length here it gets incorrectly set to 70 rather than 24.
               .contentLength(q.length)
 
             for {
-              res         <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](r.send(_))
-              binResponse <- ZIO.fromEither(res.body).orElseFail(new Throwable(s"Failed to parse result: $res"))
-              response    <- readAsResponse(binResponse._2)
+              res  <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](r.send(_))
+              body <- ZIO.fromEither(res.body).orElseFail(new Throwable(s"Failed to parse result: $res"))
             } yield assertTrue(
-              response.data.toString ==
+              body.is(_.left).data.toString ==
                 """{"characters":[{"name":"James Holden"},{"name":"Naomi Nagata"},{"name":"Amos Burton"},{"name":"Alex Kamal"},{"name":"Chrisjen Avasarala"},{"name":"Josephus Miller"},{"name":"Roberta Draper"}]}"""
             )
           },
           test("don't defer pure values") {
             val q = """{ characters { ... on Character @defer(label: "character") { name nicknames } } }"""
-            val r = run((GraphQLRequest(), null))
+            val r = run(GraphQLRequest())
               .header(Header("content-type", "application/graphql; charset=utf-8"), replaceExisting = true)
               .body(q)
               // if we don't set content-length here it gets incorrectly set to 70 rather than 24.
               .contentLength(q.length)
 
             for {
-              res         <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](r.send(_))
-              binResponse <- ZIO.fromEither(res.body).orElseFail(new Throwable(s"Failed to parse result: $res"))
-              response    <- readMultipartResponse(binResponse._2)
-            } yield assertTrue(response.length == 1)
+              res  <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](r.send(_))
+              body <- ZIO.fromEither(res.body).orElseFail(new Throwable(s"Failed to parse result: $res"))
+            } yield assertTrue(body.isLeft)
 
           }
         )
@@ -157,20 +162,18 @@ object TapirAdapterSpec {
           val query =
             """{ "query": "mutation ($files: [Upload!]!) { uploadFiles(files: $files) { hash, filename, mimetype } }", "variables": { "files": [null, null] }}"""
 
-          val parts =
-            List(
-              Part("operations", query.getBytes, contentType = Some(MediaType.ApplicationJson)),
-              Part("map", """{ "0": ["variables.files.0"], "1":  ["variables.files.1"]}""".getBytes),
-              Part("0", """image""".getBytes, contentType = Some(MediaType.ImagePng)).fileName("a.png"),
-              Part("1", """text""".getBytes, contentType = Some(MediaType.TextPlain)).fileName("a.txt")
-            )
+          val parts: List[Part[BasicRequestBody]] = List(
+            sttp.client3.multipart("operations", query.getBytes).contentType(MediaType.ApplicationJson),
+            sttp.client3.multipart("map", """{ "0": ["variables.files.0"], "1":  ["variables.files.1"]}""".getBytes),
+            sttp.client3.multipart("0", """image""".getBytes).contentType(MediaType.ImagePng).fileName("a.png"),
+            sttp.client3.multipart("1", """text""".getBytes).contentType(MediaType.TextPlain).fileName("a.txt")
+          )
 
           for {
-            res         <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](runUpload((parts, null)).send(_))
-            binResponse <- ZIO.fromEither(res.body).orElseFail(new Throwable("Failed to parse result"))
-            response    <- readAsResponse(binResponse._2)
+            res  <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](runUpload(parts).send(_))
+            body <- ZIO.fromEither(res.body).orElseFail(new Throwable("Failed to parse result"))
           } yield assertTrue(
-            response.data.toString ==
+            body.is(_.left).data.toString ==
               """{"uploadFiles":[{"hash":"6105d6cc76af400325e94d588ce511be5bfdbb73b437dc51eca43917d7a43e3d","filename":"a.png","mimetype":"image/png"},{"hash":"982d9e3eb996f559e633f4d194def3761d909f5a3b647d1a851fead67c32c9d1","filename":"a.txt","mimetype":"text/plain"}]}"""
           )
         }
@@ -180,23 +183,21 @@ object TapirAdapterSpec {
           val query =
             """{ "query": "mutation ($uploadedDocuments: [UploadedDocumentInput!]!) { uploadFilesWithExtraFields(uploadedDocuments: $uploadedDocuments) { someField1, someField2} }", "variables": { "uploadedDocuments": [{"file": null, "someField1": 1, "someField2": 2}, {"file": null, "someField1": 3}] }}"""
 
-          val parts =
-            List(
-              Part("operations", query.getBytes, contentType = Some(MediaType.ApplicationJson)),
-              Part(
-                "map",
-                """{ "0": ["variables.uploadedDocuments.0.file"], "1":  ["variables.uploadedDocuments.1.file"]}""".getBytes
-              ),
-              Part("0", """image""".getBytes, contentType = Some(MediaType.ImagePng)).fileName("a.png"),
-              Part("1", """text""".getBytes, contentType = Some(MediaType.TextPlain)).fileName("a.txt")
-            )
+          val parts = List(
+            sttp.client3.multipart("operations", query.getBytes).contentType(MediaType.ApplicationJson),
+            sttp.client3.multipart(
+              "map",
+              """{ "0": ["variables.uploadedDocuments.0.file"], "1":  ["variables.uploadedDocuments.1.file"]}""".getBytes
+            ),
+            sttp.client3.multipart("0", """image""".getBytes).contentType(MediaType.ImagePng).fileName("a.png"),
+            sttp.client3.multipart("1", """text""".getBytes).contentType(MediaType.TextPlain).fileName("a.txt")
+          )
 
           for {
-            res         <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](runUpload((parts, null)).send(_))
-            binResponse <- ZIO.fromEither(res.body).orElseFail(new Throwable("Failed to parse result"))
-            response    <- readAsResponse(binResponse._2)
+            res  <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](runUpload(parts).send(_))
+            body <- ZIO.fromEither(res.body).orElseFail(new Throwable("Failed to parse result"))
           } yield assertTrue(
-            response.data.toString ==
+            body.is(_.left).data.toString ==
               """{"uploadFilesWithExtraFields":[{"someField1":1,"someField2":2},{"someField1":3,"someField2":null}]}"""
           )
         }
@@ -233,10 +234,7 @@ object TapirAdapterSpec {
                                  ZIO
                                    .serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](
                                      run(
-                                       (
-                                         GraphQLRequest(Some("""mutation{ deleteCharacter(name: "Amos Burton") }""")),
-                                         null
-                                       )
+                                       GraphQLRequest(Some("""mutation{ deleteCharacter(name: "Amos Burton") }"""))
                                      ).send(_)
                                    )
                                    .delay(3 seconds)
@@ -254,9 +252,11 @@ object TapirAdapterSpec {
               } yield messages
 
             io.map(_.collect { case Right(value) => value }).map { messages =>
-              assertTrue(messages.head.`type` == Ops.ConnectionAck) &&
-              assertTrue(messages(1).payload.get.toString == """{"data":{"characterDeleted":"Amos Burton"}}""") &&
-              assertTrue(messages(2).`type` == Ops.Complete)
+              assertTrue(
+                messages.head.`type` == Ops.ConnectionAck,
+                messages(1).payload.get.toString == """{"data":{"characterDeleted":"Amos Burton"}}""",
+                messages(2).`type` == Ops.Complete
+              )
             }
           } @@ TestAspect.timeout(60.seconds),
           test("graphql-ws") {
@@ -289,10 +289,7 @@ object TapirAdapterSpec {
                                  ZIO
                                    .serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](
                                      run(
-                                       (
-                                         GraphQLRequest(Some("""mutation{ deleteCharacter(name: "Amos Burton") }""")),
-                                         null
-                                       )
+                                       GraphQLRequest(Some("""mutation{ deleteCharacter(name: "Amos Burton") }"""))
                                      ).send(_)
                                    )
                                    .delay(3 seconds)
@@ -312,12 +309,12 @@ object TapirAdapterSpec {
               } yield messages
 
             io.map { messages =>
-              assertTrue(messages.head.map(_.`type`) == Right(Ops.ConnectionAck)) &&
               assertTrue(
-                messages(1).map(_.payload.get.toString) == Right("""{"data":{"characterDeleted":"Amos Burton"}}""")
-              ) &&
-              assertTrue(messages(2).map(_.`type`) == Right(Ops.Pong)) &&
-              assertTrue(messages(3).map(_.`type`) == Right(Ops.Complete))
+                messages.head.map(_.`type`) == Right(Ops.ConnectionAck),
+                messages(1).map(_.payload.get.toString) == Right("""{"data":{"characterDeleted":"Amos Burton"}}"""),
+                messages(2).map(_.`type`) == Right(Ops.Pong),
+                messages(3).map(_.`type`) == Right(Ops.Complete)
+              )
             }
           } @@ TestAspect.timeout(60.seconds)
         )
@@ -328,4 +325,81 @@ object TapirAdapterSpec {
   }.provideLayerShared(AsyncHttpClientZioBackend.layer()) @@
     before(TestService.reset) @@
     TestAspect.sequential
+
+  private class TapirClient(httpUri: Uri)(implicit
+    requestCodec: JsonCodec[GraphQLRequest],
+    mapCodec: JsonCodec[Map[String, Seq[String]]],
+    responseCodec: JsonCodec[GraphQLResponse[CalibanError]],
+    responseValueCodec: JsonCodec[ResponseValue],
+    wsInputCodec: JsonCodec[GraphQLWSInput],
+    wsOutputCodec: JsonCodec[GraphQLWSOutput]
+  ) {
+    import sttp.client3._
+
+    implicit def jsonBodySerializer[B](implicit encoder: JsonCodec[B]): BodySerializer[B] =
+      b => StringBody(encoder.encode(b), "UTF-8", MediaType.ApplicationJson)
+
+    implicit val stringShows: ShowError[String] = identity
+
+    def asJsonBody[B: JsonCodec]
+      : ResponseAs[Either[ResponseException[String, String], B], Effect[Task] with ZioStreams] =
+      asString.mapWithMetadata(
+        ResponseAs.deserializeRightWithError(
+          implicitly[JsonCodec[B]].decode(_) match {
+            case failure: DecodeResult.Failure => Left("Failed to decode")
+            case DecodeResult.Value(v)         => Right(v)
+          }
+        )
+      )
+
+    private def asStreamOrSingle(implicit
+      codec: JsonCodec[GraphQLResponse[CalibanError]]
+    ): ResponseAs[Either[ResponseException[String, String], Either[GraphQLResponse[CalibanError], Chunk[
+      GraphQLResponse[CalibanError]
+    ]]], Effect[Task] with ZioStreams] =
+      fromMetadata(
+        asStringAlways.map(error => Left(HttpError(error, StatusCode.UnprocessableEntity))),
+        ConditionalResponseAs(
+          _.contentType.exists(MediaType.unsafeParse(_) == MediaType.ApplicationJson),
+          asJsonBody[GraphQLResponse[CalibanError]](codec).mapRight(Left(_))
+        ),
+        ConditionalResponseAs(
+          _.contentType.exists(MediaType.unsafeParse(_) == MediaType.MultipartFormData),
+          asStream(ZioStreams)(readMultipartResponse)
+            .mapRight(Right(_))
+            .mapLeft(s => HttpError(s, StatusCode.UnprocessableEntity))
+        )
+      )
+
+    def runPost(request: GraphQLRequest): Request[Either[ResponseException[String, String], Either[GraphQLResponse[
+      CalibanError
+    ], Chunk[GraphQLResponse[CalibanError]]]], Any with Effect[Task] with ZioStreams] =
+      basicRequest
+        .post(httpUri)
+        .body(request)
+        .response(asStreamOrSingle)
+
+    def runUpload(
+      request: List[Part[BasicRequestBody]]
+    ): Request[Either[ResponseException[String, String], Either[GraphQLResponse[CalibanError], Chunk[
+      GraphQLResponse[CalibanError]
+    ]]], Any with Effect[Task] with ZioStreams] =
+      basicRequest
+        .post(httpUri)
+        .multipartBody(request)
+        .response(asStreamOrSingle)
+
+    private def readMultipartResponse(
+      stream: ZStream[Any, Throwable, Byte]
+    ): ZIO[Any, Throwable, Chunk[GraphQLResponse[CalibanError]]] =
+      (stream >>>
+        ZPipeline.utfDecode >>>
+        ZPipeline.splitLines >>>
+        ZPipeline.map[String, String](_.trim) >>>
+        ZPipeline.collect[String, Option[GraphQLResponse[CalibanError]]] {
+          case line if line.startsWith("{") =>
+            line.fromJson[GraphQLResponse[CalibanError]].toOption
+        }).collectSome >>> ZSink.collectAll[GraphQLResponse[CalibanError]]
+
+  }
 }

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -17,7 +17,7 @@ import zio.json._
 import zio.stream.{ ZPipeline, ZSink, ZStream }
 import zio.test.TestAspect.before
 import zio.test._
-import zio.{ test => _, ZIO, _ }
+import zio.{ test => _, _ }
 
 import scala.language.postfixOps
 

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -306,7 +306,9 @@ object TapirAdapterSpec {
     implicit def jsonBodySerializer[B](implicit encoder: JsonCodec[B]): BodySerializer[B] =
       b => StringBody(encoder.encode(b), "UTF-8", MediaType.ApplicationJson)
 
-    implicit val stringShows: ShowError[String] = identity
+    implicit val stringShows: ShowError[String] = new ShowError[String] {
+      override def show(error: String): String = error
+    }
 
     def runPost(request: GraphQLRequest): Request[Either[ResponseException[String, String], Either[GraphQLResponse[
       CalibanError

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
@@ -66,5 +66,5 @@ object TestApi extends GenericSchema[TestService with Uploads] {
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
       apolloTracing @@                // wrapper for https://github.com/apollographql/apollo-tracing
-      DeferSupport.deferSupport
+      DeferSupport.defer
 }

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
@@ -7,6 +7,7 @@ import caliban.schema.{ GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._
 import caliban.uploads.{ Upload, Uploads }
 import caliban.wrappers.ApolloTracing.apolloTracing
+import caliban.wrappers.DeferSupport
 import caliban.wrappers.Wrappers._
 import zio._
 import zio.stream.ZStream
@@ -64,5 +65,6 @@ object TestApi extends GenericSchema[TestService with Uploads] {
       timeout(3 seconds) @@           // wrapper that fails slow queries
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
-      apolloTracing                   // wrapper for https://github.com/apollographql/apollo-tracing
+      apolloTracing @@                // wrapper for https://github.com/apollographql/apollo-tracing
+      DeferSupport.deferSupport
 }

--- a/tools/src/main/scala/caliban/tools/stitching/RemoteSchemaResolver.scala
+++ b/tools/src/main/scala/caliban/tools/stitching/RemoteSchemaResolver.scala
@@ -1,7 +1,7 @@
 package caliban.tools.stitching
 
 import caliban.CalibanError.ExecutionError
-import caliban.execution.Field
+import caliban.execution.{ Feature, Field }
 import caliban.introspection.adt._
 import caliban.schema._
 import caliban.{ CalibanError, GraphQL, ResponseValue }
@@ -57,6 +57,7 @@ case class RemoteSchemaResolver(schema: __Schema, typeMap: Map[String, __Type]) 
       protected val additionalDirectives: List[__Directive]            = schema.directives
       protected val schemaBuilder: caliban.schema.RootSchemaBuilder[R] = builder
       protected val wrappers: List[caliban.wrappers.Wrapper[R]]        = List()
+      protected val features: Set[Feature]                             = Set.empty
     }
   }
 }

--- a/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
+++ b/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
@@ -9,6 +9,7 @@ import zio.test.Assertion._
 import zio.test._
 import schema.Annotations._
 import caliban.Macros.gqldoc
+import caliban.execution.Feature
 
 object RemoteSchemaSpec extends ZIOSpecDefault {
   sealed trait EnumType  extends Product with Serializable
@@ -110,6 +111,7 @@ object RemoteSchemaSpec extends ZIOSpecDefault {
         )
       protected val additionalDirectives: List[__Directive]       = List()
       protected val wrappers: List[caliban.wrappers.Wrapper[Any]] = List()
+      override protected val features: Set[Feature]               = Set.empty
     }
 
 }


### PR DESCRIPTION
Description copied over from #1378 

Update: The spec has been moved forward, defer is now supported out of the box by apollo-client, so I am re-opening this to not forget about it.

Adds experimental support for the `@defer` ~and the `@stream`~ based on the current [RFC](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md) and supercedes #1148  

You can read more at the provided links but the tldr for it is that when enabled the client can make requests such as

```graphql
{
  characters {
    name
    ... @defer(label:"moreinfo") {
        # Note that @stream will not be part of this PR but left as an example
    	nicknames @stream(initialCount:1)
        connections(by:Origin) {
          name
        }
    }
  }
}
```

And the executor will move deferred and streaming components into a separate execution chain that will be delivered _after_ the primary payload. To do this the server adapter needs to detect the presence of deferred fields and switch the response from `application/json` to `multipart/mixed` (optionally we could also look at supporting `text/eventstream` or via websockets). The primary payload is then sent with the deferred fields not included, but has a couple extra top-level fields indicating that there is more data coming. The subsequent payloads contain data as well as a `path` which tells the client how to patch in the data.

Because this behavior is still experimental (very few clients support it) it is still opt-in, and because using it requires the transport to be changed it is much safer to force servers to opt-in to this behavior, especially if they roll their own adapters.

For testing I forked this lib: https://github.com/n1ru4l/graphql-bleeding-edge-playground and modified some values locally so I could test against a running server, though I still have a task to fix all the adapters because in order to support the streaming behavior the response types needed to be updated to use binary streams directly instead of the higher level `GraphQLResponse`.

- [x] Fix Http4s encoding
- [x] Test all the adapters
- [ ] Update the docs

Further reading:

The working group repository for the defer/stream specification
https://github.com/robrichard/defer-stream-wg

*Edit:*

There were some changes to the spec that I need to account for: https://github.com/graphql/graphql-spec/pull/742/files