### PR TITLE
feat: Add observability wrappers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.17 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test
+      - run: sbt ++2.12.17 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test tracing/test
       - save_cache:
           key: sbtcache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.10 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile monixInterop/compile tapirInterop/test clientJVM/test federation/test reporting/test
+      - run: sbt ++2.13.10 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile monixInterop/compile tapirInterop/test clientJVM/test federation/test reporting/test tracing/test
       - save_cache:
           key: sbtcache
           paths:
@@ -80,7 +80,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.2.2 core/test catsInterop/compile benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile zioHttp/test tapirInterop/test http4s/test federation/test reporting/test
+      - run: sbt ++3.2.2 core/test catsInterop/compile benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile zioHttp/test tapirInterop/test http4s/test federation/test reporting/test tracing/test
       - save_cache:
           key: sbtcache
           paths:

--- a/build.sbt
+++ b/build.sbt
@@ -184,19 +184,13 @@ lazy val tracing = project
   .settings(name := "caliban-tracing")
   .settings(commonSettings)
   .settings(
-    scalaVersion := scala213,
-    crossScalaVersions -= scala212, // zio-telemetry is only published for 2.13 and 3.x
-    buildInfoKeys    := Seq[BuildInfoKey](
-      "scalaPartialVersion" -> CrossVersion.partialVersion(scalaVersion.value),
-      "scalafmtVersion"     -> scalafmtVersion
-    ),
     buildInfoPackage := "caliban.tracing",
     buildInfoObject  := "BuildInfo"
   )
   .settings(
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
-      "dev.zio"         %% "zio-opentelemetry"         % "3.0.0-RC2",
+      "dev.zio"         %% "zio-opentelemetry"         % "3.0.0-RC3",
       "dev.zio"         %% "zio-test"                  % zioVersion % Test,
       "dev.zio"         %% "zio-test-sbt"              % zioVersion % Test,
       "io.opentelemetry" % "opentelemetry-sdk-testing" % "1.23.0"   % Test

--- a/build.sbt
+++ b/build.sbt
@@ -27,13 +27,8 @@ val zioInteropReactiveVersion = "2.0.1"
 val zioConfigVersion          = "3.0.7"
 val zqueryVersion             = "0.4.0"
 val zioJsonVersion            = "0.4.2"
-<<<<<<< HEAD
 val zioHttpVersion            = "0.0.4"
-val zioOpenTelemetryVersion   = "3.0.0-RC4"
-=======
-val zioHttpVersion            = "2.0.0-RC10"
 val zioOpenTelemetryVersion   = "3.0.0-RC5"
->>>>>>> 9d1ee721 (bump deps)
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,13 @@ val zioInteropReactiveVersion = "2.0.1"
 val zioConfigVersion          = "3.0.7"
 val zqueryVersion             = "0.4.0"
 val zioJsonVersion            = "0.4.2"
+<<<<<<< HEAD
 val zioHttpVersion            = "0.0.4"
 val zioOpenTelemetryVersion   = "3.0.0-RC4"
+=======
+val zioHttpVersion            = "2.0.0-RC10"
+val zioOpenTelemetryVersion   = "3.0.0-RC5"
+>>>>>>> 9d1ee721 (bump deps)
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -178,6 +178,32 @@ lazy val tools = project
   )
   .dependsOn(core, clientJVM)
 
+lazy val tracing = project
+  .in(file("tracing"))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(name := "caliban-tracing")
+  .settings(commonSettings)
+  .settings(
+    scalaVersion := scala213,
+    crossScalaVersions -= scala212, // zio-telemetry is only published for 2.13 and 3.x
+    buildInfoKeys    := Seq[BuildInfoKey](
+      "scalaPartialVersion" -> CrossVersion.partialVersion(scalaVersion.value),
+      "scalafmtVersion"     -> scalafmtVersion
+    ),
+    buildInfoPackage := "caliban.tracing",
+    buildInfoObject  := "BuildInfo"
+  )
+  .settings(
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
+    libraryDependencies ++= Seq(
+      "dev.zio"         %% "zio-opentelemetry"         % "3.0.0-RC2",
+      "dev.zio"         %% "zio-test"                  % zioVersion % Test,
+      "dev.zio"         %% "zio-test-sbt"              % zioVersion % Test,
+      "io.opentelemetry" % "opentelemetry-sdk-testing" % "1.23.0"   % Test
+    )
+  )
+  .dependsOn(core, tools)
+
 lazy val codegenSbt = project
   .in(file("codegen-sbt"))
   .settings(name := "caliban-codegen-sbt")

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ val zioConfigVersion          = "3.0.7"
 val zqueryVersion             = "0.4.0"
 val zioJsonVersion            = "0.4.2"
 val zioHttpVersion            = "0.0.4"
