### PR TITLE
Optimise JSON encoding for `circe` and `zioJson`

### DIFF
--- a/core/src/main/scala/caliban/interop/circe/circe.scala
+++ b/core/src/main/scala/caliban/interop/circe/circe.scala
@@ -39,25 +39,7 @@ object json {
 
   private[caliban] object ValueCirce {
     import io.circe._
-    val valueEncoder: Encoder[Value]                           = Encoder
-      .instance[Value] {
-        case NullValue           => Json.Null
-        case v: IntValue         =>
-          v match {
-            case IntValue.IntNumber(value)    => Json.fromInt(value)
-            case IntValue.LongNumber(value)   => Json.fromLong(value)
-            case IntValue.BigIntNumber(value) => Json.fromBigInt(value)
-          }
-        case v: FloatValue       =>
-          v match {
-            case FloatValue.FloatNumber(value)      => Json.fromFloatOrNull(value)
-            case FloatValue.DoubleNumber(value)     => Json.fromDoubleOrNull(value)
-            case FloatValue.BigDecimalNumber(value) => Json.fromBigDecimal(value)
-          }
-        case StringValue(value)  => Json.fromString(value)
-        case BooleanValue(value) => Json.fromBoolean(value)
-        case EnumValue(value)    => Json.fromString(value)
-      }
+
     private def jsonToInputValue(json: Json): InputValue       =
       json.fold(
         NullValue,
@@ -73,11 +55,20 @@ object json {
     val inputValueDecoder: Decoder[InputValue]                 = Decoder.instance(hcursor => Right(jsonToInputValue(hcursor.value)))
     val inputValueEncoder: Encoder[InputValue]                 = Encoder
       .instance[InputValue] {
-        case value: Value                   => valueEncoder.apply(value)
-        case InputValue.ListValue(values)   => Json.arr(values.map(inputValueEncoder.apply): _*)
-        case InputValue.ObjectValue(fields) =>
+        case NullValue                          => Json.Null
+        case IntValue.IntNumber(value)          => Json.fromInt(value)
+        case IntValue.LongNumber(value)         => Json.fromLong(value)
+        case IntValue.BigIntNumber(value)       => Json.fromBigInt(value)
+        case FloatValue.FloatNumber(value)      => Json.fromFloatOrNull(value)
+        case FloatValue.DoubleNumber(value)     => Json.fromDoubleOrNull(value)
+        case FloatValue.BigDecimalNumber(value) => Json.fromBigDecimal(value)
+        case StringValue(value)                 => Json.fromString(value)
+        case BooleanValue(value)                => Json.fromBoolean(value)
+        case EnumValue(value)                   => Json.fromString(value)
+        case InputValue.ListValue(values)       => Json.arr(values.map(inputValueEncoder.apply): _*)
+        case InputValue.ObjectValue(fields)     =>
           Json.obj(fields.map { case (k, v) => k -> inputValueEncoder.apply(v) }.toList: _*)
-        case InputValue.VariableValue(name) => Json.fromString(name)
+        case InputValue.VariableValue(name)     => Json.fromString(name)
       }
     private def jsonToResponseValue(json: Json): ResponseValue =
       json.fold(
@@ -103,11 +94,20 @@ object json {
       Decoder.instance(hcursor => Right(jsonToResponseValue(hcursor.value)))
     val responseValueEncoder: Encoder[ResponseValue] = Encoder
       .instance[ResponseValue] {
-        case value: Value                      => valueEncoder.apply(value)
-        case ResponseValue.ListValue(values)   => Json.arr(values.map(responseValueEncoder.apply): _*)
-        case ResponseValue.ObjectValue(fields) =>
+        case NullValue                          => Json.Null
+        case IntValue.IntNumber(value)          => Json.fromInt(value)
+        case IntValue.LongNumber(value)         => Json.fromLong(value)
+        case IntValue.BigIntNumber(value)       => Json.fromBigInt(value)
+        case FloatValue.FloatNumber(value)      => Json.fromFloatOrNull(value)
+        case FloatValue.DoubleNumber(value)     => Json.fromDoubleOrNull(value)
+        case FloatValue.BigDecimalNumber(value) => Json.fromBigDecimal(value)
+        case StringValue(value)                 => Json.fromString(value)
+        case BooleanValue(value)                => Json.fromBoolean(value)
+        case EnumValue(value)                   => Json.fromString(value)
+        case ResponseValue.ListValue(values)    => Json.arr(values.map(responseValueEncoder.apply): _*)
+        case ResponseValue.ObjectValue(fields)  =>
           Json.obj(fields.map { case (k, v) => k -> responseValueEncoder.apply(v) }: _*)
-        case s: ResponseValue.StreamValue      => Json.fromString(s.toString)
+        case s: ResponseValue.StreamValue       => Json.fromString(s.toString)
       }
   }
 

--- a/core/src/main/scala/caliban/interop/zio/zio.scala
+++ b/core/src/main/scala/caliban/interop/zio/zio.scala
@@ -231,26 +231,6 @@ private[caliban] object ValueZIOJson {
   import zio.json._
   import zio.json.internal.{ Lexer, RetractReader, Write }
 
-  val valueEncoder: JsonEncoder[Value] = (a: Value, indent: Option[Int], out: Write) =>
-    a match {
-      case Value.NullValue     => Null.encoder.unsafeEncode(NullValue, indent, out)
-      case v: IntValue         =>
-        v match {
-          case IntValue.IntNumber(value)    => JsonEncoder.int.unsafeEncode(value, indent, out)
-          case IntValue.LongNumber(value)   => JsonEncoder.long.unsafeEncode(value, indent, out)
-          case IntValue.BigIntNumber(value) => JsonEncoder.bigInteger.unsafeEncode(value.bigInteger, indent, out)
-        }
-      case v: FloatValue       =>
-        v match {
-          case FloatValue.FloatNumber(value)      => JsonEncoder.float.unsafeEncode(value, indent, out)
-          case FloatValue.DoubleNumber(value)     => JsonEncoder.double.unsafeEncode(value, indent, out)
-          case FloatValue.BigDecimalNumber(value) => JsonEncoder.bigDecimal.unsafeEncode(value.bigDecimal, indent, out)
-        }
-      case StringValue(value)  => JsonEncoder.string.unsafeEncode(value, indent, out)
-      case BooleanValue(value) => JsonEncoder.boolean.unsafeEncode(value, indent, out)
-      case EnumValue(value)    => JsonEncoder.string.unsafeEncode(value, indent, out)
-    }
-
   object Null {
     private[this] val nullChars: Array[Char]          = "null".toCharArray
     val encoder: JsonEncoder[NullValue.type]          = (a: NullValue.type, indent: Option[Int], out: Write) => out.write("null")
@@ -333,11 +313,20 @@ private[caliban] object ValueZIOJson {
 
   val inputValueEncoder: JsonEncoder[InputValue] = (a: InputValue, indent: Option[Int], out: Write) =>
     a match {
-      case value: Value                   => valueEncoder.unsafeEncode(value, indent, out)
-      case InputValue.ListValue(values)   => JsonEncoder.list(inputValueEncoder).unsafeEncode(values, indent, out)
-      case InputValue.ObjectValue(fields) =>
+      case Value.NullValue                    => Null.encoder.unsafeEncode(NullValue, indent, out)
+      case IntValue.IntNumber(value)          => JsonEncoder.int.unsafeEncode(value, indent, out)
+      case IntValue.LongNumber(value)         => JsonEncoder.long.unsafeEncode(value, indent, out)
+      case IntValue.BigIntNumber(value)       => JsonEncoder.bigInteger.unsafeEncode(value.bigInteger, indent, out)
+      case FloatValue.FloatNumber(value)      => JsonEncoder.float.unsafeEncode(value, indent, out)
+      case FloatValue.DoubleNumber(value)     => JsonEncoder.double.unsafeEncode(value, indent, out)
+      case FloatValue.BigDecimalNumber(value) => JsonEncoder.bigDecimal.unsafeEncode(value.bigDecimal, indent, out)
+      case StringValue(value)                 => JsonEncoder.string.unsafeEncode(value, indent, out)
+      case BooleanValue(value)                => JsonEncoder.boolean.unsafeEncode(value, indent, out)
+      case EnumValue(value)                   => JsonEncoder.string.unsafeEncode(value, indent, out)
+      case InputValue.ListValue(values)       => JsonEncoder.list(inputValueEncoder).unsafeEncode(values, indent, out)
+      case InputValue.ObjectValue(fields)     =>
         JsonEncoder.map(JsonFieldEncoder.string, inputValueEncoder).unsafeEncode(fields, indent, out)
-      case InputValue.VariableValue(name) => JsonEncoder.string.unsafeEncode(name, indent, out)
+      case InputValue.VariableValue(name)     => JsonEncoder.string.unsafeEncode(name, indent, out)
     }
 
   val responseValueDecoder: JsonDecoder[ResponseValue] = (trace: List[JsonDecoder.JsonError], in: RetractReader) => {
@@ -360,10 +349,19 @@ private[caliban] object ValueZIOJson {
   implicit val responseValueEncoder: JsonEncoder[ResponseValue] =
     (a: ResponseValue, indent: Option[Int], out: Write) =>
       a match {
-        case value: Value                      => valueEncoder.unsafeEncode(value, indent, out)
-        case ResponseValue.ListValue(values)   => Arr.responseEncoder.unsafeEncode(values, indent, out)
-        case ResponseValue.ObjectValue(fields) => Obj.responseEncoder.unsafeEncode(fields, indent, out)
-        case s: ResponseValue.StreamValue      => JsonEncoder.string.unsafeEncode(s.toString, indent, out)
+        case Value.NullValue                    => Null.encoder.unsafeEncode(NullValue, indent, out)
+        case IntValue.IntNumber(value)          => JsonEncoder.int.unsafeEncode(value, indent, out)
+        case IntValue.LongNumber(value)         => JsonEncoder.long.unsafeEncode(value, indent, out)
+        case IntValue.BigIntNumber(value)       => JsonEncoder.bigInteger.unsafeEncode(value.bigInteger, indent, out)
+        case FloatValue.FloatNumber(value)      => JsonEncoder.float.unsafeEncode(value, indent, out)
+        case FloatValue.DoubleNumber(value)     => JsonEncoder.double.unsafeEncode(value, indent, out)
+        case FloatValue.BigDecimalNumber(value) => JsonEncoder.bigDecimal.unsafeEncode(value.bigDecimal, indent, out)
+        case StringValue(value)                 => JsonEncoder.string.unsafeEncode(value, indent, out)
+        case BooleanValue(value)                => JsonEncoder.boolean.unsafeEncode(value, indent, out)
+        case EnumValue(value)                   => JsonEncoder.string.unsafeEncode(value, indent, out)
+        case ResponseValue.ListValue(values)    => Arr.responseEncoder.unsafeEncode(values, indent, out)
+        case ResponseValue.ObjectValue(fields)  => Obj.responseEncoder.unsafeEncode(fields, indent, out)
+        case s: ResponseValue.StreamValue       => JsonEncoder.string.unsafeEncode(s.toString, indent, out)
       }
 
 }


### PR DESCRIPTION
Followup of https://github.com/ghostdogpr/caliban/pull/1527#issuecomment-1356883960

TLDR: these changes bring an improvement of **~75%** (zioJson) and **~50%** (circe) in terms of throughput for encoding the GraphQL response objects to JSON