### PR TITLE
Let requestInterceptor eliminate part of the environment

### DIFF
--- a/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -24,18 +24,18 @@ import scala.concurrent.{ ExecutionContext, Future }
 class AkkaHttpAdapter private (private val options: AkkaHttpServerOptions)(implicit ec: ExecutionContext) {
   private val akkaInterpreter = AkkaHttpServerInterpreter(options)(ec)
 
-  def makeHttpService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
+  def makeHttpService[R, IR, E](
+    interpreter: GraphQLInterpreter[R & IR, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
     queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+    requestInterceptor: RequestInterceptor[IR] = RequestInterceptor.empty
   )(implicit
     runtime: Runtime[R],
     requestCodec: JsonCodec[GraphQLRequest],
     responseCodec: JsonCodec[GraphQLResponse[E]]
   ): Route = {
-    val endpoints = TapirAdapter.makeHttpService[R, E](
+    val endpoints = TapirAdapter.makeHttpService[R, IR, E](
       interpreter,
       skipValidation,
       enableIntrospection,

--- a/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
+++ b/adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala
@@ -29,7 +29,7 @@ class AkkaHttpAdapter private (private val options: AkkaHttpServerOptions)(impli
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
     queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[IR] = RequestInterceptor.empty
+    requestInterceptor: RequestInterceptor[R, IR] = RequestInterceptor.empty
   )(implicit
     runtime: Runtime[R],
     requestCodec: JsonCodec[GraphQLRequest],
@@ -45,19 +45,19 @@ class AkkaHttpAdapter private (private val options: AkkaHttpServerOptions)(impli
     akkaInterpreter.toRoute(endpoints.map(TapirAdapter.convertHttpEndpointToFuture(_)))
   }
 
-  def makeHttpUploadService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
+  def makeHttpUploadService[R, IR, E](
+    interpreter: GraphQLInterpreter[R with IR, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
     queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+    requestInterceptor: RequestInterceptor[R, IR] = RequestInterceptor.empty
   )(implicit
     runtime: Runtime[R],
     requestCodec: JsonCodec[GraphQLRequest],
     mapCodec: JsonCodec[Map[String, Seq[String]]],
     responseCodec: JsonCodec[GraphQLResponse[E]]
   ): Route = {
-    val endpoint = TapirAdapter.makeHttpUploadService[R, E](
+    val endpoint = TapirAdapter.makeHttpUploadService[R, IR, E](
       interpreter,
       skipValidation,
       enableIntrospection,
@@ -67,13 +67,13 @@ class AkkaHttpAdapter private (private val options: AkkaHttpServerOptions)(impli
     akkaInterpreter.toRoute(TapirAdapter.convertHttpEndpointToFuture(endpoint))
   }
 
-  def makeWebSocketService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
+  def makeWebSocketService[R, IR, E](
+    interpreter: GraphQLInterpreter[R with IR, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
     keepAliveTime: Option[Duration] = None,
     queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty,
+    requestInterceptor: RequestInterceptor[R, IR] = RequestInterceptor.empty,
     webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty
   )(implicit
     ec: ExecutionContext,
@@ -82,7 +82,7 @@ class AkkaHttpAdapter private (private val options: AkkaHttpServerOptions)(impli
     inputCodec: JsonCodec[GraphQLWSInput],
     outputCodec: JsonCodec[GraphQLWSOutput]
   ): Route = {
-    val endpoint = TapirAdapter.makeWebSocketService[R, E](
+    val endpoint = TapirAdapter.makeWebSocketService[R, IR, E](
       interpreter,
       skipValidation,
       enableIntrospection,

--- a/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
+++ b/adapters/http4s/src/main/scala/caliban/Http4sAdapter.scala
@@ -1,291 +1,291 @@
-package caliban
+// package caliban
 
-import caliban.execution.QueryExecution
-import caliban.interop.cats.{ CatsInterop, ToEffect }
-import caliban.interop.tapir.TapirAdapter.{ zioMonadError, CalibanPipe, ZioWebSockets }
-import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks }
-import cats.data.Kleisli
-import cats.effect.Async
-import cats.~>
-import org.http4s._
-import org.http4s.server.websocket.WebSocketBuilder2
-import sttp.capabilities.WebSockets
-import sttp.capabilities.fs2.Fs2Streams
-import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.Endpoint
-import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.http4s.Http4sServerInterpreter
-import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
-import zio._
-import zio.interop.catz.concurrentInstance
+// import caliban.execution.QueryExecution
+// import caliban.interop.cats.{ CatsInterop, ToEffect }
+// import caliban.interop.tapir.TapirAdapter.{ zioMonadError, CalibanPipe, ZioWebSockets }
+// import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks }
+// import cats.data.Kleisli
+// import cats.effect.Async
+// import cats.~>
+// import org.http4s._
+// import org.http4s.server.websocket.WebSocketBuilder2
+// import sttp.capabilities.WebSockets
+// import sttp.capabilities.fs2.Fs2Streams
+// import sttp.tapir.Codec.JsonCodec
+// import sttp.tapir.Endpoint
+// import sttp.tapir.server.ServerEndpoint
+// import sttp.tapir.server.http4s.Http4sServerInterpreter
+// import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
+// import zio._
+// import zio.interop.catz.concurrentInstance
 
-object Http4sAdapter {
+// object Http4sAdapter {
 
-  def makeHttpService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
-  )(implicit
-    requestCodec: JsonCodec[GraphQLRequest],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
-  ): HttpRoutes[RIO[R, *]] = {
-    val endpoints = TapirAdapter.makeHttpService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      queryExecution,
-      requestInterceptor
-    )
-    ZHttp4sServerInterpreter().from(endpoints).toRoutes
-  }
+//   def makeHttpService[R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+//   )(implicit
+//     requestCodec: JsonCodec[GraphQLRequest],
+//     responseCodec: JsonCodec[GraphQLResponse[E]]
+//   ): HttpRoutes[RIO[R, *]] = {
+//     val endpoints = TapirAdapter.makeHttpService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       queryExecution,
+//       requestInterceptor
+//     )
+//     ZHttp4sServerInterpreter().from(endpoints).toRoutes
+//   }
 
-  def makeHttpServiceF[F[_]: Async, R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
-  )(implicit
-    interop: ToEffect[F, R],
-    requestCodec: JsonCodec[GraphQLRequest],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
-  ): HttpRoutes[F] = {
-    val endpoints  = TapirAdapter.makeHttpService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      queryExecution,
-      requestInterceptor
-    )
-    val endpointsF = endpoints.map(convertHttpEndpointToF[F, R])
-    Http4sServerInterpreter().toRoutes(endpointsF)
-  }
+//   def makeHttpServiceF[F[_]: Async, R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+//   )(implicit
+//     interop: ToEffect[F, R],
+//     requestCodec: JsonCodec[GraphQLRequest],
+//     responseCodec: JsonCodec[GraphQLResponse[E]]
+//   ): HttpRoutes[F] = {
+//     val endpoints  = TapirAdapter.makeHttpService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       queryExecution,
+//       requestInterceptor
+//     )
+//     val endpointsF = endpoints.map(convertHttpEndpointToF[F, R])
+//     Http4sServerInterpreter().toRoutes(endpointsF)
+//   }
 
-  def makeHttpUploadService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
-  )(implicit
-    requestCodec: JsonCodec[GraphQLRequest],
-    mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
-  ): HttpRoutes[RIO[R, *]] = {
-    val endpoint = TapirAdapter.makeHttpUploadService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      queryExecution,
-      requestInterceptor
-    )
-    ZHttp4sServerInterpreter().from(endpoint).toRoutes
-  }
+//   def makeHttpUploadService[R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+//   )(implicit
+//     requestCodec: JsonCodec[GraphQLRequest],
+//     mapCodec: JsonCodec[Map[String, Seq[String]]],
+//     responseCodec: JsonCodec[GraphQLResponse[E]]
+//   ): HttpRoutes[RIO[R, *]] = {
+//     val endpoint = TapirAdapter.makeHttpUploadService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       queryExecution,
+//       requestInterceptor
+//     )
+//     ZHttp4sServerInterpreter().from(endpoint).toRoutes
+//   }
 
-  def makeHttpUploadServiceF[F[_]: Async, R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
-  )(implicit
-    interop: ToEffect[F, R],
-    requestCodec: JsonCodec[GraphQLRequest],
-    mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
-  ): HttpRoutes[F] = {
-    val endpoint  = TapirAdapter.makeHttpUploadService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      queryExecution,
-      requestInterceptor
-    )
-    val endpointF = convertHttpEndpointToF[F, R](endpoint)
-    Http4sServerInterpreter().toRoutes(endpointF)
-  }
+//   def makeHttpUploadServiceF[F[_]: Async, R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+//   )(implicit
+//     interop: ToEffect[F, R],
+//     requestCodec: JsonCodec[GraphQLRequest],
+//     mapCodec: JsonCodec[Map[String, Seq[String]]],
+//     responseCodec: JsonCodec[GraphQLResponse[E]]
+//   ): HttpRoutes[F] = {
+//     val endpoint  = TapirAdapter.makeHttpUploadService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       queryExecution,
+//       requestInterceptor
+//     )
+//     val endpointF = convertHttpEndpointToF[F, R](endpoint)
+//     Http4sServerInterpreter().toRoutes(endpointF)
+//   }
 
-  def makeWebSocketService[R, R1 <: R, E](
-    builder: WebSocketBuilder2[RIO[R, *]],
-    interpreter: GraphQLInterpreter[R1, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    keepAliveTime: Option[Duration] = None,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty,
-    webSocketHooks: WebSocketHooks[R1, E] = WebSocketHooks.empty
-  )(implicit
-    inputCodec: JsonCodec[GraphQLWSInput],
-    outputCodec: JsonCodec[GraphQLWSOutput]
-  ): HttpRoutes[RIO[R1, *]] = {
-    val endpoint = TapirAdapter.makeWebSocketService[R1, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      keepAliveTime,
-      queryExecution,
-      requestInterceptor,
-      webSocketHooks
-    )
-    ZHttp4sServerInterpreter[R1]()
-      .fromWebSocket(endpoint)
-      .toRoutes(builder.asInstanceOf[WebSocketBuilder2[RIO[R1, *]]])
-  }
+//   def makeWebSocketService[R, R1 <: R, E](
+//     builder: WebSocketBuilder2[RIO[R, *]],
+//     interpreter: GraphQLInterpreter[R1, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     keepAliveTime: Option[Duration] = None,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty,
+//     webSocketHooks: WebSocketHooks[R1, E] = WebSocketHooks.empty
+//   )(implicit
+//     inputCodec: JsonCodec[GraphQLWSInput],
+//     outputCodec: JsonCodec[GraphQLWSOutput]
+//   ): HttpRoutes[RIO[R1, *]] = {
+//     val endpoint = TapirAdapter.makeWebSocketService[R1, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       keepAliveTime,
+//       queryExecution,
+//       requestInterceptor,
+//       webSocketHooks
+//     )
+//     ZHttp4sServerInterpreter[R1]()
+//       .fromWebSocket(endpoint)
+//       .toRoutes(builder.asInstanceOf[WebSocketBuilder2[RIO[R1, *]]])
+//   }
 
-  def makeWebSocketServiceF[F[_]: Async, R, E](
-    builder: WebSocketBuilder2[F],
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    keepAliveTime: Option[Duration] = None,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty,
-    webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty
-  )(implicit
-    interop: CatsInterop[F, R],
-    runtime: Runtime[R],
-    inputCodec: JsonCodec[GraphQLWSInput],
-    outputCodec: JsonCodec[GraphQLWSOutput]
-  ): HttpRoutes[F] = {
-    val endpoint  = TapirAdapter.makeWebSocketService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      keepAliveTime,
-      queryExecution,
-      requestInterceptor,
-      webSocketHooks
-    )
-    val endpointF = convertWebSocketEndpointToF[F, R](endpoint)
-    Http4sServerInterpreter().toWebSocketRoutes(endpointF)(builder)
-  }
+//   def makeWebSocketServiceF[F[_]: Async, R, E](
+//     builder: WebSocketBuilder2[F],
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     keepAliveTime: Option[Duration] = None,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty,
+//     webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty
+//   )(implicit
+//     interop: CatsInterop[F, R],
+//     runtime: Runtime[R],
+//     inputCodec: JsonCodec[GraphQLWSInput],
+//     outputCodec: JsonCodec[GraphQLWSOutput]
+//   ): HttpRoutes[F] = {
+//     val endpoint  = TapirAdapter.makeWebSocketService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       keepAliveTime,
+//       queryExecution,
+//       requestInterceptor,
+//       webSocketHooks
+//     )
+//     val endpointF = convertWebSocketEndpointToF[F, R](endpoint)
+//     Http4sServerInterpreter().toWebSocketRoutes(endpointF)(builder)
+//   }
 
-  /**
-   * Utility function to create an http4s middleware that can extracts something from each request
-   * and provide a layer to eliminate the ZIO environment
-   * @param route an http4s route
-   * @param f a function from a request to a ZLayer
-   * @tparam R the environment type to eliminate
-   * @return a new route without the R requirement
-   */
-  def provideLayerFromRequest[R](route: HttpRoutes[RIO[R, *]], f: Request[Task] => TaskLayer[R])(implicit
-    tagged: Tag[R]
-  ): HttpRoutes[Task] =
-    Kleisli { (req: Request[Task[*]]) =>
-      val to: Task ~> RIO[R, *] = new (Task ~> RIO[R, *]) {
-        def apply[A](fa: Task[A]): RIO[R, A] = fa
-      }
+//   /**
+//    * Utility function to create an http4s middleware that can extracts something from each request
+//    * and provide a layer to eliminate the ZIO environment
+//    * @param route an http4s route
+//    * @param f a function from a request to a ZLayer
+//    * @tparam R the environment type to eliminate
+//    * @return a new route without the R requirement
+//    */
+//   def provideLayerFromRequest[R](route: HttpRoutes[RIO[R, *]], f: Request[Task] => TaskLayer[R])(implicit
+//     tagged: Tag[R]
+//   ): HttpRoutes[Task] =
+//     Kleisli { (req: Request[Task[*]]) =>
+//       val to: Task ~> RIO[R, *] = new (Task ~> RIO[R, *]) {
+//         def apply[A](fa: Task[A]): RIO[R, A] = fa
+//       }
 
-      val from: RIO[R, *] ~> Task = new (RIO[R, *] ~> Task) {
-        def apply[A](fa: RIO[R, A]): Task[A] = fa.provideLayer(f(req))
-      }
+//       val from: RIO[R, *] ~> Task = new (RIO[R, *] ~> Task) {
+//         def apply[A](fa: RIO[R, A]): Task[A] = fa.provideLayer(f(req))
+//       }
 
-      route(req.mapK(to)).mapK(from).map(_.mapK(from))
-    }
+//       route(req.mapK(to)).mapK(from).map(_.mapK(from))
+//     }
 
-  /**
-   * Utility function to create an http4s middleware that can extracts something from each request
-   * and provide a layer to eliminate some part of the ZIO environment
-   * @param route an http4s route
-   * @param f a function from a request to a ZLayer
-   * @tparam R the remaining environment
-   * @tparam R1 the environment to eliminate
-   * @return a new route that requires only R
-   */
-  def provideSomeLayerFromRequest[R, R1](
-    route: HttpRoutes[RIO[R with R1, *]],
-    f: Request[RIO[R, *]] => RLayer[R, R1]
-  )(implicit tagged: Tag[R1]): HttpRoutes[RIO[R, *]] =
-    Kleisli { (req: Request[RIO[R, *]]) =>
-      val to: RIO[R, *] ~> RIO[R with R1, *] = new (RIO[R, *] ~> RIO[R with R1, *]) {
-        def apply[A](fa: RIO[R, A]): RIO[R with R1, A] = fa
-      }
+//   /**
+//    * Utility function to create an http4s middleware that can extracts something from each request
+//    * and provide a layer to eliminate some part of the ZIO environment
+//    * @param route an http4s route
+//    * @param f a function from a request to a ZLayer
+//    * @tparam R the remaining environment
+//    * @tparam R1 the environment to eliminate
+//    * @return a new route that requires only R
+//    */
+//   def provideSomeLayerFromRequest[R, R1](
+//     route: HttpRoutes[RIO[R with R1, *]],
+//     f: Request[RIO[R, *]] => RLayer[R, R1]
+//   )(implicit tagged: Tag[R1]): HttpRoutes[RIO[R, *]] =
+//     Kleisli { (req: Request[RIO[R, *]]) =>
+//       val to: RIO[R, *] ~> RIO[R with R1, *] = new (RIO[R, *] ~> RIO[R with R1, *]) {
+//         def apply[A](fa: RIO[R, A]): RIO[R with R1, A] = fa
+//       }
 
-      val from: RIO[R with R1, *] ~> RIO[R, *] = new (RIO[R with R1, *] ~> RIO[R, *]) {
-        def apply[A](fa: RIO[R with R1, A]): RIO[R, A] = fa.provideSomeLayer[R](f(req))
-      }
+//       val from: RIO[R with R1, *] ~> RIO[R, *] = new (RIO[R with R1, *] ~> RIO[R, *]) {
+//         def apply[A](fa: RIO[R with R1, A]): RIO[R, A] = fa.provideSomeLayer[R](f(req))
+//       }
 
-      route(req.mapK(to)).mapK(from).map(_.mapK(from))
-    }
+//       route(req.mapK(to)).mapK(from).map(_.mapK(from))
+//     }
 
-  /**
-   * If you wish to use `Http4sServerInterpreter` with cats-effect IO instead of `ZHttp4sServerInterpreter`,
-   * you can use this function to convert the tapir endpoints to their cats-effect counterpart.
-   */
-  def convertHttpEndpointToF[F[_], R](
-    endpoint: ServerEndpoint[Any, RIO[R, *]]
-  )(implicit interop: ToEffect[F, R]): ServerEndpoint[Any, F] =
-    ServerEndpoint[
-      endpoint.SECURITY_INPUT,
-      endpoint.PRINCIPAL,
-      endpoint.INPUT,
-      endpoint.ERROR_OUTPUT,
-      endpoint.OUTPUT,
-      Any,
-      F
-    ](
-      endpoint.endpoint,
-      _ => a => interop.toEffect(endpoint.securityLogic(zioMonadError)(a)),
-      _ => u => req => interop.toEffect(endpoint.logic(zioMonadError)(u)(req))
-    )
+//   /**
+//    * If you wish to use `Http4sServerInterpreter` with cats-effect IO instead of `ZHttp4sServerInterpreter`,
+//    * you can use this function to convert the tapir endpoints to their cats-effect counterpart.
+//    */
+//   def convertHttpEndpointToF[F[_], R](
+//     endpoint: ServerEndpoint[Any, RIO[R, *]]
+//   )(implicit interop: ToEffect[F, R]): ServerEndpoint[Any, F] =
+//     ServerEndpoint[
+//       endpoint.SECURITY_INPUT,
+//       endpoint.PRINCIPAL,
+//       endpoint.INPUT,
+//       endpoint.ERROR_OUTPUT,
+//       endpoint.OUTPUT,
+//       Any,
+//       F
+//     ](
+//       endpoint.endpoint,
+//       _ => a => interop.toEffect(endpoint.securityLogic(zioMonadError)(a)),
+//       _ => u => req => interop.toEffect(endpoint.logic(zioMonadError)(u)(req))
+//     )
 
-  /**
-   * If you wish to use `Http4sServerInterpreter` with cats-effect IO instead of `ZHttp4sServerInterpreter`,
-   * you can use this function to convert the tapir endpoints to their cats-effect counterpart.
-   */
-  def convertWebSocketEndpointToF[F[_], R](
-    endpoint: ServerEndpoint[ZioWebSockets, RIO[R, *]]
-  )(implicit interop: CatsInterop[F, R], runtime: Runtime[R]): ServerEndpoint[Fs2Streams[F] with WebSockets, F] = {
-    type Fs2Pipe = fs2.Pipe[F, GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput]]
+//   /**
+//    * If you wish to use `Http4sServerInterpreter` with cats-effect IO instead of `ZHttp4sServerInterpreter`,
+//    * you can use this function to convert the tapir endpoints to their cats-effect counterpart.
+//    */
+//   def convertWebSocketEndpointToF[F[_], R](
+//     endpoint: ServerEndpoint[ZioWebSockets, RIO[R, *]]
+//   )(implicit interop: CatsInterop[F, R], runtime: Runtime[R]): ServerEndpoint[Fs2Streams[F] with WebSockets, F] = {
+//     type Fs2Pipe = fs2.Pipe[F, GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput]]
 
-    val e = endpoint
-      .asInstanceOf[
-        ServerEndpoint.Full[
-          endpoint.SECURITY_INPUT,
-          endpoint.PRINCIPAL,
-          endpoint.INPUT,
-          endpoint.ERROR_OUTPUT,
-          (String, CalibanPipe),
-          ZioWebSockets,
-          RIO[R, *]
-        ]
-      ]
+//     val e = endpoint
+//       .asInstanceOf[
+//         ServerEndpoint.Full[
+//           endpoint.SECURITY_INPUT,
+//           endpoint.PRINCIPAL,
+//           endpoint.INPUT,
+//           endpoint.ERROR_OUTPUT,
+//           (String, CalibanPipe),
+//           ZioWebSockets,
+//           RIO[R, *]
+//         ]
+//       ]
 
-    ServerEndpoint[
-      endpoint.SECURITY_INPUT,
-      endpoint.PRINCIPAL,
-      endpoint.INPUT,
-      endpoint.ERROR_OUTPUT,
-      (String, Fs2Pipe),
-      Fs2Streams[F] with WebSockets,
-      F
-    ](
-      e.endpoint
-        .asInstanceOf[Endpoint[endpoint.SECURITY_INPUT, endpoint.INPUT, endpoint.ERROR_OUTPUT, (String, Fs2Pipe), Any]],
-      _ => a => interop.toEffect(e.securityLogic(zioMonadError)(a)),
-      _ =>
-        u =>
-          req =>
-            interop.toEffect(
-              e.logic(zioMonadError)(u)(req)
-                .map(_.map { case (protocol, zioPipe) =>
-                  import zio.stream.interop.fs2z._
-                  (
-                    protocol,
-                    fs2InputStream =>
-                      zioPipe(
-                        fs2InputStream
-                          .translate(interop.fromEffectK)
-                          .toZStream()
-                          .provideEnvironment(runtime.environment)
-                      ).toFs2Stream
-                        .translate(interop.toEffectK)
-                  )
-                })
-            )
-    )
-  }
+//     ServerEndpoint[
+//       endpoint.SECURITY_INPUT,
+//       endpoint.PRINCIPAL,
+//       endpoint.INPUT,
+//       endpoint.ERROR_OUTPUT,
+//       (String, Fs2Pipe),
+//       Fs2Streams[F] with WebSockets,
+//       F
+//     ](
+//       e.endpoint
+//         .asInstanceOf[Endpoint[endpoint.SECURITY_INPUT, endpoint.INPUT, endpoint.ERROR_OUTPUT, (String, Fs2Pipe), Any]],
+//       _ => a => interop.toEffect(e.securityLogic(zioMonadError)(a)),
+//       _ =>
+//         u =>
+//           req =>
+//             interop.toEffect(
+//               e.logic(zioMonadError)(u)(req)
+//                 .map(_.map { case (protocol, zioPipe) =>
+//                   import zio.stream.interop.fs2z._
+//                   (
+//                     protocol,
+//                     fs2InputStream =>
+//                       zioPipe(
+//                         fs2InputStream
+//                           .translate(interop.fromEffectK)
+//                           .toZStream()
+//                           .provideEnvironment(runtime.environment)
+//                       ).toFs2Stream
+//                         .translate(interop.toEffectK)
+//                   )
+//                 })
+//             )
+//     )
+//   }
 
-}
+// }

--- a/adapters/http4s/src/test/scala/caliban/Http4sAdapterSpec.scala
+++ b/adapters/http4s/src/test/scala/caliban/Http4sAdapterSpec.scala
@@ -1,92 +1,92 @@
-package caliban
+// package caliban
 
-import caliban.interop.tapir.TestData.sampleCharacters
-import caliban.interop.tapir.{ FakeAuthorizationInterceptor, TapirAdapterSpec, TestApi, TestService }
-import caliban.uploads.Uploads
-import com.comcast.ip4s._
-import com.github.plokhotnyuk.jsoniter_scala.core._
-import com.github.plokhotnyuk.jsoniter_scala.macros._
-import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.server.Router
-import org.http4s.server.middleware.CORS
-import sttp.client3.UriContext
-import sttp.tapir.Codec.JsonCodec
-import zio._
-import zio.interop.catz._
-import zio.test.{ Live, ZIOSpecDefault }
+// import caliban.interop.tapir.TestData.sampleCharacters
+// import caliban.interop.tapir.{ FakeAuthorizationInterceptor, TapirAdapterSpec, TestApi, TestService }
+// import caliban.uploads.Uploads
+// import com.comcast.ip4s._
+// import com.github.plokhotnyuk.jsoniter_scala.core._
+// import com.github.plokhotnyuk.jsoniter_scala.macros._
+// import org.http4s.ember.server.EmberServerBuilder
+// import org.http4s.server.Router
+// import org.http4s.server.middleware.CORS
+// import sttp.client3.UriContext
+// import sttp.tapir.Codec.JsonCodec
+// import zio._
+// import zio.interop.catz._
+// import zio.test.{ Live, ZIOSpecDefault }
 
-import scala.language.postfixOps
+// import scala.language.postfixOps
 
-object Http4sAdapterSpec extends ZIOSpecDefault {
+// object Http4sAdapterSpec extends ZIOSpecDefault {
 
-  type Env         = TestService with Uploads
-  type TestTask[A] = RIO[Env, A]
+//   type Env         = TestService with Uploads
+//   type TestTask[A] = RIO[Env, A]
 
-  private val envLayer = TestService.make(sampleCharacters) ++ Uploads.empty
+//   private val envLayer = TestService.make(sampleCharacters) ++ Uploads.empty
 
-  private def apiLayer(implicit
-    requestCodec: JsonCodec[GraphQLRequest],
-    mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseCodec: JsonCodec[GraphQLResponse[CalibanError]],
-    wsInputCodec: JsonCodec[GraphQLWSInput],
-    wsOutputCodec: JsonCodec[GraphQLWSOutput]
-  ) = envLayer >>> ZLayer.scoped {
-    for {
-      interpreter <- TestApi.api.interpreter
-      _           <- EmberServerBuilder
-                       .default[TestTask]
-                       .withHost(host"localhost")
-                       .withPort(port"8087")
-                       .withHttpWebSocketApp(wsBuilder =>
-                         Router[TestTask](
-                           "/api/graphql"    -> CORS.policy(
-                             Http4sAdapter.makeHttpService[Env, CalibanError](
-                               interpreter,
-                               requestInterceptor = FakeAuthorizationInterceptor.bearer
-                             )
-                           ),
-                           "/upload/graphql" -> CORS.policy(Http4sAdapter.makeHttpUploadService[Env, CalibanError](interpreter)),
-                           "/ws/graphql"     -> CORS.policy(
-                             Http4sAdapter.makeWebSocketService[Env, Env, CalibanError](wsBuilder, interpreter)
-                           )
-                         ).orNotFound
-                       )
-                       .build
-                       .toScopedZIO
-                       .forkScoped
-      _           <- Live.live(Clock.sleep(3 seconds))
-      service     <- ZIO.service[TestService]
-    } yield service
-  }
+//   private def apiLayer(implicit
+//     requestCodec: JsonCodec[GraphQLRequest],
+//     mapCodec: JsonCodec[Map[String, Seq[String]]],
+//     responseCodec: JsonCodec[GraphQLResponse[CalibanError]],
+//     wsInputCodec: JsonCodec[GraphQLWSInput],
+//     wsOutputCodec: JsonCodec[GraphQLWSOutput]
+//   ) = envLayer >>> ZLayer.scoped {
+//     for {
+//       interpreter <- TestApi.api.interpreter
+//       _           <- EmberServerBuilder
+//                        .default[TestTask]
+//                        .withHost(host"localhost")
+//                        .withPort(port"8087")
+//                        .withHttpWebSocketApp(wsBuilder =>
+//                          Router[TestTask](
+//                            "/api/graphql"    -> CORS.policy(
+//                              Http4sAdapter.makeHttpService[Env, CalibanError](
+//                                interpreter,
+//                                requestInterceptor = FakeAuthorizationInterceptor.bearer
+//                              )
+//                            ),
+//                            "/upload/graphql" -> CORS.policy(Http4sAdapter.makeHttpUploadService[Env, CalibanError](interpreter)),
+//                            "/ws/graphql"     -> CORS.policy(
+//                              Http4sAdapter.makeWebSocketService[Env, Env, CalibanError](wsBuilder, interpreter)
+//                            )
+//                          ).orNotFound
+//                        )
+//                        .build
+//                        .toScopedZIO
+//                        .forkScoped
+//       _           <- Live.live(Clock.sleep(3 seconds))
+//       service     <- ZIO.service[TestService]
+//     } yield service
+//   }
 
-  override def spec = suite("Http4sAdapterSpec") {
-    val suites =
-      List(
-        Some({
-          import sttp.tapir.json.circe._
-          TapirAdapterSpec
-            .makeSuite(
-              "circe codec",
-              uri"http://localhost:8087/api/graphql",
-              uploadUri = Some(uri"http://localhost:8087/upload/graphql"),
-              wsUri = Some(uri"ws://localhost:8087/ws/graphql")
-            )
-            .provideLayerShared(apiLayer)
-        }),
-        Some({
-          import sttp.tapir.json.jsoniter._
-          implicit val mapCodec: JsonValueCodec[Map[String, Seq[String]]] = JsonCodecMaker.make
+//   override def spec = suite("Http4sAdapterSpec") {
+//     val suites =
+//       List(
+//         Some({
+//           import sttp.tapir.json.circe._
+//           TapirAdapterSpec
+//             .makeSuite(
+//               "circe codec",
+//               uri"http://localhost:8087/api/graphql",
+//               uploadUri = Some(uri"http://localhost:8087/upload/graphql"),
+//               wsUri = Some(uri"ws://localhost:8087/ws/graphql")
+//             )
+//             .provideLayerShared(apiLayer)
+//         }),
+//         Some({
+//           import sttp.tapir.json.jsoniter._
+//           implicit val mapCodec: JsonValueCodec[Map[String, Seq[String]]] = JsonCodecMaker.make
 
-          TapirAdapterSpec
-            .makeSuite(
-              "jsoniter codec",
-              uri"http://localhost:8087/api/graphql",
-              uploadUri = Some(uri"http://localhost:8087/upload/graphql"),
-              wsUri = Some(uri"ws://localhost:8087/ws/graphql")
-            )
-            .provideLayerShared(apiLayer) @@ TestUtils.skipJdk8
-        })
-      )
-    ZIO.succeed(suites.flatten)
-  }
-}
+//           TapirAdapterSpec
+//             .makeSuite(
+//               "jsoniter codec",
+//               uri"http://localhost:8087/api/graphql",
+//               uploadUri = Some(uri"http://localhost:8087/upload/graphql"),
+//               wsUri = Some(uri"ws://localhost:8087/ws/graphql")
+//             )
+//             .provideLayerShared(apiLayer) @@ TestUtils.skipJdk8
+//         })
+//       )
+//     ZIO.succeed(suites.flatten)
+//   }
+// }

--- a/adapters/play/src/main/scala/caliban/PlayAdapter.scala
+++ b/adapters/play/src/main/scala/caliban/PlayAdapter.scala
@@ -1,185 +1,185 @@
-package caliban
+// package caliban
 
-import akka.stream.{ Materializer, OverflowStrategy }
-import akka.stream.scaladsl.{ Flow, Sink, Source }
-import caliban.execution.QueryExecution
-import caliban.interop.tapir.TapirAdapter.{ zioMonadError, CalibanPipe, ZioWebSockets }
-import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks }
-import play.api.routing.Router.Routes
-import sttp.capabilities.WebSockets
-import sttp.capabilities.akka.AkkaStreams
-import sttp.capabilities.akka.AkkaStreams.Pipe
-import sttp.model.StatusCode
-import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.PublicEndpoint
-import sttp.tapir.model.ServerRequest
-import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.play.{ PlayServerInterpreter, PlayServerOptions }
-import zio._
-import zio.stream.ZStream
+// import akka.stream.{ Materializer, OverflowStrategy }
+// import akka.stream.scaladsl.{ Flow, Sink, Source }
+// import caliban.execution.QueryExecution
+// import caliban.interop.tapir.TapirAdapter.{ zioMonadError, CalibanPipe, ZioWebSockets }
+// import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks }
+// import play.api.routing.Router.Routes
+// import sttp.capabilities.WebSockets
+// import sttp.capabilities.akka.AkkaStreams
+// import sttp.capabilities.akka.AkkaStreams.Pipe
+// import sttp.model.StatusCode
+// import sttp.tapir.Codec.JsonCodec
+// import sttp.tapir.PublicEndpoint
+// import sttp.tapir.model.ServerRequest
+// import sttp.tapir.server.ServerEndpoint
+// import sttp.tapir.server.play.{ PlayServerInterpreter, PlayServerOptions }
+// import zio._
+// import zio.stream.ZStream
 
-import scala.concurrent.{ ExecutionContext, Future }
+// import scala.concurrent.{ ExecutionContext, Future }
 
-class PlayAdapter private (private val options: Option[PlayServerOptions]) {
-  private def playInterpreter(implicit mat: Materializer) =
-    options.fold(PlayServerInterpreter())(PlayServerInterpreter(_))
+// class PlayAdapter private (private val options: Option[PlayServerOptions]) {
+//   private def playInterpreter(implicit mat: Materializer) =
+//     options.fold(PlayServerInterpreter())(PlayServerInterpreter(_))
 
-  def makeHttpService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
-  )(implicit
-    runtime: Runtime[R],
-    materializer: Materializer,
-    requestCodec: JsonCodec[GraphQLRequest],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
-  ): Routes = {
-    val endpoints = TapirAdapter.makeHttpService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      queryExecution,
-      requestInterceptor
-    )
-    playInterpreter.toRoutes(endpoints.map(TapirAdapter.convertHttpEndpointToFuture(_)))
-  }
+//   def makeHttpService[R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+//   )(implicit
+//     runtime: Runtime[R],
+//     materializer: Materializer,
+//     requestCodec: JsonCodec[GraphQLRequest],
+//     responseCodec: JsonCodec[GraphQLResponse[E]]
+//   ): Routes = {
+//     val endpoints = TapirAdapter.makeHttpService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       queryExecution,
+//       requestInterceptor
+//     )
+//     playInterpreter.toRoutes(endpoints.map(TapirAdapter.convertHttpEndpointToFuture(_)))
+//   }
 
-  def makeHttpUploadService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
-  )(implicit
-    runtime: Runtime[R],
-    materializer: Materializer,
-    requestCodec: JsonCodec[GraphQLRequest],
-    mapCodec: JsonCodec[Map[String, Seq[String]]],
-    responseCodec: JsonCodec[GraphQLResponse[E]]
-  ): Routes = {
-    val endpoint = TapirAdapter.makeHttpUploadService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      queryExecution,
-      requestInterceptor
-    )
-    playInterpreter.toRoutes(TapirAdapter.convertHttpEndpointToFuture(endpoint))
-  }
+//   def makeHttpUploadService[R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+//   )(implicit
+//     runtime: Runtime[R],
+//     materializer: Materializer,
+//     requestCodec: JsonCodec[GraphQLRequest],
+//     mapCodec: JsonCodec[Map[String, Seq[String]]],
+//     responseCodec: JsonCodec[GraphQLResponse[E]]
+//   ): Routes = {
+//     val endpoint = TapirAdapter.makeHttpUploadService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       queryExecution,
+//       requestInterceptor
+//     )
+//     playInterpreter.toRoutes(TapirAdapter.convertHttpEndpointToFuture(endpoint))
+//   }
 
-  def makeWebSocketService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    keepAliveTime: Option[Duration] = None,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty,
-    webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty
-  )(implicit
-    ec: ExecutionContext,
-    runtime: Runtime[R],
-    materializer: Materializer,
-    inputCodec: JsonCodec[GraphQLWSInput],
-    outputCodec: JsonCodec[GraphQLWSOutput]
-  ): Routes = {
-    val endpoint = TapirAdapter.makeWebSocketService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      keepAliveTime,
-      queryExecution,
-      requestInterceptor,
-      webSocketHooks
-    )
-    playInterpreter.toRoutes(
-      PlayAdapter.convertWebSocketEndpoint(
-        endpoint.asInstanceOf[
-          ServerEndpoint.Full[
-            Unit,
-            Unit,
-            (ServerRequest, String),
-            StatusCode,
-            (String, CalibanPipe),
-            ZioWebSockets,
-            RIO[R, *]
-          ]
-        ]
-      )
-    )
-  }
-}
+//   def makeWebSocketService[R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     keepAliveTime: Option[Duration] = None,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty,
+//     webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty
+//   )(implicit
+//     ec: ExecutionContext,
+//     runtime: Runtime[R],
+//     materializer: Materializer,
+//     inputCodec: JsonCodec[GraphQLWSInput],
+//     outputCodec: JsonCodec[GraphQLWSOutput]
+//   ): Routes = {
+//     val endpoint = TapirAdapter.makeWebSocketService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       keepAliveTime,
+//       queryExecution,
+//       requestInterceptor,
+//       webSocketHooks
+//     )
+//     playInterpreter.toRoutes(
+//       PlayAdapter.convertWebSocketEndpoint(
+//         endpoint.asInstanceOf[
+//           ServerEndpoint.Full[
+//             Unit,
+//             Unit,
+//             (ServerRequest, String),
+//             StatusCode,
+//             (String, CalibanPipe),
+//             ZioWebSockets,
+//             RIO[R, *]
+//           ]
+//         ]
+//       )
+//     )
+//   }
+// }
 
