### PR TITLE
Micro-optimization for resolving custom object schema fields

### DIFF
--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -173,7 +173,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
 
       override def resolve(value: A): Step[R1] = {
         val fieldsBuilder = Map.newBuilder[String, Step[R1]]
-        fieldsForResolve.foreach { case (f, plan) => fieldsBuilder += f.name -> plan(value)}
+        fieldsForResolve.foreach { case (f, plan) => fieldsBuilder += f.name -> plan(value) }
         ObjectStep(name, fieldsBuilder.result())
       }
     }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -169,8 +169,13 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
           )
         } else makeObject(Some(name), description, fields(isInput, isSubscription).map(_._1), directives)
 
-      override def resolve(value: A): Step[R1] =
-        ObjectStep(name, fields(false, false).map { case (f, plan) => f.name -> plan(value) }.toMap)
+      private lazy val fieldsForResolve = fields(false, false)
+
+      override def resolve(value: A): Step[R1] = {
+        val fieldsBuilder = Map.newBuilder[String, Step[R1]]
+        fieldsForResolve.foreach { case (f, plan) => fieldsBuilder += f.name -> plan(value)}
+        ObjectStep(name, fieldsBuilder.result())
+      }
     }
 
   /**


### PR DESCRIPTION
I was looking at some application profiling results at work, and I've noticed that there was a rather surprising amount of CPU time (~2 - 3% of the total application CPU load) that was spent on this method (note that the API has many recursive types which require hand-rolled object schemas).

I _think_ the reason for that is that we are calling the `FieldAttributes => List[(__Field, V => Step[R1])]` lambda on each invocation of the `resolve` method when it's not dependent on the `value: T` input, whereas we probably don't need to