### PR TITLE
Fix hanging of non-APQ requests

### DIFF
--- a/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
@@ -97,7 +97,7 @@ object ApolloPersistedQueries {
                 }
                 .flatMap(process)
                 .catchAll(ex => ZIO.succeed(GraphQLResponse(NullValue, List(ex))))
-            case None       => process(request)
+            case None       => docVar.succeed(None) *> process(request)
           }
     }
 

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -256,6 +256,15 @@ object WrappersSpec extends ZIOSpecDefault {
           )
         )
         List(
+          test("non-APQ queries are processed normally") {
+            case class Test(test: String)
+
+            (for {
+              interpreter <- (graphQL(RootResolver(Test("ok"))) @@ apolloPersistedQueries).interpreter
+              result      <- interpreter.executeRequest(GraphQLRequest(query = Some("{test}")))
+            } yield assertTrue(result.asJson.noSpaces == """{"data":{"test":"ok"}}"""))
+              .provide(ApolloPersistedQueries.live)
+          },
           test("hash not found") {
             case class Test(test: String)
             val interpreter = (graphQL(RootResolver(Test("ok"))) @@ apolloPersistedQueries).interpreter


### PR DESCRIPTION
Seems that non-APQ queries would hang since we wouldn't fulfil the promise. Fixed the issue and added a test to catch this issue