-object PlayAdapter extends PlayAdapter(None) {
+// object PlayAdapter extends PlayAdapter(None) {
 
-  def apply(options: PlayServerOptions) =
-    new PlayAdapter(Some(options))
+//   def apply(options: PlayServerOptions) =
+//     new PlayAdapter(Some(options))
 
-  type AkkaPipe = Flow[GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput], Any]
+//   type AkkaPipe = Flow[GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput], Any]
 
-  def convertWebSocketEndpoint[R](
-    endpoint: ServerEndpoint.Full[
-      Unit,
-      Unit,
-      (ServerRequest, String),
-      StatusCode,
-      (String, CalibanPipe),
-      ZioWebSockets,
-      RIO[
-        R,
-        *
-      ]
-    ]
-  )(implicit
-    ec: ExecutionContext,
-    runtime: Runtime[R],
-    materializer: Materializer
-  ): ServerEndpoint[AkkaStreams with WebSockets, Future] =
-    ServerEndpoint[
-      Unit,
-      Unit,
-      (ServerRequest, String),
-      StatusCode,
-      (String, AkkaPipe),
-      AkkaStreams with WebSockets,
-      Future
-    ](
-      endpoint.endpoint
-        .asInstanceOf[
-          PublicEndpoint[
-            (ServerRequest, String),
-            StatusCode,
-            (String, Pipe[GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput]]),
-            Any
-          ]
-        ],
-      _ => _ => Future.successful(Right(())),
-      _ =>
-        _ =>
-          req =>
-            Unsafe
-              .unsafe(implicit u => runtime.unsafe.runToFuture(endpoint.logic(zioMonadError)(())(req)).future)
-              .map(_.map { case (protocol, zioPipe) =>
-                val io =
-                  for {
-                    inputQueue     <- Queue.unbounded[GraphQLWSInput]
-                    input           = ZStream.fromQueue(inputQueue)
-                    output          = zioPipe(input)
-                    sink            =
-                      Sink.foreachAsync[GraphQLWSInput](1)(input =>
-                        Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(inputQueue.offer(input).unit).future)
-                      )
-                    (queue, source) =
-                      Source.queue[Either[GraphQLWSClose, GraphQLWSOutput]](0, OverflowStrategy.fail).preMaterialize()
-                    fiber          <- output.foreach(msg => ZIO.fromFuture(_ => queue.offer(msg))).forkDaemon
-                    flow            = Flow.fromSinkAndSourceCoupled(sink, source).watchTermination() { (_, f) =>
-                                        f.onComplete(_ =>
-                                          Unsafe.unsafe(implicit u => runtime.unsafe.run(fiber.interrupt).getOrThrowFiberFailure())
-                                        )
-                                      }
-                  } yield (protocol, flow)
-                Unsafe.unsafe(implicit u => runtime.unsafe.run(io).getOrThrowFiberFailure())
-              })
-    )
-}
+//   def convertWebSocketEndpoint[R](
+//     endpoint: ServerEndpoint.Full[
+//       Unit,
+//       Unit,
+//       (ServerRequest, String),
+//       StatusCode,
+//       (String, CalibanPipe),
+//       ZioWebSockets,
+//       RIO[
+//         R,
+//         *
+//       ]
+//     ]
+//   )(implicit
+//     ec: ExecutionContext,
+//     runtime: Runtime[R],
+//     materializer: Materializer
+//   ): ServerEndpoint[AkkaStreams with WebSockets, Future] =
+//     ServerEndpoint[
+//       Unit,
+//       Unit,
+//       (ServerRequest, String),
+//       StatusCode,
+//       (String, AkkaPipe),
+//       AkkaStreams with WebSockets,
+//       Future
+//     ](
+//       endpoint.endpoint
+//         .asInstanceOf[
+//           PublicEndpoint[
+//             (ServerRequest, String),
+//             StatusCode,
+//             (String, Pipe[GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput]]),
+//             Any
+//           ]
+//         ],
+//       _ => _ => Future.successful(Right(())),
+//       _ =>
+//         _ =>
+//           req =>
+//             Unsafe
+//               .unsafe(implicit u => runtime.unsafe.runToFuture(endpoint.logic(zioMonadError)(())(req)).future)
+//               .map(_.map { case (protocol, zioPipe) =>
+//                 val io =
+//                   for {
+//                     inputQueue     <- Queue.unbounded[GraphQLWSInput]
+//                     input           = ZStream.fromQueue(inputQueue)
+//                     output          = zioPipe(input)
+//                     sink            =
+//                       Sink.foreachAsync[GraphQLWSInput](1)(input =>
+//                         Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(inputQueue.offer(input).unit).future)
+//                       )
+//                     (queue, source) =
+//                       Source.queue[Either[GraphQLWSClose, GraphQLWSOutput]](0, OverflowStrategy.fail).preMaterialize()
+//                     fiber          <- output.foreach(msg => ZIO.fromFuture(_ => queue.offer(msg))).forkDaemon
+//                     flow            = Flow.fromSinkAndSourceCoupled(sink, source).watchTermination() { (_, f) =>
+//                                         f.onComplete(_ =>
+//                                           Unsafe.unsafe(implicit u => runtime.unsafe.run(fiber.interrupt).getOrThrowFiberFailure())
+//                                         )
+//                                       }
+//                   } yield (protocol, flow)
+//                 Unsafe.unsafe(implicit u => runtime.unsafe.run(io).getOrThrowFiberFailure())
+//               })
+//     )
+// }

