### PR TITLE
Switch to jsoniter client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -277,12 +277,12 @@ lazy val tapirInterop = project
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.2").cross(CrossVersion.full)))
     } ++
       Seq(
-        "com.softwaremill.sttp.tapir"   %% "tapir-core"        % tapirVersion,
-        "com.softwaremill.sttp.tapir"   %% "tapir-zio"         % tapirVersion,
-        "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client" % tapirVersion % Test,
-        "com.softwaremill.sttp.client3" %% "zio"               % sttpVersion  % Test,
-        "dev.zio"                       %% "zio-test"          % zioVersion   % Test,
-        "dev.zio"                       %% "zio-test-sbt"      % zioVersion   % Test
+        "com.softwaremill.sttp.tapir"   %% "tapir-core"                    % tapirVersion,
+        "com.softwaremill.sttp.tapir"   %% "tapir-zio"                     % tapirVersion,
+        "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"             % tapirVersion % Test,
+        "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % sttpVersion  % Test,
+        "dev.zio"                       %% "zio-test"                      % zioVersion   % Test,
+        "dev.zio"                       %% "zio-test-sbt"                  % zioVersion   % Test
       )
   )
   .dependsOn(core)
@@ -306,7 +306,6 @@ lazy val http4s = project
         "org.http4s"                            %% "http4s-ember-server"     % http4sVersion   % Test,
         "dev.zio"                               %% "zio-test"                % zioVersion      % Test,
         "dev.zio"                               %% "zio-test-sbt"            % zioVersion      % Test,
-        "com.softwaremill.sttp.client3"         %% "zio"                     % sttpVersion     % Test,
         "com.softwaremill.sttp.client3"         %% "circe"                   % sttpVersion     % Test,
         "io.circe"                              %% "circe-generic"           % circeVersion    % Test,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"   % jsoniterVersion % Test
@@ -362,7 +361,6 @@ lazy val play = project
       "dev.zio"                       %% "zio-test-sbt"          % zioVersion   % Test,
       "com.typesafe.play"             %% "play-akka-http-server" % playVersion  % Test,
       "io.circe"                      %% "circe-generic"         % circeVersion % Test,
-      "com.softwaremill.sttp.client3" %% "zio"                   % sttpVersion  % Test,
       "com.softwaremill.sttp.client3" %% "circe"                 % sttpVersion  % Test,
       compilerPlugin(("org.typelevel" %% "kind-projector"        % "0.13.2").cross(CrossVersion.full))
     )

--- a/build.sbt
+++ b/build.sbt
@@ -417,13 +417,14 @@ lazy val clientLaminext = crossProject(JSPlatform)
     Test / scalaJSUseMainModuleInitializer := true,
     Test / scalaJSUseTestModuleInitializer := false,
     libraryDependencies ++= Seq(
-      "io.laminext" %%% "core"            % laminextVersion,
-      "io.laminext" %%% "fetch"           % laminextVersion,
-      "io.laminext" %%% "fetch-circe"     % laminextVersion,
-      "io.laminext" %%% "websocket"       % laminextVersion,
-      "io.laminext" %%% "websocket-circe" % laminextVersion,
-      "dev.zio"     %%% "zio-test"        % zioVersion % Test,
-      "dev.zio"     %%% "zio-test-sbt"    % zioVersion % Test
+      "io.laminext"                           %%% "core"                % laminextVersion,
+      "io.laminext"                           %%% "fetch"               % laminextVersion,
+      "io.laminext"                           %%% "fetch-circe"         % laminextVersion,
+      "io.laminext"                           %%% "websocket"           % laminextVersion,
+      "io.laminext"                           %%% "websocket-circe"     % laminextVersion,
+      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % jsoniterVersion,
+      "dev.zio"                               %%% "zio-test"            % zioVersion % Test,
+      "dev.zio"                               %%% "zio-test-sbt"        % zioVersion % Test
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -378,11 +378,13 @@ lazy val client    = crossProject(JSPlatform, JVMPlatform)
   .settings(
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
-      "io.circe"                      %%% "circe-parser" % circeVersion,
-      "com.softwaremill.sttp.client3" %%% "core"         % sttpVersion,
-      "com.softwaremill.sttp.client3" %%% "circe"        % sttpVersion,
-      "dev.zio"                       %%% "zio-test"     % zioVersion % Test,
-      "dev.zio"                       %%% "zio-test-sbt" % zioVersion % Test
+      "io.circe"                             %%% "circe-parser"          % circeVersion,
+      "com.softwaremill.sttp.client3"        %%% "core"                  % sttpVersion,
+      "com.softwaremill.sttp.client3"        %%% "jsoniter"              % sttpVersion,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % jsoniterVersion,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterVersion % Provided,
+      "dev.zio"                              %%% "zio-test"              % zioVersion      % Test,
+      "dev.zio"                              %%% "zio-test-sbt"          % zioVersion      % Test
     )
   )
 lazy val clientJVM = client.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -168,14 +168,13 @@ lazy val tools = project
   .settings(
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
-      "org.scalameta"                  % "scalafmt-interfaces"           % scalafmtVersion,
-      "io.get-coursier"                % "interface"                     % "1.0.12",
-      "com.softwaremill.sttp.client3" %% "zio"                           % sttpVersion,
-      "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % sttpVersion,
-      "dev.zio"                       %% "zio-config"                    % zioConfigVersion,
-      "dev.zio"                       %% "zio-config-magnolia"           % zioConfigVersion,
-      "dev.zio"                       %% "zio-test"                      % zioVersion % Test,
-      "dev.zio"                       %% "zio-test-sbt"                  % zioVersion % Test
+      "org.scalameta"                  % "scalafmt-interfaces" % scalafmtVersion,
+      "io.get-coursier"                % "interface"           % "1.0.12",
+      "com.softwaremill.sttp.client3" %% "zio"                 % sttpVersion,
+      "dev.zio"                       %% "zio-config"          % zioConfigVersion,
+      "dev.zio"                       %% "zio-config-magnolia" % zioConfigVersion,
+      "dev.zio"                       %% "zio-test"            % zioVersion % Test,
+      "dev.zio"                       %% "zio-test-sbt"        % zioVersion % Test
     )
   )
   .dependsOn(core, clientJVM)
