### PR TITLE
Don't require a schema for excluded fields (Scala 3 only)

### DIFF
--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -63,7 +63,7 @@ trait CommonSchemaDerivation {
         makeSumSchema[R, A](members, info, annotations)(m)
 
       case m: Mirror.ProductOf[A] =>
-        lazy val fields      = recurse[R, m.MirroredElemLabels, m.MirroredElemTypes]()()
+        lazy val fields      = recurse[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()()
         def annotations      = Macros.annotations[A]
         def info             = Macros.typeInfo[A]
         def paramAnnotations = Macros.paramAnnotations[A].toMap

--- a/core/src/test/scala-3/caliban/schema/ExcludedFieldSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/ExcludedFieldSpec.scala
@@ -1,0 +1,11 @@
+package caliban.schema
+
+import caliban.schema.Annotations.GQLExcluded
+
+/** Compile-time "test", which ensures that we don't need to define a schema for fields annotated with @GQLExcluded */
+object ExcludedFieldSpec {
+  final case class Foo(value: String)
+  final case class Bar(value: String, @GQLExcluded foo: Foo, num: Int)
+
+  given Schema[Any, Bar] = Schema.derived
+}

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -168,11 +168,17 @@ object SchemaSpec extends ZIOSpecDefault {
         )
       },
       test("GQLExcluded") {
-        case class QueryType(a: String, @GQLExcluded b: String)
+        case class Bar(value: String)
+        case class Foo(foo: String, @GQLExcluded bar: Bar)
+        case class QueryType(a: String, @GQLExcluded b: String, foo: Foo)
         case class Query(query: QueryType)
-        val gql      = graphQL(RootResolver(Query(QueryType("a", "b"))))
+        val gql      = graphQL(RootResolver(Query(QueryType("a", "b", Foo("foo", Bar("bar"))))))
         val expected = """schema {
                          |  query: Query
+                         |}
+
+                         |type Foo {
+                         |  foo: String!
                          |}
 
                          |type Query {
@@ -181,6 +187,7 @@ object SchemaSpec extends ZIOSpecDefault {
 
                          |type QueryType {
                          |  a: String!
+                         |  foo: Foo!
                          |}""".stripMargin
         assertTrue(gql.render == expected)
       },


### PR DESCRIPTION
I'm putting this here before I forget about it. We don't need to merge it in now, it can be done after the semi-derivation PR is finalised and merged in.

With these changes, we no longer need to define a Schema for types that are exluded via the  `@GQLExcluded` annotation.

Unfortunately I couldn't figure out how to make this work for Scala 2 as well