--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -1,74 +1,74 @@
-package caliban
+// package caliban
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import caliban.interop.tapir.TestData.sampleCharacters
-import caliban.interop.tapir.{ FakeAuthorizationInterceptor, TapirAdapterSpec, TestApi, TestService }
-import caliban.uploads.Uploads
-import play.api.Mode
-import play.api.routing._
-import play.api.routing.sird._
-import play.core.server.{ AkkaHttpServer, ServerConfig }
-import sttp.client3.UriContext
-import zio._
-import zio.test.{ Live, ZIOSpecDefault }
+// import akka.actor.ActorSystem
+// import akka.stream.Materializer
+// import caliban.interop.tapir.TestData.sampleCharacters
+// import caliban.interop.tapir.{ FakeAuthorizationInterceptor, TapirAdapterSpec, TestApi, TestService }
+// import caliban.uploads.Uploads
+// import play.api.Mode
+// import play.api.routing._
+// import play.api.routing.sird._
+// import play.core.server.{ AkkaHttpServer, ServerConfig }
+// import sttp.client3.UriContext
+// import zio._
+// import zio.test.{ Live, ZIOSpecDefault }
 
-import scala.language.postfixOps
+// import scala.language.postfixOps
 
-object PlayAdapterSpec extends ZIOSpecDefault {
-  import sttp.tapir.json.play._
+// object PlayAdapterSpec extends ZIOSpecDefault {
+//   import sttp.tapir.json.play._
 
-  private val interceptor = FakeAuthorizationInterceptor.bearer
+//   private val interceptor = FakeAuthorizationInterceptor.bearer
 
-  private val envLayer = TestService.make(sampleCharacters) ++ Uploads.empty
+//   private val envLayer = TestService.make(sampleCharacters) ++ Uploads.empty
 
-  private val apiLayer = envLayer >>> ZLayer.scoped {
-    for {
-      system      <- ZIO.succeed(ActorSystem()).withFinalizer(sys => ZIO.fromFuture(_ => sys.terminate()).ignore)
-      ec           = system.dispatcher
-      mat          = Materializer(system)
-      runtime     <- ZIO.runtime[TestService with Uploads]
-      interpreter <- TestApi.api.interpreter
-      router       = Router.from {
-                       case req @ POST(p"/api/graphql")    =>
-                         PlayAdapter
-                           .makeHttpService(interpreter, requestInterceptor = interceptor)(
-                             runtime,
-                             mat,
-                             implicitly,
-                             implicitly
-                           )
-                           .apply(req)
-                       case req @ POST(p"/upload/graphql") =>
-                         PlayAdapter
-                           .makeHttpUploadService(interpreter)(runtime, mat, implicitly, implicitly, implicitly)
-                           .apply(req)
-                       case req @ GET(p"/ws/graphql")      =>
-                         PlayAdapter.makeWebSocketService(interpreter)(ec, runtime, mat, implicitly, implicitly).apply(req)
-                     }
-      _           <- ZIO
-                       .attempt(
-                         AkkaHttpServer.fromRouterWithComponents(
-                           ServerConfig(
-                             mode = Mode.Dev,
-                             port = Some(8088),
-                             address = "127.0.0.1"
-                           )
-                         )(_ => router.routes)
-                       )
-                       .withFinalizer(server => ZIO.attempt(server.stop()).ignore)
-      _           <- Live.live(Clock.sleep(3 seconds))
-      service     <- ZIO.service[TestService]
-    } yield service
-  }
+//   private val apiLayer = envLayer >>> ZLayer.scoped {
+//     for {
+//       system      <- ZIO.succeed(ActorSystem()).withFinalizer(sys => ZIO.fromFuture(_ => sys.terminate()).ignore)
+//       ec           = system.dispatcher
+//       mat          = Materializer(system)
+//       runtime     <- ZIO.runtime[TestService with Uploads]
+//       interpreter <- TestApi.api.interpreter
+//       router       = Router.from {
+//                        case req @ POST(p"/api/graphql")    =>
+//                          PlayAdapter
+//                            .makeHttpService(interpreter, requestInterceptor = interceptor)(
+//                              runtime,
+//                              mat,
+//                              implicitly,
+//                              implicitly
+//                            )
+//                            .apply(req)
+//                        case req @ POST(p"/upload/graphql") =>
+//                          PlayAdapter
+//                            .makeHttpUploadService(interpreter)(runtime, mat, implicitly, implicitly, implicitly)
+//                            .apply(req)
+//                        case req @ GET(p"/ws/graphql")      =>
+//                          PlayAdapter.makeWebSocketService(interpreter)(ec, runtime, mat, implicitly, implicitly).apply(req)
+//                      }
+//       _           <- ZIO
+//                        .attempt(
+//                          AkkaHttpServer.fromRouterWithComponents(
+//                            ServerConfig(
+//                              mode = Mode.Dev,
+//                              port = Some(8088),
+//                              address = "127.0.0.1"
+//                            )
+//                          )(_ => router.routes)
+//                        )
+//                        .withFinalizer(server => ZIO.attempt(server.stop()).ignore)
+//       _           <- Live.live(Clock.sleep(3 seconds))
+//       service     <- ZIO.service[TestService]
+//     } yield service
+//   }
 
-  override def spec = {
-    val suite = TapirAdapterSpec.makeSuite(
-      "PlayAdapterSpec",
-      uri"http://localhost:8088/api/graphql",
-      uploadUri = Some(uri"http://localhost:8088/upload/graphql"),
-      wsUri = Some(uri"ws://localhost:8088/ws/graphql")
-    )
-    suite.provideLayerShared(apiLayer)
-  }
-}
+//   override def spec = {
+//     val suite = TapirAdapterSpec.makeSuite(
+//       "PlayAdapterSpec",
+//       uri"http://localhost:8088/api/graphql",
+//       uploadUri = Some(uri"http://localhost:8088/upload/graphql"),
+//       wsUri = Some(uri"ws://localhost:8088/ws/graphql")
+//     )
+//     suite.provideLayerShared(apiLayer)
+//   }
+// }

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -1,88 +1,88 @@
-package caliban
+// package caliban
 
-import caliban.execution.QueryExecution
-import caliban.interop.tapir.ws.Protocol
-import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks }
-import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult
-import sttp.tapir.server.ziohttp.{ ZioHttpInterpreter, ZioHttpServerOptions }
-import zhttp.http._
-import zhttp.service.ChannelEvent
-import zhttp.service.ChannelEvent.UserEvent.HandshakeComplete
-import zhttp.service.ChannelEvent.{ ChannelRead, UserEventTriggered }
-import zhttp.socket._
-import zio._
-import zio.stream._
+// import caliban.execution.QueryExecution
+// import caliban.interop.tapir.ws.Protocol
+// import caliban.interop.tapir.{ RequestInterceptor, TapirAdapter, WebSocketHooks }
+// import sttp.tapir.Codec.JsonCodec
+// import sttp.tapir.DecodeResult
+// import sttp.tapir.server.ziohttp.{ ZioHttpInterpreter, ZioHttpServerOptions }
+// import zhttp.http._
+// import zhttp.service.ChannelEvent
+// import zhttp.service.ChannelEvent.UserEvent.HandshakeComplete
+// import zhttp.service.ChannelEvent.{ ChannelRead, UserEventTriggered }
+// import zhttp.socket._
+// import zio._
+// import zio.stream._
 
-object ZHttpAdapter {
+// object ZHttpAdapter {
 
-  def makeHttpService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
-  )(implicit
-    requestCodec: JsonCodec[GraphQLRequest],
-    responseCodec: JsonCodec[GraphQLResponse[E]],
-    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
-  ): HttpApp[R, Throwable] = {
-    val endpoints = TapirAdapter.makeHttpService[R, E](
-      interpreter,
-      skipValidation,
-      enableIntrospection,
-      queryExecution,
-      requestInterceptor
-    )
-    ZioHttpInterpreter(serverOptions).toHttp(endpoints)
-  }
+//   def makeHttpService[R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+//   )(implicit
+//     requestCodec: JsonCodec[GraphQLRequest],
+//     responseCodec: JsonCodec[GraphQLResponse[E]],
+//     serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
+//   ): HttpApp[R, Throwable] = {
+//     val endpoints = TapirAdapter.makeHttpService[R, E](
+//       interpreter,
+//       skipValidation,
+//       enableIntrospection,
+//       queryExecution,
+//       requestInterceptor
+//     )
+//     ZioHttpInterpreter(serverOptions).toHttp(endpoints)
+//   }
 
-  def makeWebSocketService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
-    skipValidation: Boolean = false,
-    enableIntrospection: Boolean = true,
-    keepAliveTime: Option[Duration] = None,
-    queryExecution: QueryExecution = QueryExecution.Parallel,
-    webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty
-  )(implicit inputCodec: JsonCodec[GraphQLWSInput], outputCodec: JsonCodec[GraphQLWSOutput]): HttpApp[R, E] =
-    Http.fromFunctionZIO[Request] { req =>
-      val protocol = req.headers.header("Sec-WebSocket-Protocol") match {
-        case Some((_, value)) => Protocol.fromName(value.toString)
-        case None             => Protocol.Legacy
-      }
+//   def makeWebSocketService[R, E](
+//     interpreter: GraphQLInterpreter[R, E],
+//     skipValidation: Boolean = false,
+//     enableIntrospection: Boolean = true,
+//     keepAliveTime: Option[Duration] = None,
+//     queryExecution: QueryExecution = QueryExecution.Parallel,
+//     webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty
+//   )(implicit inputCodec: JsonCodec[GraphQLWSInput], outputCodec: JsonCodec[GraphQLWSOutput]): HttpApp[R, E] =
+//     Http.fromFunctionZIO[Request] { req =>
+//       val protocol = req.headers.header("Sec-WebSocket-Protocol") match {
+//         case Some((_, value)) => Protocol.fromName(value.toString)
+//         case None             => Protocol.Legacy
+//       }
 
-      for {
-        queue <- Queue.unbounded[GraphQLWSInput]
-        pipe  <- protocol
-                   .make(
-                     interpreter,
-                     skipValidation,
-                     enableIntrospection,
-                     keepAliveTime,
-                     queryExecution,
-                     webSocketHooks
-                   )
-        in     = ZStream.fromQueueWithShutdown(queue)
-        out    = pipe(in).map {
-                   case Right(output) => WebSocketFrame.Text(outputCodec.encode(output))
-                   case Left(close)   => WebSocketFrame.Close(close.code, Some(close.reason))
-                 }
-        socket = Http
-                   .collectZIO[WebSocketChannelEvent] {
-                     case ChannelEvent(ch, UserEventTriggered(HandshakeComplete)) =>
-                       out.runForeach(ch.writeAndFlush(_)).race(ch.awaitClose)
-                     case ChannelEvent(_, ChannelRead(WebSocketFrame.Text(text))) =>
-                       ZIO.fromEither {
-                         inputCodec.decode(text) match {
-                           case DecodeResult.Value(v)    => Right(v)
-                           case DecodeResult.Error(_, e) => Left(e)
-                           case f: DecodeResult.Failure  => Left(new Throwable(s"failed to decode input: ${f.toString}"))
-                         }
-                       }.flatMap(queue.offer)
-                   }
-        app   <- Response.fromSocketApp(
-                   socket.toSocketApp.withProtocol(SocketProtocol.subProtocol(protocol.name))
-                 )
-      } yield app
-    }
-}
+//       for {
+//         queue <- Queue.unbounded[GraphQLWSInput]
+//         pipe  <- protocol
+//                    .make(
+//                      interpreter,
+//                      skipValidation,
+//                      enableIntrospection,
+//                      keepAliveTime,
+//                      queryExecution,
+//                      webSocketHooks
+//                    )
+//         in     = ZStream.fromQueueWithShutdown(queue)
+//         out    = pipe(in).map {
+//                    case Right(output) => WebSocketFrame.Text(outputCodec.encode(output))
+//                    case Left(close)   => WebSocketFrame.Close(close.code, Some(close.reason))
+//                  }
+//         socket = Http
+//                    .collectZIO[WebSocketChannelEvent] {
+//                      case ChannelEvent(ch, UserEventTriggered(HandshakeComplete)) =>
+//                        out.runForeach(ch.writeAndFlush(_)).race(ch.awaitClose)
+//                      case ChannelEvent(_, ChannelRead(WebSocketFrame.Text(text))) =>
+//                        ZIO.fromEither {
+//                          inputCodec.decode(text) match {
+//                            case DecodeResult.Value(v)    => Right(v)
+//                            case DecodeResult.Error(_, e) => Left(e)
+//                            case f: DecodeResult.Failure  => Left(new Throwable(s"failed to decode input: ${f.toString}"))
+//                          }
+//                        }.flatMap(queue.offer)
+//                    }
+//         app   <- Response.fromSocketApp(
+//                    socket.toSocketApp.withProtocol(SocketProtocol.subProtocol(protocol.name))
+//                  )
+//       } yield app
+//     }
+// }

