### PR TITLE
Fix scalafmt newline issue

### DIFF
--- a/codegen-sbt/src/sbt-test/codegen/gen-client-task/.scalafmt.conf
+++ b/codegen-sbt/src/sbt-test/codegen/gen-client-task/.scalafmt.conf
@@ -1,0 +1,4 @@
+version = "3.1.2"
+
+runner.dialect = scala213
+preset = default

--- a/codegen-sbt/src/sbt-test/codegen/gen-client-task/project/plugins.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/gen-client-task/project/plugins.sbt
@@ -3,3 +3,4 @@ sys.props.get("plugin.version") match {
   case _       => sys.error("""|The system property 'plugin.version' is not defined.
                                |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")

--- a/codegen-sbt/src/sbt-test/codegen/gen-client-task/test
+++ b/codegen-sbt/src/sbt-test/codegen/gen-client-task/test
@@ -10,6 +10,7 @@ $ mkdir play23/com/caliban/client
 
 > calibanGenClient project/schema-to-check-name-uniqueness.graphql src/main/scala/client/ClientNameUniqueness.scala --packageName client
 $ exists src/main/scala/client/ClientNameUniqueness.scala
+> scalafmtCheck
 
 > calibanGenClient project/schema-to-check-name-uniqueness.graphql app/com/caliban/client/ClientPlayFramework.scala --packageName client
 $ exists app/com/caliban/client/ClientPlayFramework.scala
@@ -22,9 +23,14 @@ $ exec sh verify.sh ClientPlayFramework ./play23/com/caliban/client/ClientPlayFr
 $ mkdir src/main/scala/genview
 $ mkdir src/main/scala/genview/client
 
-> calibanGenClient project/schema-to-check-name-uniqueness.graphql src/main/scala/genview/client/ClientNameUniqueness.scala --packageName genview.client --genView true
+> calibanGenClient project/schema-to-check-name-uniqueness.graphql src/main/scala/genview/client/ClientNameUniqueness.scala --packageName genview.client --genView true --enableFmt true
 $ exists src/main/scala/genview/client/ClientNameUniqueness.scala
 $ exec sh verify.sh StarshipView ./src/main/scala/genview/client/ClientNameUniqueness.scala
+> scalafmtCheck
+
+> calibanGenClient project/schema-to-check-name-uniqueness.graphql src/main/scala/genview/client/ClientNameUniqueness.scala --packageName genview.client --genView true --enableFmt false
+-> scalafmtCheck
+
 > calibanGenClient project/gitlab-schema.graphql src/main/scala/genview/client/ClientGitLab.scala --packageName genview.client --genView true --splitFiles true --enableFmt false
 $ exists src/main/scala/genview/client/package.scala
 $ exec sh verify.sh ProjectID ./src/main/scala/genview/client/package.scala

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -66,7 +66,7 @@ object Codegen {
                                     ZIO.blocking(
                                       ZIO
                                         .attempt(new PrintWriter(new File(path)))
-                                        .acquireReleaseWithAuto(pw => ZIO.attempt(pw.println(objectCode)))
+                                        .acquireReleaseWithAuto(pw => ZIO.attempt(pw.print(objectCode)))
                                         .as(new File(path))
                                     )
                                   }


### PR DESCRIPTION
PR to resolve https://github.com/ghostdogpr/caliban/issues/1510, where generated, formatted, files were getting an extra newline added causing `scalafmtCheck` to fail.

I've added `scalafmtCheck` commands to the `codegen/gen-client-task` test for coverage, but this has involved adding `scalafmt` config to the test project which could add to maintenance overhead. Happy to be guided as to how you would like the tests, if at all.

The fix in current form does mean that non-formatted files won't have a newline terminator which is not ideal, but I doubt anyone would be paying too much attention to the layout of unformatted files so haven't tried to address this.