### PR TITLE
chore: upgrade tapir to 1.2.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,20 +29,6 @@ jobs:
             - "~/.ivy2/cache"
             - "~/.sbt"
             - "~/.m2"
-  test212_jdk8:
-    docker:
-      - image: cimg/openjdk:8.0-node
-    steps:
-      - checkout
-      - restore_cache:
-          key: sbtcache
-      - run: sbt ++2.12.17 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test
-      - save_cache:
-          key: sbtcache
-          paths:
-            - "~/.ivy2/cache"
-            - "~/.sbt"
-            - "~/.m2"
   scripted212_jdk:
     docker:
       - image: cimg/openjdk:11.0-node
@@ -197,12 +183,6 @@ workflows:
           filters:
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - test212_jdk8:
-          requires:
-            - lint
-          filters:
-            tags:
-              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
       - scripted212_jdk:
           requires:
             - lint
@@ -249,7 +229,6 @@ workflows:
           context: Sonatype
           requires:
             - test212_jdk
-            - test212_jdk8
             - scripted212_jdk
             - scripted3_jdk
             - test213_jdk

--- a/adapters/http4s/src/test/scala/caliban/Http4sAdapterSpec.scala
+++ b/adapters/http4s/src/test/scala/caliban/Http4sAdapterSpec.scala
@@ -84,7 +84,7 @@ object Http4sAdapterSpec extends ZIOSpecDefault {
               uploadUri = Some(uri"http://localhost:8087/upload/graphql"),
               wsUri = Some(uri"ws://localhost:8087/ws/graphql")
             )
-            .provideLayerShared(apiLayer) @@ TestUtils.skipJdk8
+            .provideLayerShared(apiLayer)
         })
       )
     ZIO.succeed(suites.flatten)

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -6,11 +6,10 @@ import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks 
 import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.DecodeResult
 import sttp.tapir.server.ziohttp.{ ZioHttpInterpreter, ZioHttpServerOptions }
-import zhttp.http._
-import zhttp.service.ChannelEvent
-import zhttp.service.ChannelEvent.UserEvent.HandshakeComplete
-import zhttp.service.ChannelEvent.{ ChannelRead, UserEventTriggered }
-import zhttp.socket._
+import zio.http._
+import zio.http.ChannelEvent.UserEvent.HandshakeComplete
+import zio.http.ChannelEvent.{ ChannelRead, UserEventTriggered }
+import zio.http.socket._
 import zio._
 import zio.stream._
 
@@ -44,45 +43,48 @@ object ZHttpAdapter {
     keepAliveTime: Option[Duration] = None,
     queryExecution: QueryExecution = QueryExecution.Parallel,
     webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty
-  )(implicit inputCodec: JsonCodec[GraphQLWSInput], outputCodec: JsonCodec[GraphQLWSOutput]): HttpApp[R, E] =
-    Http.fromFunctionZIO[Request] { req =>
-      val protocol = req.headers.header("Sec-WebSocket-Protocol") match {
-        case Some((_, value)) => Protocol.fromName(value.toString)
-        case None             => Protocol.Legacy
-      }
+  )(implicit inputCodec: JsonCodec[GraphQLWSInput], outputCodec: JsonCodec[GraphQLWSOutput]): App[R] =
+    Handler
+      .fromFunctionZIO[Request] { req =>
+        val protocol = req.headers.secWebSocketProtocol match {
+          case Some(value) => Protocol.fromName(value.toString)
+          case None        => Protocol.Legacy
+        }
 
-      for {
-        queue <- Queue.unbounded[GraphQLWSInput]
-        pipe  <- protocol
-                   .make(
-                     interpreter,
-                     skipValidation,
-                     enableIntrospection,
-                     keepAliveTime,
-                     queryExecution,
-                     webSocketHooks
-                   )
-        in     = ZStream.fromQueueWithShutdown(queue)
-        out    = pipe(in).map {
-                   case Right(output) => WebSocketFrame.Text(outputCodec.encode(output))
-                   case Left(close)   => WebSocketFrame.Close(close.code, Some(close.reason))
-                 }
-        socket = Http
-                   .collectZIO[WebSocketChannelEvent] {
-                     case ChannelEvent(ch, UserEventTriggered(HandshakeComplete)) =>
-                       out.runForeach(ch.writeAndFlush(_)).race(ch.awaitClose)
-                     case ChannelEvent(_, ChannelRead(WebSocketFrame.Text(text))) =>
-                       ZIO.fromEither {
-                         inputCodec.decode(text) match {
-                           case DecodeResult.Value(v)    => Right(v)
-                           case DecodeResult.Error(_, e) => Left(e)
-                           case f: DecodeResult.Failure  => Left(new Throwable(s"failed to decode input: ${f.toString}"))
-                         }
-                       }.flatMap(queue.offer)
+        for {
+          queue <- Queue.unbounded[GraphQLWSInput]
+          pipe  <- protocol
+                     .make(
+                       interpreter,
+                       skipValidation,
+                       enableIntrospection,
+                       keepAliveTime,
+                       queryExecution,
+                       webSocketHooks
+                     )
+          in     = ZStream.fromQueueWithShutdown(queue)
+          out    = pipe(in).map {
+                     case Right(output) => WebSocketFrame.Text(outputCodec.encode(output))
+                     case Left(close)   => WebSocketFrame.Close(close.code, Some(close.reason))
                    }
-        app   <- Response.fromSocketApp(
-                   socket.toSocketApp.withProtocol(SocketProtocol.subProtocol(protocol.name))
-                 )
-      } yield app
-    }
+          socket = Http
+                     .collectZIO[WebSocketChannelEvent] {
+                       case ChannelEvent(ch, UserEventTriggered(HandshakeComplete)) =>
+                         out.runForeach(ch.writeAndFlush(_)).race(ch.awaitClose)
+                       case ChannelEvent(_, ChannelRead(WebSocketFrame.Text(text))) =>
+                         ZIO.fromEither {
+                           inputCodec.decode(text) match {
+                             case DecodeResult.Value(v)    => Right(v)
+                             case DecodeResult.Error(_, e) => Left(e)
+                             case f: DecodeResult.Failure  =>
+                               Left(new Throwable(s"failed to decode input: ${f.toString}"))
+                           }
+                         }.flatMap(queue.offer)
+                     }
+          app   <- Response.fromSocketApp(
+                     socket.toSocketApp.withProtocol(SocketProtocol(subprotocols = Some(protocol.name)))
+                   )
+        } yield app
+      }
+      .toHttp
 }

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val playVersion               = "2.8.19"
 val playJsonVersion           = "2.9.4"
 val scalafmtVersion           = "3.7.2"
 val sttpVersion               = "3.8.0"