--- a/adapters/zio-http/src/test/scala/caliban/ZHttpAdapterSpec.scala
+++ b/adapters/zio-http/src/test/scala/caliban/ZHttpAdapterSpec.scala
@@ -1,46 +1,46 @@
-package caliban
+// package caliban
 
-import caliban.interop.tapir.TestData.sampleCharacters
-import caliban.interop.tapir.{ FakeAuthorizationInterceptor, TapirAdapterSpec, TestApi, TestService }
-import caliban.uploads.Uploads
-import sttp.client3.UriContext
-import zhttp.http._
-import zhttp.service.Server
-import zio._
-import zio.test.{ Live, ZIOSpecDefault }
+// import caliban.interop.tapir.TestData.sampleCharacters
+// import caliban.interop.tapir.{ FakeAuthorizationInterceptor, TapirAdapterSpec, TestApi, TestService }
+// import caliban.uploads.Uploads
+// import sttp.client3.UriContext
+// import zhttp.http._
+// import zhttp.service.Server
+// import zio._
+// import zio.test.{ Live, ZIOSpecDefault }
 
-import scala.language.postfixOps
+// import scala.language.postfixOps
 
-object ZHttpAdapterSpec extends ZIOSpecDefault {
-  import sttp.tapir.json.zio._
+// object ZHttpAdapterSpec extends ZIOSpecDefault {
+//   import sttp.tapir.json.zio._
 
-  private val envLayer = TestService.make(sampleCharacters) ++ Uploads.empty
+//   private val envLayer = TestService.make(sampleCharacters) ++ Uploads.empty
 
-  private val apiLayer = envLayer >>> ZLayer.scoped {
-    for {
-      interpreter <- TestApi.api.interpreter
-      _           <- Server
-                       .start(
-                         8089,
-                         Http.collectHttp[Request] {
-                           case _ -> !! / "api" / "graphql" =>
-                             ZHttpAdapter.makeHttpService(interpreter, requestInterceptor = FakeAuthorizationInterceptor.bearer)
-                           case _ -> !! / "ws" / "graphql"  =>
-                             ZHttpAdapter.makeWebSocketService(interpreter)
-                         }
-                       )
-                       .forkScoped
-      _           <- Live.live(Clock.sleep(3 seconds))
-      service     <- ZIO.service[TestService]
-    } yield service
-  }
+//   private val apiLayer = envLayer >>> ZLayer.scoped {
+//     for {
+//       interpreter <- TestApi.api.interpreter
+//       _           <- Server
+//                        .start(
+//                          8089,
+//                          Http.collectHttp[Request] {
+//                            case _ -> !! / "api" / "graphql" =>
+//                              ZHttpAdapter.makeHttpService(interpreter, requestInterceptor = FakeAuthorizationInterceptor.bearer)
+//                            case _ -> !! / "ws" / "graphql"  =>
+//                              ZHttpAdapter.makeWebSocketService(interpreter)
+//                          }
+//                        )
+//                        .forkScoped
+//       _           <- Live.live(Clock.sleep(3 seconds))
+//       service     <- ZIO.service[TestService]
+//     } yield service
+//   }
 
-  override def spec = suite("ZIO Http") {
-    val suite = TapirAdapterSpec.makeSuite(
-      "ZHttpAdapterSpec",
-      uri"http://localhost:8089/api/graphql",
-      wsUri = Some(uri"ws://localhost:8089/ws/graphql")
-    )
-    suite.provideLayerShared(apiLayer)
-  }
-}
+//   override def spec = suite("ZIO Http") {
+//     val suite = TapirAdapterSpec.makeSuite(
+//       "ZHttpAdapterSpec",
+//       uri"http://localhost:8089/api/graphql",
+//       wsUri = Some(uri"ws://localhost:8089/ws/graphql")
+//     )
+//     suite.provideLayerShared(apiLayer)
+//   }
+// }

--- a/examples/src/main/scala/example/akkahttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/akkahttp/AuthExampleApp.scala
@@ -32,7 +32,7 @@ object AuthExampleApp extends App {
         case header if header.is("token") => header.value
       } match {
         case Some(token) =>
-          effect.provideSomeLayer[R](ZLayer.succeed[Any](AuthToken(token)))
+          effect.provideSomeLayer[R](ZLayer.succeed[Auth](AuthToken(token)))
         case _           => ZIO.fail(TapirResponse(StatusCode.Forbidden))
       }
   }
@@ -54,7 +54,7 @@ object AuthExampleApp extends App {
                         .orElse(request.connectionInfo.remote.map(_.getAddress.getHostAddress))
                         .map(IP)
                     }.orDie
-        clientIP <- effect.provideSomeLayer[R](ZLayer.succeed[Any](ip))
+        clientIP <- effect.provideSomeLayer[R](ZLayer.succeed[ClientIP](ip))
       } yield clientIP
   }
 
@@ -63,8 +63,8 @@ object AuthExampleApp extends App {
   case class Query(token: RIO[Auth, String], ip: RIO[ClientIP, String])
   private val resolver                          = RootResolver(
     Query(
-      token = ZIO.serviceWithZIO[Auth](_.get).map(_.value),
-      ip = ZIO.serviceWithZIO[ClientIP](_.get).map(_.map(_.value).getOrElse("no ip"))
+      token = ZIO.serviceWith[Auth](_.value),
+      ip = ZIO.serviceWith[ClientIP](_.map(_.value).getOrElse("no ip"))
     )
   )
   private val api                               = graphQL(resolver)

--- a/examples/src/main/scala/example/akkahttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/akkahttp/AuthExampleApp.scala
@@ -2,12 +2,12 @@ package example.akkahttp
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.server.Directives.{ getFromResource, path, _ }
+import akka.http.scaladsl.server.Directives._
 import caliban.GraphQL._
+import caliban.{ AkkaHttpAdapter, RootResolver }
 import caliban.interop.tapir.RequestInterceptor
 import caliban.interop.tapir.TapirAdapter.TapirResponse
 import caliban.schema.GenericSchema
-import caliban.{ AkkaHttpAdapter, RootResolver }
 import sttp.model.StatusCode
 import sttp.tapir.json.circe._
 import sttp.tapir.model.ServerRequest
@@ -15,8 +15,6 @@ import zio.{ RIO, Runtime, Unsafe, ZIO, ZLayer }
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.io.StdIn
-import zio.Scope
-import _root_.cats.effect.Fiber
 
 object AuthExampleApp extends App {
 

--- a/examples/src/main/scala/example/akkahttp/performance/AuthExampleAppPerformance.scala
+++ b/examples/src/main/scala/example/akkahttp/performance/AuthExampleAppPerformance.scala
@@ -1,0 +1,94 @@
+package example.akkahttp.performance
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Directives.{ getFromResource, path, _ }
+import caliban.GraphQL._
+import caliban.interop.tapir.RequestInterceptor
+import caliban.interop.tapir.TapirAdapter.TapirResponse
+import caliban.schema.GenericSchema
+import caliban.{ AkkaHttpAdapter, RootResolver }
+import sttp.model.StatusCode
+import sttp.tapir.json.circe._
+import sttp.tapir.model.ServerRequest
+import zio.{ FiberRef, RIO, Runtime, Unsafe, ZIO, ZLayer }
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.io.StdIn
+
+object AuthExampleAppPerformance extends App {
+
+  case class AuthToken(value: String)
+
+  type Auth = FiberRef[Option[AuthToken]]
+
+  object AuthInterceptor extends RequestInterceptor[Auth, Auth] {
+    override def apply[R <: Auth, A](
+      request: ServerRequest
+    )(effect: ZIO[R with Auth, TapirResponse, A]): ZIO[R, TapirResponse, A] =
+      request.headers.collectFirst {
+        case header if header.is("token") => header.value
+      } match {
+        case Some(token) => ZIO.serviceWithZIO[Auth](_.set(Some(AuthToken(token)))) *> effect
+        case _           => ZIO.fail(TapirResponse(StatusCode.Forbidden))
+      }
+  }
+
+  case class IP(value: String)
+
+  type ClientIP = FiberRef[Option[IP]]
+
+  object ClientIPInterceptor extends RequestInterceptor[ClientIP, ClientIP] {
+    override def apply[R <: ClientIP, A](request: ServerRequest)(
+      effect: ZIO[R with ClientIP, TapirResponse, A]
+    ): ZIO[R with ClientIP, TapirResponse, A] = {
+      val ip = request
+        .header("X-Forwarded-For")
+        .orElse(request.header("X-Real-IP"))
+        .orElse(request.header("Remote-Address"))
+        .orElse(request.connectionInfo.remote.map(_.getAddress.getHostAddress))
+        .map(IP)
+      ZIO.serviceWithZIO[ClientIP](_.set(ip)) *> effect
+    }
+  }
+
+  val schema: GenericSchema[Auth with ClientIP] = new GenericSchema[Auth with ClientIP] {}
+  import schema._
+  case class Query(token: RIO[Auth, Option[String]], ip: RIO[ClientIP, Option[String]])
+  private val resolver                          = RootResolver(
+    Query(
+      token = ZIO.serviceWithZIO[Auth](_.get).map(_.map(_.value)),
+      ip = ZIO.serviceWithZIO[ClientIP](_.get).map(_.map(_.value))
+    )
+  )
+  private val api                               = graphQL(resolver)
+
+  implicit val system: ActorSystem                        = ActorSystem()
+  implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+
+  // Note that we must initialize the runtime with any FiberRefs we intend to
+  // pass on so that they are present in the environment for our ContextWrapper(s)
+  // For the auth we wrap in an option, but you could just as well use something
+  // like AuthToken("__INVALID") or a sealed trait hierarchy with an invalid member
+  val initLayer: ZLayer[Any, Nothing, Auth with ClientIP] =
+    ZLayer.scoped(FiberRef.make(Option.empty[AuthToken])) ++ ZLayer.scoped(FiberRef.make(Option.empty[IP]))
+
+  implicit val runtime: Runtime[Auth with ClientIP] = Unsafe.unsafe(implicit u => Runtime.unsafe.fromLayer(initLayer))
+
+  val interpreter = Unsafe.unsafe(implicit u => runtime.unsafe.run(api.interpreter).getOrThrow())
+  val adapter     = AkkaHttpAdapter.default
+
+  val route =
+    path("api" / "graphql") {
+      adapter.makeHttpService[Auth with ClientIP, Any, Throwable](interpreter, requestInterceptor = AuthInterceptor)
+    } ~ path("graphiql") {
+      getFromResource("graphiql.html")
+    }
+
+  val bindingFuture = Http().newServerAt("localhost", 8088).bind(route)
+  println(s"Server online at http://localhost:8088/\nPress RETURN to stop...")
+  StdIn.readLine()
+  bindingFuture
+    .flatMap(_.unbind())
+    .onComplete(_ => system.terminate())
+}

--- a/examples/src/main/scala/example/federation/FederatedApp.scala
+++ b/examples/src/main/scala/example/federation/FederatedApp.scala
@@ -1,70 +1,70 @@
-package example.federation
+// package example.federation
 
-import example.federation.FederationData.characters.sampleCharacters
-import example.federation.FederationData.episodes.sampleEpisodes
+// import example.federation.FederationData.characters.sampleCharacters
+// import example.federation.FederationData.episodes.sampleEpisodes
 
-import caliban.Http4sAdapter
-import cats.data.Kleisli
-import com.comcast.ip4s._
-import org.http4s.StaticFile
-import org.http4s.implicits._
-import org.http4s.server.Router
-import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.server.middleware.CORS
-import zio._
-import zio.interop.catz._
+// import caliban.Http4sAdapter
+// import cats.data.Kleisli
+// import com.comcast.ip4s._
+// import org.http4s.StaticFile
+// import org.http4s.implicits._
+// import org.http4s.server.Router
+// import org.http4s.ember.server.EmberServerBuilder
+// import org.http4s.server.middleware.CORS
+// import zio._
+// import zio.interop.catz._
 
-object FederatedApp extends CatsApp {
-  import sttp.tapir.json.circe._
+// object FederatedApp extends CatsApp {
+//   import sttp.tapir.json.circe._
 
-  type ExampleTask[A] = RIO[Any, A]
+//   type ExampleTask[A] = RIO[Any, A]
 
-  val service1 =
-    CharacterService
-      .make(sampleCharacters)
-      .memoize
-      .flatMap(layer =>
-        for {
-          interpreter <- FederatedApi.Characters.api.interpreter.map(_.provideLayer(layer))
-          _           <- EmberServerBuilder
-                           .default[ExampleTask]
-                           .withHost(host"localhost")
-                           .withPort(port"8089")
-                           .withHttpApp(
-                             Router[ExampleTask](
-                               "/api/graphql" -> CORS.policy(Http4sAdapter.makeHttpService(interpreter)),
-                               "/graphiql"    -> Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
-                             ).orNotFound
-                           )
-                           .build
-                           .toScopedZIO
-                           .forever
-        } yield ()
-      )
+//   val service1 =
+//     CharacterService
+//       .make(sampleCharacters)
+//       .memoize
+//       .flatMap(layer =>
+//         for {
+//           interpreter <- FederatedApi.Characters.api.interpreter.map(_.provideLayer(layer))
+//           _           <- EmberServerBuilder
+//                            .default[ExampleTask]
+//                            .withHost(host"localhost")
+//                            .withPort(port"8089")
+//                            .withHttpApp(
+//                              Router[ExampleTask](
+//                                "/api/graphql" -> CORS.policy(Http4sAdapter.makeHttpService(interpreter)),
+//                                "/graphiql"    -> Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
+//                              ).orNotFound
+//                            )
+//                            .build
+//                            .toScopedZIO
+//                            .forever
+//         } yield ()
+//       )
 
-  val service2 =
-    EpisodeService
-      .make(sampleEpisodes)
-      .memoize
-      .flatMap(layer =>
-        for {
-          interpreter <- FederatedApi.Episodes.api.interpreter.map(_.provideLayer(layer))
-          _           <- EmberServerBuilder
-                           .default[ExampleTask]
-                           .withHost(host"localhost")
-                           .withPort(port"8088")
-                           .withHttpApp(
-                             Router[ExampleTask](
-                               "/api/graphql" -> CORS.policy(Http4sAdapter.makeHttpService(interpreter)),
-                               "/graphiql"    -> Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
-                             ).orNotFound
-                           )
-                           .build
-                           .toScopedZIO
-                           .forever
-        } yield ()
-      )
+//   val service2 =
+//     EpisodeService
+//       .make(sampleEpisodes)
+//       .memoize
+//       .flatMap(layer =>
+//         for {
+//           interpreter <- FederatedApi.Episodes.api.interpreter.map(_.provideLayer(layer))
+//           _           <- EmberServerBuilder
+//                            .default[ExampleTask]
+//                            .withHost(host"localhost")
+//                            .withPort(port"8088")
+//                            .withHttpApp(
+//                              Router[ExampleTask](
+//                                "/api/graphql" -> CORS.policy(Http4sAdapter.makeHttpService(interpreter)),
+//                                "/graphiql"    -> Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
+//                              ).orNotFound
+//                            )
+//                            .build
+//                            .toScopedZIO
+//                            .forever
+//         } yield ()
+//       )
 
-  override def run =
-    (service1 race service2).exitCode
-}
+//   override def run =
+//     (service1 race service2).exitCode
+// }

--- a/examples/src/main/scala/example/federation/v2/FederatedApp.scala
+++ b/examples/src/main/scala/example/federation/v2/FederatedApp.scala
@@ -1,41 +1,41 @@
-package example.federation.v2
+// package example.federation.v2
 
-import caliban.ZHttpAdapter
-import example.federation.v2.FederationData.characters.sampleCharacters
-import example.federation.v2.FederationData.episodes.sampleEpisodes
-import zhttp.http._
-import zhttp.service.Server
-import zio._
+// import caliban.ZHttpAdapter
+// import example.federation.v2.FederationData.characters.sampleCharacters
+// import example.federation.v2.FederationData.episodes.sampleEpisodes
+// import zhttp.http._
+// import zhttp.service.Server
+// import zio._
 
-object FederatedApp extends ZIOAppDefault {
-  import sttp.tapir.json.circe._
+// object FederatedApp extends ZIOAppDefault {
+//   import sttp.tapir.json.circe._
 
-  val characterServer = for {
-    interpreter <- FederatedApi.Characters.api.interpreter
-    _           <- Server
-                     .start(
-                       8088,
-                       Http.collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
-                         ZHttpAdapter.makeHttpService(interpreter)
-                       }
-                     )
-                     .forever
-  } yield ()
+//   val characterServer = for {
+//     interpreter <- FederatedApi.Characters.api.interpreter
+//     _           <- Server
+//                      .start(
+//                        8088,
+//                        Http.collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
+//                          ZHttpAdapter.makeHttpService(interpreter)
+//                        }
+//                      )
+//                      .forever
+//   } yield ()
 
-  val episodeServer = for {
-    interpreter <- FederatedApi.Episodes.api.interpreter
-    _           <- Server
-                     .start(
-                       8089,
-                       Http.collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
-                         ZHttpAdapter.makeHttpService(interpreter)
-                       }
-                     )
-                     .forever
-  } yield ()
+//   val episodeServer = for {
+//     interpreter <- FederatedApi.Episodes.api.interpreter
+//     _           <- Server
+//                      .start(
+//                        8089,
+//                        Http.collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
+//                          ZHttpAdapter.makeHttpService(interpreter)
+//                        }
+//                      )
+//                      .forever
+//   } yield ()
 
-  override def run =
-    (characterServer race episodeServer)
-      .provideLayer(EpisodeService.make(sampleEpisodes) ++ CharacterService.make(sampleCharacters))
-      .exitCode
-}
+//   override def run =
+//     (characterServer race episodeServer)
+//       .provideLayer(EpisodeService.make(sampleEpisodes) ++ CharacterService.make(sampleCharacters))
+//       .exitCode
+// }

