### PR TITLE
Adds support for adding directives to individual enums

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -131,7 +131,8 @@ trait CommonSchemaDerivation[R] {
               name,
               description,
               annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
-              annotations.collectFirst { case GQLDeprecated(reason) => reason }
+              annotations.collectFirst { case GQLDeprecated(reason) => reason },
+              Some(annotations.collect { case GQLDirective(dir) => dir }.toList).filter(_.nonEmpty)
             )
           },
           Some(ctx.typeName.full),

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -218,7 +218,8 @@ trait CommonSchemaDerivation {
           name,
           description,
           getDeprecatedReason(annotations).isDefined,
-          getDeprecatedReason(annotations)
+          getDeprecatedReason(annotations),
+          Some(annotations.collect { case GQLDirective(dir) => dir }.toList).filter(_.nonEmpty)
         )
       },
       Some(info.full),

--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -225,7 +225,7 @@ object Rendering {
   private def renderEnumValue(v: __EnumValue): String =
     s"${renderDescription(v.description)}${v.name}${if (v.isDeprecated)
       s" @deprecated${v.deprecationReason.fold("")(reason => s"""(reason: "$reason")""")}"
-    else ""}"
+    else ""}${renderDirectives(v.directives)}"
 
   private def renderDefaultValue(a: __InputValue): String = a.defaultValue.fold("")(d => s" = $d")
 

--- a/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
@@ -8,19 +8,20 @@ case class __EnumValue(
   name: String,
   description: Option[String],
   isDeprecated: Boolean,
-  deprecationReason: Option[String]
+  deprecationReason: Option[String],
+  directives: Option[List[Directive]]
 ) {
   def toEnumValueDefinition: EnumValueDefinition =
     EnumValueDefinition(
       description,
       name,
-      if (isDeprecated)
+      (if (isDeprecated)
         List(
           Directive(
             "deprecated",
             List(deprecationReason.map(reason => "reason" -> StringValue(reason))).flatten.toMap
           )
         )
-      else Nil
+      else Nil) ++ directives.getOrElse(Nil)
     )
 }

--- a/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
@@ -16,12 +16,12 @@ case class __EnumValue(
       description,
       name,
       (if (isDeprecated)
-        List(
-          Directive(
-            "deprecated",
-            List(deprecationReason.map(reason => "reason" -> StringValue(reason))).flatten.toMap
-          )
-        )
-      else Nil) ++ directives.getOrElse(Nil)
+         List(
+           Directive(
+             "deprecated",
+             List(deprecationReason.map(reason => "reason" -> StringValue(reason))).flatten.toMap
+           )
+         )
+       else Nil) ++ directives.getOrElse(Nil)
     )
 }

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -575,6 +575,58 @@ object ParserSpec extends ZIOSpecDefault {
           )
         }
       },
+      test("enum with directives") {
+        val enumWithDirectives =
+          """enum join__Graph {
+            | CHARACTERS @join__graph(name: "characters", url: "http://localhost:4000")
+            | EPISODES @join__graph(name: "episodes", url: "http://localhost:4001")
+            |}""".stripMargin
+
+        Parser.parseQuery(enumWithDirectives).map { doc =>
+          assertTrue(
+            doc == Document(
+              List(
+                EnumTypeDefinition(
+                  description = None,
+                  name = "join__Graph",
+                  directives = Nil,
+                  enumValuesDefinition = List(
+                    EnumValueDefinition(
+                      description = None,
+                      enumValue = "CHARACTERS",
+                      directives = List(
+                        Directive(
+                          name = "join__graph",
+                          arguments = Map(
+                            "name" -> StringValue("characters"),
+                            "url"  -> StringValue("http://localhost:4000")
+                          ),
+                          index = 31
+                        )
+                      )
+                    ),
+                    EnumValueDefinition(
+                      description = None,
+                      enumValue = "EPISODES",
+                      directives = List(
+                        Directive(
+                          name = "join__graph",
+                          arguments = Map(
+                            "name" -> StringValue("episodes"),
+                            "url"  -> StringValue("http://localhost:4001")
+                          ),
+                          index = 104
+                        )
+                      )
+                    )
+                  )
+                )
+              ),
+              sourceMapper = SourceMapper.apply(enumWithDirectives)
+            )
+          )
+        }
+      },
       test("extend schema with directives") {
         val gqlSchemaExtension = "extend schema @addedDirective"
         Parser.parseQuery(gqlSchemaExtension).map { doc =>

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -232,7 +232,7 @@ object SchemaSpec extends ZIOSpecDefault {
           @GQLDirective(Directive("join__Graph", Map("name" -> StringValue("A")))) case object A extends MyEnum
           @GQLDirective(Directive("join__Graph", Map("name" -> StringValue("B")))) case object B extends MyEnum
         }
-        case class Queries(enum: MyEnum)
+        case class Queries(myEnum: MyEnum)
         implicit val queriesSchema: Schema[Any, Queries] = genAll
 
         assertTrue(

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -1,9 +1,11 @@
 package caliban.schema
 
 import java.util.UUID
+import caliban.Value.StringValue
 import caliban._
 import caliban.introspection.adt.{ __DeprecatedArgs, __Type, __TypeKind }
-import caliban.schema.Annotations.{ GQLExcluded, GQLInterface, GQLUnion, GQLValueType }
+import caliban.parsing.adt.Directive
+import caliban.schema.Annotations.{ GQLDirective, GQLExcluded, GQLInterface, GQLUnion, GQLValueType }
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 import zio.query.ZQuery
@@ -223,6 +225,27 @@ object SchemaSpec extends ZIOSpecDefault {
                          |  b: B!
                          |}""".stripMargin
         assertTrue(gql.render == expected)
+      },
+      test("enum supported directives") {
+        sealed trait MyEnum
+        object MyEnum {
+          @GQLDirective(Directive("join__Graph", Map("name" -> StringValue("A")))) case object A extends MyEnum
+          @GQLDirective(Directive("join__Graph", Map("name" -> StringValue("B")))) case object B extends MyEnum
+        }
+        case class Queries(enum: MyEnum)
+        implicit val queriesSchema: Schema[Any, Queries] = genAll
+
+        assertTrue(
+          Types
+            .collectTypes(introspect[Queries])
+            .find(_.name contains "MyEnum")
+            .flatMap(_.enumValues(__DeprecatedArgs()))
+            .map(_.flatMap(_.directives.toList.flatten))
+            .get == List(
+            Directive("join__Graph", Map("name" -> StringValue("A"))),
+            Directive("join__Graph", Map("name" -> StringValue("B")))
+          )
+        )
       }
     )
 