@@ -278,12 +277,12 @@ lazy val tapirInterop = project
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.2").cross(CrossVersion.full)))
     } ++
       Seq(
-        "com.softwaremill.sttp.tapir"   %% "tapir-core"                    % tapirVersion,
-        "com.softwaremill.sttp.tapir"   %% "tapir-zio"                     % tapirVersion,
-        "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"             % tapirVersion % Test,
-        "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % sttpVersion  % Test,
-        "dev.zio"                       %% "zio-test"                      % zioVersion   % Test,
-        "dev.zio"                       %% "zio-test-sbt"                  % zioVersion   % Test
+        "com.softwaremill.sttp.tapir"   %% "tapir-core"        % tapirVersion,
+        "com.softwaremill.sttp.tapir"   %% "tapir-zio"         % tapirVersion,
+        "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client" % tapirVersion % Test,
+        "com.softwaremill.sttp.client3" %% "zio"               % sttpVersion  % Test,
+        "dev.zio"                       %% "zio-test"          % zioVersion   % Test,
+        "dev.zio"                       %% "zio-test-sbt"      % zioVersion   % Test
       )
   )
   .dependsOn(core)
@@ -299,18 +298,18 @@ lazy val http4s = project
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.2").cross(CrossVersion.full)))
     } ++
       Seq(
-        "dev.zio"                               %% "zio-interop-cats"              % zioInteropCats3Version,
-        "org.typelevel"                         %% "cats-effect"                   % catsEffect3Version,
-        "com.softwaremill.sttp.tapir"           %% "tapir-http4s-server-zio"       % tapirVersion,
-        "com.softwaremill.sttp.tapir"           %% "tapir-json-circe"              % tapirVersion    % Test,
-        "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"          % tapirVersion    % Test,
-        "org.http4s"                            %% "http4s-ember-server"           % http4sVersion   % Test,
-        "dev.zio"                               %% "zio-test"                      % zioVersion      % Test,
-        "dev.zio"                               %% "zio-test-sbt"                  % zioVersion      % Test,
-        "com.softwaremill.sttp.client3"         %% "async-http-client-backend-zio" % sttpVersion     % Test,
-        "com.softwaremill.sttp.client3"         %% "circe"                         % sttpVersion     % Test,
-        "io.circe"                              %% "circe-generic"                 % circeVersion    % Test,
-        "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"         % jsoniterVersion % Test
+        "dev.zio"                               %% "zio-interop-cats"        % zioInteropCats3Version,
+        "org.typelevel"                         %% "cats-effect"             % catsEffect3Version,
+        "com.softwaremill.sttp.tapir"           %% "tapir-http4s-server-zio" % tapirVersion,
+        "com.softwaremill.sttp.tapir"           %% "tapir-json-circe"        % tapirVersion    % Test,
+        "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"    % tapirVersion    % Test,
+        "org.http4s"                            %% "http4s-ember-server"     % http4sVersion   % Test,
+        "dev.zio"                               %% "zio-test"                % zioVersion      % Test,
+        "dev.zio"                               %% "zio-test-sbt"            % zioVersion      % Test,
+        "com.softwaremill.sttp.client3"         %% "zio"                     % sttpVersion     % Test,
+        "com.softwaremill.sttp.client3"         %% "circe"                   % sttpVersion     % Test,
+        "io.circe"                              %% "circe-generic"           % circeVersion    % Test,
+        "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"   % jsoniterVersion % Test
       )
   )
   .dependsOn(core % "compile->compile;test->test", tapirInterop % "compile->compile;test->test", catsInterop)
@@ -356,16 +355,16 @@ lazy val play = project
     crossScalaVersions -= scala3,
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
-      "com.typesafe.play"             %% "play"                          % playVersion,
-      "com.softwaremill.sttp.tapir"   %% "tapir-play-server"             % tapirVersion,
-      "com.softwaremill.sttp.tapir"   %% "tapir-json-play"               % tapirVersion % Test,
-      "dev.zio"                       %% "zio-test"                      % zioVersion   % Test,
-      "dev.zio"                       %% "zio-test-sbt"                  % zioVersion   % Test,
-      "com.typesafe.play"             %% "play-akka-http-server"         % playVersion  % Test,
-      "io.circe"                      %% "circe-generic"                 % circeVersion % Test,
-      "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % sttpVersion  % Test,
-      "com.softwaremill.sttp.client3" %% "circe"                         % sttpVersion  % Test,
-      compilerPlugin(("org.typelevel" %% "kind-projector"                % "0.13.2").cross(CrossVersion.full))
+      "com.typesafe.play"             %% "play"                  % playVersion,
+      "com.softwaremill.sttp.tapir"   %% "tapir-play-server"     % tapirVersion,
+      "com.softwaremill.sttp.tapir"   %% "tapir-json-play"       % tapirVersion % Test,
+      "dev.zio"                       %% "zio-test"              % zioVersion   % Test,
+      "dev.zio"                       %% "zio-test-sbt"          % zioVersion   % Test,
+      "com.typesafe.play"             %% "play-akka-http-server" % playVersion  % Test,
+      "io.circe"                      %% "circe-generic"         % circeVersion % Test,
+      "com.softwaremill.sttp.client3" %% "zio"                   % sttpVersion  % Test,
+      "com.softwaremill.sttp.client3" %% "circe"                 % sttpVersion  % Test,
+      compilerPlugin(("org.typelevel" %% "kind-projector"        % "0.13.2").cross(CrossVersion.full))
     )
   )
   .dependsOn(core, tapirInterop % "compile->compile;test->test")