--- a/examples/src/main/scala/example/http4s/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/http4s/AuthExampleApp.scala
@@ -1,69 +1,69 @@
-package example.http4s
+// package example.http4s
 
-import caliban.GraphQL._
-import caliban.schema.GenericSchema
-import caliban.{ Http4sAdapter, RootResolver }
-import com.comcast.ip4s._
-import org.http4s.{ HttpRoutes, Response }
-import org.http4s.dsl.Http4sDsl
-import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.server.Router
-import org.typelevel.ci.CIString
-import zio._
-import zio.interop.catz._
+// import caliban.GraphQL._
+// import caliban.schema.GenericSchema
+// import caliban.{ Http4sAdapter, RootResolver }
+// import com.comcast.ip4s._
+// import org.http4s.{ HttpRoutes, Response }
+// import org.http4s.dsl.Http4sDsl
+// import org.http4s.ember.server.EmberServerBuilder
+// import org.http4s.server.Router
+// import org.typelevel.ci.CIString
+// import zio._
+// import zio.interop.catz._
 
-object AuthExampleApp extends CatsApp {
-  import sttp.tapir.json.circe._
+// object AuthExampleApp extends CatsApp {
+//   import sttp.tapir.json.circe._
 
-  // Simple service that returns the token coming from the request
-  trait Auth {
-    def token: String
-  }
+//   // Simple service that returns the token coming from the request
+//   trait Auth {
+//     def token: String
+//   }
 
-  type AuthTask[A] = RIO[Auth, A]
-  type MyTask[A]   = RIO[Any, A]
+//   type AuthTask[A] = RIO[Auth, A]
+//   type MyTask[A]   = RIO[Any, A]
 
-  case class MissingToken() extends Throwable
+//   case class MissingToken() extends Throwable
 
-  // http4s middleware that extracts a token from the request and eliminate the Auth layer dependency
-  object AuthMiddleware {
-    def apply(route: HttpRoutes[AuthTask]): HttpRoutes[MyTask] =
-      Http4sAdapter.provideSomeLayerFromRequest[Any, Auth](
-        route,
-        _.headers.get(CIString("token")) match {
-          case Some(value) => ZLayer.succeed(new Auth { override def token: String = value.head.value })
-          case None        => ZLayer.fail(MissingToken())
-        }
-      )
-  }
+//   // http4s middleware that extracts a token from the request and eliminate the Auth layer dependency
+//   object AuthMiddleware {
+//     def apply(route: HttpRoutes[AuthTask]): HttpRoutes[MyTask] =
+//       Http4sAdapter.provideSomeLayerFromRequest[Any, Auth](
+//         route,
+//         _.headers.get(CIString("token")) match {
+//           case Some(value) => ZLayer.succeed(new Auth { override def token: String = value.head.value })
+//           case None        => ZLayer.fail(MissingToken())
+//         }
+//       )
+//   }
 
-  // http4s error handler to customize the response for our throwable
-  object dsl extends Http4sDsl[MyTask]
-  import dsl._
-  val errorHandler: PartialFunction[Throwable, MyTask[Response[MyTask]]] = { case MissingToken() => Forbidden() }
+//   // http4s error handler to customize the response for our throwable
+//   object dsl extends Http4sDsl[MyTask]
+//   import dsl._
+//   val errorHandler: PartialFunction[Throwable, MyTask[Response[MyTask]]] = { case MissingToken() => Forbidden() }
 
-  // our GraphQL API
-  val schema: GenericSchema[Auth] = new GenericSchema[Auth] {}
-  import schema._
-  case class Query(token: RIO[Auth, String])
-  private val resolver            = RootResolver(Query(ZIO.serviceWith[Auth](_.token)))
-  private val api                 = graphQL(resolver)
+//   // our GraphQL API
+//   val schema: GenericSchema[Auth] = new GenericSchema[Auth] {}
+//   import schema._
+//   case class Query(token: RIO[Auth, String])
+//   private val resolver            = RootResolver(Query(ZIO.serviceWith[Auth](_.token)))
+//   private val api                 = graphQL(resolver)
 
-  override def run =
-    for {
-      interpreter <- api.interpreter
-      _           <- EmberServerBuilder
-                       .default[MyTask]
-                       .withErrorHandler(errorHandler)
-                       .withHost(host"localhost")
-                       .withPort(port"8088")
-                       .withHttpWebSocketApp(wsBuilder =>
-                         Router[MyTask](
-                           "/api/graphql" -> AuthMiddleware(Http4sAdapter.makeHttpService(interpreter)),
-                           "/ws/graphql"  -> AuthMiddleware(Http4sAdapter.makeWebSocketService(wsBuilder, interpreter))
-                         ).orNotFound
-                       )
-                       .build
-                       .toScopedZIO *> ZIO.never
-    } yield ()
-}
+//   override def run =
+//     for {
+//       interpreter <- api.interpreter
+//       _           <- EmberServerBuilder
+//                        .default[MyTask]
+//                        .withErrorHandler(errorHandler)
+//                        .withHost(host"localhost")
+//                        .withPort(port"8088")
+//                        .withHttpWebSocketApp(wsBuilder =>
+//                          Router[MyTask](
+//                            "/api/graphql" -> AuthMiddleware(Http4sAdapter.makeHttpService(interpreter)),
+//                            "/ws/graphql"  -> AuthMiddleware(Http4sAdapter.makeWebSocketService(wsBuilder, interpreter))
+//                          ).orNotFound
+//                        )
+//                        .build
+//                        .toScopedZIO *> ZIO.never
+//     } yield ()
+// }

--- a/examples/src/main/scala/example/http4s/AuthExampleAppF.scala
+++ b/examples/src/main/scala/example/http4s/AuthExampleAppF.scala
@@ -1,145 +1,145 @@
-package example.http4s
+// package example.http4s
 
-import caliban.GraphQL._
-import caliban.interop.cats.{ CatsInterop, InjectEnv }
-import caliban.schema.GenericSchema
-import caliban.{ CalibanError, GraphQL, Http4sAdapter, RootResolver }
-import cats.data.{ Kleisli, OptionT }
-import cats.MonadThrow
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-import cats.effect.{ Async, IO, IOApp, Resource }
-import cats.effect.std.Dispatcher
-import cats.mtl.Local
-import cats.mtl.syntax.local._
-import com.comcast.ip4s._
-import org.http4s.{ HttpApp, HttpRoutes, Request, Response }
-import org.http4s.server.Server
-import org.http4s.dsl.Http4sDsl
-import org.http4s.implicits._
-import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.server.Router
-import org.typelevel.ci._
-import zio.{ Runtime, ZEnvironment }
+// import caliban.GraphQL._
+// import caliban.interop.cats.{ CatsInterop, InjectEnv }
+// import caliban.schema.GenericSchema
+// import caliban.{ CalibanError, GraphQL, Http4sAdapter, RootResolver }
+// import cats.data.{ Kleisli, OptionT }
+// import cats.MonadThrow
+// import cats.syntax.flatMap._
+// import cats.syntax.functor._
+// import cats.effect.{ Async, IO, IOApp, Resource }
+// import cats.effect.std.Dispatcher
+// import cats.mtl.Local
+// import cats.mtl.syntax.local._
+// import com.comcast.ip4s._
+// import org.http4s.{ HttpApp, HttpRoutes, Request, Response }
+// import org.http4s.server.Server
+// import org.http4s.dsl.Http4sDsl
+// import org.http4s.implicits._
+// import org.http4s.ember.server.EmberServerBuilder
+// import org.http4s.server.Router
+// import org.typelevel.ci._
+// import zio.{ Runtime, ZEnvironment }
 
-/**
- * The examples shows how to utilize contextual interop between cats-effect and ZIO.
- *
- * Run server:
- * examples/runMain example.http4s.AuthExampleAppF
- *
- * Send a request:
- * curl -X POST -H "X-Token: my-token" -d '{"query": "query { token }"}' localhost:8088/api/graphql
- *
- * Response:
- * {"data":{"token":"my-token"}}
- */
-object AuthExampleAppF extends IOApp.Simple {
+// /**
+//  * The examples shows how to utilize contextual interop between cats-effect and ZIO.
+//  *
+//  * Run server:
+//  * examples/runMain example.http4s.AuthExampleAppF
+//  *
+//  * Send a request:
+//  * curl -X POST -H "X-Token: my-token" -d '{"query": "query { token }"}' localhost:8088/api/graphql
+//  *
+//  * Response:
+//  * {"data":{"token":"my-token"}}
+//  */
+// object AuthExampleAppF extends IOApp.Simple {
 
-  type AuthLocal[F[_]] = Local[F, AuthInfo]
-  object AuthLocal {
-    def apply[F[_]](implicit ev: AuthLocal[F]): AuthLocal[F] = ev
+//   type AuthLocal[F[_]] = Local[F, AuthInfo]
+//   object AuthLocal {
+//     def apply[F[_]](implicit ev: AuthLocal[F]): AuthLocal[F] = ev
 
-    def token[F[_]: MonadThrow](implicit local: AuthLocal[F]): F[AuthInfo.Token] =
-      local.ask.flatMap {
-        case t: AuthInfo.Token => MonadThrow[F].pure(t)
-        case AuthInfo.Empty    => MonadThrow[F].raiseError(MissingToken())
-      }
-  }
+//     def token[F[_]: MonadThrow](implicit local: AuthLocal[F]): F[AuthInfo.Token] =
+//       local.ask.flatMap {
+//         case t: AuthInfo.Token => MonadThrow[F].pure(t)
+//         case AuthInfo.Empty    => MonadThrow[F].raiseError(MissingToken())
+//       }
+//   }
 
-  sealed trait AuthInfo
-  object AuthInfo {
-    final case object Empty               extends AuthInfo
-    final case class Token(token: String) extends AuthInfo
-  }
+//   sealed trait AuthInfo
+//   object AuthInfo {
+//     final case object Empty               extends AuthInfo
+//     final case class Token(token: String) extends AuthInfo
+//   }
 
-  final case class MissingToken() extends Throwable
+//   final case class MissingToken() extends Throwable
 
-  // http4s middleware that extracts a token from the request and executes the request with AuthInfo available in the scope
-  object AuthMiddleware {
-    private val TokenHeader = ci"X-Token"
+//   // http4s middleware that extracts a token from the request and executes the request with AuthInfo available in the scope
+//   object AuthMiddleware {
+//     private val TokenHeader = ci"X-Token"
 
-    def httpRoutes[F[_]: MonadThrow: AuthLocal](routes: HttpRoutes[F]): HttpRoutes[F] =
-      Kleisli { (req: Request[F]) =>
-        req.headers.get(TokenHeader) match {
-          case Some(token) => routes.run(req).scope(AuthInfo.Token(token.head.value): AuthInfo)
-          case None        => OptionT.liftF(MonadThrow[F].raiseError(MissingToken()))
-        }
-      }
-  }
+//     def httpRoutes[F[_]: MonadThrow: AuthLocal](routes: HttpRoutes[F]): HttpRoutes[F] =
+//       Kleisli { (req: Request[F]) =>
+//         req.headers.get(TokenHeader) match {
+//           case Some(token) => routes.run(req).scope(AuthInfo.Token(token.head.value): AuthInfo)
+//           case None        => OptionT.liftF(MonadThrow[F].raiseError(MissingToken()))
+//         }
+//       }
+//   }
 
-  // Simple service that returns the token coming from the request
-  final case class Query[F[_]](token: F[String])
+//   // Simple service that returns the token coming from the request
+//   final case class Query[F[_]](token: F[String])
 
-  class GQL[F[_]: MonadThrow: AuthLocal](implicit interop: CatsInterop[F, AuthInfo]) {
+//   class GQL[F[_]: MonadThrow: AuthLocal](implicit interop: CatsInterop[F, AuthInfo]) {
 
-    def createGraphQL: GraphQL[AuthInfo] = {
-      val schema: GenericSchema[AuthInfo] = new GenericSchema[AuthInfo] {}
-      import schema._
-      import caliban.interop.cats.implicits._ // summons `Schema[Auth, F[String]]` instance
+//     def createGraphQL: GraphQL[AuthInfo] = {
+//       val schema: GenericSchema[AuthInfo] = new GenericSchema[AuthInfo] {}
+//       import schema._
+//       import caliban.interop.cats.implicits._ // summons `Schema[Auth, F[String]]` instance
 
-      graphQL(RootResolver(query))
-    }
+//       graphQL(RootResolver(query))
+//     }
 
-    private def query: Query[F] =
-      Query(
-        token = AuthLocal.token[F].map(authInfo => authInfo.token)
-      )
-  }
+//     private def query: Query[F] =
+//       Query(
+//         token = AuthLocal.token[F].map(authInfo => authInfo.token)
+//       )
+//   }
 
-  class Api[F[_]: Async: AuthLocal](implicit interop: CatsInterop[F, AuthInfo]) extends Http4sDsl[F] {
-    import sttp.tapir.json.circe._
+//   class Api[F[_]: Async: AuthLocal](implicit interop: CatsInterop[F, AuthInfo]) extends Http4sDsl[F] {
+//     import sttp.tapir.json.circe._
 
-    def httpApp(graphQL: GraphQL[AuthInfo]): F[HttpApp[F]] =
-      for {
-        routes <- createRoutes(graphQL)
-      } yield Router("/api/graphql" -> AuthMiddleware.httpRoutes(routes)).orNotFound
+//     def httpApp(graphQL: GraphQL[AuthInfo]): F[HttpApp[F]] =
+//       for {
+//         routes <- createRoutes(graphQL)
+//       } yield Router("/api/graphql" -> AuthMiddleware.httpRoutes(routes)).orNotFound
 
-    def createRoutes(graphQL: GraphQL[AuthInfo]): F[HttpRoutes[F]] =
-      for {
-        interpreter <- interop.toEffect(graphQL.interpreter)
-      } yield Http4sAdapter.makeHttpServiceF[F, AuthInfo, CalibanError](interpreter)
+//     def createRoutes(graphQL: GraphQL[AuthInfo]): F[HttpRoutes[F]] =
+//       for {
+//         interpreter <- interop.toEffect(graphQL.interpreter)
+//       } yield Http4sAdapter.makeHttpServiceF[F, AuthInfo, CalibanError](interpreter)
 
-    // http4s error handler to customize the response for our throwable
-    def errorHandler: PartialFunction[Throwable, F[Response[F]]] = { case MissingToken() => Forbidden() }
-  }
+//     // http4s error handler to customize the response for our throwable
+//     def errorHandler: PartialFunction[Throwable, F[Response[F]]] = { case MissingToken() => Forbidden() }
+//   }
 
-  def program[F[_]: Async: AuthLocal](implicit
-    runtime: Runtime[AuthInfo],
-    injector: InjectEnv[F, AuthInfo]
-  ): Resource[F, Server] = {
+//   def program[F[_]: Async: AuthLocal](implicit
+//     runtime: Runtime[AuthInfo],
+//     injector: InjectEnv[F, AuthInfo]
+//   ): Resource[F, Server] = {
 
-    def makeHttpServer(
-      httpApp: HttpApp[F],
-      errorHandler: PartialFunction[Throwable, F[Response[F]]]
-    ): Resource[F, Server] =
-      EmberServerBuilder
-        .default[F]
-        .withErrorHandler(errorHandler)
-        .withHost(host"localhost")
-        .withPort(port"8088")
-        .withHttpApp(httpApp)
-        .build
+//     def makeHttpServer(
+//       httpApp: HttpApp[F],
+//       errorHandler: PartialFunction[Throwable, F[Response[F]]]
+//     ): Resource[F, Server] =
+//       EmberServerBuilder
+//         .default[F]
+//         .withErrorHandler(errorHandler)
+//         .withHost(host"localhost")
+//         .withPort(port"8088")
+//         .withHttpApp(httpApp)
+//         .build
 
-    Dispatcher.parallel[F].flatMap { dispatcher =>
-      implicit val interop: CatsInterop.Contextual[F, AuthInfo] = CatsInterop.contextual(dispatcher)
+//     Dispatcher.parallel[F].flatMap { dispatcher =>
+//       implicit val interop: CatsInterop.Contextual[F, AuthInfo] = CatsInterop.contextual(dispatcher)
 
-      val gql = new GQL[F]
-      val api = new Api[F]
+//       val gql = new GQL[F]
+//       val api = new Api[F]
 
-      for {
-        httpApp    <- Resource.eval(api.httpApp(gql.createGraphQL))
-        httpServer <- makeHttpServer(httpApp, api.errorHandler)
-      } yield httpServer
-    }
-  }
+//       for {
+//         httpApp    <- Resource.eval(api.httpApp(gql.createGraphQL))
+//         httpServer <- makeHttpServer(httpApp, api.errorHandler)
+//       } yield httpServer
+//     }
+//   }
 
-  def run: IO[Unit] = {
-    type Effect[A] = Kleisli[IO, AuthInfo, A]
+//   def run: IO[Unit] = {
+//     type Effect[A] = Kleisli[IO, AuthInfo, A]
 
-    implicit val runtime: Runtime[AuthInfo] = Runtime.default.withEnvironment(ZEnvironment(AuthInfo.Empty))
+//     implicit val runtime: Runtime[AuthInfo] = Runtime.default.withEnvironment(ZEnvironment(AuthInfo.Empty))
 
-    program[Effect].useForever.run(AuthInfo.Empty).void
-  }
+//     program[Effect].useForever.run(AuthInfo.Empty).void
+//   }
 
-}
+// }