+val zioOpenTelemetryVersion   = "3.0.0-RC4"
 
 inThisBuild(
   List(
@@ -190,7 +191,7 @@ lazy val tracing = project
   .settings(
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
-      "dev.zio"         %% "zio-opentelemetry"         % "3.0.0-RC3",
+      "dev.zio"         %% "zio-opentelemetry"         % zioOpenTelemetryVersion,
       "dev.zio"         %% "zio-test"                  % zioVersion % Test,
       "dev.zio"         %% "zio-test-sbt"              % zioVersion % Test,
       "io.opentelemetry" % "opentelemetry-sdk-testing" % "1.23.0"   % Test

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -201,7 +201,7 @@ object Executor {
   }
 
   private def fieldInfo(field: Field, path: List[Either[String, Int]], fieldDirectives: List[Directive]): FieldInfo =
-    FieldInfo(field.alias.getOrElse(field.name), field, path, fieldDirectives)
+    FieldInfo(field.alias.getOrElse(field.name), field, path, fieldDirectives, field.parentType)
 
   private def reduceList[R](list: List[ReducedStep[R]], areItemsNullable: Boolean): ReducedStep[R] =
     if (list.forall(_.isInstanceOf[PureStep]))

--- a/core/src/main/scala/caliban/execution/FieldInfo.scala
+++ b/core/src/main/scala/caliban/execution/FieldInfo.scala
@@ -1,10 +1,12 @@
 package caliban.execution
 
+import caliban.introspection.adt.__Type
 import caliban.parsing.adt.Directive
 
 case class FieldInfo(
   name: String,
   details: Field,
   path: List[Either[String, Int]],
-  directives: List[Directive] = Nil
+  directives: List[Directive] = Nil,
+  parent: Option[__Type]
 )

--- a/core/src/main/scala/caliban/wrappers/FieldMetrics.scala
+++ b/core/src/main/scala/caliban/wrappers/FieldMetrics.scala
@@ -1,0 +1,90 @@
+package caliban.wrappers
+
+import caliban.CalibanError
+import caliban.ResponseValue
+import caliban.execution.FieldInfo
+import zio._
+import zio.metrics.Metric
+import zio.query.ZQuery
+import zio.metrics.MetricKeyType.Histogram
+import zio.metrics.MetricLabel
+
+object FieldMetrics {
+  private[caliban] val defaultBuckets = Histogram.Boundaries(
+    Chunk(
+      .005d, .01d, .025d, .05d, .075d, .1d, .25d, .5d, .75d, 1d, 2.5d, 5d, 7.5d, 10d
+    )
+  )
+
+  type Timing = (String, Long)
+  private def fieldDuration(name: String, field: String, buckets: Histogram.Boundaries) =
+    Metric.histogram(name, buckets).tagged("field", field)
+
+  private def fieldTotal(name: String, field: String) =
+    Metric.counter(name).tagged("field", field)
+
+  def wrapper(
+    totalLabel: String = "graphql_fields_total",
+    durationLabel: String = "graphql_fields_duration_seconds",
+    buckets: Histogram.Boundaries = defaultBuckets,
+    extraLabels: Set[MetricLabel] = Set.empty
+  ): Wrapper.EffectfulWrapper[Any] =
+    Wrapper.EffectfulWrapper(
+      for {
+        ref <- Ref.make(List.empty[Timing])
+      } yield fieldDuration(totalLabel, durationLabel, ref, buckets, extraLabels)
+    )
+
+  private def fieldDuration(
+    totalLabel: String,
+    durationLabel: String,
+    ref: Ref[List[Timing]],
+    buckets: Histogram.Boundaries,
+    extraLabels: Set[MetricLabel]
+  ): Wrapper.FieldWrapper[Any] =
+    new Wrapper.FieldWrapper[Any] {
+      override def wrap[R](
+        query: ZQuery[R, CalibanError.ExecutionError, ResponseValue],
+        info: FieldInfo
+      ): ZQuery[R, CalibanError.ExecutionError, ResponseValue] =
+        for {
+          summarized            <-
+            query
+              .ensuring(ZQuery.fromZIO(fieldTotal(totalLabel, fieldName(info)).tagged(extraLabels).increment))
+              .summarized(Clock.nanoTime)((_, _))
+          ((start, end), result) = summarized
+          measure               <- ZQuery.fromZIO(for {
+                                     currentPath <- ZIO.succeed(toPath(info))
+                                     popped      <- ref.modify { state =>
+                                                      val (popped, rest) = state.partition { case (path, _) =>
+                                                        path.startsWith(currentPath)
+                                                      }
+                                                      (popped, rest)
+                                                    }
+                                     offset       = if (popped.isEmpty) ("", 0L)
+                                                    else popped.maxBy { case (_, duration) => duration }
+                                     duration     = end - start - offset._2
+                                     _           <- ref.update(current => (currentPath, duration + offset._2) :: current)
+                                   } yield duration / 1e9)
+          _                     <-
+            ZQuery.fromZIO(fieldDuration(durationLabel, fieldName(info), buckets).tagged(extraLabels).update(measure))
+        } yield result
+    }
+
+  private def fieldName(fieldInfo: FieldInfo): String = {
+    val parent = fieldInfo.parent.flatMap(_.name).getOrElse("Unknown")
+    s"$parent.${fieldInfo.details.name}"
+  }
+
+  private def toPath(info: FieldInfo) =
+    (Left(info.name) :: info.path).foldRight("") { case (part, acc) =>
+      val withDot =
+        if (acc == "") acc
+        else s"$acc."
+
+      withDot + (part match {
+        case Left(value) => value
+        case Right(i)    => i.toString
+      })
+    }
+}

--- a/core/src/main/scala/caliban/wrappers/FieldMetrics.scala
+++ b/core/src/main/scala/caliban/wrappers/FieldMetrics.scala
@@ -50,7 +50,7 @@ object FieldMetrics {
         for {
           summarized            <-
             query
-              .ensuring(ZQuery.fromZIO(fieldTotal(totalLabel, fieldName(info)).tagged(extraLabels).increment))
+              .ensuring(fieldTotal(totalLabel, fieldName(info)).tagged(extraLabels).increment)
               .summarized(Clock.nanoTime)((_, _))
           ((start, end), result) = summarized
           measure               <- ZQuery.fromZIO(for {

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -45,6 +45,17 @@ object Wrappers {
     onSlowQueries(duration) { case (time, query) => printLine(s"Slow query took ${time.render}:\n$query").orDie }
 
   /**
+   * Returns a wrapper that logs slow queries
+   * @param duration threshold above which queries are considered slow
+   */
+  def logSlowQueries(duration: Duration): OverallWrapper[Any] =
+    onSlowQueries(duration) { case (time, query) =>
+      ZIO.logAnnotate("query", query) {
+        ZIO.logWarning(s"Slow query took ${time.render}:\n$query")
+      }
+    }
+
+  /**
    * Returns a wrapper that runs a given function in case of slow queries
    * @param duration threshold above which queries are considered slow
    */

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -53,7 +53,7 @@ object Wrappers {
   def logSlowQueries(duration: Duration): OverallWrapper[Any] =
     onSlowQueries(duration) { case (time, query) =>
       ZIO.logAnnotate("query", query) {
-        ZIO.logWarning(s"Slow query took ${time.render}:\n$query")
+        ZIO.logWarning(s"Slow query took ${time.render}")
       }
     }
 

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -9,6 +9,8 @@ import caliban.wrappers.Wrapper.{ OverallWrapper, ValidationWrapper }
 import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse }
 import zio._
 import zio.Console.{ printLine, printLineError }
+import zio.metrics.MetricKeyType.Histogram
+import zio.metrics.MetricLabel
 
 import scala.annotation.tailrec
 
@@ -148,6 +150,22 @@ object Wrappers {
             }
           }
     }
+
+  /**
+   * Returns a wrapper that adds field metrics to the query
+   *
+   * @param totalLabel the name of the total fields metric
+   * @param durationLabel the name of the duration metric
+   * @param buckets the buckets to use for the duration metric
+   * @param extraLabels extra labels to add to the metrics
+   */
+  def metrics(
+    totalLabel: String = "graphql_fields_total",
+    durationLabel: String = "graphql_fields_duration_seconds",
+    buckets: Histogram.Boundaries = FieldMetrics.defaultBuckets,
+    extraLabels: Set[MetricLabel] = Set.empty
+  ): Wrapper.EffectfulWrapper[Any] =
+    FieldMetrics.wrapper(totalLabel, durationLabel, buckets, extraLabels)
 
   private def countFields(field: Field): UIO[Int] =
     innerFields(field.fields)

--- a/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
@@ -18,7 +18,7 @@ object FieldMetricsSpec extends ZIOSpecDefault {
   case class Person(
     name: NameArgs => ZIO[Any, Nothing, String],
     age: ZIO[Any, Nothing, Int],
-    friends: ZIO[Any, Nothing, List[Person]] = ZIO.succeed(List(Person("Bob"), Person("Alice"), Person("Joe")))
+    friends: ZIO[Any, Nothing, List[Friend]] = ZIO.succeed(List(Friend("Bob"), Friend("Alice"), Friend("Joe")))
   )
   object Person {
     def apply(name: String): Person = new Person(
@@ -26,7 +26,21 @@ object FieldMetricsSpec extends ZIOSpecDefault {
       age = (Random.nextIntBetween(0, 100) zip Random.nextIntBetween(0, 500)).flatMap { case (i, d) =>
         ZIO.succeed(i).delay(d.milliseconds)
       },
-      friends = randomSleep.as(List(Person("Joe"), Person("Bob"), Person("Alice")))
+      friends = randomSleep.as(List(Friend("Joe"), Friend("Bob"), Friend("Alice")))
+    )
+  }
+
+  case class Friend(
+    name: NameArgs => ZIO[Any, Nothing, String],
+    age: ZIO[Any, Nothing, Int]
+  )
+
+  object Friend {
+    def apply(name: String): Friend = new Friend(
+      name = (args: NameArgs) => ZIO.sleep(args.delay.milliseconds).as(name),
+      age = (Random.nextIntBetween(0, 100) zip Random.nextIntBetween(0, 500)).flatMap { case (i, d) =>
+        ZIO.succeed(i).delay(d.milliseconds)
+      }
     )
   }
 
@@ -64,10 +78,12 @@ object FieldMetricsSpec extends ZIOSpecDefault {
         res         <- fiber.join
         root        <- metric.tagged("field", "Queries.person").value
         name        <- metric.tagged("field", "Person.name").value
+        friendsName <- metric.tagged("field", "Friend.name").value
       } yield assertTrue(res.errors == List.empty) &&
         assertTrue(getCountForDuration(root, 0.5) == 1) &&
         assertTrue(getCountForDuration(name, 0.1) == 1) && // top-level name
-        assertTrue(getCountForDuration(name, 0.5) == 4) // top level + three friends
+        assertTrue(getCountForDuration(name, 0.5) == 1) &&     // top level
+        assertTrue(getCountForDuration(friendsName, 0.5) == 3) // three friends
     }
   )
 }

--- a/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
@@ -18,7 +18,7 @@ object FieldMetricsSpec extends ZIOSpecDefault {
   case class Person(
     name: NameArgs => ZIO[Any, Nothing, String],
     age: ZIO[Any, Nothing, Int],
-    friends: ZIO[Any, Nothing, List[Friend]] = ZIO.succeed(List(Friend("Bob"), Friend("Alice"), Friend("Joe")))
+    friends: ZIO[Any, Nothing, List[Friend]]
   )
   object Person {
     def apply(name: String): Person = new Person(

--- a/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
@@ -4,6 +4,8 @@ import caliban.GraphQL.graphQL
 import caliban.Macros.gqldoc
 import caliban.RootResolver
 import caliban.schema.Annotations.GQLDefault
+import caliban.schema.ArgBuilder.auto._
+import caliban.schema.Schema.auto._
 import zio._
 import zio.metrics.Metric
 import zio.metrics.{ Metric, MetricLabel, MetricState }

--- a/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
@@ -1,0 +1,73 @@
+package caliban.wrappers
+
+import caliban.GraphQL.graphQL
+import caliban.Macros.gqldoc
+import caliban.RootResolver
+import caliban.schema.Annotations.GQLDefault
+import zio._
+import zio.metrics.Metric
+import zio.metrics.{ Metric, MetricLabel, MetricState }
+import zio.test._
+
+object FieldMetricsSpec extends ZIOSpecDefault {
+  val randomSleep: ZIO[Any, Nothing, Unit] = Random.nextIntBetween(0, 500).flatMap(t => ZIO.sleep(t.millis))
+  val buckets                              = FieldMetrics.defaultBuckets
+
+  case class PersonArgs(name: String)
+  case class NameArgs(@GQLDefault("500") delay: Int)
+  case class Person(
+    name: NameArgs => ZIO[Any, Nothing, String],
+    age: ZIO[Any, Nothing, Int],
+    friends: ZIO[Any, Nothing, List[Person]] = ZIO.succeed(List(Person("Bob"), Person("Alice"), Person("Joe")))
+  )
+  object Person {
+    def apply(name: String): Person = new Person(
+      name = (args: NameArgs) => ZIO.sleep(args.delay.milliseconds).as(name),
+      age = (Random.nextIntBetween(0, 100) zip Random.nextIntBetween(0, 500)).flatMap { case (i, d) =>
+        ZIO.succeed(i).delay(d.milliseconds)
+      },
+      friends = randomSleep.as(List(Person("Joe"), Person("Bob"), Person("Alice")))
+    )
+  }
+
+  case class Queries(
+    person: PersonArgs => ZIO[Any, Nothing, Person] = args => randomSleep *> ZIO.succeed(Person(args.name))
+  )
+
+  val api = graphQL(
+    RootResolver(
+      Queries()
+    )
+  )
+
+  def getCountForDuration(value: MetricState.Histogram, duration: Double) =
+    value.buckets.find(_._1 == duration).map(_._2.toInt).get
+
+  def spec: Spec[TestEnvironment with Scope, Any] = suite("FieldMetricsSpec")(
+    test("measures the duration of a field correctly") {
+      val metric =
+        Metric.histogram("graphql_fields_duration_seconds", buckets).tagged("test", "success")
+      val query  = gqldoc("""{
+            person(name: "Carol") {
+                name(delay: 100)
+                age
+                friends {
+                    name
+                    age
+                }
+            }
+        }""")
+      for {
+        interpreter <- (api @@ Wrappers.metrics(extraLabels = Set(MetricLabel("test", "success")))).interpreter
+        fiber       <- interpreter.execute(query).fork
+        _           <- TestClock.adjust(30.seconds)
+        res         <- fiber.join
+        root        <- metric.tagged("field", "Queries.person").value
+        name        <- metric.tagged("field", "Person.name").value
+      } yield assertTrue(res.errors == List.empty) &&
+        assertTrue(getCountForDuration(root, 0.5) == 1) &&
+        assertTrue(getCountForDuration(name, 0.1) == 1) && // top-level name
+        assertTrue(getCountForDuration(name, 0.5) == 4) // top level + three friends
+    }
+  )
+}

--- a/tracing/src/main/scala/caliban/tracing/FieldTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/FieldTracer.scala
@@ -3,12 +3,12 @@ package caliban.tracing
 import caliban.CalibanError
 import caliban.ResponseValue
 import caliban.execution.FieldInfo
+import io.opentelemetry.api.trace.StatusCode
 import caliban.wrappers.Wrapper.FieldWrapper
 import zio._
-import zio.query.DataSourceAspect
-import zio.query.ZQuery
+import zio.query.{ QueryAspect, ZQuery }
 import zio.query._
-import zio.telemetry.opentelemetry.tracing.Tracing
+import zio.telemetry.opentelemetry.tracing.{ ErrorMapper, Tracing }
 
 object FieldTracer {
   val wrapper = new FieldWrapper[Tracing] {
@@ -16,18 +16,16 @@ object FieldTracer {
       query: ZQuery[R, CalibanError.ExecutionError, ResponseValue],
       info: FieldInfo
     ): ZQuery[R, CalibanError.ExecutionError, ResponseValue] =
-      query @@ traced(info.name)
-  }
-
-  private def traced[R <: Tracing](name: String) = new DataSourceAspect[R] {
-    def apply[R1 <: R, A](dataSource: DataSource[R1, A]): DataSource[R1, A] =
-      new DataSource[R1, A] {
-        val identifier = s"${dataSource.identifier} @@ traced"
-
-        def runAll(requests: Chunk[Chunk[A]])(implicit trace: zio.Trace): ZIO[R1, Nothing, CompletedRequestMap] =
-          ZIO.serviceWithZIO[Tracing](
-            _.span(name)(dataSource.runAll(requests))
-          )
+      ZQuery.acquireReleaseWith(
+        ZIO.serviceWithZIO[Tracing](_.spanUnsafe(info.name))
+      ) { case (span, end) => end } { case (span, _) =>
+        query.foldCauseQuery(
+          cause => {
+            val status = cause.failureOption.flatMap(ErrorMapper.default.body.lift).getOrElse(StatusCode.ERROR)
+            ZQuery.fromZIO(ZIO.succeed(span.setStatus(status, cause.prettyPrint))) *> ZQuery.failCause(cause)
+          },
+          value => ZQuery.succeed(value)
+        )
       }
   }
 }

--- a/tracing/src/main/scala/caliban/tracing/FieldTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/FieldTracer.scala
@@ -1,0 +1,33 @@
+package caliban.tracing
+
+import caliban.CalibanError
+import caliban.ResponseValue
+import caliban.execution.FieldInfo
+import caliban.wrappers.Wrapper.FieldWrapper
+import zio._
+import zio.query.DataSourceAspect
+import zio.query.ZQuery
+import zio.query._
+import zio.telemetry.opentelemetry.tracing.Tracing
+
+object FieldTracer {
+  val wrapper = new FieldWrapper[Tracing] {
+    def wrap[R <: Tracing](
+      query: ZQuery[R, CalibanError.ExecutionError, ResponseValue],
+      info: FieldInfo
+    ): ZQuery[R, CalibanError.ExecutionError, ResponseValue] =
+      query @@ traced(info.name)
+  }
+
+  private def traced[R <: Tracing](name: String) = new DataSourceAspect[R] {
+    def apply[R1 <: R, A](dataSource: DataSource[R1, A]): DataSource[R1, A] =
+      new DataSource[R1, A] {
+        val identifier = s"${dataSource.identifier} @@ traced"
+
+        def runAll(requests: Chunk[Chunk[A]])(implicit trace: zio.Trace): ZIO[R1, Nothing, CompletedRequestMap] =
+          ZIO.serviceWithZIO[Tracing](
+            _.span(name)(dataSource.runAll(requests))
+          )
+      }
+  }
+}

--- a/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
@@ -50,17 +50,16 @@ object SchemaTracer {
     RemoteQuery.apply(maskField(field)).toGraphQLRequest.query.getOrElse("")
 
   private def maskArguments(args: Map[String, InputValue]): Map[String, InputValue] =
-    args.view
-      .mapValues(v =>
-        v match {
-          case _: ObjectValue      => ObjectValue(Map.empty)
-          case _: StringValue      => StringValue("")
-          case _: Value.IntValue   => IntNumber(0)
-          case _: Value.FloatValue => FloatNumber(0f)
-          case x                   => x
-        }
-      )
-      .toMap
+    args.map { case (k, v) =>
+      val v1 = v match {
+        case _: ObjectValue      => ObjectValue(Map.empty)
+        case _: StringValue      => StringValue("")
+        case _: Value.IntValue   => IntNumber(0)
+        case _: Value.FloatValue => FloatNumber(0f)
+        case x                   => x
+      }
+      (k, v1)
+    }.toMap
 
   private def maskField(f: Field): Field =
     f.copy(

--- a/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
@@ -1,0 +1,70 @@
+package caliban.tracing
+
+import caliban.CalibanError
+import caliban.GraphQLResponse
+import caliban.InputValue
+import caliban.InputValue.ObjectValue
+import caliban.Value
+import caliban.Value.FloatValue.FloatNumber
+import caliban.Value.IntValue.IntNumber
+import caliban.Value.StringValue
+import caliban.execution.ExecutionRequest
+import caliban.execution.Field
+import caliban.tools.stitching.RemoteQuery
+import caliban.wrappers.Wrapper.ExecutionWrapper
+import io.opentelemetry.api.trace.SpanKind
+import zio.telemetry.opentelemetry.tracing.ErrorMapper
+import zio.telemetry.opentelemetry.tracing.Tracing
+import zio._
+
+object SchemaTracer {
+  val wrapper = new ExecutionWrapper[Tracing] {
+    def wrap[R <: Tracing](
+      f: ExecutionRequest => ZIO[R, Nothing, GraphQLResponse[CalibanError]]
+    ): ExecutionRequest => ZIO[R, Nothing, GraphQLResponse[CalibanError]] =
+      request => {
+        val parentField = request.field.fields.head.name
+
+        // skip introspection queries
+        if (parentField == "__schema") f(request)
+        else
+          ZIO.serviceWithZIO[Tracing](tracer =>
+            tracer.span[R, Nothing, GraphQLResponse[CalibanError]](
+              "query",
+              SpanKind.INTERNAL,
+              ErrorMapper.default
+            ) {
+              ZIO.foreach(attributes(request.field)) { case (k, v) =>
+                tracer.setAttribute(k, v)
+              } *> f(request)
+            }
+          )
+      }
+  }
+
+  private def attributes[T, R](
+    field: Field
+  ) = List("query" -> graphQLQuery(field))
+
+  private def graphQLQuery(field: Field): String =
+    RemoteQuery.apply(maskField(field)).toGraphQLRequest.query.getOrElse("")
+
+  private def maskArguments(args: Map[String, InputValue]): Map[String, InputValue] =
+    args.view
+      .mapValues(v =>
+        v match {
+          case _: ObjectValue      => ObjectValue(Map.empty)
+          case _: StringValue      => StringValue("")
+          case _: Value.IntValue   => IntNumber(0)
+          case _: Value.FloatValue => FloatNumber(0f)
+          case x                   => x
+        }
+      )
+      .toMap
+
+  private def maskField(f: Field): Field =
+    f.copy(
+      arguments = maskArguments(f.arguments),
+      fields = f.fields.map(maskField)
+    )
+}

--- a/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
@@ -31,8 +31,7 @@ object SchemaTracer {
           ZIO.serviceWithZIO[Tracing](tracer =>
             tracer.span[R, Nothing, GraphQLResponse[CalibanError]](
               "query",
-              SpanKind.INTERNAL,
-              ErrorMapper.default
+              SpanKind.INTERNAL
             ) {
               ZIO.foreach(attributes(request.field)) { case (k, v) =>
                 tracer.setAttribute(k, v)

--- a/tracing/src/main/scala/caliban/tracing/TracingWrapper.scala
+++ b/tracing/src/main/scala/caliban/tracing/TracingWrapper.scala
@@ -1,0 +1,5 @@
+package caliban.tracing
+
+object TracingWrapper {
+  val traced = SchemaTracer.wrapper @@ FieldTracer.wrapper
+}

--- a/tracing/src/test/scala/caliban/tracing/MockTracer.scala
+++ b/tracing/src/test/scala/caliban/tracing/MockTracer.scala
@@ -1,0 +1,40 @@
+package caliban.tracing
+
+import caliban.GraphQL.graphQL
+import caliban.Macros.gqldoc
+import caliban.RootResolver
+import caliban.schema.Annotations.GQLDefault
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import zio._
+import zio.telemetry.opentelemetry.context.ContextStorage
+import zio.telemetry.opentelemetry.tracing.Tracing
+import zio.test._
+
+import scala.jdk.CollectionConverters._
+
+// Taken from zio-telemetry
+object TracingMock {
+  val inMemoryTracer: UIO[(InMemorySpanExporter, Tracer)] = for {
+    spanExporter   <- ZIO.succeed(InMemorySpanExporter.create())
+    spanProcessor  <- ZIO.succeed(SimpleSpanProcessor.create(spanExporter))
+    tracerProvider <- ZIO.succeed(SdkTracerProvider.builder().addSpanProcessor(spanProcessor).build())
+    tracer          = tracerProvider.get("TracingTest")
+  } yield (spanExporter, tracer)
+
+  val inMemoryTracerLayer: ULayer[InMemorySpanExporter with Tracer with ContextStorage] =
+    ZLayer.fromZIOEnvironment(inMemoryTracer.map { case (inMemorySpanExporter, tracer) =>
+      ZEnvironment(inMemorySpanExporter).add(tracer)
+    }) ++ ContextStorage.fiberRef
+
+  val layer: ULayer[Tracing with InMemorySpanExporter with Tracer] =
+    inMemoryTracerLayer >>> (Tracing.live ++ inMemoryTracerLayer)
+
+  def getFinishedSpans =
+    ZIO
+      .service[InMemorySpanExporter]
+      .map(_.getFinishedSpanItems.asScala.toList)
+}

--- a/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
+++ b/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
@@ -3,6 +3,8 @@ package caliban.tracing
 import caliban.GraphQL.graphQL
 import caliban.Macros.gqldoc
 import caliban.RootResolver
+import caliban.schema.ArgBuilder.auto._
+import caliban.schema.Schema.auto._
 import zio._
 import zio.query._
 import zio.test._

--- a/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
+++ b/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
@@ -26,7 +26,7 @@ object TracingWrapperSpec extends ZIOSpecDefault {
   case class Person(
     name: ZQuery[Any, Throwable, String],
     age: ZIO[Any, Nothing, Int],
-    friends: ZIO[Any, Nothing, List[Person]] = ZIO.succeed(List(Person("Bob"), Person("Alice"), Person("Joe")))
+    friends: ZIO[Any, Nothing, List[Friend]]
   )
   object Person {
     def apply(name: String): Person = new Person(
@@ -34,7 +34,20 @@ object TracingWrapperSpec extends ZIOSpecDefault {
       age = (Random.nextIntBetween(0, 100) zip Random.nextIntBetween(0, 500)).flatMap { case (i, d) =>
         ZIO.succeed(i).delay(d.milliseconds)
       },
-      friends = randomSleep.as(List(Person("Joe"), Person("Bob"), Person("Alice")))
+      friends = randomSleep.as(List(Friend("Joe"), Friend("Bob"), Friend("Alice")))
+    )
+  }
+
+  case class Friend(
+    name: ZQuery[Any, Throwable, String],
+    age: ZIO[Any, Nothing, Int]
+  )
+  object Friend {
+    def apply(name: String): Friend = new Friend(
+      name = ZQuery.fromZIO(randomSleep) *> ZQuery.fromRequest(GetName(name))(NamesDatasource),
+      age = (Random.nextIntBetween(0, 100) zip Random.nextIntBetween(0, 500)).flatMap { case (i, d) =>
+        ZIO.succeed(i).delay(d.milliseconds)
+      }
     )
   }
 

--- a/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
+++ b/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
@@ -1,0 +1,76 @@
+package caliban.tracing
+
+import caliban.GraphQL.graphQL
+import caliban.Macros.gqldoc
+import caliban.RootResolver
+import zio._
+import zio.query._
+import zio.test._
+
+import Assertion._
+
+object TracingWrapperSpec extends ZIOSpecDefault {
+  val randomSleep: ZIO[Any, Nothing, Unit] = Random.nextIntBetween(0, 500).flatMap(t => ZIO.sleep(t.millis))
+
+  final case class GetName(name: String) extends Request[Throwable, String]
+
+  val NamesDatasource = new DataSource.Batched[Any, GetName] {
+    override val identifier: String                                                                               = "NamesDatasource"
+    override def run(requests: Chunk[GetName])(implicit trace: zio.Trace): ZIO[Any, Nothing, CompletedRequestMap] =
+      ZIO.succeed(requests.foldLeft(CompletedRequestMap.empty) { case (map, req) =>
+        map.insert(req)(Right(req.name))
+      })
+  }
+
+  case class PersonArgs(name: String)
+  case class Person(
+    name: ZQuery[Any, Throwable, String],
+    age: ZIO[Any, Nothing, Int],
+    friends: ZIO[Any, Nothing, List[Person]] = ZIO.succeed(List(Person("Bob"), Person("Alice"), Person("Joe")))
+  )
+  object Person {
+    def apply(name: String): Person = new Person(
+      name = ZQuery.fromZIO(randomSleep) *> ZQuery.fromRequest(GetName(name))(NamesDatasource),
+      age = (Random.nextIntBetween(0, 100) zip Random.nextIntBetween(0, 500)).flatMap { case (i, d) =>
+        ZIO.succeed(i).delay(d.milliseconds)
+      },
+      friends = randomSleep.as(List(Person("Joe"), Person("Bob"), Person("Alice")))
+    )
+  }
+
+  case class Queries(
+    person: PersonArgs => ZIO[Any, Nothing, Person] = args => randomSleep *> ZIO.succeed(Person(args.name))
+  )
+
+  val api = graphQL(
+    RootResolver(
+      Queries()
+    )
+  ) @@ TracingWrapper.traced
+
+  def spec = suite("TracingWrapperSpec")(
+    test("traces the batched steps") {
+      val query = gqldoc("""{
+            person(name: "Carol") {
+                name
+                age
+                friends {
+                    name
+                    age
+                }
+            }
+        }""")
+      for {
+        interpreter <- api.interpreter
+        fiber       <- interpreter.execute(query).fork
+        _           <- TestClock.adjust(30.seconds)
+        res         <- fiber.join
+        spans       <- TracingMock.getFinishedSpans.map(_.map(_.getName()))
+      } yield assertTrue(res.errors.isEmpty) &&
+        // only two names since we're only measuring the batched calls
+        assert(spans)(hasSameElements(List("name", "name", "person", "friends", "person", "query")))
+    }.provide(
+      TracingMock.layer
+    )
+  )
+}

--- a/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
+++ b/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
@@ -80,8 +80,7 @@ object TracingWrapperSpec extends ZIOSpecDefault {
         res         <- fiber.join
         spans       <- TracingMock.getFinishedSpans.map(_.map(_.getName()))
       } yield assertTrue(res.errors.isEmpty) &&
-        // only two names since we're only measuring the batched calls
-        assert(spans)(hasSameElements(List("name", "name", "person", "friends", "person", "query")))
+        assertTrue(spans == List("age", "age", "age", "age", "name", "friends", "person", "query"))
     }.provide(
       TracingMock.layer
     )

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -249,3 +249,18 @@ import zio.telemetry.opentelemetry.Tracing
 val api: GraphQL[Any] = ???
 val tracedApi = api @@ TracingWrapper.traced
 ```
+
+This will now make sure that any effect (ZIO or ZQuery) is measured as its own span, which makes it easy to spot potential optimizations (such as sequential loading) in your schema.
+
+More or less like this:
+
+```
+query         |----------------------------------------------|
+field a         |-------|
+field b                  |-------|
+nested field                      |-----------------------|
+nested field a                      |-------------------|
+nested field b                      |-------------------|
+```
+
+which makes it easy to spot that e.g field a and field b could be resolved in parallel.

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -67,7 +67,9 @@ Caliban comes with a few pre-made wrappers in `caliban.wrappers.Wrappers`:
 - `timeout` returns a wrapper that fails queries taking more than a specified time
 - `printErrors` returns a wrapper that prints errors
 - `printSlowQueries` returns a wrapper that prints slow queries
+- `logSlowQueries` returns a wrapper that logs slow queries via ZIO's built-in logging
 - `onSlowQueries` returns a wrapper that can run a given function on slow queries
+- `metrics` returns a wrapper that adds field-level metrics (count & duration) to the schema
 
 In addition to those, Caliban also ships with some non-spec but standard wrappers
 - `caliban.wrappers.ApolloTracing.apolloTracing` returns a wrapper that adds tracing data into the `extensions` field of each response following [Apollo Tracing](https://github.com/apollographql/apollo-tracing) format.
@@ -227,3 +229,23 @@ to fields. In this case the field resolver will override the type cost, however 
 We may also specify a "multipliers" argument when using arguments. This will match the argument names and use numeric argument values to multiply the base value.
 In the above case this means that a query that specifies a `limit` of `10` for the `spokenLines` field will have the base field cost multipled by 10 resulting in a total cost
 of execution of `1000`
+
+## OpenTelemetry Tracing
+
+Caliban ships with support for OpenTelemtry tracing via integration with [zio-telemetry](https://github.com/zio/zio-telemetry) via the `caliban-tracing` package.
+
+In order to use tracing, first add `caliban-tracing` to your `built.sbt`.
+
+```scala
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-tracing" % "2.0.2"
+```
+
+Then add it to your schema as any other wrapper:
+
+```scala
+import caliban.tracing.TracingWrapper
+import zio.telemetry.opentelemetry.Tracing
+
+val api: GraphQL[Any] = ???
+val tracedApi = api @@ TracingWrapper.traced
+```

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -232,7 +232,7 @@ of execution of `1000`
 
 ## OpenTelemetry Tracing
 
-Caliban ships with support for OpenTelemtry tracing via integration with [zio-telemetry](https://github.com/zio/zio-telemetry) via the `caliban-tracing` package.
+Caliban ships with support for OpenTelemetry tracing via integration with [zio-telemetry](https://github.com/zio/zio-telemetry) in the `caliban-tracing` package.
 
 In order to use tracing, first add `caliban-tracing` to your `built.sbt`.
 


### PR DESCRIPTION
Hey!

This adds some wrappers for improving the observability of Caliban APIs.

There's a metrics middleware that both measures the duration of fields as well as the total execution count for a field, handy for e.g specifying SLOs per field (such as successsful fields resolving faster than 500ms / all fields). In order to get any sort of sane names for these metrics I had to add the parent type to `FieldInfo` (which can probably be useful in other situations as well).

It also adds `caliban-tracing` which contains integration with zio-telemetry. It's a bit finicky at the moment because it only works if your resolvers actually uses batching via DataSources, but @adamgfraser would look into adding a more general `QueryAspect` which would make it possible to do for all requests.