### PR TITLE
Add `isIntrospection` field on `Document`

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -111,7 +111,7 @@ trait GraphQL[-R] { self =>
               wrap((request: GraphQLRequest) =>
                 (for {
                   doc              <- wrap(Parser.parseQuery)(parsingWrappers, request.query.getOrElse(""))
-                  intro             = Introspector.isIntrospection(doc)
+                  intro             = doc.isIntrospection
                   _                <- ZIO.when(intro && !enableIntrospection) {
                                         ZIO.fail(CalibanError.ValidationError("Introspection is disabled", ""))
                                       }

--- a/core/src/main/scala/caliban/parsing/adt/Document.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Document.scala
@@ -1,5 +1,6 @@
 package caliban.parsing.adt
 
+import caliban.introspection.Introspector
 import caliban.parsing.SourceMapper
 import caliban.parsing.adt.Definition.ExecutableDefinition.{ FragmentDefinition, OperationDefinition }
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
@@ -7,6 +8,7 @@ import caliban.parsing.adt.Definition.TypeSystemDefinition.{ DirectiveDefinition
 import caliban.parsing.adt.OperationType.{ Mutation, Query, Subscription }
 
 case class Document(definitions: List[Definition], sourceMapper: SourceMapper) {
+  lazy val isIntrospection: Boolean                                    = Introspector.isIntrospection(this)
   lazy val directiveDefinitions: List[DirectiveDefinition]             = definitions.collect { case dd: DirectiveDefinition =>
     dd
   }


### PR DESCRIPTION
I went with adding this as a public lazy val on Document while keeping `Introspector.isIntrospection` private, so that it's only computed once per execution - happy to change this if we prefer for the field not to exist on Document