--- a/examples/src/main/scala/example/http4s/ExampleApp.scala
+++ b/examples/src/main/scala/example/http4s/ExampleApp.scala
@@ -1,44 +1,44 @@
-package example.http4s
+// package example.http4s
 
-import caliban.Http4sAdapter
-import cats.data.Kleisli
-import com.comcast.ip4s._
-import example.ExampleData._
-import example.ExampleService.ExampleService
-import example.{ ExampleApi, ExampleService }
-import org.http4s.StaticFile
-import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.implicits._
-import org.http4s.server.Router
-import org.http4s.server.middleware.CORS
-import zio._
-import zio.interop.catz._
+// import caliban.Http4sAdapter
+// import cats.data.Kleisli
+// import com.comcast.ip4s._
+// import example.ExampleData._
+// import example.ExampleService.ExampleService
+// import example.{ ExampleApi, ExampleService }
+// import org.http4s.StaticFile
+// import org.http4s.ember.server.EmberServerBuilder
+// import org.http4s.implicits._
+// import org.http4s.server.Router
+// import org.http4s.server.middleware.CORS
+// import zio._
+// import zio.interop.catz._
 
-object ExampleApp extends ZIOAppDefault {
-  import sttp.tapir.json.circe._
+// object ExampleApp extends ZIOAppDefault {
+//   import sttp.tapir.json.circe._
 
-  type ExampleTask[A] = RIO[ExampleService, A]
+//   type ExampleTask[A] = RIO[ExampleService, A]
 
-  override def run =
-    ZIO
-      .runtime[ExampleService]
-      .flatMap(implicit runtime =>
-        for {
-          interpreter <- ExampleApi.api.interpreter
-          _           <- EmberServerBuilder
-                           .default[ExampleTask]
-                           .withHost(host"localhost")
-                           .withPort(port"8088")
-                           .withHttpWebSocketApp(wsBuilder =>
-                             Router[ExampleTask](
-                               "/api/graphql" -> CORS.policy(Http4sAdapter.makeHttpService(interpreter)),
-                               "/ws/graphql"  -> CORS.policy(Http4sAdapter.makeWebSocketService(wsBuilder, interpreter)),
-                               "/graphiql"    -> Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
-                             ).orNotFound
-                           )
-                           .build
-                           .toScopedZIO *> ZIO.never
-        } yield ()
-      )
-      .provideSomeLayer[Scope](ExampleService.make(sampleCharacters))
-}
+//   override def run =
+//     ZIO
+//       .runtime[ExampleService]
+//       .flatMap(implicit runtime =>
+//         for {
+//           interpreter <- ExampleApi.api.interpreter
+//           _           <- EmberServerBuilder
+//                            .default[ExampleTask]
+//                            .withHost(host"localhost")
+//                            .withPort(port"8088")
+//                            .withHttpWebSocketApp(wsBuilder =>
+//                              Router[ExampleTask](
+//                                "/api/graphql" -> CORS.policy(Http4sAdapter.makeHttpService(interpreter)),
+//                                "/ws/graphql"  -> CORS.policy(Http4sAdapter.makeWebSocketService(wsBuilder, interpreter)),
+//                                "/graphiql"    -> Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
+//                              ).orNotFound
+//                            )
+//                            .build
+//                            .toScopedZIO *> ZIO.never
+//         } yield ()
+//       )
+//       .provideSomeLayer[Scope](ExampleService.make(sampleCharacters))
+// }

--- a/examples/src/main/scala/example/http4s/ExampleAppF.scala
+++ b/examples/src/main/scala/example/http4s/ExampleAppF.scala
@@ -1,49 +1,49 @@
-package example.http4s
+// package example.http4s
 
-import caliban.interop.cats.implicits._
-import caliban.{ CalibanError, Http4sAdapter }
-import cats.data.Kleisli
-import cats.effect.std.Dispatcher
-import cats.effect.{ ExitCode, IO, IOApp }
-import com.comcast.ip4s._
-import example.ExampleData.sampleCharacters
-import example.ExampleService.ExampleService
-import example.{ ExampleApi, ExampleService }
-import org.http4s.StaticFile
-import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.implicits._
-import org.http4s.server.Router
-import org.http4s.server.middleware.CORS
-import zio.{ Runtime, Unsafe }
+// import caliban.interop.cats.implicits._
+// import caliban.{ CalibanError, Http4sAdapter }
+// import cats.data.Kleisli
+// import cats.effect.std.Dispatcher
+// import cats.effect.{ ExitCode, IO, IOApp }
+// import com.comcast.ip4s._
+// import example.ExampleData.sampleCharacters
+// import example.ExampleService.ExampleService
+// import example.{ ExampleApi, ExampleService }
+// import org.http4s.StaticFile
+// import org.http4s.ember.server.EmberServerBuilder
+// import org.http4s.implicits._
+// import org.http4s.server.Router
+// import org.http4s.server.middleware.CORS
+// import zio.{ Runtime, Unsafe }
 
-object ExampleAppF extends IOApp {
-  import sttp.tapir.json.circe._
+// object ExampleAppF extends IOApp {
+//   import sttp.tapir.json.circe._
 
-  type MyEnv = ExampleService
+//   type MyEnv = ExampleService
 
-  implicit val zioRuntime: Runtime[MyEnv] =
-    Unsafe.unsafe(implicit u => Runtime.unsafe.fromLayer(ExampleService.make(sampleCharacters)))
+//   implicit val zioRuntime: Runtime[MyEnv] =
+//     Unsafe.unsafe(implicit u => Runtime.unsafe.fromLayer(ExampleService.make(sampleCharacters)))
 
-  override def run(args: List[String]): IO[ExitCode] =
-    Dispatcher.parallel[IO].use { implicit dispatcher =>
-      for {
-        interpreter <- ExampleApi.api.interpreterAsync[IO]
-        _           <- EmberServerBuilder
-                         .default[IO]
-                         .withHost(host"localhost")
-                         .withPort(port"8088")
-                         .withHttpWebSocketApp(wsBuilder =>
-                           Router[IO](
-                             "/api/graphql" ->
-                               CORS.policy(Http4sAdapter.makeHttpServiceF[IO, MyEnv, CalibanError](interpreter)),
-                             "/ws/graphql"  ->
-                               CORS.policy(Http4sAdapter.makeWebSocketServiceF[IO, MyEnv, CalibanError](wsBuilder, interpreter)),
-                             "/graphiql"    ->
-                               Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
-                           ).orNotFound
-                         )
-                         .build
-                         .useForever
-      } yield ExitCode.Success
-    }
-}
+//   override def run(args: List[String]): IO[ExitCode] =
+//     Dispatcher.parallel[IO].use { implicit dispatcher =>
+//       for {
+//         interpreter <- ExampleApi.api.interpreterAsync[IO]
+//         _           <- EmberServerBuilder
+//                          .default[IO]
+//                          .withHost(host"localhost")
+//                          .withPort(port"8088")
+//                          .withHttpWebSocketApp(wsBuilder =>
+//                            Router[IO](
+//                              "/api/graphql" ->
+//                                CORS.policy(Http4sAdapter.makeHttpServiceF[IO, MyEnv, CalibanError](interpreter)),
+//                              "/ws/graphql"  ->
+//                                CORS.policy(Http4sAdapter.makeWebSocketServiceF[IO, MyEnv, CalibanError](wsBuilder, interpreter)),
+//                              "/graphiql"    ->
+//                                Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
+//                            ).orNotFound
+//                          )
+//                          .build
+//                          .useForever
+//       } yield ExitCode.Success
+//     }
+// }

