### PR TITLE
Fixing rendering of descriptions for multi-line descriptions ending in quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,5 @@ Want to see your company here? [Submit a PR](https://github.com/ghostdogpr/calib
 * [LeadIQ](https://leadiq.com)
 * [Sanjagh.pro](https://sanjagh.pro)
 * [Soundtrack Your Brand](https://www.soundtrackyourbrand.com)
+* [StepZen](https://www.stepzen.com)
 * [Undo](https://www.undo.app)

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -171,14 +171,15 @@ object Rendering {
       }
     }
 
-    def nl =
-      if (newline) "\n" else " "
+    def enl = if (newline) "\n" else " "
+
+    def bnl = if(newline) "\n" else ""
 
     description match {
       case None                                   => ""
       case Some(value) if value.exists(_ == '\n') =>
-        s"${renderTripleQuotedString(s"$nl$value")}$nl"
-      case Some(value)                            => s"${renderString(value)}$nl"
+        s"${renderTripleQuotedString(s"$bnl$value")}$enl"
+      case Some(value)                            => s"${renderString(value)}$enl"
     }
   }
 

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -149,11 +149,37 @@ object Rendering {
       case _                       => ""
     }
 
-  private def renderDescription(description: Option[String], newline: Boolean = true): String = description match {
-    case None                   => ""
-    case Some(value) if newline =>
-      if (value.contains("\n")) renderTripleQuotedString("\n" + value) + "\n" else renderString(value) + "\n"
-    case Some(value)            => if (value.contains("\n")) renderTripleQuotedString(value) else renderString(value) + " "
+  private def renderDescription(description: Option[String], newline: Boolean = true): String = {
+    // Most of the graphql tools (including ours) are greedy on triple quotes. To be compatible we
+    // need to break 4 or more '"' at the end of the description either with a newline or a space
+    val tripleQuote = "\"\"\""
+
+    def renderTripleQuotedString(value: String) = {
+      val valueEscaped = value.replace(tripleQuote, s"\\$tripleQuote")
+      // check if it ends in quote but it is already escaped
+      if (value.endsWith("\\\""))
+        s"$tripleQuote$valueEscaped$tripleQuote"
+      // check if it ends in quote. We need to break the sequence of 4 or more '"'
+      else if (value.last == '"')
+        if (newline)
+          s"$tripleQuote$valueEscaped\n$tripleQuote"
+        else
+          s"$tripleQuote$valueEscaped $tripleQuote"
+      else {
+        // ok. No quotes at the end of value
+        s"$tripleQuote$valueEscaped$tripleQuote"
+      }
+    }
+
+    def nl =
+      if (newline) "\n" else " "
+
+    description match {
+      case None                                   => ""
+      case Some(value) if value.exists(_ == '\n') =>
+        s"${renderTripleQuotedString(s"$nl$value")}$nl"
+      case Some(value)                            => s"${renderString(value)}$nl"
+    }
   }
 
   private def renderSpecifiedBy(specifiedBy: Option[String]): String =
@@ -221,9 +247,6 @@ object Rendering {
       case _                   => s"${fieldType.name.getOrElse("null")}"
     }
   }
-
-  private def renderTripleQuotedString(value: String) =
-    "\"\"\"" + value.replace("\"\"\"", "\\\"\"\"") + "\"\"\""
 
   private def renderString(value: String) =
     "\"" + value

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -1,9 +1,9 @@
 package caliban
 
-import caliban.Value.{ BooleanValue, EnumValue, FloatValue, IntValue, NullValue, StringValue }
+import caliban.Value._
 import caliban.introspection.adt._
+import caliban.introspection.adt.__TypeKind._
 import caliban.parsing.adt.Directive
-import __TypeKind._
 
 object Rendering {
 
@@ -154,32 +154,28 @@ object Rendering {
     // need to break 4 or more '"' at the end of the description either with a newline or a space
     val tripleQuote = "\"\"\""
 
+    def nlOrSp = if (newline) "\n" else " "
+
+    def nlOrNot = if (newline) "\n" else ""
+
     def renderTripleQuotedString(value: String) = {
       val valueEscaped = value.replace(tripleQuote, s"\\$tripleQuote")
       // check if it ends in quote but it is already escaped
       if (value.endsWith("\\\""))
-        s"$tripleQuote$valueEscaped$tripleQuote"
+        s"$tripleQuote$nlOrNot$valueEscaped$nlOrNot$tripleQuote"
       // check if it ends in quote. We need to break the sequence of 4 or more '"'
-      else if (value.last == '"')
-        if (newline)
-          s"$tripleQuote$valueEscaped\n$tripleQuote"
-        else
-          s"$tripleQuote$valueEscaped $tripleQuote"
-      else {
+      else if (value.last == '"') {
+        s"$tripleQuote$nlOrNot$valueEscaped$nlOrSp$tripleQuote"
+      } else {
         // ok. No quotes at the end of value
-        s"$tripleQuote$valueEscaped$tripleQuote"
+        s"$tripleQuote$nlOrNot$valueEscaped$nlOrNot$tripleQuote"
       }
     }
-
-    def enl = if (newline) "\n" else " "
-
-    def bnl = if(newline) "\n" else ""
-
     description match {
       case None                                   => ""
       case Some(value) if value.exists(_ == '\n') =>
-        s"${renderTripleQuotedString(s"$bnl$value")}$enl"
-      case Some(value)                            => s"${renderString(value)}$enl"
+        s"${renderTripleQuotedString(s"$value")}$nlOrSp"
+      case Some(value)                            => s"${renderString(value)}$nlOrSp"
     }
   }
 

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -150,7 +150,7 @@ object Rendering {
     }
 
   private def renderDescription(description: Option[String], newline: Boolean = true): String = {
-    // Most of the graphql tools (including ours) are greedy on triple quotes. To be compatible we
+    // Most of the graphql tools are greedy on triple quotes. To be compatible we
     // need to break 4 or more '"' at the end of the description either with a newline or a space
     val tripleQuote = "\"\"\""
 

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -7,8 +7,6 @@ import caliban.parsing.adt.Directive
 import zio.test.Assertion._
 import zio.test._
 
-import scala.annotation.tailrec
-
 object RenderingSpec extends ZIOSpecDefault {
 
   val tripleQuote = "\"\"\""
@@ -285,41 +283,4 @@ object RenderingSpec extends ZIOSpecDefault {
         assert(graphQL(resolver).render.trim)(equalTo(expected.trim))
       }
     )
-
-  sealed trait DiffResult {
-    def areEqual: Boolean
-    def commonPrefix: String
-    def diffPrefix: (String, String)
-  }
-
-  case class EqualResult(s: String) extends DiffResult {
-    override def areEqual: Boolean = true
-
-    override def commonPrefix: String = s
-
-    override def diffPrefix: (String, String) = ("", "")
-  }
-
-  case class DifferentResult(prefix: String, left1: String, left2: String) extends DiffResult {
-    override def areEqual: Boolean = false
-
-    override def commonPrefix: String = prefix
-
-    override def diffPrefix: (String, String) = (left1, left2)
-  }
-
-  def displayFirstDifference(s1: String, s2: String) = {
-    @tailrec
-    def loop(currS1: List[Char], currS2: List[Char], soFar: List[Char]): DiffResult =
-      (currS1, currS2) match {
-        case (Nil, Nil)                                 => EqualResult(s1)
-        case (Nil, _)                                   => DifferentResult(soFar.reverse.mkString, currS1.mkString, currS2.mkString)
-        case (_, Nil)                                   => DifferentResult(soFar.reverse.mkString, currS1.mkString, currS2.mkString)
-        case ((s1h :: s1t), (s2h :: s2t)) if s1h == s2h =>
-          loop(s1t, s2t, s1h :: soFar)
-        case (_, _)                                     => DifferentResult(soFar.reverse.mkString, currS1.mkString, currS2.mkString)
-      }
-    loop(s1.toList, s2.toList, List.empty)
-
-  }
 }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -194,7 +194,7 @@ object RenderingSpec extends ZIOSpecDefault {
              |  ${tripleQuote}
              |query.
              |Multi line${tripleQuote}
-             |  getUser2(${tripleQuote} argument
+             |  getUser2(${tripleQuote}argument
              |Multi line${tripleQuote} id: Int!): TheResult!
              |  "query. Single line ending in \\\"quote\\\""
              |  getUser3("argument single line ending in \\\"quote\\\"" id: Int!): TheResult!
@@ -202,7 +202,7 @@ object RenderingSpec extends ZIOSpecDefault {
              |query.
              |Multi line ending in "quote"
              |${tripleQuote}
-             |  getUser4(${tripleQuote} argument
+             |  getUser4(${tripleQuote}argument
              |Multi line ending in "quote" ${tripleQuote} id: Int!): TheResult!
              |}
              |

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -179,6 +179,72 @@ object RenderingSpec extends ZIOSpecDefault {
         assert(renderedType)(
           equalTo("\"\"\"\nA multiline \"TestType\" description\ngiven inside \\\"\"\"-quotes\n\"\"\"\ntype TestType")
         )
+      },
+      test("it should handle descriptions ending in '\"' properly") {
+        import RenderingSpecSchemaDescriptions._
+        val tripleQuote = "\"\"\""
+        val expected    =
+          s"""schema {
+             |  query: Query
+             |}
+             |
+             |type Query {
+             |  "query. Single line"
+             |  getUser1("argument single line" id: Int!): TheResult!
+             |  ${tripleQuote}
+             |query.
+             |Multi line${tripleQuote}
+             |  getUser2(${tripleQuote} argument
+             |Multi line${tripleQuote} id: Int!): TheResult!
+             |  "query. Single line ending in \\\"quote\\\""
+             |  getUser3("argument single line ending in \\\"quote\\\"" id: Int!): TheResult!
+             |  ${tripleQuote}
+             |query.
+             |Multi line ending in "quote"
+             |${tripleQuote}
+             |  getUser4(${tripleQuote} argument
+             |Multi line ending in "quote" ${tripleQuote} id: Int!): TheResult!
+             |}
+             |
+             |type R1 {
+             |  name: String!
+             |  "field. Single line"
+             |  age: Int!
+             |}
+             |
+             |type R2 {
+             |  name: String!
+             |  ${tripleQuote}
+             |field.
+             |Multi line${tripleQuote}
+             |  age: Int!
+             |}
+             |
+             |type R3 {
+             |  name: String!
+             |  "field. Single line ending in \\\"quote\\\""
+             |  age: Int!
+             |}
+             |
+             |type R4 {
+             |  name: String!
+             |  ${tripleQuote}
+             |field.
+             |Multi line ending in "quote"
+             |${tripleQuote}
+             |  age: Int!
+             |}
+             |
+             |type TheResult {
+             |  u1: R1!
+             |  u2: R2!
+             |  u3: R3!
+             |  u4: R4!
+             |}
+             |""".stripMargin
+        assert {
+          graphQL(resolverForDescriptionTest).render.trim
+        }(equalTo(expected.trim))
       }
     )
 }

--- a/core/src/test/scala/caliban/RenderingSpecSchemaDescriptions.scala
+++ b/core/src/test/scala/caliban/RenderingSpecSchemaDescriptions.scala
@@ -2,40 +2,74 @@ package caliban
 
 import caliban.schema.Annotations.GQLDescription
 
-object RenderingSpecSchemaDescriptions {
-  case class R1(name: String, @GQLDescription("field. Single line") age: Int)
+object RenderingSpecSchemaSingleLineDescription {
 
-  case class R2(name: String, @GQLDescription("field.\nMulti line") age: Int)
+  @GQLDescription("type description in a single line")
+  case class OutputValue(@GQLDescription("field description in a single line") r: Int)
 
-  case class R3(name: String, @GQLDescription("field. Single line ending in \"quote\"") age: Int)
+  case class InputValue(@GQLDescription("argument description in a single line") in: Int)
 
-  case class R4(name: String, @GQLDescription("field.\nMulti line ending in \"quote\"") age: Int)
-
-  case class MyUser1(@GQLDescription("argument single line") id: Int)
-
-  case class MyUser2(@GQLDescription("argument\nMulti line") id: Int)
-
-  case class MyUser3(@GQLDescription("argument single line ending in \"quote\"") id: Int)
-
-  case class MyUser4(@GQLDescription("argument\nMulti line ending in \"quote\"") id: Int)
-
-  case class TheResult(u1: R1, u2: R2, u3: R3, u4: R4)
+  def getResult: OutputValue = ???
 
   case class Query(
-    @GQLDescription("query. Single line") getUser1: MyUser1 => TheResult,
-    @GQLDescription("query.\nMulti line") getUser2: MyUser2 => TheResult,
-    @GQLDescription("query. Single line ending in \"quote\"") getUser3: MyUser3 => TheResult,
-    @GQLDescription("query.\nMulti line ending in \"quote\"") getUser4: MyUser4 => TheResult
+    @GQLDescription("query description in a single line") q: InputValue => OutputValue
   )
 
-  def getResult: TheResult = ???
+  val resolver = RootResolver(
+    Query(_ => getResult)
+  )
+}
 
-  val resolverForDescriptionTest = RootResolver(
-    Query(
-      _ => getResult,
-      _ => getResult,
-      _ => getResult,
-      _ => getResult
-    )
+object RenderingSpecSchemaMultiLineDescription {
+
+  @GQLDescription("type description in\nMultiple lines")
+  case class OutputValue(@GQLDescription("field description in\nMultiple lines") r: Int)
+
+  case class InputValue(@GQLDescription("argument description in\nMultiple lines") in: Int)
+
+  def getResult: OutputValue = ???
+
+  case class Query(
+    @GQLDescription("query description in\nMultiple lines") q: InputValue => OutputValue
+  )
+
+  val resolver = RootResolver(
+    Query(_ => getResult)
+  )
+}
+
+object RenderingSpecSchemaSingleLineEndingInQuoteDescription {
+
+  @GQLDescription("type description in a single line \"ending in quote\"")
+  case class OutputValue(@GQLDescription("field description in a single line \"ending in quote\"") r: Int)
+
+  case class InputValue(@GQLDescription("argument description in a single line \"ending in quote\"") in: Int)
+
+  def getResult: OutputValue = ???
+
+  case class Query(
+    @GQLDescription("query description in a single line \"ending in quote\"") q: InputValue => OutputValue
+  )
+
+  val resolver = RootResolver(
+    Query(_ => getResult)
+  )
+}
+
+object RenderingSpecSchemaMultiLineEndingInQuoteDescription {
+
+  @GQLDescription("type description in multiple lines\n\"ending in quote\"")
+  case class OutputValue(@GQLDescription("field description in multiple lines\n\"ending in quote\"") r: Int)
+
+  case class InputValue(@GQLDescription("argument description in multiple lines\n\"ending in quote\"") in: Int)
+
+  def getResult: OutputValue = ???
+
+  case class Query(
+    @GQLDescription("query description in multiple lines\n\"ending in quote\"") q: InputValue => OutputValue
+  )
+
+  val resolver = RootResolver(
+    Query(_ => getResult)
   )
 }

--- a/core/src/test/scala/caliban/RenderingSpecSchemaDescriptions.scala
+++ b/core/src/test/scala/caliban/RenderingSpecSchemaDescriptions.scala
@@ -1,0 +1,41 @@
+package caliban
+
+import caliban.schema.Annotations.GQLDescription
+
+object RenderingSpecSchemaDescriptions {
+  case class R1(name: String, @GQLDescription("field. Single line") age: Int)
+
+  case class R2(name: String, @GQLDescription("field.\nMulti line") age: Int)
+
+  case class R3(name: String, @GQLDescription("field. Single line ending in \"quote\"") age: Int)
+
+  case class R4(name: String, @GQLDescription("field.\nMulti line ending in \"quote\"") age: Int)
+
+  case class MyUser1(@GQLDescription("argument single line") id: Int)
+
+  case class MyUser2(@GQLDescription("argument\nMulti line") id: Int)
+
+  case class MyUser3(@GQLDescription("argument single line ending in \"quote\"") id: Int)
+
+  case class MyUser4(@GQLDescription("argument\nMulti line ending in \"quote\"") id: Int)
+
+  case class TheResult(u1: R1, u2: R2, u3: R3, u4: R4)
+
+  case class Query(
+    @GQLDescription("query. Single line") getUser1: MyUser1 => TheResult,
+    @GQLDescription("query.\nMulti line") getUser2: MyUser2 => TheResult,
+    @GQLDescription("query. Single line ending in \"quote\"") getUser3: MyUser3 => TheResult,
+    @GQLDescription("query.\nMulti line ending in \"quote\"") getUser4: MyUser4 => TheResult
+  )
+
+  def getResult: TheResult = ???
+
+  val resolverForDescriptionTest = RootResolver(
+    Query(
+      _ => getResult,
+      _ => getResult,
+      _ => getResult,
+      _ => getResult
+    )
+  )
+}


### PR DESCRIPTION
Even though the spec indicates that parsing triple quotes should not be greedy most of the tools (even ours) are. This PR breaks the rendering of a description that will result in four unescaped quotes.

Fixes #1449 