### PR TITLE
Micro-optimizations for `Field` construction

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -168,7 +168,7 @@ object Field {
                       if (field._condition.isDefined) field
                       else
                         field.copy(
-                          targets = typeCondition.flatMap(t => Some(Set(t.name))),
+                          targets = typeCondition.map(t => Set(t.name)),
                           _condition = subtypeNames(typeName.name, rootType)
                         )
                     addField(_field, Some(typeName.name))


### PR DESCRIPTION
I was looking at some traces at work for some recursive queries, and it caught my attention that the validation phase with `skipValidation=true` would sometimes be surprisingly high (I saw queries taking on average ~2-3ms and up to 5ms to validate even with `skipValidation=true`). 

At first I thought it might have to do something with the wrappers, but after disabling them all and validation still being quite slow I eventually managed to track down the "issue" to the `caliban.execution.Field.apply` method.

With these changes, we reduce the calls to `loop()` when the selectionSet is empty, and move `innerType.fields(__DeprecatedArgs(Some(true)))` outside of the `selectionSet.foreach` loop so that it's calculated only once.

I've run some of the benchmarks and saw some marginal improvement, although to my surprise it wasn't nearly as much as I saw in the real application. I'm guessing that this might have to do with the size of the schema but also dependent on how many of the fields are selected by the query?