--- a/examples/src/main/scala/example/interop/monix/ExampleMonixInterop.scala
+++ b/examples/src/main/scala/example/interop/monix/ExampleMonixInterop.scala
@@ -1,4 +1,4 @@
-package example.interop.monix
+// package example.interop.monix
 /*
 
 import caliban.GraphQL.graphQL

--- a/examples/src/main/scala/example/play/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/play/AuthExampleApp.scala
@@ -1,78 +1,78 @@
-package example.play
+// package example.play
 
-import akka.actor.ActorSystem
-import caliban.GraphQL.graphQL
-import caliban.interop.tapir.RequestInterceptor
-import caliban.interop.tapir.TapirAdapter.TapirResponse
-import caliban.schema.GenericSchema
-import caliban.{ PlayAdapter, RootResolver }
-import play.api.Mode
-import play.api.routing._
-import play.api.routing.sird._
-import play.core.server.{ AkkaHttpServer, ServerConfig }
-import sttp.model.StatusCode
-import sttp.tapir.json.play._
-import sttp.tapir.model.ServerRequest
-import zio.stream.ZStream
-import zio.{ FiberRef, RIO, Runtime, ULayer, Unsafe, ZIO, ZLayer }
+// import akka.actor.ActorSystem
+// import caliban.GraphQL.graphQL
+// import caliban.interop.tapir.RequestInterceptor
+// import caliban.interop.tapir.TapirAdapter.TapirResponse
+// import caliban.schema.GenericSchema
+// import caliban.{ PlayAdapter, RootResolver }
+// import play.api.Mode
+// import play.api.routing._
+// import play.api.routing.sird._
+// import play.core.server.{ AkkaHttpServer, ServerConfig }
+// import sttp.model.StatusCode
+// import sttp.tapir.json.play._
+// import sttp.tapir.model.ServerRequest
+// import zio.stream.ZStream
+// import zio.{ FiberRef, RIO, Runtime, ULayer, Unsafe, ZIO, ZLayer }
 
-import scala.concurrent.ExecutionContextExecutor
-import scala.io.StdIn.readLine
+// import scala.concurrent.ExecutionContextExecutor
+// import scala.io.StdIn.readLine
 
-object AuthExampleApp extends App {
-  case class AuthToken(value: String)
+// object AuthExampleApp extends App {
+//   case class AuthToken(value: String)
 
-  type Auth = FiberRef[Option[AuthToken]]
+//   type Auth = FiberRef[Option[AuthToken]]
 
-  implicit val system: ActorSystem                        = ActorSystem()
-  implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+//   implicit val system: ActorSystem                        = ActorSystem()
+//   implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
-  object AuthWrapper extends RequestInterceptor[Auth] {
-    override def apply[R <: Auth, A](
-      request: ServerRequest
-    )(effect: ZIO[R, TapirResponse, A]): ZIO[R, TapirResponse, A] =
-      request.header("token") match {
-        case Some(token) => ZIO.serviceWithZIO[Auth](_.set(Some(AuthToken(token)))) *> effect
-        case None        => ZIO.fail(TapirResponse(StatusCode.Forbidden))
-      }
-  }
+//   object AuthWrapper extends RequestInterceptor[Auth] {
+//     override def apply[R <: Auth, A](
+//       request: ServerRequest
+//     )(effect: ZIO[R, TapirResponse, A]): ZIO[R, TapirResponse, A] =
+//       request.header("token") match {
+//         case Some(token) => ZIO.serviceWithZIO[Auth](_.set(Some(AuthToken(token)))) *> effect
+//         case None        => ZIO.fail(TapirResponse(StatusCode.Forbidden))
+//       }
+//   }
 
-  val schema: GenericSchema[Auth] = new GenericSchema[Auth] {}
-  import schema._
-  case class Query(token: RIO[Auth, Option[String]])
-  case class Mutation(x: RIO[Auth, Option[String]])
-  case class Subscription(x: ZStream[Auth, Throwable, Option[String]])
-  private val resolver            = RootResolver(
-    Query(ZIO.serviceWithZIO[Auth](_.get).map(_.map(_.value))),
-    Mutation(ZIO.some("foo")),
-    Subscription(ZStream.empty)
-  )
-  private val api                 = graphQL(resolver)
+//   val schema: GenericSchema[Auth] = new GenericSchema[Auth] {}
+//   import schema._
+//   case class Query(token: RIO[Auth, Option[String]])
+//   case class Mutation(x: RIO[Auth, Option[String]])
+//   case class Subscription(x: ZStream[Auth, Throwable, Option[String]])
+//   private val resolver            = RootResolver(
+//     Query(ZIO.serviceWithZIO[Auth](_.get).map(_.map(_.value))),
+//     Mutation(ZIO.some("foo")),
+//     Subscription(ZStream.empty)
+//   )
+//   private val api                 = graphQL(resolver)
 
-  // Note that we must initialize the runtime with any FiberRefs we intend to
-  // pass on so that they are present in the environment for our ResultWrapper(s)
-  // For the auth we wrap in an option, but you could just as well use something
-  // like AuthToken("__INVALID") or a sealed trait hierarchy with an invalid member
-  val initLayer: ULayer[Auth]         = ZLayer.scoped(FiberRef.make(Option.empty[AuthToken]))
-  implicit val runtime: Runtime[Auth] = Unsafe.unsafe(implicit u => Runtime.unsafe.fromLayer(initLayer))
+//   // Note that we must initialize the runtime with any FiberRefs we intend to
+//   // pass on so that they are present in the environment for our ResultWrapper(s)
+//   // For the auth we wrap in an option, but you could just as well use something
+//   // like AuthToken("__INVALID") or a sealed trait hierarchy with an invalid member
+//   val initLayer: ULayer[Auth]         = ZLayer.scoped(FiberRef.make(Option.empty[AuthToken]))
+//   implicit val runtime: Runtime[Auth] = Unsafe.unsafe(implicit u => Runtime.unsafe.fromLayer(initLayer))
 
-  val interpreter = Unsafe.unsafe(implicit u => runtime.unsafe.run(api.interpreter).getOrThrow())
+//   val interpreter = Unsafe.unsafe(implicit u => runtime.unsafe.run(api.interpreter).getOrThrow())
 
-  val server = AkkaHttpServer.fromRouterWithComponents(
-    ServerConfig(
-      mode = Mode.Dev,
-      port = Some(8088),
-      address = "127.0.0.1"
-    )
-  ) { _ =>
-    Router.from {
-      case req @ POST(p"/api/graphql") =>
-        PlayAdapter.makeHttpService(interpreter, requestInterceptor = AuthWrapper).apply(req)
-      case req @ GET(p"/ws/graphql")   => PlayAdapter.makeWebSocketService(interpreter).apply(req)
-    }.routes
-  }
+//   val server = AkkaHttpServer.fromRouterWithComponents(
+//     ServerConfig(
+//       mode = Mode.Dev,
+//       port = Some(8088),
+//       address = "127.0.0.1"
+//     )
+//   ) { _ =>
+//     Router.from {
+//       case req @ POST(p"/api/graphql") =>
+//         PlayAdapter.makeHttpService(interpreter, requestInterceptor = AuthWrapper).apply(req)
+//       case req @ GET(p"/ws/graphql")   => PlayAdapter.makeWebSocketService(interpreter).apply(req)
+//     }.routes
+//   }
 
-  println("Server online at http://localhost:8088/\nPress RETURN to stop...")
-  readLine()
-  server.stop()
-}
+//   println("Server online at http://localhost:8088/\nPress RETURN to stop...")
+//   readLine()
+//   server.stop()
+// }

--- a/examples/src/main/scala/example/play/ExampleApp.scala
+++ b/examples/src/main/scala/example/play/ExampleApp.scala
@@ -1,47 +1,47 @@
-package example.play
+// package example.play
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import example.{ ExampleApi, ExampleService }
-import example.ExampleData.sampleCharacters
-import example.ExampleService.ExampleService
-import caliban.PlayAdapter
-import play.api.Mode
-import play.api.routing._
-import play.api.routing.sird._
-import play.core.server.{ AkkaHttpServer, ServerConfig }
-import zio.{ Runtime, Scope, ZIO, ZIOAppDefault }
-import scala.concurrent.ExecutionContextExecutor
+// import akka.actor.ActorSystem
+// import akka.stream.Materializer
+// import example.{ ExampleApi, ExampleService }
+// import example.ExampleData.sampleCharacters
+// import example.ExampleService.ExampleService
+// import caliban.PlayAdapter
+// import play.api.Mode
+// import play.api.routing._
+// import play.api.routing.sird._
+// import play.core.server.{ AkkaHttpServer, ServerConfig }
+// import zio.{ Runtime, Scope, ZIO, ZIOAppDefault }
+// import scala.concurrent.ExecutionContextExecutor
 
-object ExampleApp extends ZIOAppDefault {
-  import sttp.tapir.json.play._
+// object ExampleApp extends ZIOAppDefault {
+//   import sttp.tapir.json.play._
 
-  override def run =
-    (for {
-      runtime     <- ZIO.runtime[ExampleService]
-      system      <- ZIO.succeed(ActorSystem()).withFinalizer(sys => ZIO.fromFuture(_ => sys.terminate()).ignore)
-      interpreter <- ExampleApi.api.interpreter
-      _           <- ZIO.acquireRelease(
-                       ZIO.attempt(
-                         AkkaHttpServer.fromRouterWithComponents(
-                           ServerConfig(
-                             mode = Mode.Dev,
-                             port = Some(8088),
-                             address = "127.0.0.1"
-                           )
-                         ) { _ =>
-                           implicit val ec: ExecutionContextExecutor = system.dispatcher
-                           implicit val mat: Materializer            = Materializer(system)
-                           implicit val rts: Runtime[ExampleService] = runtime
-                           Router.from {
-                             case req @ POST(p"/api/graphql") => PlayAdapter.makeHttpService(interpreter).apply(req)
-                             case req @ GET(p"/ws/graphql")   => PlayAdapter.makeWebSocketService(interpreter).apply(req)
-                           }.routes
-                         }
-                       )
-                     )(server => ZIO.attempt(server.stop()).ignore)
-      _           <- zio.Console.printLine(
-                       "Server online at http://localhost:8088/\nPress RETURN to stop..."
-                     ) *> zio.Console.readLine
-    } yield ()).provideSomeLayer[Scope](ExampleService.make(sampleCharacters))
-}
+//   override def run =
+//     (for {
+//       runtime     <- ZIO.runtime[ExampleService]
+//       system      <- ZIO.succeed(ActorSystem()).withFinalizer(sys => ZIO.fromFuture(_ => sys.terminate()).ignore)
+//       interpreter <- ExampleApi.api.interpreter
+//       _           <- ZIO.acquireRelease(
+//                        ZIO.attempt(
+//                          AkkaHttpServer.fromRouterWithComponents(
+//                            ServerConfig(
+//                              mode = Mode.Dev,
+//                              port = Some(8088),
+//                              address = "127.0.0.1"
+//                            )
+//                          ) { _ =>
+//                            implicit val ec: ExecutionContextExecutor = system.dispatcher
+//                            implicit val mat: Materializer            = Materializer(system)
+//                            implicit val rts: Runtime[ExampleService] = runtime
+//                            Router.from {
+//                              case req @ POST(p"/api/graphql") => PlayAdapter.makeHttpService(interpreter).apply(req)
+//                              case req @ GET(p"/ws/graphql")   => PlayAdapter.makeWebSocketService(interpreter).apply(req)
+//                            }.routes
+//                          }
+//                        )
+//                      )(server => ZIO.attempt(server.stop()).ignore)
+//       _           <- zio.Console.printLine(
+//                        "Server online at http://localhost:8088/\nPress RETURN to stop..."
+//                      ) *> zio.Console.readLine
+//     } yield ()).provideSomeLayer[Scope](ExampleService.make(sampleCharacters))
+// }

--- a/examples/src/main/scala/example/stitching/ExampleApp.scala
+++ b/examples/src/main/scala/example/stitching/ExampleApp.scala
@@ -1,128 +1,128 @@
-package example.stitching
+// package example.stitching
 
-import caliban._
-import caliban.GraphQL.graphQL
-import caliban.schema._
-import caliban.tools.{ Options, RemoteSchema, SchemaLoader }
-import caliban.tools.stitching.{ HttpRequest, RemoteResolver, RemoteSchemaResolver, ResolveRequest }
-import sttp.capabilities.WebSockets
-import sttp.capabilities.zio.ZioStreams
-import sttp.client3.SttpBackend
-import sttp.client3.asynchttpclient.zio._
-import zio._
+// import caliban._
+// import caliban.GraphQL.graphQL
+// import caliban.schema._
+// import caliban.tools.{ Options, RemoteSchema, SchemaLoader }
+// import caliban.tools.stitching.{ HttpRequest, RemoteResolver, RemoteSchemaResolver, ResolveRequest }
+// import sttp.capabilities.WebSockets
+// import sttp.capabilities.zio.ZioStreams
+// import sttp.client3.SttpBackend
+// import sttp.client3.asynchttpclient.zio._
+// import zio._
 
-object StitchingExample extends GenericSchema[Any] {
-  val GITHUB_API = "https://api.github.com/graphql"
+// object StitchingExample extends GenericSchema[Any] {
+//   val GITHUB_API = "https://api.github.com/graphql"
 
-  case class AppUser(id: String, name: String, featuredRepository: Repository)
-  case class Repository(owner: String, name: String)
+//   case class AppUser(id: String, name: String, featuredRepository: Repository)
+//   case class Repository(owner: String, name: String)
 
-  case class GetUserQuery(name: String, repository: String)
+//   case class GetUserQuery(name: String, repository: String)
 
-  case class Queries(
-    GetUser: GetUserQuery => URIO[Any, AppUser]
-  )
+//   case class Queries(
+//     GetUser: GetUserQuery => URIO[Any, AppUser]
+//   )
 
-  val api =
-    for {
-      config     <- ZIO.environment[Configuration]
-      sttpClient <- ZIO.environment[SttpBackend[Task, ZioStreams with WebSockets]]
+//   val api =
+//     for {
+//       config     <- ZIO.environment[Configuration]
+//       sttpClient <- ZIO.environment[SttpBackend[Task, ZioStreams with WebSockets]]
 
-      schemaLoader = SchemaLoader.fromIntrospection(
-                       GITHUB_API,
-                       Some(
-                         List(
-                           Options.Header(
-                             "Authorization",
-                             s"Bearer ${config.get.githubToken}"
-                           )
-                         )
-                       )
-                     )
+//       schemaLoader = SchemaLoader.fromIntrospection(
+//                        GITHUB_API,
+//                        Some(
+//                          List(
+//                            Options.Header(
+//                              "Authorization",
+//                              s"Bearer ${config.get.githubToken}"
+//                            )
+//                          )
+//                        )
+//                      )
 
-      schema               <- schemaLoader.load
-      remoteSchema         <- ZIO.fromOption(RemoteSchema.parseRemoteSchema(schema))
-      remoteSchemaResolvers = RemoteSchemaResolver.fromSchema(remoteSchema)
-    } yield {
-      val apiRequest =
-        RemoteResolver.toQuery >>> RemoteResolver.request(GITHUB_API) >>> RemoteResolver.fromFunctionM(
-          (r: HttpRequest) =>
-            for {
-              config <- ZIO.service[Configuration]
-            } yield r.header("Authorization", s"Bearer ${config.githubToken}")
-        ) >>> RemoteResolver.execute >>> RemoteResolver.unwrap
+//       schema               <- schemaLoader.load
+//       remoteSchema         <- ZIO.fromOption(RemoteSchema.parseRemoteSchema(schema))
+//       remoteSchemaResolvers = RemoteSchemaResolver.fromSchema(remoteSchema)
+//     } yield {
+//       val apiRequest =
+//         RemoteResolver.toQuery >>> RemoteResolver.request(GITHUB_API) >>> RemoteResolver.fromFunctionM(
+//           (r: HttpRequest) =>
+//             for {
+//               config <- ZIO.service[Configuration]
+//             } yield r.header("Authorization", s"Bearer ${config.githubToken}")
+//         ) >>> RemoteResolver.execute >>> RemoteResolver.unwrap
 
-      implicit val githubProfileSchema: Schema[Any, Repository] =
-        remoteSchemaResolvers
-          .remoteResolver("Repository")(
-            RemoteResolver.fromFunction((r: ResolveRequest[Repository]) =>
-              r.field.copy(
-                name = "repository",
-                arguments = Map(
-                  "owner" -> Value.StringValue(r.args.owner),
-                  "name"  -> Value.StringValue(r.args.name)
-                )
-              )
-            ) >>> apiRequest
-          )
-          .provideEnvironment(sttpClient ++ config)
+//       implicit val githubProfileSchema: Schema[Any, Repository] =
+//         remoteSchemaResolvers
+//           .remoteResolver("Repository")(
+//             RemoteResolver.fromFunction((r: ResolveRequest[Repository]) =>
+//               r.field.copy(
+//                 name = "repository",
+//                 arguments = Map(
+//                   "owner" -> Value.StringValue(r.args.owner),
+//                   "name"  -> Value.StringValue(r.args.name)
+//                 )
+//               )
+//             ) >>> apiRequest
+//           )
+//           .provideEnvironment(sttpClient ++ config)
 
-      graphQL(
-        RootResolver(
-          Queries(
-            GetUser = query =>
-              Random.nextUUID.map(uuid =>
-                AppUser(
-                  id = uuid.toString,
-                  name = query.name,
-                  featuredRepository = Repository(query.name, query.repository)
-                )
-              )
-          )
-        )
-      )
-    }
-}
+//       graphQL(
+//         RootResolver(
+//           Queries(
+//             GetUser = query =>
+//               Random.nextUUID.map(uuid =>
+//                 AppUser(
+//                   id = uuid.toString,
+//                   name = query.name,
+//                   featuredRepository = Repository(query.name, query.repository)
+//                 )
+//               )
+//           )
+//         )
+//       )
+//     }
+// }
 
-case class Configuration(githubToken: String)
+// case class Configuration(githubToken: String)
 
-object Configuration {
-  def fromEnvironment = ZLayer {
-    for {
-      githubToken <- read("GITHUB_TOKEN")
-    } yield Configuration(githubToken)
-  }
+// object Configuration {
+//   def fromEnvironment = ZLayer {
+//     for {
+//       githubToken <- read("GITHUB_TOKEN")
+//     } yield Configuration(githubToken)
+//   }
 
-  private def read(key: String): Task[String] = ZIO.attempt(sys.env(key))
-}
+//   private def read(key: String): Task[String] = ZIO.attempt(sys.env(key))
+// }
 
-import zio.stream._
-import zhttp.http._
-import zhttp.service.Server
-import caliban.ZHttpAdapter
+// import zio.stream._
+// import zhttp.http._
+// import zhttp.service.Server
+// import caliban.ZHttpAdapter
 
-object ExampleApp extends ZIOAppDefault {
-  import sttp.tapir.json.circe._
+// object ExampleApp extends ZIOAppDefault {
+//   import sttp.tapir.json.circe._
 
-  private val graphiql = Http.fromStream(ZStream.fromResource("graphiql.html"))
+//   private val graphiql = Http.fromStream(ZStream.fromResource("graphiql.html"))
 
-  override def run =
-    (for {
-      api         <- StitchingExample.api
-      interpreter <- api.interpreter
-      _           <- Server
-                       .start(
-                         8088,
-                         Http.collectHttp[Request] {
-                           case _ -> !! / "api" / "graphql" => ZHttpAdapter.makeHttpService(interpreter)
-                           case _ -> !! / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
-                           case _ -> !! / "graphiql"        => graphiql
-                         }
-                       )
-                       .forever
-    } yield ())
-      .provideSomeLayer[Scope](
-        AsyncHttpClientZioBackend.layer() ++ Configuration.fromEnvironment
-      )
-      .exitCode
-}
+//   override def run =
+//     (for {
+//       api         <- StitchingExample.api
+//       interpreter <- api.interpreter
+//       _           <- Server
+//                        .start(
+//                          8088,
+//                          Http.collectHttp[Request] {
+//                            case _ -> !! / "api" / "graphql" => ZHttpAdapter.makeHttpService(interpreter)
+//                            case _ -> !! / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
+//                            case _ -> !! / "graphiql"        => graphiql
+//                          }
+//                        )
+//                        .forever
+//     } yield ())
+//       .provideSomeLayer[Scope](
+//         AsyncHttpClientZioBackend.layer() ++ Configuration.fromEnvironment
+//       )
+//       .exitCode
+// }

--- a/examples/src/main/scala/example/tapir/ExampleApp.scala
+++ b/examples/src/main/scala/example/tapir/ExampleApp.scala
@@ -1,58 +1,58 @@
-package example.tapir
+// package example.tapir
 
-import example.tapir.Endpoints._
-import caliban.interop.tapir._
-import caliban.{ GraphQL, Http4sAdapter }
-import cats.data.Kleisli
-import com.comcast.ip4s._
-import org.http4s.StaticFile
-import org.http4s.implicits._
-import org.http4s.server.Router
-import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.server.middleware.CORS
-import sttp.tapir.server.ServerEndpoint
-import zio._
-import zio.interop.catz._
+// import example.tapir.Endpoints._
+// import caliban.interop.tapir._
+// import caliban.{ GraphQL, Http4sAdapter }
+// import cats.data.Kleisli
+// import com.comcast.ip4s._
+// import org.http4s.StaticFile
+// import org.http4s.implicits._
+// import org.http4s.server.Router
+// import org.http4s.ember.server.EmberServerBuilder
+// import org.http4s.server.middleware.CORS
+// import sttp.tapir.server.ServerEndpoint
+// import zio._
+// import zio.interop.catz._
 
-object ExampleApp extends CatsApp {
-  import sttp.tapir.json.circe._
+// object ExampleApp extends CatsApp {
+//   import sttp.tapir.json.circe._
 
-  // approach 1: using `Endpoint` and providing the logic
-  val graphql: GraphQL[Any] =
-    addBook.toGraphQL((bookAddLogic _).tupled) |+|
-      deleteBook.toGraphQL((bookDeleteLogic _).tupled) |+|
-      booksListing.toGraphQL((bookListingLogic _).tupled)
+//   // approach 1: using `Endpoint` and providing the logic
+//   val graphql: GraphQL[Any] =
+//     addBook.toGraphQL((bookAddLogic _).tupled) |+|
+//       deleteBook.toGraphQL((bookDeleteLogic _).tupled) |+|
+//       booksListing.toGraphQL((bookListingLogic _).tupled)
 
-  // approach 2: using the `ServerEndpoint` where logic is already provided
-  type MyIO[+A] = IO[String, A]
+//   // approach 2: using the `ServerEndpoint` where logic is already provided
+//   type MyIO[+A] = IO[String, A]
 
-  val addBookEndpoint: ServerEndpoint.Full[Unit, Unit, (Book, String), String, Unit, Any, MyIO]                        =
-    addBook.serverLogic[MyIO] { case (book, token) => bookAddLogic(book, token).either }
-  val deleteBookEndpoint: ServerEndpoint.Full[Unit, Unit, (String, String), String, Unit, Any, MyIO]                   =
-    deleteBook.serverLogic[MyIO] { case (title, token) => bookDeleteLogic(title, token).either }
-  val booksListingEndpoint: ServerEndpoint.Full[Unit, Unit, (Option[Int], Option[Int]), Nothing, List[Book], Any, UIO] =
-    booksListing.serverLogic[UIO] { case (year, limit) => bookListingLogic(year, limit).map(Right(_)) }
+//   val addBookEndpoint: ServerEndpoint.Full[Unit, Unit, (Book, String), String, Unit, Any, MyIO]                        =
+//     addBook.serverLogic[MyIO] { case (book, token) => bookAddLogic(book, token).either }
+//   val deleteBookEndpoint: ServerEndpoint.Full[Unit, Unit, (String, String), String, Unit, Any, MyIO]                   =
+//     deleteBook.serverLogic[MyIO] { case (title, token) => bookDeleteLogic(title, token).either }
+//   val booksListingEndpoint: ServerEndpoint.Full[Unit, Unit, (Option[Int], Option[Int]), Nothing, List[Book], Any, UIO] =
+//     booksListing.serverLogic[UIO] { case (year, limit) => bookListingLogic(year, limit).map(Right(_)) }
 
-  val graphql2: GraphQL[Any] =
-    addBookEndpoint.toGraphQL |+| deleteBookEndpoint.toGraphQL |+| booksListingEndpoint.toGraphQL
+//   val graphql2: GraphQL[Any] =
+//     addBookEndpoint.toGraphQL |+| deleteBookEndpoint.toGraphQL |+| booksListingEndpoint.toGraphQL
 
-  type MyTask[A] = Task[A]
+//   type MyTask[A] = Task[A]
 
-  override def run =
-    (for {
-      interpreter <- graphql.interpreter
-      _           <- EmberServerBuilder
-                       .default[MyTask]
-                       .withHost(host"localhost")
-                       .withPort(port"8088")
-                       .withHttpApp(
-                         Router[MyTask](
-                           "/api/graphql" -> CORS.policy(Http4sAdapter.makeHttpService(interpreter)),
-                           "/graphiql"    -> Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
-                         ).orNotFound
-                       )
-                       .build
-                       .toScopedZIO
-                       .forever
-    } yield ()).exitCode
-}
+//   override def run =
+//     (for {
+//       interpreter <- graphql.interpreter
+//       _           <- EmberServerBuilder
+//                        .default[MyTask]
+//                        .withHost(host"localhost")
+//                        .withPort(port"8088")
+//                        .withHttpApp(
+//                          Router[MyTask](
+//                            "/api/graphql" -> CORS.policy(Http4sAdapter.makeHttpService(interpreter)),
+//                            "/graphiql"    -> Kleisli.liftF(StaticFile.fromResource("/graphiql.html", None))
+//                          ).orNotFound
+//                        )
+//                        .build
+//                        .toScopedZIO
+//                        .forever
+//     } yield ()).exitCode
+// }

--- a/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
@@ -1,131 +1,131 @@
-package example.ziohttp
+// package example.ziohttp
 
-import caliban.GraphQL.graphQL
-import caliban.Value.StringValue
-import caliban._
-import caliban.interop.tapir.{ StreamTransformer, WebSocketHooks }
-import caliban.schema.GenericSchema
-import example.ExampleData._
-import example.{ ExampleApi, ExampleService }
-import sttp.tapir.json.circe._
-import zhttp.http._
-import zhttp.service.Server
-import zio._
-import zio.stream._
+// import caliban.GraphQL.graphQL
+// import caliban.Value.StringValue
+// import caliban._
+// import caliban.interop.tapir.{ StreamTransformer, WebSocketHooks }
+// import caliban.schema.GenericSchema
+// import example.ExampleData._
+// import example.{ ExampleApi, ExampleService }
+// import sttp.tapir.json.circe._
+// import zhttp.http._
+// import zhttp.service.Server
+// import zio._
+// import zio.stream._
 
-case object Unauthorized extends RuntimeException("Unauthorized")
+// case object Unauthorized extends RuntimeException("Unauthorized")
 
-trait Auth {
-  type Unauthorized = Unauthorized.type
+// trait Auth {
+//   type Unauthorized = Unauthorized.type
 
-  def currentUser: IO[Unauthorized, String]
-  def setUser(name: Option[String]): UIO[Unit]
-}
+//   def currentUser: IO[Unauthorized, String]
+//   def setUser(name: Option[String]): UIO[Unit]
+// }
 
-object Auth {
+// object Auth {
 
-  val http: ULayer[Auth] = ZLayer.scoped {
-    FiberRef
-      .make[Option[String]](None)
-      .map { ref =>
-        new Auth {
-          def currentUser: IO[Unauthorized, String]    =
-            ref.get.flatMap {
-              case Some(v) => ZIO.succeed(v)
-              case None    => ZIO.fail(Unauthorized)
-            }
-          def setUser(name: Option[String]): UIO[Unit] = ref.set(name)
-        }
-      }
-  }
+//   val http: ULayer[Auth] = ZLayer.scoped {
+//     FiberRef
+//       .make[Option[String]](None)
+//       .map { ref =>
+//         new Auth {
+//           def currentUser: IO[Unauthorized, String]    =
+//             ref.get.flatMap {
+//               case Some(v) => ZIO.succeed(v)
+//               case None    => ZIO.fail(Unauthorized)
+//             }
+//           def setUser(name: Option[String]): UIO[Unit] = ref.set(name)
+//         }
+//       }
+//   }
 
-  object WebSockets {
-    private val wsSession = Http.fromZIO(Ref.make[Option[String]](None))
+//   object WebSockets {
+//     private val wsSession = Http.fromZIO(Ref.make[Option[String]](None))
 
-    def live[R <: Auth](
-      interpreter: GraphQLInterpreter[R, CalibanError]
-    ): HttpApp[R, CalibanError] =
-      wsSession.flatMap { session =>
-        val auth =
-          new Auth {
-            def currentUser: IO[Unauthorized, String]    =
-              session.get.flatMap {
-                case Some(v) => ZIO.succeed(v)
-                case None    => ZIO.fail(Unauthorized)
-              }
-            def setUser(name: Option[String]): UIO[Unit] = session.set(name)
-          }
+//     def live[R <: Auth](
+//       interpreter: GraphQLInterpreter[R, CalibanError]
+//     ): HttpApp[R, CalibanError] =
+//       wsSession.flatMap { session =>
+//         val auth =
+//           new Auth {
+//             def currentUser: IO[Unauthorized, String]    =
+//               session.get.flatMap {
+//                 case Some(v) => ZIO.succeed(v)
+//                 case None    => ZIO.fail(Unauthorized)
+//               }
+//             def setUser(name: Option[String]): UIO[Unit] = session.set(name)
+//           }
 
-        val webSocketHooks = WebSocketHooks.init[R, CalibanError](payload =>
-          ZIO
-            .fromOption(payload match {
-              case InputValue.ObjectValue(fields) =>
-                fields.get("Authorization").flatMap {
-                  case StringValue(s) => Some(s)
-                  case _              => None
-                }
-              case _                              => None
-            })
-            .orElseFail(CalibanError.ExecutionError("Unable to decode payload"))
-            .flatMap(user => auth.setUser(Some(user)))
-        ) ++
-          WebSocketHooks.afterInit(ZIO.failCause(Cause.empty).delay(10.seconds)) ++
-          WebSocketHooks
-            .message(new StreamTransformer[Auth, Nothing] {
-              def transform[R1 <: Auth, E1 >: Nothing](
-                stream: ZStream[R1, E1, GraphQLWSOutput]
-              ): ZStream[R1, E1, GraphQLWSOutput] = stream.updateService[Auth](_ => auth)
-            })
+//         val webSocketHooks = WebSocketHooks.init[R, CalibanError](payload =>
+//           ZIO
+//             .fromOption(payload match {
+//               case InputValue.ObjectValue(fields) =>
+//                 fields.get("Authorization").flatMap {
+//                   case StringValue(s) => Some(s)
+//                   case _              => None
+//                 }
+//               case _                              => None
+//             })
+//             .orElseFail(CalibanError.ExecutionError("Unable to decode payload"))
+//             .flatMap(user => auth.setUser(Some(user)))
+//         ) ++
+//           WebSocketHooks.afterInit(ZIO.failCause(Cause.empty).delay(10.seconds)) ++
+//           WebSocketHooks
+//             .message(new StreamTransformer[Auth, Nothing] {
+//               def transform[R1 <: Auth, E1 >: Nothing](
+//                 stream: ZStream[R1, E1, GraphQLWSOutput]
+//               ): ZStream[R1, E1, GraphQLWSOutput] = stream.updateService[Auth](_ => auth)
+//             })
 
-        ZHttpAdapter.makeWebSocketService(interpreter, webSocketHooks = webSocketHooks)
-      }
-  }
+//         ZHttpAdapter.makeWebSocketService(interpreter, webSocketHooks = webSocketHooks)
+//       }
+//   }
 
-  def middleware[R](
-    app: Http[R, Throwable, Request, Response]
-  ): HttpApp[R with Auth, Throwable] =
-    Http
-      .fromFunctionZIO[Request] { (request: Request) =>
-        val user = request.headers.authorization.map(_.toString())
+//   def middleware[R](
+//     app: Http[R, Throwable, Request, Response]
+//   ): HttpApp[R with Auth, Throwable] =
+//     Http
+//       .fromFunctionZIO[Request] { (request: Request) =>
+//         val user = request.headers.authorization.map(_.toString())
 
-        ZIO.serviceWithZIO[Auth](_.setUser(user)).as(app)
-      }
-      .flatten
-}
+//         ZIO.serviceWithZIO[Auth](_.setUser(user)).as(app)
+//       }
+//       .flatten
+// }
 
-object Authed extends GenericSchema[Auth] {
-  case class Queries(
-    whoAmI: ZIO[Auth, Unauthorized.type, String] = ZIO.serviceWithZIO[Auth](_.currentUser)
-  )
-  case class Subscriptions(
-    whoAmI: ZStream[Auth, Unauthorized.type, String] =
-      ZStream.fromZIO(ZIO.serviceWithZIO[Auth](_.currentUser)).repeat(Schedule.spaced(10.seconds))
-  )
+// object Authed extends GenericSchema[Auth] {
+//   case class Queries(
+//     whoAmI: ZIO[Auth, Unauthorized.type, String] = ZIO.serviceWithZIO[Auth](_.currentUser)
+//   )
+//   case class Subscriptions(
+//     whoAmI: ZStream[Auth, Unauthorized.type, String] =
+//       ZStream.fromZIO(ZIO.serviceWithZIO[Auth](_.currentUser)).repeat(Schedule.spaced(10.seconds))
+//   )
 
-  val api = graphQL(RootResolver(Queries(), None, Subscriptions()))
-}
+//   val api = graphQL(RootResolver(Queries(), None, Subscriptions()))
+// }
 
-object AuthExampleApp extends ZIOAppDefault {
+// object AuthExampleApp extends ZIOAppDefault {
 
-  private val graphiql = Http.fromStream(ZStream.fromResource("graphiql.html"))
+//   private val graphiql = Http.fromStream(ZStream.fromResource("graphiql.html"))
 
-  override def run =
-    (for {
-      interpreter <- (ExampleApi.api |+| Authed.api).interpreter
-      _           <- Server
-                       .start(
-                         8088,
-                         Http.collectHttp[Request] {
-                           case _ -> !! / "api" / "graphql" =>
-                             Auth.middleware(
-                               ZHttpAdapter.makeHttpService(interpreter)
-                             )
-                           case _ -> !! / "ws" / "graphql"  => Auth.WebSockets.live(interpreter)
-                           case _ -> !! / "graphiql"        => graphiql
-                         }
-                       )
-                       .forever
-    } yield ())
-      .provideSomeLayer[Scope](ExampleService.make(sampleCharacters) ++ Auth.http)
-      .exitCode
-}
+//   override def run =
+//     (for {
+//       interpreter <- (ExampleApi.api |+| Authed.api).interpreter
+//       _           <- Server
+//                        .start(
+//                          8088,
+//                          Http.collectHttp[Request] {
+//                            case _ -> !! / "api" / "graphql" =>
+//                              Auth.middleware(
+//                                ZHttpAdapter.makeHttpService(interpreter)
+//                              )
+//                            case _ -> !! / "ws" / "graphql"  => Auth.WebSockets.live(interpreter)
+//                            case _ -> !! / "graphiql"        => graphiql
+//                          }
+//                        )
+//                        .forever
+//     } yield ())
+//       .provideSomeLayer[Scope](ExampleService.make(sampleCharacters) ++ Auth.http)
+//       .exitCode
+// }

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -1,33 +1,33 @@
-package example.ziohttp
+// package example.ziohttp
 
-import example.ExampleData._
-import example.{ ExampleApi, ExampleService }
+// import example.ExampleData._
+// import example.{ ExampleApi, ExampleService }
 
-import caliban.ZHttpAdapter
-import zio._
-import zio.stream._
-import zhttp.http._
-import zhttp.service.Server
+// import caliban.ZHttpAdapter
+// import zio._
+// import zio.stream._
+// import zhttp.http._
+// import zhttp.service.Server
 
-object ExampleApp extends ZIOAppDefault {
-  import sttp.tapir.json.circe._
+// object ExampleApp extends ZIOAppDefault {
+//   import sttp.tapir.json.circe._
 
-  private val graphiql = Http.fromStream(ZStream.fromResource("graphiql.html"))
+//   private val graphiql = Http.fromStream(ZStream.fromResource("graphiql.html"))
 
-  override def run =
-    (for {
-      interpreter <- ExampleApi.api.interpreter
-      _           <- Server
-                       .start(
-                         8088,
-                         Http.collectHttp[Request] {
-                           case _ -> !! / "api" / "graphql" => ZHttpAdapter.makeHttpService(interpreter)
-                           case _ -> !! / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
-                           case _ -> !! / "graphiql"        => graphiql
-                         }
-                       )
-                       .forever
-    } yield ())
-      .provideLayer(ExampleService.make(sampleCharacters))
-      .exitCode
-}
+//   override def run =
+//     (for {
+//       interpreter <- ExampleApi.api.interpreter
+//       _           <- Server
+//                        .start(
+//                          8088,
+//                          Http.collectHttp[Request] {
+//                            case _ -> !! / "api" / "graphql" => ZHttpAdapter.makeHttpService(interpreter)
+//                            case _ -> !! / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(interpreter)
+//                            case _ -> !! / "graphiql"        => graphiql
+//                          }
+//                        )
+//                        .forever
+//     } yield ())
+//       .provideLayer(ExampleService.make(sampleCharacters))
+//       .exitCode
+// }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala
@@ -16,7 +16,7 @@ trait RequestInterceptor[-R, +DynR] { self =>
       override def apply[R2 <: R1, A](request: ServerRequest)(
         e: ZIO[R2 with DynR with DynR2, TapirResponse, A]
       ): ZIO[R2, TapirResponse, A] =
-        that.apply[R2, A](request)(self.apply[R2, A](request)(e))
+        that.apply[R2, A](request)(self.apply[R2 with DynR2, A](request)(e))
     }
 }
 

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala
@@ -8,13 +8,13 @@ import zio.ZIO
  * RequestInterceptor provides a way to extract context from the http request, potentially failing before
  * query execution or injecting context into ZIO environment.
  */
