### PR TITLE
Change client codegen for _ fields

### DIFF
--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -67,11 +67,6 @@ object ClientWriter {
       name
     }
 
-    def safeName(name: String): String =
-      if (reservedKeywords.contains(name) || name.endsWith("_")) s"`$name`"
-      else if (caseClassReservedFields.contains(name)) s"$name$$"
-      else name
-
     def safeTypeName(typeName: String): String =
       mappingClashedTypeNames.getOrElse(typeName, scalarMappingsWithDefaults.getOrElse(typeName, safeName(typeName)))
 

--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -24,11 +24,6 @@ object SchemaWriter {
       definition -> tuples.map(_._2)
     }
 
-    def safeName(name: String): String =
-      if (reservedKeywords.contains(name) || name.endsWith("_")) s"`$name`"
-      else if (caseClassReservedFields.contains(name)) s"$name$$"
-      else name
-
     def reservedType(typeDefinition: ObjectTypeDefinition): Boolean =
       typeDefinition.name == "Query" || typeDefinition.name == "Mutation" || typeDefinition.name == "Subscription"
 
@@ -121,10 +116,10 @@ object SchemaWriter {
           }
 
         s"""${unions.keys.map(writeUnionSealedTrait).mkString("\n")}
-        
+
         ${unionsWithoutReusedMembers.map { case (union, objects) => writeNotReusedMembers(union, objects) }
           .mkString("\n")}
-        
+
         ${reusedUnionMembers.map { case (objectType, unions) => writeReusedUnionMember(objectType, unions) }
           .mkString("\n")}
          """

--- a/tools/src/main/scala/caliban/tools/package.scala
+++ b/tools/src/main/scala/caliban/tools/package.scala
@@ -70,4 +70,10 @@ package object tools {
 
   val tripleQuotes = "\"\"\""
   val doubleQuotes = "\""
+
+  def safeName(name: String): String =
+    if (name == "_") "_$" // scala 3 does not allow a name of `_`
+    else if (reservedKeywords.contains(name) || name.endsWith("_")) s"`$name`"
+    else if (caseClassReservedFields.contains(name)) s"$name$$"
+    else name
 }

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -747,12 +747,14 @@ object Client {
           )
         }
       },
-      test("safe names with leading and tailing _") {
+      test("safe names with underscores") {
         val schema =
           """
              type Character {
+               _: Boolean # Fake field because GraphQL does not support empty objects
                _name_: String
                _nickname: String
+               age_: Int
              }
             """.stripMargin
 
@@ -766,10 +768,14 @@ object Client {
 
   type Character
   object Character {
+    def _$ : SelectionBuilder[Character, scala.Option[Boolean]]      =
+      _root_.caliban.client.SelectionBuilder.Field("_", OptionOf(Scalar()))
     def `_name_` : SelectionBuilder[Character, scala.Option[String]] =
       _root_.caliban.client.SelectionBuilder.Field("_name_", OptionOf(Scalar()))
     def _nickname: SelectionBuilder[Character, scala.Option[String]] =
       _root_.caliban.client.SelectionBuilder.Field("_nickname", OptionOf(Scalar()))
+    def `age_` : SelectionBuilder[Character, scala.Option[Int]]      =
+      _root_.caliban.client.SelectionBuilder.Field("age_", OptionOf(Scalar()))
   }
 
 }


### PR DESCRIPTION
A underscore with backticks is not valid in Scala 3 so convert them into `_$` instead.

Closes #1388