### PR TITLE
Memoize and optimize selection of fragments during `Field` creation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,10 @@ lazy val core = project
       if (scalaVersion.value == scala3) {
         Seq()
       } else {
-        Seq(
+        val scala212Deps = if (scalaVersion.value == scala212) {
+          Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.9.0")
+        } else Seq()
+        scala212Deps ++ Seq(
           "com.propensive"    %% "magnolia"  % magnoliaVersion,
           "com.propensive"    %% "mercator"  % mercatorVersion,
           "com.typesafe.play" %% "play-json" % playJsonVersion % Optional

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -118,10 +118,7 @@ object Field {
 
               val _fields = if (checkDirectives(resolvedDirectives)) {
                 fragments.get(name).map { f =>
-                  val t = innerType.possibleTypes
-                    .flatMap(_.find(_.name.contains(f.typeCondition.name)))
-                    .orElse(rootType.types.get(f.typeCondition.name))
-                    .getOrElse(fieldType)
+                  val t = rootType.types.getOrElse(f.typeCondition.name, fieldType)
                   loop(f.selectionSet, t).map { field =>
                     if (field._condition.isDefined) field
                     else

--- a/core/src/test/scala/caliban/execution/FieldSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldSpec.scala
@@ -146,7 +146,7 @@ object FieldSpec extends ZIOSpecDefault {
                 FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"))),
                 FieldTree.Leaf("id", "String!"),
                 FieldTree.Leaf("count", "Int!"),
-                FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"), FieldTree.Leaf("num", "Int!"))),
+                FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"), FieldTree.Leaf("num", "Int!")))
               )
             )
           )

--- a/core/src/test/scala/caliban/execution/FieldSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldSpec.scala
@@ -122,8 +122,11 @@ object FieldSpec extends ZIOSpecDefault {
             ... on Interface {
               id
             }
+            ... @include(if: true) {
+              count
+            }
             inner { num }
-            count
+            inner { num }
           }
         }
       }""")
@@ -142,8 +145,8 @@ object FieldSpec extends ZIOSpecDefault {
                 FieldTree.Leaf("id", "String!"),
                 FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"))),
                 FieldTree.Leaf("id", "String!"),
-                FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"))),
-                FieldTree.Leaf("count", "Int!")
+                FieldTree.Leaf("count", "Int!"),
+                FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"), FieldTree.Leaf("num", "Int!"))),
               )
             )
           )


### PR DESCRIPTION
As discussed on Discord, memoizing the creation of fragments provides a significant performance boost. For the `fragmentsQuery` benchmark, this translates to:

```shell
[info] GraphQLBenchmarks.fragmentsCaliban  thrpt    5  104.550 ± 0.505  ops/s # Before
[info] GraphQLBenchmarks.fragmentsCaliban  thrpt    5  135.401 ± 0.987  ops/s # After
```

My big concern however is that we perhaps can't out-right memoize this due to the computation being dependent on `innerType` (more info in the comments below). However, all the tests seem to pass and I couldn't manage to create a case where the same `FragmentSpread(...)` would result in different `Field` being generated based on different `innerType`. Happy to hear your thoughts on what I could further try to test this

I've also included some other minor optimizations and cleanups in this PR - happy to remove them if we want to have a cleaner view of the memoization changes