-trait RequestInterceptor[-R, DynR] { self =>
+trait RequestInterceptor[-R, +DynR] { self =>
   def apply[R1 <: R, A](request: ServerRequest)(e: ZIO[R1 with DynR, TapirResponse, A]): ZIO[R1, TapirResponse, A]
 
-  def |+|[R1 <: R, DynR2](that: RequestInterceptor[R1, DynR2]): RequestInterceptor[R1, DynR] =
-    new RequestInterceptor[R1, DynR] {
+  def |+|[R1 <: R, DynR2](that: RequestInterceptor[R1, DynR2]): RequestInterceptor[R1, DynR with DynR2] =
+    new RequestInterceptor[R1, DynR with DynR2] {
       override def apply[R2 <: R1, A](request: ServerRequest)(
-        e: ZIO[R2 with DynR, TapirResponse, A]
+        e: ZIO[R2 with DynR with DynR2, TapirResponse, A]
       ): ZIO[R2, TapirResponse, A] =
         that.apply[R2, A](request)(self.apply[R2, A](request)(e))
     }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala
@@ -8,17 +8,20 @@ import zio.ZIO
  * RequestInterceptor provides a way to extract context from the http request, potentially failing before
  * query execution or injecting context into ZIO environment.
  */
-trait RequestInterceptor[-R] { self =>
-  def apply[R1 <: R, A](request: ServerRequest)(e: ZIO[R, TapirResponse, A]): ZIO[R1, TapirResponse, A]
+trait RequestInterceptor[-R, DynR] { self =>
+  def apply[R1 <: R, A](request: ServerRequest)(e: ZIO[R1 with DynR, TapirResponse, A]): ZIO[R1, TapirResponse, A]
 
-  def |+|[R1 <: R](that: RequestInterceptor[R1]): RequestInterceptor[R1] = new RequestInterceptor[R1] {
-    override def apply[R2 <: R1, A](request: ServerRequest)(e: ZIO[R2, TapirResponse, A]): ZIO[R2, TapirResponse, A] =
-      that.apply[R2, A](request)(self.apply[R2, A](request)(e))
-  }
+  def |+|[R1 <: R, DynR2](that: RequestInterceptor[R1, DynR2]): RequestInterceptor[R1, DynR] =
+    new RequestInterceptor[R1, DynR] {
+      override def apply[R2 <: R1, A](request: ServerRequest)(
+        e: ZIO[R2 with DynR, TapirResponse, A]
+      ): ZIO[R2, TapirResponse, A] =
+        that.apply[R2, A](request)(self.apply[R2, A](request)(e))
+    }
 }
 
 object RequestInterceptor {
-  val empty: RequestInterceptor[Any] = new RequestInterceptor[Any] {
-    override def apply[R, A](request: ServerRequest)(e: ZIO[R, TapirResponse, A]): ZIO[R, TapirResponse, A] = e
+  val empty: RequestInterceptor[Any, Any] = new RequestInterceptor[Any, Any] {
+    override def apply[R, A](request: ServerRequest)(e: ZIO[R with Any, TapirResponse, A]): ZIO[R, TapirResponse, A] = e
   }
 }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala
@@ -9,7 +9,7 @@ import zio.ZIO
  * query execution or injecting context into ZIO environment.
  */
 trait RequestInterceptor[-R] { self =>
-  def apply[R1 <: R, A](request: ServerRequest)(e: ZIO[R1, TapirResponse, A]): ZIO[R1, TapirResponse, A]
+  def apply[R1 <: R, A](request: ServerRequest)(e: ZIO[R, TapirResponse, A]): ZIO[R1, TapirResponse, A]
 
   def |+|[R1 <: R](that: RequestInterceptor[R1]): RequestInterceptor[R1] = new RequestInterceptor[R1] {
     override def apply[R2 <: R1, A](request: ServerRequest)(e: ZIO[R2, TapirResponse, A]): ZIO[R2, TapirResponse, A] =

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -119,19 +119,19 @@ object TapirAdapter {
     postEndpoint :: getEndpoint :: Nil
   }
 
-  def makeHttpService[R, E](
-    interpreter: GraphQLInterpreter[R, E],
+  def makeHttpService[R, IR, E](
+    interpreter: GraphQLInterpreter[R & IR, E],
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
     queryExecution: QueryExecution = QueryExecution.Parallel,
-    requestInterceptor: RequestInterceptor[R] = RequestInterceptor.empty
+    requestInterceptor: RequestInterceptor[IR] = RequestInterceptor.empty
   )(implicit
     requestCodec: JsonCodec[GraphQLRequest],
     responseCodec: JsonCodec[GraphQLResponse[E]]
   ): List[ServerEndpoint[Any, RIO[R, *]]] = {
     def logic(
       request: (GraphQLRequest, ServerRequest)
-    ): RIO[R, Either[TapirResponse, GraphQLResponse[E]]] = {
+    ): RIO[R & IR, Either[TapirResponse, GraphQLResponse[E]]] = {
       val (graphQLRequest, serverRequest) = request
 
       requestInterceptor(serverRequest)(

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/FakeAuthorizationInterceptor.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/FakeAuthorizationInterceptor.scala
@@ -5,9 +5,9 @@ import sttp.tapir.model.ServerRequest
 import zio.ZIO
 
 class FakeAuthorizationInterceptor[R](authenticate: ServerRequest => ZIO[R, (Int, String), Unit])
-    extends RequestInterceptor[R] {
+    extends RequestInterceptor[R, Any] {
   override def apply[R1 <: R, A](request: ServerRequest)(
-    e: ZIO[R1, TapirAdapter.TapirResponse, A]
+    e: ZIO[R1 with Any, TapirAdapter.TapirResponse, A]
   ): ZIO[R1, TapirAdapter.TapirResponse, A] =
     authenticate(request).mapError { case (status, str) =>
       TapirResponse(StatusCode(status), body = str)
@@ -17,7 +17,7 @@ class FakeAuthorizationInterceptor[R](authenticate: ServerRequest => ZIO[R, (Int
 
 object FakeAuthorizationInterceptor {
 
-  val bearer: RequestInterceptor[Any] =
+  val bearer: RequestInterceptor[Any, Any] =
     new FakeAuthorizationInterceptor[Any](req =>
       ZIO.fail((401, "You are unauthorized!")).when(req.headers("X-Invalid").nonEmpty).unit
     )


### PR DESCRIPTION
This is a rough showcase for how `requestInterceptor` could be changed to eliminate the part of the environment `R` of GraphQLInterpreter[R, E] which should be resolved at runtime. E.g. for auth tokens.

This allows `HttpAdaptor.makeHttpService` (as well as the upload adaptor and websocket adaptor) to only require the environment needed to build the route. Currently it is suggested to provide dummy values in a `FiberRef` which the interceptors can then override at runtime.

As I was playing around with some APIs, I found it awkward that the types state that the request interceptors would provide some of the environment, but I still needed to provide the full environment when creating the route.

I've commented out a lot of files to keep this proof-of-concept slim. It is relevant to look at

* `adapters/akka-http/src/main/scala/caliban/AkkaHttpAdapter.scala`
* `examples/src/main/scala/example/akkahttp/AuthExampleApp.scala`
* `interop/tapir/src/main/scala/caliban/interop/tapir/RequestInterceptor.scala`
* `interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala`

Would you be interested in accepting a change like this? And do let me know if my motivation for this isn't clear enough 😊 