### PR TITLE
Fixing rendering of descriptions for multi-line descriptions ending in quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,5 @@ Want to see your company here? [Submit a PR](https://github.com/ghostdogpr/calib
 * [LeadIQ](https://leadiq.com)
 * [Sanjagh.pro](https://sanjagh.pro)
 * [Soundtrack Your Brand](https://www.soundtrackyourbrand.com)
+* [StepZen](https://www.stepzen.com)
 * [Undo](https://www.undo.app)

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -171,14 +171,15 @@ object Rendering {
       }
     }
 
-    def nl =
-      if (newline) "\n" else " "
+    def enl = if (newline) "\n" else " "
+
+    def bnl = if(newline) "\n" else ""
 
     description match {
       case None                                   => ""
       case Some(value) if value.exists(_ == '\n') =>
-        s"${renderTripleQuotedString(s"$nl$value")}$nl"
-      case Some(value)                            => s"${renderString(value)}$nl"
+        s"${renderTripleQuotedString(s"$bnl$value")}$enl"
+      case Some(value)                            => s"${renderString(value)}$enl"
     }
   }
 

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -149,11 +149,37 @@ object Rendering {
       case _                       => ""
     }
 
-  private def renderDescription(description: Option[String], newline: Boolean = true): String = description match {
-    case None                   => ""
-    case Some(value) if newline =>
-      if (value.contains("\n")) renderTripleQuotedString("\n" + value) + "\n" else renderString(value) + "\n"
-    case Some(value)            => if (value.contains("\n")) renderTripleQuotedString(value) else renderString(value) + " "
+  private def renderDescription(description: Option[String], newline: Boolean = true): String = {
+    // Most of the graphql tools (including ours) are greedy on triple quotes. To be compatible we
+    // need to break 4 or more '"' at the end of the description either with a newline or a space
+    val tripleQuote = "\"\"\""
+
+    def renderTripleQuotedString(value: String) = {
+      val valueEscaped = value.replace(tripleQuote, s"\\$tripleQuote")
+      // check if it ends in quote but it is already escaped
+      if (value.endsWith("\\\""))
+        s"$tripleQuote$valueEscaped$tripleQuote"
+      // check if it ends in quote. We need to break the sequence of 4 or more '"'
+      else if (value.last == '"')
+        if (newline)
+          s"$tripleQuote$valueEscaped\n$tripleQuote"
+        else
+          s"$tripleQuote$valueEscaped $tripleQuote"
+      else {
+        // ok. No quotes at the end of value
+        s"$tripleQuote$valueEscaped$tripleQuote"
+      }
+    }
+
+    def nl =
+      if (newline) "\n" else " "
+
+    description match {
+      case None                                   => ""
+      case Some(value) if value.exists(_ == '\n') =>
+        s"${renderTripleQuotedString(s"$nl$value")}$nl"
+      case Some(value)                            => s"${renderString(value)}$nl"
+    }
   }
 
   private def renderSpecifiedBy(specifiedBy: Option[String]): String =
@@ -221,9 +247,6 @@ object Rendering {
       case _                   => s"${fieldType.name.getOrElse("null")}"
     }
   }
-
-  private def renderTripleQuotedString(value: String) =
-    "\"\"\"" + value.replace("\"\"\"", "\\\"\"\"") + "\"\"\""
 
   private def renderString(value: String) =
     "\"" + value

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -194,7 +194,7 @@ object RenderingSpec extends ZIOSpecDefault {
              |  ${tripleQuote}
              |query.
              |Multi line${tripleQuote}
-             |  getUser2(${tripleQuote} argument
+             |  getUser2(${tripleQuote}argument
              |Multi line${tripleQuote} id: Int!): TheResult!
              |  "query. Single line ending in \\\"quote\\\""
              |  getUser3("argument single line ending in \\\"quote\\\"" id: Int!): TheResult!
@@ -202,7 +202,7 @@ object RenderingSpec extends ZIOSpecDefault {
              |query.
              |Multi line ending in "quote"
              |${tripleQuote}
-             |  getUser4(${tripleQuote} argument
+             |  getUser4(${tripleQuote}argument
              |Multi line ending in "quote" ${tripleQuote} id: Int!): TheResult!
              |}
              |

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -179,6 +179,72 @@ object RenderingSpec extends ZIOSpecDefault {
         assert(renderedType)(
           equalTo("\"\"\"\nA multiline \"TestType\" description\ngiven inside \\\"\"\"-quotes\n\"\"\"\ntype TestType")
         )
+      },
+      test("it should handle descriptions ending in '\"' properly") {
+        import RenderingSpecSchemaDescriptions._
+        val tripleQuote = "\"\"\""
+        val expected    =
+          s"""schema {
+             |  query: Query
+             |}
+             |
+             |type Query {
+             |  "query. Single line"
+             |  getUser1("argument single line" id: Int!): TheResult!
+             |  ${tripleQuote}
+             |query.
+             |Multi line${tripleQuote}
+             |  getUser2(${tripleQuote} argument
+             |Multi line${tripleQuote} id: Int!): TheResult!
+             |  "query. Single line ending in \\\"quote\\\""
+             |  getUser3("argument single line ending in \\\"quote\\\"" id: Int!): TheResult!
+             |  ${tripleQuote}
+             |query.
+             |Multi line ending in "quote"
+             |${tripleQuote}
+             |  getUser4(${tripleQuote} argument
+             |Multi line ending in "quote" ${tripleQuote} id: Int!): TheResult!
+             |}
+             |
+             |type R1 {
+             |  name: String!
+             |  "field. Single line"
+             |  age: Int!
+             |}
+             |
+             |type R2 {
+             |  name: String!
+             |  ${tripleQuote}
+             |field.
+             |Multi line${tripleQuote}
+             |  age: Int!
+             |}
+             |
+             |type R3 {
+             |  name: String!
+             |  "field. Single line ending in \\\"quote\\\""
+             |  age: Int!
+             |}
+             |
+             |type R4 {
+             |  name: String!
+             |  ${tripleQuote}
+             |field.
+             |Multi line ending in "quote"
+             |${tripleQuote}
+             |  age: Int!
+             |}
+             |
+             |type TheResult {
+             |  u1: R1!
+             |  u2: R2!
+             |  u3: R3!
+             |  u4: R4!
+             |}
+             |""".stripMargin
+        assert {
+          graphQL(resolverForDescriptionTest).render.trim
+        }(equalTo(expected.trim))
       }
     )
 }

--- a/core/src/test/scala/caliban/RenderingSpecSchemaDescriptions.scala
+++ b/core/src/test/scala/caliban/RenderingSpecSchemaDescriptions.scala
@@ -1,0 +1,41 @@
+package caliban
+
+import caliban.schema.Annotations.GQLDescription
+
+object RenderingSpecSchemaDescriptions {
+  case class R1(name: String, @GQLDescription("field. Single line") age: Int)
+
+  case class R2(name: String, @GQLDescription("field.\nMulti line") age: Int)
+
+  case class R3(name: String, @GQLDescription("field. Single line ending in \"quote\"") age: Int)
+
+  case class R4(name: String, @GQLDescription("field.\nMulti line ending in \"quote\"") age: Int)
+
+  case class MyUser1(@GQLDescription("argument single line") id: Int)
+
+  case class MyUser2(@GQLDescription("argument\nMulti line") id: Int)
+
+  case class MyUser3(@GQLDescription("argument single line ending in \"quote\"") id: Int)
+
+  case class MyUser4(@GQLDescription("argument\nMulti line ending in \"quote\"") id: Int)
+
+  case class TheResult(u1: R1, u2: R2, u3: R3, u4: R4)
+
+  case class Query(
+    @GQLDescription("query. Single line") getUser1: MyUser1 => TheResult,
+    @GQLDescription("query.\nMulti line") getUser2: MyUser2 => TheResult,
+    @GQLDescription("query. Single line ending in \"quote\"") getUser3: MyUser3 => TheResult,
+    @GQLDescription("query.\nMulti line ending in \"quote\"") getUser4: MyUser4 => TheResult
+  )
+
+  def getResult: TheResult = ???
+
+  val resolverForDescriptionTest = RootResolver(
+    Query(
+      _ => getResult,
+      _ => getResult,
+      _ => getResult,
+      _ => getResult
+    )
+  )
+}


### PR DESCRIPTION
Even though the spec indicates that parsing triple quotes should not be greedy most of the tools (even ours) are. This PR breaks the rendering of a description that will result in four unescaped quotes.

Fixes #1449 