### PR TITLE
Add parsing of introspection response JSON string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
   scripted3_jdk:
     docker:
       - image: cimg/openjdk:11.0-node
+    resource_class: medium+
     steps:
       - checkout
       - restore_cache:

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -19,12 +19,6 @@ import zio.URIO
 
 object IntrospectionClient {
 
-  def introspect(introspectionJson: String): UIO[Document] = {
-    val result: Either[CalibanClientError, Document] =
-      introspection.decode(introspectionJson).map { case (result, errors, extensions) => result }
-    ZIO.succeed(result).absolve.orDie
-  }
-
   def introspect(uri: String, headers: Option[List[Options.Header]]): RIO[SttpClient, Document] =
     for {
       parsedUri <- ZIO.fromEither(Uri.parse(uri)).mapError(cause => new Exception(s"Invalid URL: $cause"))
@@ -222,7 +216,7 @@ object IntrospectionClient {
       } ~
       __Type.possibleTypes(typeRef)).mapN(mapType _)
 
-  private val introspection: SelectionBuilder[RootQuery, Document] =
+  val introspection: SelectionBuilder[RootQuery, Document] =
     Query.__schema {
       (__Schema.queryType(__Type.name) ~
         __Schema.mutationType(__Type.name) ~

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -14,8 +14,7 @@ import caliban.parsing.adt.Type.{ ListType, NamedType }
 import caliban.parsing.adt.{ Directive, Document, Type }
 import sttp.client3._
 import sttp.model.Uri
-import zio.{ RIO, UIO, ZIO }
-import zio.URIO
+import zio.{ RIO, ZIO }
 
 object IntrospectionClient {
 

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -14,9 +14,16 @@ import caliban.parsing.adt.Type.{ ListType, NamedType }
 import caliban.parsing.adt.{ Directive, Document, Type }
 import sttp.client3._
 import sttp.model.Uri
-import zio.{ RIO, ZIO }
+import zio.{ RIO, UIO, ZIO }
+import zio.URIO
 
 object IntrospectionClient {
+
+  def introspect(introspectionJson: String): UIO[Document] = {
+    val result: Either[CalibanClientError, Document] =
+      introspection.decode(introspectionJson).map { case (result, errors, extensions) => result }
+    ZIO.succeed(result).absolve.orDie
+  }
 
   def introspect(uri: String, headers: Option[List[Options.Header]]): RIO[SttpClient, Document] =
     for {


### PR DESCRIPTION
Based on the explorations of this [proof-of-concept repo](https://github.com/undo-insurance/internal-gateway-poc).

The goal is to be able to stitch a Sangria graph at the root level within the same codebase, without doing network calls.

In order to do that we need to build a Caliban `__Schema` from a `sangria.schema.Schema`

**Possible adaptations?**

1. Change the `IntrospectionClient` to take a function which produces the introspection JSON data structure as a string.
```scala
def introspect(produceIntrospectionJsonString: _ => String): UIO[Document]
```
2. Expose the introspection JSON payload parsing from the introspection client, so consumers can produce a `Document` on their own from an introspection JSON representation.
3. Additional ideas we haven't thought of 😀 