--- a/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
@@ -30,7 +30,7 @@ object ValidationSchemaSpec extends ZIOSpecDefault {
               Types.makeEnum(
                 name = Some("nonEmptyEnum"),
                 description = None,
-                values = List(__EnumValue("A", None, true, None)),
+                values = List(__EnumValue("A", None, true, None, None)),
                 origin = None
               )
             )
@@ -44,7 +44,8 @@ object ValidationSchemaSpec extends ZIOSpecDefault {
               name = Some("EmptyEnum"),
               description = None,
               values = Nil,
-              origin = None
+              origin = None,
+              directives = None
             ),
             "Enum EmptyEnum doesn't contain any values"
           )

--- a/tools/src/main/scala/caliban/tools/RemoteSchema.scala
+++ b/tools/src/main/scala/caliban/tools/RemoteSchema.scala
@@ -201,7 +201,8 @@ object RemoteSchema {
       name = definition.enumValue,
       description = definition.description,
       isDeprecated = isDeprecated(definition.directives),
-      deprecationReason = deprecationReason(definition.directives)
+      deprecationReason = deprecationReason(definition.directives),
+      directives = toDirectives(definition.directives)
     )
 
   private def toInputObjectType(


### PR DESCRIPTION
Discovered this while working on a spike for a caliban gateway. The federation v2 schemas declare a special enum for the subgraph configurations

```graphql
enum join__Graph {
  EPISODES @join__graph(name: "episodes", url: "http://localhost:4002")
  PEOPLE @join__graph(name: "people", url: "http://localhost:4001")
  REVIEWS @join__graph(name: "reviews", url: "http://localhost:4003")
}
```

This requires that the implementation be able to interpret directives on individual enums. We seemed to have it in the EnumDefinition when parsing but not in the final `enum` that we represent when executing the graph.