@@ -437,19 +436,19 @@ lazy val examples = project
     crossScalaVersions -= scala3,
     libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % "always",
     libraryDependencies ++= Seq(
-      "org.typelevel"                         %% "cats-mtl"                      % catsMtlVersion,
-      "org.http4s"                            %% "http4s-ember-server"           % http4sVersion,
-      "org.http4s"                            %% "http4s-dsl"                    % http4sVersion,
-      "com.softwaremill.sttp.client3"         %% "async-http-client-backend-zio" % sttpVersion,
-      "io.circe"                              %% "circe-generic"                 % circeVersion,
-      "dev.zio"                               %% "zio-http"                      % zioHttpVersion,
-      "com.typesafe.play"                     %% "play-akka-http-server"         % playVersion,
-      "com.typesafe.akka"                     %% "akka-actor-typed"              % akkaVersion,
-      "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"          % tapirVersion,
-      "com.softwaremill.sttp.tapir"           %% "tapir-json-circe"              % tapirVersion,
-      "com.softwaremill.sttp.tapir"           %% "tapir-json-play"               % tapirVersion,
-      "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"          % tapirVersion,
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"         % jsoniterVersion % Provided
+      "org.typelevel"                         %% "cats-mtl"              % catsMtlVersion,
+      "org.http4s"                            %% "http4s-ember-server"   % http4sVersion,
+      "org.http4s"                            %% "http4s-dsl"            % http4sVersion,
+      "com.softwaremill.sttp.client3"         %% "zio"                   % sttpVersion,
+      "io.circe"                              %% "circe-generic"         % circeVersion,
+      "dev.zio"                               %% "zio-http"              % zioHttpVersion,
+      "com.typesafe.play"                     %% "play-akka-http-server" % playVersion,
+      "com.typesafe.akka"                     %% "akka-actor-typed"      % akkaVersion,
+      "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"  % tapirVersion,
+      "com.softwaremill.sttp.tapir"           %% "tapir-json-circe"      % tapirVersion,
+      "com.softwaremill.sttp.tapir"           %% "tapir-json-play"       % tapirVersion,
+      "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"  % tapirVersion,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterVersion % Provided
     )
   )
   .dependsOn(
@@ -528,10 +527,10 @@ lazy val docs = project
     scalacOptions -= "-Xfatal-warnings",
     scalacOptions += "-Wunused:imports",
     libraryDependencies ++= Seq(
-      "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % sttpVersion,
-      "io.circe"                      %% "circe-generic"                 % circeVersion,
-      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"              % tapirVersion,
-      "org.typelevel"                 %% "cats-mtl"                      % catsMtlVersion
+      "com.softwaremill.sttp.client3" %% "zio"              % sttpVersion,
+      "io.circe"                      %% "circe-generic"    % circeVersion,
+      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe" % tapirVersion,
+      "org.typelevel"                 %% "cats-mtl"         % catsMtlVersion
     )
   )
   .dependsOn(core, catsInterop, tapirInterop, http4s, tools)