-val tapirVersion              = "1.2.2"
+val tapirVersion              = "1.2.10"
 val zioVersion                = "2.0.10"
 val zioInteropCats2Version    = "22.0.0.0"
 val zioInteropCats3Version    = "23.0.0.1"
@@ -27,7 +27,7 @@ val zioInteropReactiveVersion = "2.0.1"
 val zioConfigVersion          = "3.0.7"
 val zqueryVersion             = "0.4.0"
 val zioJsonVersion            = "0.4.2"
-val zioHttpVersion            = "2.0.0-RC10"
+val zioHttpVersion            = "0.0.4"
 
 inThisBuild(
   List(
@@ -36,7 +36,7 @@ inThisBuild(
     organization             := "com.github.ghostdogpr",
     homepage                 := Some(url("https://github.com/ghostdogpr/caliban")),
     licenses                 := List(License.Apache2),
-    resolvers += "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots",
+    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     Test / parallelExecution := false,
     scmInfo                  := Some(
       ScmInfo(
@@ -298,9 +298,10 @@ lazy val zioHttp = project
   .settings(name := "caliban-zio-http")
   .settings(commonSettings)
   .settings(
+    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
-      "io.d11"                      %% "zhttp"                 % zioHttpVersion,
+      "dev.zio"                     %% "zio-http"              % zioHttpVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server" % tapirVersion,
       "dev.zio"                     %% "zio-json"              % zioJsonVersion % Test,
       "com.softwaremill.sttp.tapir" %% "tapir-json-zio"        % tapirVersion   % Test
@@ -419,7 +420,7 @@ lazy val examples = project
       "org.http4s"                            %% "http4s-dsl"                    % http4sVersion,
       "com.softwaremill.sttp.client3"         %% "async-http-client-backend-zio" % sttpVersion,
       "io.circe"                              %% "circe-generic"                 % circeVersion,
-      "io.d11"                                %% "zhttp"                         % zioHttpVersion,
+      "dev.zio"                               %% "zio-http"                      % zioHttpVersion,
       "com.typesafe.play"                     %% "play-akka-http-server"         % playVersion,
       "com.typesafe.akka"                     %% "akka-actor-typed"              % akkaVersion,
       "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"          % tapirVersion,

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -579,12 +579,4 @@ object TestUtils {
 
     val resolverEmpty = new RootResolver(Option.empty[Unit], Option.empty[Unit], Option.empty[Unit])
   }
-
-  val skipJdk8: TestAspectPoly = {
-    System.getProperty("java.version").split('.').toList match {
-      case "1" :: "8" :: _ => TestAspect.ignore
-      case "8" :: _        => TestAspect.ignore
-      case _               => TestAspect.identity
-    }
-  }
 }

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLRequestJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLRequestJsoniterSpec.scala
@@ -48,5 +48,5 @@ object GraphQLRequestJsoniterSpec extends ZIOSpecDefault {
             """{"query":"{}","operationName":"op","variables":{"hello":"world","answer":42,"isAwesome":true,"name":null}}"""
         )
       }
-    ) @@ TestUtils.skipJdk8
+    )
 }

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
@@ -95,5 +95,5 @@ object GraphQLResponseJsoniterSpec extends ZIOSpecDefault {
           )
         )
       }
