### PR TITLE
initial repeatable directives support

### DIFF
--- a/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala-2/caliban/parsing/parsers/Parsers.scala
@@ -305,9 +305,15 @@ private[caliban] object Parsers extends SelectionParsers {
 
   def directiveDefinition(implicit ev: P[Any]): P[DirectiveDefinition] =
     P(
-      stringValue.? ~ "directive @" ~/ name ~ argumentDefinitions.? ~ "on" ~ ("|".? ~ directiveLocation) ~ ("|" ~ directiveLocation).rep
-    ).map { case (description, name, args, firstLoc, otherLoc) =>
-      DirectiveDefinition(description.map(_.value), name, args.getOrElse(Nil), otherLoc.toSet + firstLoc)
+      stringValue.? ~ "directive @" ~/ name ~ argumentDefinitions.? ~ "repeatable".!.? ~ "on" ~ ("|".? ~ directiveLocation) ~ ("|" ~ directiveLocation).rep
+    ).map { case (description, name, args, repeatable, firstLoc, otherLoc) =>
+      DirectiveDefinition(
+        description.map(_.value),
+        name,
+        args.getOrElse(Nil),
+        repeatable.isDefined,
+        otherLoc.toSet + firstLoc
+      )
     }
 
   def typeDefinition(implicit ev: P[Any]): P[TypeDefinition] =

--- a/core/src/main/scala-3/caliban/parsing/Parser.scala
+++ b/core/src/main/scala-3/caliban/parsing/Parser.scala
@@ -531,11 +531,18 @@ object Parser {
   private val directiveDefinition: P[DirectiveDefinition] =
     ((stringValue <* whitespaceWithComment).?.with1 ~
       (P.string("directive @") *> name <* whitespaceWithComment) ~
-      ((argumentDefinitions <* whitespaceWithComment).? <* P.string("on") <* whitespaceWithComment1) ~
+      (argumentDefinitions <* whitespaceWithComment).? ~
+      ((P.string("repeatable") <* whitespaceWithComment).? <* P.string("on") <* whitespaceWithComment1) ~
       ((P.char('|') <* whitespaceWithComment).? *> directiveLocation <* whitespaceWithComment) ~
       (P.char('|') *> whitespaceWithComment *> directiveLocation).repSep0(whitespaceWithComment)).map {
-      case ((((description, name), args), firstLoc), otherLoc) =>
-        DirectiveDefinition(description.map(_.value), name, args.getOrElse(Nil), otherLoc.toList.toSet + firstLoc)
+      case (((((description, name), args), repeatable), firstLoc), otherLoc) =>
+        DirectiveDefinition(
+          description.map(_.value),
+          name,
+          args.getOrElse(Nil),
+          repeatable.isDefined,
+          otherLoc.toList.toSet + firstLoc
+        )
     }
 
   private val typeDefinition: P[TypeDefinition] =

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -124,7 +124,10 @@ object Rendering {
     }
     val directiveLocations = locationStrings.mkString(" | ")
 
-    val body = s"""directive @${directive.name}${inputs} on ${directiveLocations}""".stripMargin
+    val on = if (directive.repeatable) { "repeatable on" }
+    else { "on" }
+
+    val body = s"""directive @${directive.name}${inputs} ${on} ${directiveLocations}""".stripMargin
 
     renderDescription(directive.description) match {
       case ""        => body

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -21,7 +21,8 @@ object Introspector extends IntrospectionDerivation {
         "The @skip directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument."
       ),
       Set(__DirectiveLocation.FIELD, __DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
-      List(__InputValue("if", None, () => Types.boolean.nonNull, None))
+      List(__InputValue("if", None, () => Types.boolean.nonNull, None)),
+      repeatable = false
     ),
     __Directive(
       "include",
@@ -29,7 +30,8 @@ object Introspector extends IntrospectionDerivation {
         "The @include directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument."
       ),
       Set(__DirectiveLocation.FIELD, __DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
-      List(__InputValue("if", None, () => Types.boolean.nonNull, None))
+      List(__InputValue("if", None, () => Types.boolean.nonNull, None)),
+      repeatable = false
     ),
     __Directive(
       "specifiedBy",
@@ -37,7 +39,8 @@ object Introspector extends IntrospectionDerivation {
         "The @specifiedBy directive is used within the type system definition language to provide a URL for specifying the behavior of custom scalar types. The URL should point to a human-readable specification of the data format, serialization, and coercion rules. It must not appear on built-in scalar types."
       ),
       Set(__DirectiveLocation.SCALAR),
-      List(__InputValue("url", None, () => Types.string.nonNull, None))
+      List(__InputValue("url", None, () => Types.string.nonNull, None)),
+      repeatable = false
     )
   )
 

--- a/core/src/main/scala/caliban/introspection/adt/__Directive.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Directive.scala
@@ -6,8 +6,15 @@ case class __Directive(
   name: String,
   description: Option[String],
   locations: Set[__DirectiveLocation],
-  args: List[__InputValue]
+  args: List[__InputValue],
+  repeatable: Boolean
 ) {
   def toDirectiveDefinition: DirectiveDefinition =
-    DirectiveDefinition(description, name, args.map(_.toInputValueDefinition), locations.map(_.toDirectiveLocation))
+    DirectiveDefinition(
+      description,
+      name,
+      args.map(_.toInputValueDefinition),
+      repeatable,
+      locations.map(_.toDirectiveLocation)
+    )
 }

--- a/core/src/main/scala/caliban/parsing/adt/Definition.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Definition.scala
@@ -43,6 +43,7 @@ object Definition {
       description: Option[String],
       name: String,
       args: List[InputValueDefinition],
+      repeatable: Boolean,
       locations: Set[DirectiveLocation]
     ) extends TypeSystemDefinition
 

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -9,7 +9,75 @@ import zio.test._
 
 object RenderingSpec extends ZIOSpecDefault {
 
-  val tripleQuote = "\"\"\""
+  val tripleQuote                              = "\"\"\""
+  private val expectedDirectiveRenderingResult =
+    """"Test directive"
+      |directive @test(foo: Int) on FIELD_DEFINITION
+      |"Repeatable test directive"
+      |directive @repeatable(bar: Int) repeatable on FIELD_DEFINITION
+      |
+      |schema @link(url: "https://example.com", import: ["@key", {name: "@provides", as: "@self"}]) {
+      |  query: Query
+      |}
+      |
+      |"Description of custom scalar emphasizing proper captain ship names"
+      |scalar CaptainShipName @specifiedBy(url: "http://someUrl")
+      |
+      |union Role @uniondirective = Captain | Engineer | Mechanic | Pilot
+      |
+      |enum Origin @enumdirective {
+      |  BELT
+      |  EARTH
+      |  MARS
+      |  MOON @deprecated(reason: "Use: EARTH | MARS | BELT")
+      |}
+      |
+      |input CharacterInput @inputobjdirective {
+      |  name: String! @external
+      |  nicknames: [String!]! @required
+      |  origin: Origin!
+      |}
+      |
+      |interface Human {
+      |  name: String! @external
+      |}
+      |
+      |type Captain {
+      |  shipName: CaptainShipName!
+      |}
+      |
+      |type Character implements Human @key(name: "name") {
+      |  name: String! @external
+      |  nicknames: [String!]! @required
+      |  origin: Origin!
+      |  role: Role
+      |}
+      |
+      |type Engineer {
+      |  shipName: String!
+      |}
+      |
+      |type Mechanic {
+      |  shipName: String!
+      |}
+      |
+      |type Narrator implements Human {
+      |  name: String!
+      |}
+      |
+      |type Pilot {
+      |  shipName: String!
+      |}
+      |
+      |"Queries"
+      |type Query {
+      |  "Return all characters from a given origin"
+      |  characters(origin: Origin): [Character!]!
+      |  character(name: String!): Character @deprecated(reason: "Use `characters`")
+      |  charactersIn(names: [String!]!): [Character!]!
+      |  exists(character: CharacterInput!): Boolean!
+      |  human: Human!
+      |}"""
 
   override def spec =
     suite("rendering")(
@@ -17,76 +85,12 @@ object RenderingSpec extends ZIOSpecDefault {
         assert(
           graphQL(
             resolver,
-            directives = List(Directives.Test),
+            directives = List(Directives.Test, Directives.Repeatable),
             schemaDirectives = List(SchemaDirectives.Link)
           ).render.trim
         )(
           equalTo(
-            """"Test directive"
-              |directive @test(foo: Int) on FIELD_DEFINITION
-              |
-              |schema @link(url: "https://example.com", import: ["@key", {name: "@provides", as: "@self"}]) {
-              |  query: Query
-              |}
-              |
-              |"Description of custom scalar emphasizing proper captain ship names"
-              |scalar CaptainShipName @specifiedBy(url: "http://someUrl")
-              |
-              |union Role @uniondirective = Captain | Engineer | Mechanic | Pilot
-              |
-              |enum Origin @enumdirective {
-              |  BELT
-              |  EARTH
-              |  MARS
-              |  MOON @deprecated(reason: "Use: EARTH | MARS | BELT")
-              |}
-              |
-              |input CharacterInput @inputobjdirective {
-              |  name: String! @external
-              |  nicknames: [String!]! @required
-              |  origin: Origin!
-              |}
-              |
-              |interface Human {
-              |  name: String! @external
-              |}
-              |
-              |type Captain {
-              |  shipName: CaptainShipName!
-              |}
-              |
-              |type Character implements Human @key(name: "name") {
-              |  name: String! @external
-              |  nicknames: [String!]! @required
-              |  origin: Origin!
-              |  role: Role
-              |}
-              |
-              |type Engineer {
-              |  shipName: String!
-              |}
-              |
-              |type Mechanic {
-              |  shipName: String!
-              |}
-              |
-              |type Narrator implements Human {
-              |  name: String!
-              |}
-              |
-              |type Pilot {
-              |  shipName: String!
-              |}
-              |
-              |"Queries"
-              |type Query {
-              |  "Return all characters from a given origin"
-              |  characters(origin: Origin): [Character!]!
-              |  character(name: String!): Character @deprecated(reason: "Use `characters`")
-              |  charactersIn(names: [String!]!): [Character!]!
-              |  exists(character: CharacterInput!): Boolean!
-              |  human: Human!
-              |}""".stripMargin.trim
+            expectedDirectiveRenderingResult.stripMargin.trim
           )
         )
       },

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -168,7 +168,24 @@ object TestUtils {
           None,
           None
         )
-      )
+      ),
+      repeatable = false
+    )
+
+    val Repeatable = __Directive(
+      name = "repeatable",
+      description = Some("Repeatable test directive"),
+      locations = Set(__DirectiveLocation.FIELD_DEFINITION),
+      args = List(
+        __InputValue(
+          "bar",
+          None,
+          () => Types.int,
+          None,
+          None
+        )
+      ),
+      repeatable = true
     )
   }
 

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -1125,6 +1125,28 @@ object ParserSpec extends ZIOSpecDefault {
                   None,
                   "test",
                   List.empty,
+                  repeatable = false,
+                  Set(
+                    TypeSystemDefinition.DirectiveLocation.TypeSystemDirectiveLocation.FIELD_DEFINITION
+                  )
+                )
+              ),
+              sourceMapper = SourceMapper.apply(gqlInputExtension)
+            )
+          )
+        }
+      },
+      test("parse repeatable directives") {
+        val gqlInputExtension = "directive @test repeatable on FIELD_DEFINITION"
+        Parser.parseQuery(gqlInputExtension).map { doc =>
+          assertTrue(
+            doc == Document(
+              List(
+                DirectiveDefinition(
+                  None,
+                  "test",
+                  List.empty,
+                  repeatable = true,
                   Set(
                     TypeSystemDefinition.DirectiveLocation.TypeSystemDirectiveLocation.FIELD_DEFINITION
                   )

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -296,7 +296,7 @@ object ValidationSpec extends ZIOSpecDefault {
                  name @skip(if: true) @skip(if: true)
                }
              }""")
-        check(query, "Directive 'skip' is defined twice.")
+        check(query, "Directive 'skip' is defined more than once.")
       },
       test("variable types don't match") {
         val query = gqldoc("""

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -308,7 +308,8 @@ object WrappersSpec extends ZIOSpecDefault {
           Set(
             __DirectiveLocation.QUERY
           ),
-          Nil
+          Nil,
+          repeatable = false
         )
         val interpreter          = (graphQL(
           resolver,

--- a/federation/src/main/scala/caliban/federation/FederationV1.scala
+++ b/federation/src/main/scala/caliban/federation/FederationV1.scala
@@ -10,17 +10,37 @@ class FederationV1
           "external",
           Some("The @external directive is used to mark a field as owned by another service"),
           locations = Set(__DirectiveLocation.FIELD_DEFINITION),
-          args = Nil
+          args = Nil,
+          repeatable = false
         ),
-        __Directive("requires", None, locations = Set(__DirectiveLocation.FIELD_DEFINITION), args = _FieldSet :: Nil),
-        __Directive("provides", None, locations = Set(__DirectiveLocation.FIELD_DEFINITION), args = _FieldSet :: Nil),
+        __Directive(
+          "requires",
+          None,
+          locations = Set(__DirectiveLocation.FIELD_DEFINITION),
+          args = _FieldSet :: Nil,
+          repeatable = false
+        ),
+        __Directive(
+          "provides",
+          None,
+          locations = Set(__DirectiveLocation.FIELD_DEFINITION),
+          args = _FieldSet :: Nil,
+          repeatable = false
+        ),
         __Directive(
           "key",
           None,
           locations = Set(__DirectiveLocation.OBJECT, __DirectiveLocation.INTERFACE),
-          args = _FieldSet :: Nil
+          args = _FieldSet :: Nil,
+          repeatable = true
         ),
-        __Directive("extends", None, locations = Set(__DirectiveLocation.OBJECT, __DirectiveLocation.INTERFACE), Nil)
+        __Directive(
+          "extends",
+          None,
+          locations = Set(__DirectiveLocation.OBJECT, __DirectiveLocation.INTERFACE),
+          Nil,
+          repeatable = false
+        )
       ),
       Nil
     )

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -137,12 +137,14 @@ object IntrospectionClient {
     name: String,
     description: Option[String],
     locations: List[__DirectiveLocation],
-    args: List[InputValueDefinition]
+    args: List[InputValueDefinition],
+    repeatable: Boolean
   ): DirectiveDefinition =
     DirectiveDefinition(
       description,
       name,
       args,
+      repeatable,
       locations.map {
         case __DirectiveLocation.QUERY                  => ExecutableDirectiveLocation.QUERY
         case __DirectiveLocation.MUTATION               => ExecutableDirectiveLocation.MUTATION
@@ -225,7 +227,8 @@ object IntrospectionClient {
           (__Directive.name ~
             __Directive.description ~
             __Directive.locations ~
-            __Directive.args(inputValue)).mapN(mapDirective _)
+            __Directive.args(inputValue) ~
+            __Directive.isRepeatable).mapN(mapDirective _)
         }
     }.map { case (schema, types, directives) => Document(schema :: types ++ directives, SourceMapper.empty) }
 }

--- a/tools/src/main/scala/caliban/tools/RemoteSchema.scala
+++ b/tools/src/main/scala/caliban/tools/RemoteSchema.scala
@@ -272,6 +272,7 @@ object RemoteSchema {
       name = definition.name,
       description = definition.description,
       args = definition.args.map(toInputValue(_, definitions)),
+      repeatable = definition.repeatable,
       locations = definition.locations.map(toDirectiveLocation)
     )
 

--- a/tools/src/main/scala/caliban/tools/SchemaComparison.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaComparison.scala
@@ -278,12 +278,18 @@ object SchemaComparison {
     val argChanges         =
       compareArguments(left.args.map(a => a.name -> a).toMap, right.args.map(a => a.name -> a).toMap, target)
 
+    val repeatableChanges = if (left.repeatable == right.repeatable) {
+      Nil
+    } else {
+      List(DirectiveDefinitionRepeatableChanged(left.name, left.repeatable, right.repeatable))
+    }
+
     val locationAdded   =
       (right.locations -- left.locations).map(l => DirectiveLocationAdded(l, left.name)).toList
     val locationDeleted =
       (left.locations -- right.locations).map(l => DirectiveLocationDeleted(l, left.name)).toList
 
-    descriptionChanges ++ argChanges ++ locationAdded ++ locationDeleted
+    descriptionChanges ++ argChanges ++ repeatableChanges ++ locationAdded ++ locationDeleted
   }
 
   private def compareAllDirectiveDefinitions(

--- a/tools/src/main/scala/caliban/tools/SchemaComparisonChange.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaComparisonChange.scala
@@ -69,13 +69,23 @@ object SchemaComparisonChange {
     override def breaking: Boolean = true
   }
 
-  case class DirectiveDefinitionAdded(directiveName: String)                            extends SchemaComparisonChange {
+  case class DirectiveDefinitionAdded(directiveName: String)   extends SchemaComparisonChange {
     override def toString: String = s"Directive '$directiveName' was added."
   }
-  case class DirectiveDefinitionDeleted(directiveName: String)                          extends SchemaComparisonChange {
+  case class DirectiveDefinitionDeleted(directiveName: String) extends SchemaComparisonChange {
     override def toString: String  = s"Directive '$directiveName' was deleted."
     override def breaking: Boolean = true
   }
+
+  case class DirectiveDefinitionRepeatableChanged(directiveName: String, from: Boolean, to: Boolean)
+      extends SchemaComparisonChange {
+    override def toString: String  = s"Directive '$directiveName' repeatability changed from '$from' to '$to'."
+    // it is compatible to go from allowing something once to allowing it multiple times
+    // but incompatible to go from allowing it multiple times to allowing it once
+    // therefore from=true to=false is breaking, from=false to=true is not
+    override def breaking: Boolean = from
+  }
+
   case class DirectiveLocationAdded(location: DirectiveLocation, directiveName: String) extends SchemaComparisonChange {
     override def toString: String = s"Location '$location' was added on directive '$directiveName'."
   }

--- a/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
@@ -22,6 +22,17 @@ object SchemaComparisonSpec extends ZIOSpecDefault {
       diff = compareDocuments(s1, s2)
     } yield assertTrue(diff.map(_.toString) == expected)
 
+  def compareChanges(
+    schema1: String,
+    schema2: String,
+    expected: List[SchemaComparisonChange]
+  ): ZIO[Any, CalibanError.ParsingError, TestResult] =
+    for {
+      s1  <- Parser.parseQuery(schema1)
+      s2  <- Parser.parseQuery(schema2)
+      diff = compareDocuments(s1, s2)
+    } yield assertTrue(diff == expected)
+
   override def spec =
     suite("SchemaComparisonSpec")(
       test("field changed") {
@@ -233,6 +244,27 @@ object SchemaComparisonSpec extends ZIOSpecDefault {
         for {
           diff <- SchemaComparison.compare(SchemaLoader.fromString(schema), SchemaLoader.fromCaliban(api))
         } yield assertTrue(diff == Nil)
-      }
+      },
+      suite("repeatable directive")(
+        test("becomes repeatable") {
+          val nonRepeatable = "directive @test on FIELD_DEFINITION"
+          val repeatable    = "directive @test repeatable on FIELD_DEFINITION"
+
+          val expected = SchemaComparisonChange.DirectiveDefinitionRepeatableChanged("test", from = false, to = true)
+
+          compareChanges(nonRepeatable, repeatable, List(expected)) &&
+          assertTrue(!expected.breaking)
+        },
+        test("becomes non-repeatable") {
+          val repeatable    = "directive @test repeatable on FIELD_DEFINITION"
+          val nonRepeatable = "directive @test on FIELD_DEFINITION"
+
+          val expected = SchemaComparisonChange.DirectiveDefinitionRepeatableChanged("test", from = true, to = false)
+
+          compareChanges(repeatable, nonRepeatable, List(expected)) &&
+          assertTrue(expected.breaking)
+
+        }
+      )
     )
 }


### PR DESCRIPTION
Part of #1159

This parses and renders repeatable directives, and skips them in uniqueness checks

I could not tell if any changes were necessary to actually use repeatable directives, but this was enough for our use case to generate a client from a schema that had repeatable directives in it. If such changes are needed I could use some guidance on what those are

When accounting for repeatability in uniqueness checks, I checked repeatability from the definition of the directive, but I made an assumption that directives were defined only once and that all referenced directives have a definition, further assuming that was validated elsewhere. If this is inaccurate I could also use some guidance on what I missed and/or how you'd like to address it

I wanted to add a test that showed "repeated repeatable directives do not error" but the `ValidationSpec` only has failure tests and I didn't notice any similar happy-path tests where I should place it. If you'd like to see the test I'm willing to add such a test wherever you prefer

There are a few places in the spec that mention non-repeatable directives in validation for extensions, but I didn't find any existing validation for extensions to alter. If I missed them then point me in their direction and I'll try to filter out repeatable directives there too