--- a/build.sbt
+++ b/build.sbt
@@ -378,7 +378,6 @@ lazy val client    = crossProject(JSPlatform, JVMPlatform)
   .settings(
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
-      "io.circe"                             %%% "circe-parser"          % circeVersion,
       "com.softwaremill.sttp.client3"        %%% "core"                  % sttpVersion,
       "com.softwaremill.sttp.client3"        %%% "jsoniter"              % sttpVersion,
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % jsoniterVersion,
@@ -419,9 +418,7 @@ lazy val clientLaminext = crossProject(JSPlatform)
     libraryDependencies ++= Seq(
       "io.laminext"                           %%% "core"                % laminextVersion,
       "io.laminext"                           %%% "fetch"               % laminextVersion,
-      "io.laminext"                           %%% "fetch-circe"         % laminextVersion,
       "io.laminext"                           %%% "websocket"           % laminextVersion,
-      "io.laminext"                           %%% "websocket-circe"     % laminextVersion,
       "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % jsoniterVersion,
       "dev.zio"                               %%% "zio-test"            % zioVersion % Test,
       "dev.zio"                               %%% "zio-test-sbt"        % zioVersion % Test

--- a/client-laminext/src/main/scala/caliban/client/laminext/package.scala
+++ b/client-laminext/src/main/scala/caliban/client/laminext/package.scala
@@ -6,7 +6,6 @@ import caliban.client.__Value.__ObjectValue
 import caliban.client.ws.{ GraphQLWSRequest, GraphQLWSResponse }
 import com.github.plokhotnyuk.jsoniter_scala.core.writeToString
 import com.raquo.airstream.core.EventStream
-import io.circe.Json
 import io.laminext.fetch.jsoniter._
 import io.laminext.websocket.jsoniter._
 import io.laminext.websocket.{ WebSocket, WebSocketBuilder, WebSocketReceiveBuilder }

--- a/client-laminext/src/main/scala/io/laminext/fetch/NonOkayResponse.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/NonOkayResponse.scala
@@ -1,0 +1,5 @@
+package io.laminext.fetch
+
+import org.scalajs.dom.Response
+
+class NonOkayResponse(val response: Response) extends Throwable

--- a/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchEventStreamBuilderJsoniterOps.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchEventStreamBuilderJsoniterOps.scala
@@ -1,0 +1,53 @@
+package io.laminext.fetch.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{ readFromString, JsonValueCodec }
+import com.raquo.laminar.api.L._
+import io.laminext.fetch.{ NonOkayResponse, ResponseError }
+import org.scalajs.dom.Response
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.scalajs.js.Thenable.Implicits._
+import scala.util.control.NonFatal
+class FetchEventStreamBuilderJsoniterOps(underlying: FetchEventStreamBuilder) {
+
+  private def decodeResponse[A](
+    response: Response
+  )(implicit codec: JsonValueCodec[A], ec: ExecutionContext): Future[A] =
+    response.text().flatMap { text =>
+      try Future.successful(readFromString[A](text)) match {
+        case NonFatal(e) => Future.failed(ResponseError(e, response))
+      }
+    }
+
+  private def acceptJson(b: FetchEventStreamBuilder): FetchEventStreamBuilder =
+    b.updateHeaders(_.updated("accept", "application/json"))
+
+  def decode[A](implicit decoder: JsonValueCodec[A], ec: ExecutionContext): EventStream[FetchResponse[A]] =
+    acceptJson(underlying).build(decodeResponse[A](_))
+
+  def decodeEither[NonOkay, Okay](implicit
+    decodeNonOkay: JsonValueCodec[NonOkay],
+    decodeOkay: JsonValueCodec[Okay],
+    ec: ExecutionContext
+  ): EventStream[FetchResponse[Either[NonOkay, Okay]]] =
+    acceptJson(underlying).build { response =>
+      if (response.ok) {
+        decodeResponse[Okay](response).map(Right(_))
+      } else {
+        decodeResponse[NonOkay](response).map(Left(_))
+      }
+    }
+
+  def decodeOkay[Okay](implicit
+    decodeOkay: JsonValueCodec[Okay],
+    ec: ExecutionContext
+  ): EventStream[FetchResponse[Okay]] =
+    acceptJson(underlying).build { response =>
+      if (response.ok) {
+        decodeResponse(response)
+      } else {
+        Future.failed(new NonOkayResponse(response))
+      }
+    }
+
+}

--- a/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchEventStreamBuilderJsoniterOps.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchEventStreamBuilderJsoniterOps.scala
@@ -15,7 +15,8 @@ class FetchEventStreamBuilderJsoniterOps(underlying: FetchEventStreamBuilder) {
     response: Response
   )(implicit codec: JsonValueCodec[A], ec: ExecutionContext): Future[A] =
     response.text().flatMap { text =>
-      try Future.successful(readFromString[A](text)) match {
+      try Future.successful(readFromString[A](text))
+      catch {
         case NonFatal(e) => Future.failed(ResponseError(e, response))
       }
     }

--- a/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchEventStreamBuilderJsoniterOps.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchEventStreamBuilderJsoniterOps.scala
@@ -1,13 +1,14 @@
-package io.laminext.fetch.jsoniter
+package io.laminext.fetch
+package jsoniter
 
 import com.github.plokhotnyuk.jsoniter_scala.core.{ readFromString, JsonValueCodec }
 import com.raquo.laminar.api.L._
-import io.laminext.fetch.{ NonOkayResponse, ResponseError }
 import org.scalajs.dom.Response
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.scalajs.js.Thenable.Implicits._
 import scala.util.control.NonFatal
+
 class FetchEventStreamBuilderJsoniterOps(underlying: FetchEventStreamBuilder) {
 
   private def decodeResponse[A](

--- a/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchJsoniterSyntax.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchJsoniterSyntax.scala
@@ -2,6 +2,8 @@ package io.laminext.fetch.jsoniter
 
 import com.github.plokhotnyuk.jsoniter_scala.core.{ writeToString, JsonValueCodec }
 
+import scala.language.implicitConversions
+
 trait FetchJsoniterSyntax {
 
   implicit def jsonRequestBody[A](value: A)(implicit encoder: JsonValueCodec[A]): ToRequestBody =

--- a/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchJsoniterSyntax.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchJsoniterSyntax.scala
@@ -7,6 +7,6 @@ trait FetchJsoniterSyntax {
   implicit def jsonRequestBody[A](value: A)(implicit encoder: JsonValueCodec[A]): ToRequestBody =
     new JsonToRequestBody(writeToString(value))
 
-  implicit def fetchEventStreamBuilderSyntaxCirce(b: FetchEventStreamBuilder): FetchEventStreamBuilderJsoniterOps =
+  implicit def fetchEventStreamBuilderSyntaxJsoniter(b: FetchEventStreamBuilder): FetchEventStreamBuilderJsoniterOps =
     new FetchEventStreamBuilderJsoniterOps(b)
 }

--- a/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchJsoniterSyntax.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/FetchJsoniterSyntax.scala
@@ -1,0 +1,12 @@
+package io.laminext.fetch.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{ writeToString, JsonValueCodec }
+
+trait FetchJsoniterSyntax {
+
+  implicit def jsonRequestBody[A](value: A)(implicit encoder: JsonValueCodec[A]): ToRequestBody =
+    new JsonToRequestBody(writeToString(value))
+
+  implicit def fetchEventStreamBuilderSyntaxCirce(b: FetchEventStreamBuilder): FetchEventStreamBuilderJsoniterOps =
+    new FetchEventStreamBuilderJsoniterOps(b)
+}

--- a/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/JsonToRequestBody.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/JsonToRequestBody.scala
@@ -1,0 +1,15 @@
+package io.laminext.fetch.jsoniter
+
+import org.scalajs.dom.BodyInit
+
+import scala.scalajs.js
+import scala.scalajs.js.UndefOr
+
+class JsonToRequestBody(jsonStr: String) extends ToRequestBody {
+
+  override def apply(): UndefOr[BodyInit] = jsonStr
+
+  override def updateHeaders(headers: js.UndefOr[Map[String, String]]): js.UndefOr[Map[String, String]] =
+    headers.getOrElse(Map.empty).updated("content-type", "application/json; charset=utf-8")
+
+}

--- a/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/package.scala
+++ b/client-laminext/src/main/scala/io/laminext/fetch/jsoniter/package.scala
@@ -1,0 +1,3 @@
+package io.laminext.fetch
+
+package object jsoniter extends ReExports with FetchSyntax with FetchJsoniterSyntax

--- a/client-laminext/src/main/scala/io/laminext/websocket/jsoniter/WebSocketReceiveBuilderJsoniterOps.scala
+++ b/client-laminext/src/main/scala/io/laminext/websocket/jsoniter/WebSocketReceiveBuilderJsoniterOps.scala
@@ -1,0 +1,26 @@
+package io.laminext.websocket.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{ readFromString, writeToString, JsonValueCodec }
+import io.laminext.websocket.{ initialize, receive, send, WebSocketBuilder, WebSocketReceiveBuilder }
+
+import scala.util.control.NonFatal
+
+class WebSocketReceiveBuilderJsoniterOps(b: WebSocketReceiveBuilder) {
+
+  @inline def json[Receive, Send](implicit
+    receiveCodec: JsonValueCodec[Receive],
+    sendCodec: JsonValueCodec[Send]
+  ): WebSocketBuilder[Receive, Send] =
+    new WebSocketBuilder[Receive, Send](
+      url = b.url,
+      protocol = b.protocol,
+      initializer = initialize.text,
+      sender = send.text[Send](writeToString(_)),
+      receiver = receive.text[Receive] { text =>
+        try Right(readFromString[Receive](text))
+        catch {
+          case NonFatal(e) => Left(e)
+        }
+      }
+    )
+}

--- a/client-laminext/src/main/scala/io/laminext/websocket/jsoniter/package.scala
+++ b/client-laminext/src/main/scala/io/laminext/websocket/jsoniter/package.scala
@@ -1,0 +1,7 @@
+package io.laminext.websocket
+
+package object jsoniter extends ReExports {
+
+  implicit def webSocketReceiveBuilderSyntax(b: WebSocketReceiveBuilder): WebSocketReceiveBuilderJsoniterOps =
+    new WebSocketReceiveBuilderJsoniterOps(b)
+}

--- a/client-laminext/src/main/scala/io/laminext/websocket/jsoniter/package.scala
+++ b/client-laminext/src/main/scala/io/laminext/websocket/jsoniter/package.scala
@@ -1,5 +1,7 @@
 package io.laminext.websocket
 
+import scala.language.implicitConversions
+
 package object jsoniter extends ReExports {
 
   implicit def webSocketReceiveBuilderSyntax(b: WebSocketReceiveBuilder): WebSocketReceiveBuilderJsoniterOps =

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -1,7 +1,6 @@
 package caliban.client
 
 import caliban.client.__Value.{ __BooleanValue, __ListValue, __NullValue, __NumberValue, __ObjectValue, __StringValue }
-import io.circe.Json
 
 import scala.annotation.implicitNotFound
 import java.util.UUID

--- a/client/src/main/scala/caliban/client/ArgEncoder.scala
+++ b/client/src/main/scala/caliban/client/ArgEncoder.scala
@@ -51,5 +51,5 @@ object ArgEncoder {
   implicit def list[A](implicit ev: ArgEncoder[A]): ArgEncoder[List[A]] = (value: List[A]) =>
     __ListValue(value.map(ev.encode))
 
-  implicit val json: ArgEncoder[Json] = (value: Json) => __Value.valueDecoder.decodeJson(value).getOrElse(__NullValue)
+  implicit val json: ArgEncoder[__ObjectValue] = (value: __ObjectValue) => value
 }

--- a/client/src/main/scala/caliban/client/GraphQLRequest.scala
+++ b/client/src/main/scala/caliban/client/GraphQLRequest.scala
@@ -1,7 +1,7 @@
 package caliban.client
 
-import io.circe.syntax._
-import io.circe.{ Encoder, Json }
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 /**
  * Represents a GraphQL request, containing a query and a map of variables.
@@ -10,12 +10,6 @@ case class GraphQLRequest(query: String, variables: Map[String, __Value])
 
 object GraphQLRequest {
 
-  implicit val encoder: Encoder[GraphQLRequest] = (req: GraphQLRequest) =>
-    Json.obj(
-      "query"     -> Json.fromString(req.query),
-      "variables" -> Json.obj(req.variables.map { case (k, v) =>
-        k -> v.asJson
-      }.toList: _*)
-    )
+  implicit val jsonEncoder: JsonValueCodec[GraphQLRequest] = JsonCodecMaker.makeCirceLike[GraphQLRequest]
 
 }

--- a/client/src/main/scala/caliban/client/GraphQLResponse.scala
+++ b/client/src/main/scala/caliban/client/GraphQLResponse.scala
@@ -1,7 +1,8 @@
 package caliban.client
 
 import caliban.client.__Value.__ObjectValue
-import io.circe.{ Decoder, HCursor, Json }
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 /**
  * Represents the result of a GraphQL query, containing a data object and a list of errors.
@@ -9,21 +10,11 @@ import io.circe.{ Decoder, HCursor, Json }
 case class GraphQLResponse(
   data: Option[__Value],
   errors: List[GraphQLResponseError] = Nil,
-  extensions: Option[Json] = None
+  extensions: Option[__ObjectValue] = None
 )
 
 object GraphQLResponse {
 
-  implicit val objectValueDecoder: Decoder[__ObjectValue] = Decoder[__Value].emap {
-    case o @ __ObjectValue(_) => Right(o)
-    case _                    => Left("Invalid value, should be an object.")
-  }
-
-  implicit val decoder: Decoder[GraphQLResponse] = (c: HCursor) =>
-    for {
-      data       <- c.downField("data").as[Option[__Value]]
-      errors     <- c.downField("errors").as[Option[List[GraphQLResponseError]]]
-      extensions <- c.downField("extensions").as[Option[Json]]
-    } yield GraphQLResponse(data, errors.getOrElse(Nil), extensions)
+  implicit val jsonCodec: JsonValueCodec[GraphQLResponse] = JsonCodecMaker.makeCirceLike[GraphQLResponse]
 
 }

--- a/client/src/main/scala/caliban/client/ScalarDecoder.scala
+++ b/client/src/main/scala/caliban/client/ScalarDecoder.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 
 import caliban.client.CalibanClientError.DecodingError
 import caliban.client.__Value._
-import io.circe.Json
 
 import scala.annotation.implicitNotFound
 
@@ -83,5 +82,5 @@ object ScalarDecoder {
     case __ObjectValue(Nil) => Right(())
     case other              => Left(DecodingError(s"Can't build Unit from input $other"))
   }
-  implicit val json: ScalarDecoder[Json]             = value => Right(__Value.valueEncoder(value))
+  implicit val json: ScalarDecoder[__Value]          = value => Right(value)
 }

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -1,6 +1,7 @@
 package caliban.client
 
-import com.github.plokhotnyuk.jsoniter_scala.core.{ JsonReader, JsonValueCodec, JsonWriter }
+import com.github.plokhotnyuk.jsoniter_scala.core.{ writeToString, JsonReader, JsonValueCodec, JsonWriter }
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 import scala.annotation.switch
 import scala.collection.immutable.TreeMap
@@ -23,7 +24,8 @@ sealed trait __Value { self =>
 }
 
 object __Value {
-  private final val MaxDepth = 512
+  private final val MaxDepth                                    = 512
+  private implicit val stringCodecMaker: JsonValueCodec[String] = JsonCodecMaker.make[String]
 
   case object __NullValue                                   extends __Value {
     override def toString: String = "null"
@@ -35,7 +37,7 @@ object __Value {
     override def toString: String = value
   }
   case class __StringValue(value: String)                   extends __Value {
-    override def toString: String = s""""$value""""
+    override def toString: String = writeToString(value)
   }
   case class __BooleanValue(value: Boolean)                 extends __Value {
     override def toString: String = value.toString

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -24,7 +24,7 @@ sealed trait __Value { self =>
 }
 
 object __Value {
-  private final val MaxDepth                                    = 512
+  private final val MaxDepth                                    = 1023
   private implicit val stringCodecMaker: JsonValueCodec[String] = JsonCodecMaker.make[String]
 
   case object __NullValue                                   extends __Value {

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -1,7 +1,6 @@
 package caliban.client
 
 import com.github.plokhotnyuk.jsoniter_scala.core.{ JsonReader, JsonValueCodec, JsonWriter }
-import io.circe.Json
 
 import scala.annotation.switch
 import scala.collection.immutable.TreeMap
@@ -36,7 +35,7 @@ object __Value {
     override def toString: String = value
   }
   case class __StringValue(value: String)                   extends __Value {
-    override def toString: String = Json.fromString(value).toString
+    override def toString: String = s""""$value""""
   }
   case class __BooleanValue(value: Boolean)                 extends __Value {
     override def toString: String = value.toString

--- a/client/src/main/scala/caliban/client/__Value.scala
+++ b/client/src/main/scala/caliban/client/__Value.scala
@@ -1,6 +1,10 @@
 package caliban.client
 
-import io.circe.{ Decoder, Encoder, Json }
+import com.github.plokhotnyuk.jsoniter_scala.core.{ JsonReader, JsonValueCodec, JsonWriter }
+import io.circe.Json
+
+import scala.annotation.switch
+import scala.collection.immutable.TreeMap
 
 /**
  * Value that can be returned by the server or sent as an argument.
@@ -20,6 +24,8 @@ sealed trait __Value { self =>
 }
 
 object __Value {
+  private final val MaxDepth = 512
+
   case object __NullValue                                   extends __Value {
     override def toString: String = "null"
   }
@@ -43,27 +49,108 @@ object __Value {
       fields.map { case (name, value) => s"""$name:${value.toString}""" }.mkString("{", ",", "}")
   }
 
-  private def jsonToValue(json: Json): __Value =
-    json.fold(
-      __NullValue,
-      __BooleanValue.apply,
-      number => __NumberValue(number.toBigDecimal getOrElse BigDecimal(number.toDouble)),
-      __StringValue.apply,
-      array => __Value.__ListValue(array.toList.map(jsonToValue)),
-      obj => __Value.__ObjectValue(obj.toList.map { case (k, v) => k -> jsonToValue(v) })
-    )
+  object __ObjectValue {
+    implicit val codec: JsonValueCodec[__ObjectValue] = new JsonValueCodec[__ObjectValue] {
+      def decodeValue(in: JsonReader, default: __ObjectValue): __ObjectValue = {
+        val b = in.nextToken()
+        if (b == '{') {
+          in.rollbackToken()
+          decodeJsonValue(in, MaxDepth) match {
+            case v: __ObjectValue => v
+            case v                => in.decodeError(s"expected object but received $v")
+          }
+        } else in.decodeError(s"expected object but received $b")
+      }
 
-  private def valueToJson(a: __Value): Json = a match {
-    case `__NullValue`         => Json.Null
-    case __NumberValue(value)  => Json.fromBigDecimal(value)
-    case __StringValue(value)  => Json.fromString(value)
-    case __EnumValue(value)    => Json.fromString(value)
-    case __BooleanValue(value) => Json.fromBoolean(value)
-    case __ListValue(values)   => Json.fromValues(values.map(valueToJson))
-    case __ObjectValue(fields) => Json.obj(fields.map { case (k, v) => k -> valueToJson(v) }: _*)
+      def encodeValue(x: __ObjectValue, out: JsonWriter): Unit =
+        encodeJsonValue(x, out, MaxDepth)
+
+      def nullValue: __ObjectValue =
+        null.asInstanceOf[__ObjectValue]
+    }
   }
 
-  implicit val valueDecoder: Decoder[__Value] = Decoder.instance(hcursor => Right(jsonToValue(hcursor.value)))
+  implicit val jsonCodec: JsonValueCodec[__Value] = new JsonValueCodec[__Value] {
+    def decodeValue(in: JsonReader, default: __Value): __Value =
+      decodeJsonValue(in, MaxDepth)
 
-  implicit val valueEncoder: Encoder[__Value] = (a: __Value) => valueToJson(a)
+    def encodeValue(x: __Value, out: JsonWriter): Unit =
+      encodeJsonValue(x, out, MaxDepth)
+
+    def nullValue: __Value = __NullValue
+  }
+
+  private val emptyValueObject = __ObjectValue(Nil)
+  private val emptyValueList   = __ListValue(Nil)
+
+  private def encodeJsonValue(x: __Value, out: JsonWriter, depth: Int): Unit = x match {
+    case __NumberValue(value)  => out.writeVal(value)
+    case __EnumValue(value)    => out.writeVal(value)
+    case __StringValue(value)  => out.writeVal(value)
+    case __BooleanValue(value) => out.writeVal(value)
+    case __ListValue(values)   =>
+      val newDepth = depth - 1
+      if (newDepth < 0) out.encodeError("Max depth reached")
+      out.writeArrayStart()
+      values.foreach(encodeJsonValue(_, out, depth - 1))
+      out.writeArrayEnd()
+    case __ObjectValue(fields) =>
+      val newDepth = depth - 1
+      if (newDepth < 0) out.encodeError("Max depth reached")
+      out.writeObjectStart()
+      fields.foreach { case (name, value) =>
+        out.writeKey(name)
+        encodeJsonValue(value, out, depth - 1)
+      }
+      out.writeObjectEnd()
+    case `__NullValue`         => out.writeNull()
+  }
+
+  private def decodeJsonValue(in: JsonReader, depth: Int): __Value = {
+    val b = in.nextToken()
+    (b: @switch) match {
+      case 'n'                                                             =>
+        in.readNullOrError(__NullValue, "unexpected JSON value")
+      case 't' | 'f'                                                       =>
+        in.rollbackToken()
+        __BooleanValue(in.readBoolean())
+      case '{'                                                             =>
+        val newDepth = depth - 1
+        if (newDepth < 0) in.decodeError("Max depth reached")
+        else if (in.isNextToken('}')) emptyValueObject
+        else {
+          in.rollbackToken()
+          val fields = TreeMap.newBuilder[String, __Value]
+          while ({
+            fields += in.readKeyAsString() -> decodeJsonValue(in, newDepth)
+            in.isNextToken(',')
+          }) ()
+          if (in.isCurrentToken('}')) __ObjectValue(fields.result().toList)
+          else in.objectEndOrCommaError()
+        }
+      case '['                                                             =>
+        val newDepth = depth - 1
+        if (newDepth < 0) in.decodeError("Max depth reached")
+        else if (in.isNextToken(']')) emptyValueList
+        else {
+          in.rollbackToken()
+          val values = Array.newBuilder[__Value]
+          while ({
+            values += decodeJsonValue(in, newDepth)
+            in.isNextToken(',')
+          }) ()
+          if (in.isCurrentToken(']')) __ListValue(values.result().toList)
+          else in.arrayEndOrCommaError()
+        }
+      case '"'                                                             =>
+        in.rollbackToken()
+        __StringValue(in.readString(null))
+      case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '-' =>
+        in.rollbackToken()
+        __NumberValue(in.readBigDecimal(null))
+      case c                                                               =>
+        in.decodeError(s"unexpected token: $c")
+    }
+  }
+
 }

--- a/client/src/main/scala/caliban/client/ws/GraphQLWSRequest.scala
+++ b/client/src/main/scala/caliban/client/ws/GraphQLWSRequest.scala
@@ -1,16 +1,12 @@
 package caliban.client.ws
 
 import caliban.client.GraphQLRequest
-import io.circe.syntax._
-import io.circe.{ Encoder, Json }
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 case class GraphQLWSRequest(`type`: String, id: Option[String], payload: Option[GraphQLRequest])
 
 object GraphQLWSRequest {
-  implicit val graphQLWSRequestEncoder: Encoder[GraphQLWSRequest] = (req: GraphQLWSRequest) =>
-    Json.obj(
-      "type"    -> Json.fromString(req.`type`),
-      "id"      -> req.id.fold(Json.Null)(Json.fromString),
-      "payload" -> req.payload.fold(Json.Null)(_.asJson)
-    )
+  implicit val graphQLWSRequestEncoder: JsonValueCodec[GraphQLWSRequest] =
+    JsonCodecMaker.makeCirceLike[GraphQLWSRequest]
 }

--- a/client/src/main/scala/caliban/client/ws/GraphQLWSResponse.scala
+++ b/client/src/main/scala/caliban/client/ws/GraphQLWSResponse.scala
@@ -1,14 +1,12 @@
 package caliban.client.ws
 
-import io.circe.{ Decoder, HCursor, Json }
+import caliban.client.__Value.__ObjectValue
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
-case class GraphQLWSResponse(`type`: String, id: Option[String], payload: Option[Json])
+case class GraphQLWSResponse(`type`: String, id: Option[String], payload: Option[__ObjectValue])
 
 object GraphQLWSResponse {
-  implicit val graphQLWSResponseEncoder: Decoder[GraphQLWSResponse] = (c: HCursor) =>
-    for {
-      t       <- c.downField("type").as[String]
-      id      <- c.downField("id").as[Option[String]]
-      payload <- c.downField("payload").as[Option[Json]]
-    } yield GraphQLWSResponse(t, id, payload)
+  implicit val graphQLWSResponseEncoder: JsonValueCodec[GraphQLWSResponse] =
+    JsonCodecMaker.makeCirceLike[GraphQLWSResponse]
 }

--- a/client/src/test/scala/caliban/client/GraphQLResponseSpec.scala
+++ b/client/src/test/scala/caliban/client/GraphQLResponseSpec.scala
@@ -1,13 +1,15 @@
 package caliban.client
 
 import caliban.client.GraphQLResponseError.Location
+import caliban.client.__Value.__ObjectValue
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import zio.test.Assertion._
 import zio.test._
-
 import zio.ZIO
-
 import io.circe.parser.decode
 import io.circe.Json
+
+import scala.util.Try
 
 object GraphQLResponseSpec extends ZIOSpecDefault {
 
@@ -16,8 +18,8 @@ object GraphQLResponseSpec extends ZIOSpecDefault {
       test("can be parsed from JSON") {
         val response =
           """{"errors":[{"message":"Parse error on \"direction\" (STRING) at [1, 107]","locations":[{"line":1,"column":107}]}]}"""
-        assert(decode[GraphQLResponse](response))(
-          isRight(
+        assert(Try(readFromString[GraphQLResponse](response)))(
+          isSuccess(
             equalTo(
               GraphQLResponse(
                 None,
@@ -71,9 +73,9 @@ object GraphQLResponseSpec extends ZIOSpecDefault {
               |}""".stripMargin
 
         for {
-          response   <- ZIO.fromEither(decode[GraphQLResponse](responseRawJson))
-          data       <- ZIO.fromEither(decode[__Value](dataRawJson))
-          extensions <- ZIO.fromEither(decode[Json](extensionsRawJson))
+          response   <- ZIO.attempt(readFromString[GraphQLResponse](responseRawJson))
+          data       <- ZIO.attempt(readFromString[__Value](dataRawJson))
+          extensions <- ZIO.attempt(readFromString[__ObjectValue](extensionsRawJson))
         } yield assertTrue(
           response == GraphQLResponse(
             Some(data),

--- a/client/src/test/scala/caliban/client/GraphQLResponseSpec.scala
+++ b/client/src/test/scala/caliban/client/GraphQLResponseSpec.scala
@@ -6,8 +6,6 @@ import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import zio.test.Assertion._
 import zio.test._
 import zio.ZIO
-import io.circe.parser.decode
-import io.circe.Json
 
 import scala.util.Try
 

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
@@ -34,8 +34,8 @@ lazy val calibanLib: Seq[ModuleID] =
   }
 
 lazy val sttp = Seq(
-  "com.softwaremill.sttp.client3" %% "core"                          % "3.4.0",
-  "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % "3.4.0"
+  "com.softwaremill.sttp.client3" %% "core" % "3.4.0",
+  "com.softwaremill.sttp.client3" %% "zio"  % "3.4.0"
 )
 
 // ### App Modules ###

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
@@ -34,8 +34,8 @@ lazy val calibanLib: Seq[ModuleID] =
   }
 
 lazy val sttp = Seq(
-  "com.softwaremill.sttp.client3" %% "core" % "3.4.0",
-  "com.softwaremill.sttp.client3" %% "zio"  % "3.4.0"
+  "com.softwaremill.sttp.client3" %% "core" % "3.8.13",
+  "com.softwaremill.sttp.client3" %% "zio"  % "3.8.13"
 )
 
 // ### App Modules ###

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/clients/src/main/scala/poc/caliban/client/PotatoesClient.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/clients/src/main/scala/poc/caliban/client/PotatoesClient.scala
@@ -4,7 +4,7 @@ import poc.caliban.client.generated.potatoes._
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.SttpBackend
-import zio.Task
+import zio.{Task, ZIO}
 
 trait PotatoesClient {
   def eradicate(name: String): Task[Unit]
@@ -20,6 +20,6 @@ final class PotatoesClientLive(backend: SttpBackend[Task, ZioStreams with WebSoc
       .eradicate(name)
       .toRequest(serverUrl)
       .send(backend)
-      .foldZIO(Task.fail(_), r => Task.fromEither(r.body).unit)
+      .foldZIO(ZIO.fail(_), r => ZIO.fromEither(r.body).unit)
 
 }

--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -1,7 +1,7 @@
 package caliban.interop.jsoniter
 
 import caliban.Value._
-import caliban._
+import caliban.{ GraphQLResponse, _ }
 import caliban.parsing.adt.LocationInfo
 import com.github.plokhotnyuk.jsoniter_scala.core._
 

--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -1,7 +1,7 @@
 package caliban.interop.jsoniter
 
 import caliban.Value._
-import caliban.{ GraphQLResponse, _ }
+import caliban._
 import caliban.parsing.adt.LocationInfo
 import com.github.plokhotnyuk.jsoniter_scala.core._
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "com.github.ghostdogpr"         %% "caliban-tools"                 % calibanVersion,
   "org.http4s"                    %% "http4s-ember-server"           % "0.23.16",
   "org.http4s"                    %% "http4s-dsl"                    % "0.23.16",
-  "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % "3.3.18",
+  "com.softwaremill.sttp.client3" %% "zio"                           % "3.3.18",
   "io.circe"                      %% "circe-generic"                 % "0.14.1",
   "com.typesafe.play"             %% "play-akka-http-server"         % "2.8.14",
   "com.typesafe.akka"             %% "akka-actor-typed"              % "2.6.18",

--- a/examples/src/main/scala/example/client/ExampleApp.scala
+++ b/examples/src/main/scala/example/client/ExampleApp.scala
@@ -5,7 +5,7 @@ import caliban.client.CalibanClientError
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3._
-import sttp.client3.asynchttpclient.zio._
+import sttp.client3.httpclient.zio.HttpClientZioBackend
 import zio.Console.printLine
 import zio._
 
@@ -63,7 +63,7 @@ object ExampleApp extends ZIOAppDefault {
     val call2 = sendRequest(query.toRequest(uri, useVariables = true))
 
     (call1 *> call2)
-      .provideLayer(AsyncHttpClientZioBackend.layer())
+      .provideLayer(HttpClientZioBackend.layer())
       .exitCode
   }
 }

--- a/examples/src/main/scala/example/stitching/ExampleApp.scala
+++ b/examples/src/main/scala/example/stitching/ExampleApp.scala
@@ -10,7 +10,7 @@ import caliban.tools.stitching.{ HttpRequest, RemoteResolver, RemoteSchemaResolv
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.SttpBackend
-import sttp.client3.asynchttpclient.zio._
+import sttp.client3.httpclient.zio._
 import zio._
 
 object StitchingExample extends GenericSchema[Any] {
@@ -123,7 +123,7 @@ object ExampleApp extends ZIOAppDefault {
                        )
     } yield ())
       .provide(
-        AsyncHttpClientZioBackend.layer(),
+        HttpClientZioBackend.layer(),
         Configuration.fromEnvironment,
         Server.default
       )

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -6,7 +6,7 @@ import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, GraphQLWSInput, 
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.SttpBackend
-import sttp.client3.httpclient.zio.HttpClientZioBackend
+import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
 import sttp.model.{ Header, MediaType, Method, Part, QueryParams, StatusCode, Uri }
 import sttp.tapir.AttributeKey
 import sttp.tapir.Codec.JsonCodec
@@ -276,7 +276,7 @@ object TapirAdapterSpec {
     )
 
     ZIO.succeed(tests.flatten)
-  }.provideLayerShared(ZLayer.scoped(HttpClientZioBackend.scoped())) @@
+  }.provideLayerShared(AsyncHttpClientZioBackend.layer()) @@
     before(TestService.reset) @@
     TestAspect.sequential
 }

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -6,7 +6,7 @@ import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, GraphQLWSInput, 
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.SttpBackend
-import sttp.client3.asynchttpclient.zio._
+import sttp.client3.httpclient.zio.HttpClientZioBackend
 import sttp.model.{ Header, MediaType, Method, Part, QueryParams, StatusCode, Uri }
 import sttp.tapir.AttributeKey
 import sttp.tapir.Codec.JsonCodec
@@ -276,7 +276,7 @@ object TapirAdapterSpec {
     )
 
     ZIO.succeed(tests.flatten)
-  }.provideLayerShared(ZLayer.scoped(AsyncHttpClientZioBackend.scoped())) @@
+  }.provideLayerShared(ZLayer.scoped(HttpClientZioBackend.scoped())) @@
     before(TestService.reset) @@
     TestAspect.sequential
 }

--- a/tools/src/main/scala/caliban/tools/SchemaLoader.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaLoader.scala
@@ -3,7 +3,7 @@ package caliban.tools
 import caliban.GraphQL
 import caliban.parsing.Parser
 import caliban.parsing.adt.Document
-import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
+import sttp.client3.httpclient.zio.HttpClientZioBackend
 import zio.{ Task, ZIO }
 
 trait SchemaLoader {
@@ -30,7 +30,7 @@ object SchemaLoader {
   case class FromIntrospection private[SchemaLoader] (url: String, headers: Option[List[Options.Header]])
       extends SchemaLoader {
     override def load: Task[Document] =
-      IntrospectionClient.introspect(url, headers).provideLayer(AsyncHttpClientZioBackend.layer())
+      IntrospectionClient.introspect(url, headers).provideLayer(HttpClientZioBackend.layer())
   }
 
   def fromCaliban[R](api: GraphQL[R]): SchemaLoader                                       = FromCaliban(api)

--- a/tools/src/main/scala/caliban/tools/stitching/RemoteResolver.scala
+++ b/tools/src/main/scala/caliban/tools/stitching/RemoteResolver.scala
@@ -8,7 +8,7 @@ import caliban.ResponseValue.ObjectValue
 import caliban.tools.SttpClient
 
 import sttp.client3._
-import sttp.client3.circe._
+import sttp.client3.jsoniter._
 
 case class RemoteResolver[-R, +E, -A, +B](
   run: A => ZIO[R, E, B]


### PR DESCRIPTION
Migrates the client utilities to jsoniter for better performance. As a plus, because there is no built in AST we now use the `__ObjectValue` in most places which means we don't need to expose the underlying json lib anymore.