-    ) @@ TestUtils.skipJdk8
+    )
 }

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLWSInputJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLWSInputJsoniterSpec.scala
@@ -32,5 +32,5 @@ object GraphQLWSInputJsoniterSpec extends ZIOSpecDefault {
 
         assertTrue(writeToString(res) == """{"type":"some type","id":"id","payload":{"field":"yo"}}""")
       }
-    ) @@ TestUtils.skipJdk8
+    )
 }

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLWSOutputJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLWSOutputJsoniterSpec.scala
@@ -32,5 +32,5 @@ object GraphQLWSOutputJsoniterSpec extends ZIOSpecDefault {
 
         assertTrue(writeToString(res) == """{"type":"some type","id":"id","payload":{"field":"yo"}}""")
       }
-    ) @@ TestUtils.skipJdk8
+    )
 }

--- a/examples/src/main/scala/example/federation/v2/FederatedApp.scala
+++ b/examples/src/main/scala/example/federation/v2/FederatedApp.scala
@@ -3,8 +3,7 @@ package example.federation.v2
 import caliban.ZHttpAdapter
 import example.federation.v2.FederationData.characters.sampleCharacters
 import example.federation.v2.FederationData.episodes.sampleEpisodes
-import zhttp.http._
-import zhttp.service.Server
+import zio.http._
 import zio._
 
 object FederatedApp extends ZIOAppDefault {
@@ -12,30 +11,36 @@ object FederatedApp extends ZIOAppDefault {
 
   val characterServer = for {
     interpreter <- FederatedApi.Characters.api.interpreter
-    _           <- Server
-                     .start(
-                       8088,
-                       Http.collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
-                         ZHttpAdapter.makeHttpService(interpreter)
-                       }
-                     )
-                     .forever
+    config       = ServerConfig.live(ServerConfig.default.port(8088))
+    _           <-
+      Server
+        .serve(
+          Http
+            .collectRoute[Request] { case _ -> !! / "api" / "graphql" =>
+              ZHttpAdapter.makeHttpService(interpreter)
+            }
+            .withDefaultErrorResponse
+        )
+        .provideSome[CharacterService](Server.live, config)
   } yield ()
 
   val episodeServer = for {
     interpreter <- FederatedApi.Episodes.api.interpreter
-    _           <- Server
-                     .start(
-                       8089,
-                       Http.collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
-                         ZHttpAdapter.makeHttpService(interpreter)
-                       }
-                     )
-                     .forever
+    config       = ServerConfig.live(ServerConfig.default.port(8089))
+    _           <-
+      Server
+        .serve(
+          Http
+            .collectRoute[Request] { case _ -> !! / "api" / "graphql" =>
+              ZHttpAdapter.makeHttpService(interpreter)
+            }
+            .withDefaultErrorResponse
+        )
+        .provideSome[EpisodeService](Server.live, config)
   } yield ()
 
   override def run =
     (characterServer race episodeServer)
-      .provideLayer(EpisodeService.make(sampleEpisodes) ++ CharacterService.make(sampleCharacters))
+      .provide(EpisodeService.make(sampleEpisodes), CharacterService.make(sampleCharacters))
       .exitCode
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,4 @@ addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.11.0")
 addSbtPlugin("org.scalameta"      % "sbt-mdoc"                 % "2.3.7")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13"
+addDependencyTreePlugin


### PR DESCRIPTION
Tests are currently failing with:

``` - ZHttpAdapterSpec
      Exception in thread "zio-fiber-25" java.util.concurrent.RejectedExecutionException: Unable to run zio.internal.FiberRuntime@16eeabe0
        at zio.Executor.submitOrThrow(Executor.scala:79)
        at zio.test.TestClock.default(TestClock.scala:408)
5 tests passed. 0 tests failed. 0 tests ignored.


    - ZIO Http - ZHttpAdapterSpec
      Exception in thread "zio-fiber-25" java.util.concurrent.RejectedExecutionException: Unable to run zio.internal.FiberRuntime@16eeabe0
        at zio.Executor.submitOrThrow(Executor.scala:79)
        at zio.test.TestClock.default(TestClock.scala:408)
Executed in 14 s 109 ms
```