### PR TITLE
Update docs for 2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,25 +149,25 @@ jobs:
           echo $PGP_SECRET | base64 --decode | gpg --import --no-tty --batch --yes
       - run: sbt clean ci-release
 
-#  microsite:
-#    docker:
-#      - image: cimg/node:16.13
-#    steps:
-#      - checkout
-#      - run: |
-#          if [ "$(git diff --numstat HEAD^ -- vuepress)" ]; then
-#            cd vuepress
-#            npm install
-#            npm run docs:build
-#            cd ..
-#            rm -rf docs
-#            cp -r vuepress/docs/.vuepress/dist docs
-#            git add docs
-#            git config user.name "Pierre Ricadat"
-#            git config user.email "ghostdogpr@gmail.com"
-#            git commit -m "[ci skip] update docs"
-#            git push
-#          fi
+  microsite:
+    docker:
+      - image: cimg/node:16.13
+    steps:
+      - checkout
+      - run: |
+          if [ "$(git diff --numstat HEAD^ -- vuepress)" ]; then
+            cd vuepress
+            npm install
+            npm run docs:build
+            cd ..
+            rm -rf docs
+            cp -r vuepress/docs/.vuepress/dist docs
+            git add docs
+            git config user.name "Pierre Ricadat"
+            git config user.email "ghostdogpr@gmail.com"
+            git commit -m "[ci skip] update docs"
+            git push
+          fi
 
 workflows:
   version: 2
@@ -243,8 +243,8 @@ workflows:
                 - series/2.x
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-#      - microsite:
-#          filters:
-#            branches:
-#              only:
-#                - series/2.x
+      - microsite:
+          filters:
+            branches:
+              only:
+                - series/2.x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,25 +149,25 @@ jobs:
           echo $PGP_SECRET | base64 --decode | gpg --import --no-tty --batch --yes
       - run: sbt clean ci-release
 
-  microsite:
-    docker:
-      - image: cimg/node:16.13
-    steps:
-      - checkout
-      - run: |
-          if [ "$(git diff --numstat HEAD^ -- vuepress)" ]; then
-            cd vuepress
-            npm install
-            npm run docs:build
-            cd ..
-            rm -rf docs
-            cp -r vuepress/docs/.vuepress/dist docs
-            git add docs
-            git config user.name "Pierre Ricadat"
-            git config user.email "ghostdogpr@gmail.com"
-            git commit -m "[ci skip] update docs"
-            git push
-          fi
+#  microsite:
+#    docker:
+#      - image: cimg/node:16.13
+#    steps:
+#      - checkout
+#      - run: |
+#          if [ "$(git diff --numstat HEAD^ -- vuepress)" ]; then
+#            cd vuepress
+#            npm install
+#            npm run docs:build
+#            cd ..
+#            rm -rf docs
+#            cp -r vuepress/docs/.vuepress/dist docs
+#            git add docs
+#            git config user.name "Pierre Ricadat"
+#            git config user.email "ghostdogpr@gmail.com"
+#            git commit -m "[ci skip] update docs"
+#            git push
+#          fi
 
 workflows:
   version: 2
@@ -243,8 +243,8 @@ workflows:
                 - series/2.x
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - microsite:
-          filters:
-            branches:
-              only:
-                - series/2.x
+#      - microsite:
+#          filters:
+#            branches:
+#              only:
+#                - series/2.x

--- a/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
+++ b/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
@@ -1,7 +1,6 @@
 package caliban
 
 import caliban.Data._
-import caliban.GraphQL._
 import caliban.parsing.Parser
 import io.circe.Json
 import org.openjdk.jmh.annotations._

--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmark.scala
@@ -1,7 +1,6 @@
 package caliban.execution
 
-import caliban.GraphQL.graphQL
-import caliban.{ CalibanError, GraphQLInterpreter, RootResolver }
+import caliban._
 import org.openjdk.jmh.annotations._
 import zio.{ Runtime, Task, Unsafe }
 

--- a/benchmarks/src/main/scala/caliban/execution/ValidationBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/execution/ValidationBenchmark.scala
@@ -1,7 +1,6 @@
 package caliban.execution
 
-import caliban.GraphQL.graphQL
-import caliban.{ CalibanError, GraphQL, RootResolver }
+import caliban._
 import caliban.parsing.Parser
 import caliban.schema.RootType
 import caliban.validation.Validator

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/posts/src/main/scala/poc/caliban/posts/GraphQLApi.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/posts/src/main/scala/poc/caliban/posts/GraphQLApi.scala
@@ -1,9 +1,8 @@
 package poc.caliban.posts
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.schema.GenericSchema
 import caliban.wrappers.Wrappers._
-import caliban.{GraphQL, RootResolver}
 import zio._
 import zio.stream.ZStream
 

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/potatoes/src/main/scala/poc/caliban/potatoes/PotatoesApi.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/potatoes/src/main/scala/poc/caliban/potatoes/PotatoesApi.scala
@@ -1,9 +1,8 @@
 package poc.caliban.potatoes
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.schema.GenericSchema
 import caliban.wrappers.Wrappers._
-import caliban.{GraphQL, RootResolver}
 import zio._
 import zio.stream.ZStream
 

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -247,24 +247,10 @@ object GraphQL {
    * It requires an instance of [[caliban.schema.Schema]] for each operation type.
    * This schema will be derived by Magnolia automatically.
    */
-  def graphQL[R, Q, M, S: SubscriptionSchema](
+  @deprecated("Use caliban.graphQL", "2.1.0") def graphQL[R, Q, M, S: SubscriptionSchema](
     resolver: RootResolver[Q, M, S],
     directives: List[__Directive] = Nil,
     schemaDirectives: List[Directive] = Nil
-  )(implicit
-    querySchema: Schema[R, Q],
-    mutationSchema: Schema[R, M],
-    subscriptionSchema: Schema[R, S]
-  ): GraphQL[R] = new GraphQL[R] {
-    val schemaBuilder: RootSchemaBuilder[R]     = RootSchemaBuilder(
-      resolver.queryResolver.map(r => Operation(querySchema.toType_(), querySchema.resolve(r))),
-      resolver.mutationResolver.map(r => Operation(mutationSchema.toType_(), mutationSchema.resolve(r))),
-      resolver.subscriptionResolver.map(r =>
-        Operation(subscriptionSchema.toType_(isSubscription = true), subscriptionSchema.resolve(r))
-      ),
-      schemaDirectives = schemaDirectives
-    )
-    val wrappers: List[Wrapper[R]]              = Nil
-    val additionalDirectives: List[__Directive] = directives
-  }
+  )(implicit querySchema: Schema[R, Q], mutationSchema: Schema[R, M], subscriptionSchema: Schema[R, S]): GraphQL[R] =
+    caliban.graphQL[R, Q, M, S](resolver, directives, schemaDirectives)
 }

--- a/core/src/main/scala/caliban/package.scala
+++ b/core/src/main/scala/caliban/package.scala
@@ -1,0 +1,34 @@
+import caliban.introspection.adt.__Directive
+import caliban.parsing.adt.Directive
+import caliban.schema._
+import caliban.wrappers.Wrapper
+
+package object caliban {
+
+  /**
+   * Builds a GraphQL API for the given resolver.
+   *
+   * It requires an instance of [[caliban.schema.Schema]] for each operation type.
+   * This schema will be derived by Magnolia automatically.
+   */
+  def graphQL[R, Q, M, S: SubscriptionSchema](
+    resolver: RootResolver[Q, M, S],
+    directives: List[__Directive] = Nil,
+    schemaDirectives: List[Directive] = Nil
+  )(implicit
+    querySchema: Schema[R, Q],
+    mutationSchema: Schema[R, M],
+    subscriptionSchema: Schema[R, S]
+  ): GraphQL[R] = new GraphQL[R] {
+    val schemaBuilder: RootSchemaBuilder[R]     = RootSchemaBuilder(
+      resolver.queryResolver.map(r => Operation(querySchema.toType_(), querySchema.resolve(r))),
+      resolver.mutationResolver.map(r => Operation(mutationSchema.toType_(), mutationSchema.resolve(r))),
+      resolver.subscriptionResolver.map(r =>
+        Operation(subscriptionSchema.toType_(isSubscription = true), subscriptionSchema.resolve(r))
+      ),
+      schemaDirectives = schemaDirectives
+    )
+    val wrappers: List[Wrapper[R]]              = Nil
+    val additionalDirectives: List[__Directive] = directives
+  }
+}

--- a/core/src/test/scala-2/caliban/Scala2SpecificSpec.scala
+++ b/core/src/test/scala-2/caliban/Scala2SpecificSpec.scala
@@ -1,6 +1,5 @@
 package caliban
 
-import caliban.GraphQL._
 import caliban.TestUtils._
 import caliban.introspection.adt.__DeprecatedArgs
 import caliban.schema.SchemaSpec.introspect

--- a/core/src/test/scala-2/caliban/interop/play/ExecutionSpec.scala
+++ b/core/src/test/scala-2/caliban/interop/play/ExecutionSpec.scala
@@ -1,8 +1,7 @@
 package caliban.interop.play
 
-import caliban.GraphQL._
+import caliban._
 import caliban.Macros.gqldoc
-import caliban.RootResolver
 import caliban.schema.Schema.auto._
 import zio.test._
 

--- a/core/src/test/scala-3/caliban/Scala3SpecificSpec.scala
+++ b/core/src/test/scala-3/caliban/Scala3SpecificSpec.scala
@@ -1,6 +1,5 @@
 package caliban
 
-import caliban.GraphQL._
 import caliban.schema.Annotations.GQLInterface
 import caliban.schema.Schema.auto._
 import zio._

--- a/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
@@ -1,6 +1,6 @@
 package caliban.schema
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.RootResolver
 import zio.test.{ assertTrue, ZIOSpecDefault }
 

--- a/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
@@ -81,6 +81,6 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
           |}""".stripMargin
 
       assertTrue(gql.render == expected2)
-    },
+    }
   )
 }

--- a/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
@@ -6,21 +6,20 @@ import zio.test.{ assertTrue, ZIOSpecDefault }
 
 object Scala3DerivesSpec extends ZIOSpecDefault {
 
-  override def spec = suite("Scala3DerivesSpec") {
+  val expected =
+    """schema {
+      |  query: Bar
+      |}
 
-    val expected =
-      """schema {
-        |  query: Bar
-        |}
+      |type Bar {
+      |  foo: Foo!
+      |}
 
-        |type Bar {
-        |  foo: Foo!
-        |}
+      |type Foo {
+      |  value: String!
+      |}""".stripMargin
 
-        |type Foo {
-        |  value: String!
-        |}""".stripMargin
-
+  override def spec = suite("Scala3DerivesSpec")(
     test("SemiAuto derivation - default") {
       final case class Foo(value: String) derives Schema.SemiAuto
       final case class Bar(foo: Foo) derives Schema.SemiAuto
@@ -28,8 +27,7 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
       val gql = graphQL(RootResolver(Bar(Foo("foo"))))
 
       assertTrue(gql.render == expected)
-    }
-
+    },
     test("Auto derivation - default") {
       final case class Foo(value: String)
       final case class Bar(foo: Foo) derives Schema.Auto
@@ -37,8 +35,7 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
       val gql = graphQL(RootResolver(Bar(Foo("foo"))))
 
       assertTrue(gql.render == expected)
-    }
-
+    },
     test("SemiAuto derivation - custom R") {
       class Env
       object CustomSchema extends SchemaDerivation[Env]
@@ -48,8 +45,7 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
       val gql = graphQL(RootResolver(Bar(Foo("foo"))))
 
       assertTrue(gql.render == expected)
-    }
-
+    },
     test("Auto derivation - custom R") {
       class Env
       object CustomSchema extends SchemaDerivation[Env]
@@ -59,6 +55,32 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
       val gql = graphQL(RootResolver(Bar(Foo("foo"))))
 
       assertTrue(gql.render == expected)
-    }
-  }
+    },
+    test("ArgBuilder derivation - default") {
+      final case class Foo(s: String) derives Schema.SemiAuto, ArgBuilder
+      final case class Bar(foo: Foo) derives Schema.SemiAuto
+      final case class Query(f: Foo => Bar) derives Schema.SemiAuto
+
+      val gql = graphQL(RootResolver(Query(Bar(_))))
+
+      val expected2 =
+        """schema {
+          |  query: Query
+          |}
+
+          |type Bar {
+          |  foo: Foo!
+          |}
+
+          |type Foo {
+          |  s: String!
+          |}
+          |
+          |type Query {
+          |  f(s: String!): Bar!
+          |}""".stripMargin
+
+      assertTrue(gql.render == expected2)
+    },
+  )
 }

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -1,6 +1,5 @@
 //package caliban
 //
-//import caliban.GraphQL._
 //import caliban.TestUtils._
 //import caliban.introspection.adt.{ __Type, __TypeKind }
 //import caliban.parsing.adt.Directive

--- a/core/src/test/scala/caliban/execution/DefaultValueSpec.scala
+++ b/core/src/test/scala/caliban/execution/DefaultValueSpec.scala
@@ -1,7 +1,6 @@
 package caliban.execution
 
-import caliban.CalibanError
-import caliban.GraphQL._
+import caliban._
 import caliban.Macros.gqldoc
 import caliban.RootResolver
 import caliban.schema.Annotations.GQLDefault

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -3,7 +3,6 @@ package caliban.execution
 import java.util.UUID
 
 import caliban.CalibanError.ExecutionError
-import caliban.GraphQL._
 import caliban.Macros.gqldoc
 import caliban.TestUtils._
 import caliban.Value.{ BooleanValue, IntValue, NullValue, StringValue }
@@ -1067,7 +1066,7 @@ object ExecutionSpec extends ZIOSpecDefault {
 
         val queries: Queries = Queries(Seq(Foo(123)))
 
-        val calibanApi: GraphQL[Any] = GraphQL.graphQL(RootResolver(queries))
+        val calibanApi: GraphQL[Any] = graphQL(RootResolver(queries))
 
         val interpreter = calibanApi.interpreter
         val query       = gqldoc("""{
@@ -1122,7 +1121,7 @@ object ExecutionSpec extends ZIOSpecDefault {
 
         val queries: Queries = Queries(Foo())
 
-        val api: GraphQL[Any] = GraphQL.graphQL(RootResolver(queries))
+        val api: GraphQL[Any] = graphQL(RootResolver(queries))
         val interpreter       = api.interpreter
 
         val query = gqldoc("""{
@@ -1162,7 +1161,7 @@ object ExecutionSpec extends ZIOSpecDefault {
           )
         )
 
-        val api: GraphQL[Any] = GraphQL.graphQL(RootResolver(queries))
+        val api: GraphQL[Any] = graphQL(RootResolver(queries))
         val interpreter       = api.interpreter
         val query             = gqldoc("""{
             foos {
@@ -1184,7 +1183,7 @@ object ExecutionSpec extends ZIOSpecDefault {
 
         val queries = Queries(Wrapper(2))
 
-        val api: GraphQL[Any] = GraphQL.graphQL(RootResolver(queries))
+        val api: GraphQL[Any] = graphQL(RootResolver(queries))
         val interpreter       = api.interpreter
         val query             = gqldoc("""{test}""")
 
@@ -1199,7 +1198,7 @@ object ExecutionSpec extends ZIOSpecDefault {
 
         val queries = Queries(Wrapper(2))
 
-        val api: GraphQL[Any] = GraphQL.graphQL(RootResolver(queries))
+        val api: GraphQL[Any] = graphQL(RootResolver(queries))
         val interpreter       = api.interpreter
         val query             = gqldoc("""{test}""")
 

--- a/core/src/test/scala/caliban/execution/FieldArgsSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldArgsSpec.scala
@@ -1,7 +1,6 @@
 package caliban.execution
 
-import caliban.GraphQL._
-import caliban.{ GraphQLRequest, InputValue, RootResolver, Value }
+import caliban._
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 import caliban.Value.EnumValue

--- a/core/src/test/scala/caliban/execution/FieldSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldSpec.scala
@@ -1,8 +1,7 @@
 package caliban.execution
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.Macros.gqldoc
-import caliban.RootResolver
 import caliban.parsing.Parser
 import caliban.schema.Annotations.GQLInterface
 import caliban.schema._

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -1,6 +1,6 @@
 package caliban.execution
 
-import caliban.GraphQL._
+import caliban._
 import caliban.Macros.gqldoc
 import caliban.RootResolver
 import caliban.TestUtils._

--- a/core/src/test/scala/caliban/introspection/IntrospectionSpec.scala
+++ b/core/src/test/scala/caliban/introspection/IntrospectionSpec.scala
@@ -1,8 +1,7 @@
 package caliban.introspection
 
 import caliban.CalibanError.{ ExecutionError, ValidationError }
-import caliban.GraphQL._
-import caliban.GraphQLResponse
+import caliban._
 import caliban.Macros.gqldoc
 import caliban.TestUtils._
 import caliban.Value._

--- a/core/src/test/scala/caliban/relay/ConnectionSpec.scala
+++ b/core/src/test/scala/caliban/relay/ConnectionSpec.scala
@@ -52,7 +52,7 @@ object ConnectionSpec extends ZIOSpecDefault {
   )
 
   case class Query(connection: Args => ZIO[Any, CalibanError, ItemConnection])
-  val api = GraphQL.graphQL(
+  val api = graphQL(
     RootResolver(
       Query(args =>
         for {

--- a/core/src/test/scala/caliban/schema/RootTypeSpec.scala
+++ b/core/src/test/scala/caliban/schema/RootTypeSpec.scala
@@ -2,7 +2,7 @@ package caliban.schema
 
 import caliban.schema.Annotations.GQLInterface
 import caliban.schema.Schema.auto._
-import caliban.{ GraphQL, RootResolver }
+import caliban._
 import zio.test._
 
 object RootTypeSpec extends ZIOSpecDefault {
@@ -21,9 +21,9 @@ object RootTypeSpec extends ZIOSpecDefault {
         val mutations = Mutations(_ => interfaceA, _ => interfaceB)
         val resolver  = RootResolver(query, mutations)
 
-        val graphQL: GraphQL[Any] = GraphQL.graphQL(resolver)
+        val api: GraphQL[Any] = graphQL(resolver)
 
-        graphQL.validateRootSchema.map { schema =>
+        api.validateRootSchema.map { schema =>
           val rootType =
             RootType(
               schema.query.opType,
@@ -35,9 +35,11 @@ object RootTypeSpec extends ZIOSpecDefault {
           def interfaceName(tpe: String): Option[List[String]] =
             rootType.types.get(tpe).flatMap(_.interfaces()).map(_.flatMap(_.name))
 
-          assertTrue(interfaceName("A").contains(List("CommonInterface", "MyInterface"))) &&
-          assertTrue(interfaceName("B").contains(List("MyInterface"))) &&
-          assertTrue(interfaceName("MyField").contains(List("CommonInterface")))
+          assertTrue(
+            interfaceName("A").contains(List("CommonInterface", "MyInterface")),
+            interfaceName("B").contains(List("MyInterface")),
+            interfaceName("MyField").contains(List("CommonInterface"))
+          )
         }
       }
     )

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -1,8 +1,7 @@
 package caliban.schema
 
 import java.util.UUID
-import caliban.GraphQL.graphQL
-import caliban.RootResolver
+import caliban._
 import caliban.introspection.adt.{ __DeprecatedArgs, __Type, __TypeKind }
 import caliban.schema.Annotations.{ GQLExcluded, GQLInterface, GQLUnion, GQLValueType }
 import caliban.schema.Schema.auto._

--- a/core/src/test/scala/caliban/validation/InputArgumentSpec.scala
+++ b/core/src/test/scala/caliban/validation/InputArgumentSpec.scala
@@ -1,7 +1,6 @@
 package caliban.validation
 
-import caliban.{ CalibanError, GraphQLRequest, InputValue, ResponseValue, RootResolver, TriState, Value }
-import caliban.GraphQL._
+import caliban._
 import caliban.schema.ArgBuilder
 import caliban.schema.Schema.auto._
 import caliban.schema.Schema

--- a/core/src/test/scala/caliban/validation/InputObjectSpec.scala
+++ b/core/src/test/scala/caliban/validation/InputObjectSpec.scala
@@ -1,7 +1,6 @@
 package caliban.validation
 
-import caliban.{ CalibanError, GraphQLRequest, InputValue, RootResolver, TestUtils, Value }
-import caliban.GraphQL._
+import caliban._
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 import zio.test.Assertion._

--- a/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
@@ -1,7 +1,7 @@
 package caliban.validation
 
 import caliban.CalibanError.ValidationError
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.TestUtils._
 import caliban.TestUtils.InvalidSchemas._
 import caliban.introspection.adt._

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -1,8 +1,7 @@
 package caliban.validation
 
-import caliban.{ CalibanError, InputValue, RootResolver }
+import caliban._
 import caliban.CalibanError.ValidationError
-import caliban.GraphQL._
 import caliban.Macros.gqldoc
 import caliban.TestUtils._
 import caliban.Value.{ BooleanValue, IntValue, StringValue }

--- a/core/src/test/scala/caliban/wrappers/CostEstimationSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/CostEstimationSpec.scala
@@ -1,10 +1,9 @@
 package caliban.wrappers
 
 import caliban.CalibanError.ValidationError
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.Macros.gqldoc
 import caliban.ResponseValue.ObjectValue
-import caliban.RootResolver
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 import caliban.Value.{ FloatValue, IntValue }

--- a/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/FieldMetricsSpec.scala
@@ -1,8 +1,7 @@
 package caliban.wrappers
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.Macros.gqldoc
-import caliban.RootResolver
 import caliban.schema.Annotations.GQLDefault
 import caliban.schema.ArgBuilder.auto._
 import caliban.schema.Schema.auto._

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -1,7 +1,6 @@
 package caliban.wrappers
 
-import caliban.CalibanError.{ ExecutionError, ValidationError }
-import caliban.GraphQL._
+import caliban._
 import caliban.InputValue.ObjectValue
 import caliban.Macros.gqldoc
 import caliban.TestUtils._

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -1,11 +1,11 @@
 package caliban.wrappers
 
 import caliban._
+import caliban.CalibanError.{ ExecutionError, ValidationError }
 import caliban.InputValue.ObjectValue
 import caliban.Macros.gqldoc
 import caliban.TestUtils._
 import caliban.Value.{ IntValue, StringValue }
-import caliban._
 import caliban.execution.{ ExecutionRequest, FieldInfo }
 import caliban.introspection.adt.{ __Directive, __DirectiveLocation }
 import caliban.parsing.adt.Document

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 To run the examples without the rest of the project, add this to your build.sbt:
 
 ```scala
-val calibanVersion = "2.0.2"
+val calibanVersion = "2.1.0"
 
 libraryDependencies ++= Seq(
   "com.github.ghostdogpr"         %% "caliban"                       % calibanVersion,

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -2,9 +2,7 @@ package example
 
 import example.ExampleData._
 import example.ExampleService.ExampleService
-import caliban.GraphQL
-import caliban.GraphQL.graphQL
-import caliban.RootResolver
+import caliban._
 import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._

--- a/examples/src/main/scala/example/akkahttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/akkahttp/AuthExampleApp.scala
@@ -3,11 +3,10 @@ package example.akkahttp
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives.{ getFromResource, path, _ }
-import caliban.GraphQL._
+import caliban._
 import caliban.interop.tapir.RequestInterceptor
 import caliban.interop.tapir.TapirAdapter.TapirResponse
 import caliban.schema.GenericSchema
-import caliban.{ AkkaHttpAdapter, RootResolver }
 import sttp.model.StatusCode
 import sttp.tapir.json.circe._
 import sttp.tapir.model.ServerRequest

--- a/examples/src/main/scala/example/federation/FederatedApi.scala
+++ b/examples/src/main/scala/example/federation/FederatedApi.scala
@@ -1,6 +1,6 @@
 package example.federation
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.federation.EntityResolver
 import caliban.federation.tracing.ApolloFederatedTracing
 import caliban.federation.v1.{ federated, GQLKey }
@@ -9,7 +9,6 @@ import caliban.schema.{ ArgBuilder, GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._
 import caliban.wrappers.Wrapper
 import caliban.wrappers.Wrappers.{ maxDepth, maxFields, printSlowQueries, timeout }
-import caliban.{ GraphQL, GraphQLAspect, RootResolver }
 import zio._
 import zio.query.ZQuery
 import zio.stream.ZStream

--- a/examples/src/main/scala/example/federation/v2/FederatedApi.scala
+++ b/examples/src/main/scala/example/federation/v2/FederatedApi.scala
@@ -1,6 +1,6 @@
 package example.federation.v2
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.federation.EntityResolver
 import caliban.federation.tracing.ApolloFederatedTracing
 import caliban.federation.v2_0.{ federated, GQLKey }
@@ -9,7 +9,6 @@ import caliban.schema.{ ArgBuilder, GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._
 import caliban.wrappers.Wrapper
 import caliban.wrappers.Wrappers.{ maxDepth, maxFields, printSlowQueries, timeout }
-import caliban.{ GraphQL, GraphQLAspect, RootResolver }
 import zio._
 import zio.query.ZQuery
 import zio.stream.ZStream

--- a/examples/src/main/scala/example/http4s/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/http4s/AuthExampleApp.scala
@@ -1,8 +1,7 @@
 package example.http4s
 
-import caliban.GraphQL._
+import caliban._
 import caliban.schema.GenericSchema
-import caliban.{ Http4sAdapter, RootResolver }
 import com.comcast.ip4s._
 import org.http4s.{ HttpRoutes, Response }
 import org.http4s.dsl.Http4sDsl

--- a/examples/src/main/scala/example/http4s/AuthExampleAppF.scala
+++ b/examples/src/main/scala/example/http4s/AuthExampleAppF.scala
@@ -1,9 +1,8 @@
 package example.http4s
 
-import caliban.GraphQL._
+import caliban._
 import caliban.interop.cats.{ CatsInterop, InjectEnv }
 import caliban.schema.GenericSchema
-import caliban.{ CalibanError, GraphQL, Http4sAdapter, RootResolver }
 import cats.data.{ Kleisli, OptionT }
 import cats.MonadThrow
 import cats.syntax.flatMap._

--- a/examples/src/main/scala/example/interop/cats/ContextualCatsInterop.scala
+++ b/examples/src/main/scala/example/interop/cats/ContextualCatsInterop.scala
@@ -1,9 +1,8 @@
 package example.interop.cats
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.interop.cats.CatsInterop
 import caliban.schema.GenericSchema
-import caliban.{ GraphQL, RootResolver }
 import cats.data.Kleisli
 import cats.effect.std.{ Console, Dispatcher }
 import cats.effect.{ Async, ExitCode, IO, IOApp }

--- a/examples/src/main/scala/example/interop/cats/ExampleCatsInterop.scala
+++ b/examples/src/main/scala/example/interop/cats/ExampleCatsInterop.scala
@@ -1,7 +1,6 @@
 package example.interop.cats
 
-import caliban.GraphQL.graphQL
-import caliban.RootResolver
+import caliban._
 import caliban.schema.Schema.auto._
 
 import cats.effect.{ ExitCode, IO, IOApp }

--- a/examples/src/main/scala/example/interop/monix/ExampleMonixInterop.scala
+++ b/examples/src/main/scala/example/interop/monix/ExampleMonixInterop.scala
@@ -1,9 +1,8 @@
 package example.interop.monix
 /*
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.ResponseValue.{ ObjectValue, StreamValue }
-import caliban.RootResolver
 
 import cats.effect.ExitCode
 import monix.eval.{ Task, TaskApp }

--- a/examples/src/main/scala/example/optimizations/NaiveTest.scala
+++ b/examples/src/main/scala/example/optimizations/NaiveTest.scala
@@ -2,7 +2,7 @@ package example.optimizations
 
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._
-import caliban.{ GraphQL, RootResolver }
+import caliban._
 import example.optimizations.CommonData._
 import zio.Console.printLine
 import zio.{ ExitCode, ZIO, ZIOAppDefault }
@@ -85,7 +85,7 @@ object NaiveTest extends ZIOAppDefault with GenericSchema[Any] {
   implicit val queriesSchema: Schema[Any, Queries]               = Schema.gen
 
   val resolver = Queries(args => getUser(args.id))
-  val api      = GraphQL.graphQL(RootResolver(resolver))
+  val api      = graphQL(RootResolver(resolver))
 
   override def run =
     api.interpreter

--- a/examples/src/main/scala/example/optimizations/OptimizedTest.scala
+++ b/examples/src/main/scala/example/optimizations/OptimizedTest.scala
@@ -2,7 +2,7 @@ package example.optimizations
 
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._
-import caliban.{ GraphQL, RootResolver }
+import caliban._
 import example.optimizations.CommonData._
 import zio.Console.printLine
 import zio.query.DataSource.fromFunctionBatchedZIO
@@ -123,7 +123,7 @@ object OptimizedTest extends ZIOAppDefault with GenericSchema[Any] {
   implicit val queriesSchema: Schema[Any, Queries]               = Schema.gen
 
   val resolver = Queries(args => getUser(args.id))
-  val api      = GraphQL.graphQL(RootResolver(resolver))
+  val api      = graphQL(RootResolver(resolver))
 
   override def run =
     api.interpreter

--- a/examples/src/main/scala/example/play/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/play/AuthExampleApp.scala
@@ -1,11 +1,10 @@
 package example.play
 
 import akka.actor.ActorSystem
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.interop.tapir.RequestInterceptor
 import caliban.interop.tapir.TapirAdapter.TapirResponse
 import caliban.schema.GenericSchema
-import caliban.{ PlayAdapter, RootResolver }
 import play.api.Mode
 import play.api.routing._
 import play.api.routing.sird._

--- a/examples/src/main/scala/example/stitching/ExampleApp.scala
+++ b/examples/src/main/scala/example/stitching/ExampleApp.scala
@@ -1,7 +1,6 @@
 package example.stitching
 
 import caliban._
-import caliban.GraphQL.graphQL
 import caliban.schema._
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._

--- a/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
@@ -1,16 +1,14 @@
 package example.ziohttp
 
-import caliban.GraphQL.graphQL
 import caliban.Value.StringValue
 import caliban._
-import caliban.interop.tapir.{ StreamTransformer, WebSocketHooks }
+import caliban.interop.tapir.WebSocketHooks
 import caliban.schema.GenericSchema
 import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
 import sttp.tapir.json.circe._
-import zio.http._
-import zio.http.model._
 import zio._
+import zio.http._
 import zio.stream._
 
 case object Unauthorized extends RuntimeException("Unauthorized")

--- a/federation/src/main/scala/caliban/federation/FederationSupport.scala
+++ b/federation/src/main/scala/caliban/federation/FederationSupport.scala
@@ -1,10 +1,10 @@
 package caliban.federation
 
+import caliban._
 import caliban.introspection.adt._
 import caliban.parsing.adt.Directive
 import caliban.schema.Step.QueryStep
 import caliban.schema._
-import caliban.{ CalibanError, GraphQL, GraphQLAspect, RootResolver }
 import zio.query.ZQuery
 
 abstract class FederationSupport(
@@ -27,7 +27,7 @@ abstract class FederationSupport(
       _fieldSet: FieldSet = FieldSet("")
     )
 
-    GraphQL.graphQL(
+    graphQL(
       RootResolver(Query(_service = _Service(original.withSchemaDirectives(schemaDirectives).render))),
       supportedDirectives
     ) |+| original
@@ -93,7 +93,7 @@ abstract class FederationSupport(
       .withAdditionalTypes(resolvers.map(_.toType).flatMap(Types.collectTypes(_)))
       .withSchemaDirectives(schemaDirectives)
 
-    GraphQL.graphQL[R, Query, Unit, Unit](
+    graphQL[R, Query, Unit, Unit](
       RootResolver(
         Query(
           _entities = args => args.representations.map(rep => _Entity(rep.__typename, rep.fields)),

--- a/federation/src/test/scala/caliban/federation/FederationV1Spec.scala
+++ b/federation/src/test/scala/caliban/federation/FederationV1Spec.scala
@@ -1,8 +1,7 @@
 package caliban.federation
 
-import caliban.CalibanError
+import caliban._
 import caliban.CalibanError.ValidationError
-import caliban.GraphQL._
 import caliban.Macros.gqldoc
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.TestUtils._

--- a/federation/src/test/scala/caliban/federation/tracing/FederationTracingSpec.scala
+++ b/federation/src/test/scala/caliban/federation/tracing/FederationTracingSpec.scala
@@ -3,7 +3,7 @@ package caliban.federation.tracing
 import caliban.Macros.gqldoc
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.Value.{ IntValue, StringValue }
-import caliban.{ GraphQL, GraphQLRequest, RootResolver }
+import caliban._
 import caliban.schema.Schema.auto._
 import mdg.engine.proto.reports.Trace
 import zio._
@@ -33,7 +33,7 @@ object FederationTracingSpec extends ZIOSpecDefault {
 
   case class Queries(me: ZQuery[Any, Nothing, User])
 
-  val api = GraphQL.graphQL(
+  val api = graphQL(
     RootResolver(
       Queries(
         me = ZQuery.succeed(

--- a/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
+++ b/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
@@ -6,7 +6,7 @@ import caliban.Value.StringValue
 import caliban.parsing.Parser
 import caliban.parsing.adt.{ Definition, Directive }
 import caliban.schema.Schema.auto._
-import caliban.{ GraphQL, RootResolver }
+import caliban._
 import io.circe.Json
 import io.circe.parser.decode
 import zio.ZIO
@@ -187,7 +187,7 @@ object FederationV2Spec extends ZIOSpecDefault {
       hello: String
     )
 
-    val api = GraphQL.graphQL(
+    val api = graphQL(
       RootResolver(
         Query(hello = "Hello World!")
       )

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
@@ -1,8 +1,7 @@
 package caliban.interop.tapir
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.interop.tapir.TestData._
-import caliban.{ GraphQL, RootResolver }
 import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._

--- a/reporting/src/main/scala/caliban/reporting/SchemaReportingRef.scala
+++ b/reporting/src/main/scala/caliban/reporting/SchemaReportingRef.scala
@@ -1,6 +1,6 @@
 package caliban.reporting
 
-import caliban.GraphQL
+import caliban._
 import zio._
 
 import java.util.UUID

--- a/reporting/src/test/scala/caliban/reporting/ReportingDaemonSpec.scala
+++ b/reporting/src/test/scala/caliban/reporting/ReportingDaemonSpec.scala
@@ -3,7 +3,7 @@ package caliban.reporting
 import caliban.client.CalibanClientError.CommunicationError
 import caliban.reporting.ReportingError.{ ClientError, RetryableError }
 import caliban.schema.Schema.auto._
-import caliban.{ GraphQL, RootResolver }
+import caliban._
 import zio.test.{ assertTrue, TestClock, ZIOSpecDefault }
 import zio._
 
@@ -14,7 +14,7 @@ object ReportingDaemonSpec extends ZIOSpecDefault {
     user: UIO[User]
   )
 
-  val api = GraphQL.graphQL(
+  val api = graphQL(
     RootResolver(
       Query(
         "hello",

--- a/tools/src/main/scala/caliban/tools/SchemaLoader.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaLoader.scala
@@ -1,6 +1,6 @@
 package caliban.tools
 
-import caliban.GraphQL
+import caliban._
 import caliban.parsing.Parser
 import caliban.parsing.adt.Document
 import sttp.client3.httpclient.zio.HttpClientZioBackend

--- a/tools/src/main/scala/caliban/tools/compiletime/CompileTime.scala
+++ b/tools/src/main/scala/caliban/tools/compiletime/CompileTime.scala
@@ -1,6 +1,6 @@
 package caliban.tools.compiletime
 
-import caliban.GraphQL
+import caliban._
 import caliban.tools.Codegen.GenType
 import caliban.tools.compiletime.Config.ClientGenerationSettings
 import caliban.tools.{ Codegen, SchemaLoader }

--- a/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
+++ b/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
@@ -1,6 +1,5 @@
 package caliban.tools
 
-import caliban.GraphQL._
 import caliban._
 import caliban.introspection.adt._
 import caliban.schema._

--- a/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
@@ -1,12 +1,11 @@
 package caliban.tools
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.parsing.Parser
 import caliban.schema.Annotations.GQLDeprecated
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 import caliban.tools.SchemaComparison.compareDocuments
-import caliban.{ CalibanError, RootResolver }
 import zio.ZIO
 import zio.test.Assertion._
 import zio.test._

--- a/tools/src/test/scala/caliban/tools/stitching/RemoteQuerySpec.scala
+++ b/tools/src/test/scala/caliban/tools/stitching/RemoteQuerySpec.scala
@@ -1,9 +1,8 @@
 package caliban.tools.stitching
 
 import caliban.CalibanError.ValidationError
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.Macros.gqldoc
-import caliban.{ CalibanError, GraphQLInterpreter, RootResolver }
 import caliban.execution.Field
 import caliban.schema.Annotations.GQLInterface
 import caliban.schema.Schema.auto._

--- a/tracing/src/test/scala/caliban/tracing/MockTracer.scala
+++ b/tracing/src/test/scala/caliban/tracing/MockTracer.scala
@@ -1,18 +1,12 @@
 package caliban.tracing
 
-import caliban.GraphQL.graphQL
-import caliban.Macros.gqldoc
-import caliban.RootResolver
-import caliban.schema.Annotations.GQLDefault
 import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
 import zio._
 import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.tracing.Tracing
-import zio.test._
 
 import scala.jdk.CollectionConverters._
 

--- a/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
+++ b/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
@@ -1,15 +1,12 @@
 package caliban.tracing
 
-import caliban.GraphQL.graphQL
+import caliban._
 import caliban.Macros.gqldoc
-import caliban.RootResolver
 import caliban.schema.ArgBuilder.auto._
 import caliban.schema.Schema.auto._
 import zio._
 import zio.query._
 import zio.test._
-
-import Assertion._
 
 object TracingWrapperSpec extends ZIOSpecDefault {
   val randomSleep: ZIO[Any, Nothing, Unit] = Random.nextIntBetween(0, 500).flatMap(t => ZIO.sleep(t.millis))

--- a/vuepress/docs/about/README.md
+++ b/vuepress/docs/about/README.md
@@ -1,6 +1,12 @@
 # About
 
-Caliban is a project developed by Pierre Ricadat aka [@ghostdogpr](https://github.com/ghostdogpr).
+Caliban is a project created by Pierre Ricadat aka [@ghostdogpr](https://github.com/ghostdogpr).
+
+Current maintainers:
+- [@ghostdogpr](https://github.com/ghostdogpr)
+- [@paulpdaniels](https://github.com/paulpdaniels)
+- [@frekw](https://github.com/frekw)
+- [@kyri-petrou](https://github.com/kyri-petrou)
 
 The name is inspired by the SF novel and tv series [The Expanse](https://en.wikipedia.org/wiki/Caliban%27s_War).
 

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -14,13 +14,13 @@ The design principles of Caliban are the following:
 
 To use `caliban`, add the following dependency to your `build.sbt` file:
 
-```
+```scala
 "com.github.ghostdogpr" %% "caliban" % "2.1.0"
 ```
 
 The following modules are optional:
 
-```
+```scala
 "com.github.ghostdogpr" %% "caliban-http4s"     % "2.1.0" // routes for http4s
 "com.github.ghostdogpr" %% "caliban-akka-http"  % "2.1.0" // routes for akka-http
 "com.github.ghostdogpr" %% "caliban-play"       % "2.1.0" // routes for play
@@ -33,7 +33,7 @@ The following modules are optional:
 
 Support for JSON encoding / decoding of the inputs and responses is enabled by adding **one** of the following dependencies to your `build.sbt` file:
 
-```
+```scala
 "com.softwaremill.sttp.tapir" %% "tapir-json-circe"     % "1.2.11" // Circe
 "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.2.11" // Jsoniter
 "com.softwaremill.sttp.tapir" %% "tapir-json-play"      % "1.2.11" // Play JSON

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -12,32 +12,32 @@ The design principles of Caliban are the following:
 
 ## Dependencies
 
-To use `caliban`, add the following line in your `build.sbt` file:
+To use `caliban`, add the following dependency to your `build.sbt` file:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban" % "2.1.0"
+"com.github.ghostdogpr" %% "caliban" % "2.1.0"
 ```
 
 The following modules are optional:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-http4s"     % "2.1.0" // routes for http4s
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-akka-http"  % "2.1.0" // routes for akka-http
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-play"       % "2.1.0" // routes for play
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-zio-http"   % "2.1.0" // routes for zio-http
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-cats"       % "2.1.0" // interop with cats effect
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-monix"      % "2.1.0" // interop with monix
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-tapir"      % "2.1.0" // interop with tapir
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-federation" % "2.1.0" // interop with apollo federation
+"com.github.ghostdogpr" %% "caliban-http4s"     % "2.1.0" // routes for http4s
+"com.github.ghostdogpr" %% "caliban-akka-http"  % "2.1.0" // routes for akka-http
+"com.github.ghostdogpr" %% "caliban-play"       % "2.1.0" // routes for play
+"com.github.ghostdogpr" %% "caliban-zio-http"   % "2.1.0" // routes for zio-http
+"com.github.ghostdogpr" %% "caliban-cats"       % "2.1.0" // interop with cats effect
+"com.github.ghostdogpr" %% "caliban-monix"      % "2.1.0" // interop with monix
+"com.github.ghostdogpr" %% "caliban-tapir"      % "2.1.0" // interop with tapir
+"com.github.ghostdogpr" %% "caliban-federation" % "2.1.0" // interop with apollo federation
 ```
 
 Support for JSON encoding / decoding of the inputs and responses is enabled by adding **one** of the following dependencies to your `build.sbt` file:
 
 ```
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-circe"     % "1.2.11" // Circe
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.2.11" // Jsoniter
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-play"      % "1.2.11" // Play JSON
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-zio"       % "1.2.11" // ZIO JSON
+"com.softwaremill.sttp.tapir" %% "tapir-json-circe"     % "1.2.11" // Circe
+"com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.2.11" // Jsoniter
+"com.softwaremill.sttp.tapir" %% "tapir-json-play"      % "1.2.11" // Play JSON
+"com.softwaremill.sttp.tapir" %% "tapir-json-zio"       % "1.2.11" // ZIO JSON
 ```
 
 And then later in your code (you only need one!):

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -34,10 +34,10 @@ libraryDependencies += "com.github.ghostdogpr" %% "caliban-federation" % "2.1.0"
 Support for JSON encoding / decoding of the inputs and responses is enabled by adding **one** of the following dependencies to your `build.sbt` file:
 
 ```
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-circe"     % "1.2.2" // Circe
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.2.2" // Jsoniter
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-play"      % "1.2.2" // Play JSON
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-zio"       % "1.2.2" // ZIO JSON
+libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-circe"     % "1.2.11" // Circe
+libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.2.11" // Jsoniter
+libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-play"      % "1.2.11" // Play JSON
+libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-zio"       % "1.2.11" // ZIO JSON
 ```
 
 And then later in your code (you only need one!):

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -15,20 +15,20 @@ The design principles of Caliban are the following:
 To use `caliban`, add the following line in your `build.sbt` file:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban" % "2.0.2"
+libraryDependencies += "com.github.ghostdogpr" %% "caliban" % "2.1.0"
 ```
 
 The following modules are optional:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-http4s"     % "2.0.2" // routes for http4s
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-akka-http"  % "2.0.2" // routes for akka-http
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-play"       % "2.0.2" // routes for play
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-zio-http"   % "2.0.2" // routes for zio-http
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-cats"       % "2.0.2" // interop with cats effect
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-monix"      % "2.0.2" // interop with monix
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-tapir"      % "2.0.2" // interop with tapir
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-federation" % "2.0.2" // interop with apollo federation
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-http4s"     % "2.1.0" // routes for http4s
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-akka-http"  % "2.1.0" // routes for akka-http
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-play"       % "2.1.0" // routes for play
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-zio-http"   % "2.1.0" // routes for zio-http
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-cats"       % "2.1.0" // interop with cats effect
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-monix"      % "2.1.0" // interop with monix
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-tapir"      % "2.1.0" // interop with tapir
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-federation" % "2.1.0" // interop with apollo federation
 ```
 
 Support for JSON encoding / decoding of the inputs and responses is enabled by adding **one** of the following dependencies to your `build.sbt` file:

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -80,8 +80,7 @@ Then we can call the `graphQL` function which will turn our simple resolver valu
 The whole schema will be derived at compile time, meaning that if it compiles, it will be able to serve it.
 
 ```scala mdoc:silent
-import caliban.GraphQL.graphQL
-import caliban.RootResolver
+import caliban._
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -29,6 +29,7 @@ The following modules are optional:
 "com.github.ghostdogpr" %% "caliban-monix"      % "2.1.0" // interop with monix
 "com.github.ghostdogpr" %% "caliban-tapir"      % "2.1.0" // interop with tapir
 "com.github.ghostdogpr" %% "caliban-federation" % "2.1.0" // interop with apollo federation
+"com.github.ghostdogpr" %% "caliban-tracing"    % "2.1.0" // interop with zio-telemetry
 ```
 
 Support for JSON encoding / decoding of the inputs and responses is enabled by adding **one** of the following dependencies to your `build.sbt` file:

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -163,8 +163,6 @@ Creating mutations is the same as queries, except you pass them as the second ar
 
 ```scala mdoc:nest:silent
 import zio.Task
-import caliban.schema.Schema.auto._
-import caliban.schema.ArgBuilder.auto._
 
 case class CharacterArgs(name: String)
 case class Mutations(deleteCharacter: CharacterArgs => Task[Boolean])
@@ -178,7 +176,6 @@ Similarly, subscriptions are passed as the third argument to `RootResolver`:
 
 ```scala mdoc:compile-only
 import zio.stream.ZStream
-import caliban.schema.Schema.auto._
 
 case class Subscriptions(deletedCharacter: ZStream[Any, Nothing, Character])
 val subscriptions = Subscriptions(???)

--- a/vuepress/docs/docs/client-codegen.md
+++ b/vuepress/docs/docs/client-codegen.md
@@ -135,8 +135,7 @@ Let's say you have an object `CalibanServer` object in your `api` sbt module:
 ```scala
 package com.example.my.awesome.project.api
 
-import caliban.GraphQL.graphQL
-import caliban.GraphQL
+import caliban._
 
 object CalibanServer {
   

--- a/vuepress/docs/docs/client-codegen.md
+++ b/vuepress/docs/docs/client-codegen.md
@@ -10,7 +10,7 @@ both need to configure in your project to be able to generate you Caliban client
 
 To use any of these two plugins, you'll first need to add following dependency to your `project/plugins.sbt` file:
 ```scala
-addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % "2.0.2")
+addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % "2.1.0")
 ```
 
 ## CalibanPlugin

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -9,16 +9,16 @@ Just like the server module, Caliban Client offers a purely functional interface
 
 ## Dependencies
 
-To use `caliban-client`, add the following line in your `build.sbt` file:
+To use `caliban-client`, add the following dependency to your `build.sbt` file:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-client" % "2.1.0"
+"com.github.ghostdogpr" %% "caliban-client" % "2.1.0"
 ```
 
-Caliban-client is available for ScalaJS. To use it in a ScalaJS project, instead add this line to your `build.sbt` file:
+Caliban-client is available for ScalaJS. To use it in a ScalaJS project, instead add this dependency to your `build.sbt` file:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %%% "caliban-client" % "2.1.0"
+"com.github.ghostdogpr" %%% "caliban-client" % "2.1.0"
 ```
 
 ## Code generation

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -24,7 +24,7 @@ libraryDependencies += "com.github.ghostdogpr" %%% "caliban-client" % "2.0.2"
 ## Code generation
 
 Caliban provides several ways to generate the boilerplate code. To get started, we are going to generate it by running a
-simple sbt command, but you can look at the [Code generation](client-codegen) page for more options.
+simple sbt command, but you can look at the [Code generation](client-codegen.md) page for more options.
 
 You'll first need to add following dependency to your `project/plugins.sbt` file:
 ```scala

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -11,13 +11,13 @@ Just like the server module, Caliban Client offers a purely functional interface
 
 To use `caliban-client`, add the following dependency to your `build.sbt` file:
 
-```
+```scala
 "com.github.ghostdogpr" %% "caliban-client" % "2.1.0"
 ```
 
 Caliban-client is available for ScalaJS. To use it in a ScalaJS project, instead add this dependency to your `build.sbt` file:
 
-```
+```scala
 "com.github.ghostdogpr" %%% "caliban-client" % "2.1.0"
 ```
 

--- a/vuepress/docs/docs/client.md
+++ b/vuepress/docs/docs/client.md
@@ -12,13 +12,13 @@ Just like the server module, Caliban Client offers a purely functional interface
 To use `caliban-client`, add the following line in your `build.sbt` file:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-client" % "2.0.2"
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-client" % "2.1.0"
 ```
 
 Caliban-client is available for ScalaJS. To use it in a ScalaJS project, instead add this line to your `build.sbt` file:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %%% "caliban-client" % "2.0.2"
+libraryDependencies += "com.github.ghostdogpr" %%% "caliban-client" % "2.1.0"
 ```
 
 ## Code generation
@@ -28,7 +28,7 @@ simple sbt command, but you can look at the [Code generation](client-codegen.md)
 
 You'll first need to add following dependency to your `project/plugins.sbt` file:
 ```scala
-addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % "2.0.2")
+addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % "2.1.0")
 ```
 
 And to enable the plugin in your `build.sbt` file:

--- a/vuepress/docs/docs/federation.md
+++ b/vuepress/docs/docs/federation.md
@@ -6,10 +6,10 @@
 
 `caliban-federation` only depends on `caliban-core` and is very unobtrusive.
 
-To use, add the following line to your `build.sbt` file:
+To use, add the following dependency to your `build.sbt` file:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-federation" % "2.1.0"
+"com.github.ghostdogpr" %% "caliban-federation" % "2.1.0"
 ```
 
 ## Federating

--- a/vuepress/docs/docs/federation.md
+++ b/vuepress/docs/docs/federation.md
@@ -8,7 +8,7 @@
 
 To use, add the following dependency to your `build.sbt` file:
 
-```
+```scala
 "com.github.ghostdogpr" %% "caliban-federation" % "2.1.0"
 ```
 

--- a/vuepress/docs/docs/federation.md
+++ b/vuepress/docs/docs/federation.md
@@ -9,7 +9,7 @@
 To use, add the following line to your `build.sbt` file:
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-federation" % "2.0.2"
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-federation" % "2.1.0"
 ```
 
 ## Federating

--- a/vuepress/docs/docs/interop.md
+++ b/vuepress/docs/docs/interop.md
@@ -45,7 +45,7 @@ object ExampleCatsInterop extends IOApp {
   }"""
 
   override def run(args: List[String]): IO[ExitCode] =
-    Dispatcher[IO].use { implicit dispatcher => // required for a derivation of the schema
+    Dispatcher.parallel[IO].use { implicit dispatcher => // required for a derivation of the schema
       val api = graphQL(RootResolver(queries))
 
       for {
@@ -125,7 +125,7 @@ object Simple extends IOApp {
     inject: InjectEnv[F, TraceId],
     runtime: Runtime[TraceId]
   ): F[ExitCode] =
-    Dispatcher[F].use { implicit dispatcher =>
+    Dispatcher.parallel[F].use { implicit dispatcher =>
       implicit val interop: CatsInterop.Contextual[F, TraceId] = CatsInterop.contextual(dispatcher) // required for a derivation of the schema
 
       val genRandomNumber = logger.info("Generating number") >> Async[F].delay(scala.util.Random.nextInt())

--- a/vuepress/docs/docs/interop.md
+++ b/vuepress/docs/docs/interop.md
@@ -22,8 +22,7 @@ The instances are derived implicitly when `Async[F]`, `Dispatcher[F]`, and `Runt
 The following example shows how to create an interpreter and run a query while only using Cats IO.
 
 ```scala mdoc:silent
-import caliban.GraphQL.graphQL
-import caliban.RootResolver
+import caliban._
 import caliban.interop.cats.implicits._
 import caliban.schema.Schema.auto._
 import cats.effect.{ ExitCode, IO, IOApp }
@@ -86,8 +85,7 @@ val fromCE: RIO[Context, Int] = interop.fromEffect(ce)
 ```
 
 ```scala mdoc:silent
-import caliban.GraphQL.graphQL
-import caliban.{ GraphQL, RootResolver }
+import caliban._
 import caliban.interop.cats._
 import caliban.interop.cats.implicits._
 import caliban.schema.GenericSchema
@@ -182,8 +180,7 @@ In addition to that, a `Schema` for any Monix `Task` as well as `Observable` is 
 The following example shows how to create an interpreter and run a query while only using Monix Task.
 
 ```scala
-import caliban.GraphQL.graphQL
-import caliban.RootResolver
+import caliban._
 import caliban.interop.monix.implicits._
 import cats.effect.ExitCode
 import monix.eval.{ Task, TaskApp }
@@ -264,7 +261,7 @@ def bookAddLogic(book: Book, token: String): UIO[Unit] = ???
 Just like you can create an http4s route by calling `toRoute` and passing an implementation, call `toGraphQL` to create a GraphQL API:
 
 ```scala mdoc:silent
-import caliban.GraphQL
+import caliban._
 import caliban.interop.tapir._ // summons 'toGraphQL' extension
 import caliban.schema.ArgBuilder.auto._
 import caliban.schema.Schema.auto._

--- a/vuepress/docs/docs/laminext.md
+++ b/vuepress/docs/docs/laminext.md
@@ -5,7 +5,7 @@ It is depending on [Laminext](https://laminext.dev), a library that provides nic
 
 To use it, import the `caliban-client-laminext` module:
 ```
-libraryDependencies += "com.github.ghostdogpr" %%% "caliban-client-laminext" % "2.0.2"
+libraryDependencies += "com.github.ghostdogpr" %%% "caliban-client-laminext" % "2.1.0"
 ```
 
 Add the following import to your code:

--- a/vuepress/docs/docs/laminext.md
+++ b/vuepress/docs/docs/laminext.md
@@ -5,7 +5,7 @@ It is depending on [Laminext](https://laminext.dev), a library that provides nic
 
 To use it, import the `caliban-client-laminext` module:
 ```
-libraryDependencies += "com.github.ghostdogpr" %%% "caliban-client-laminext" % "2.1.0"
+"com.github.ghostdogpr" %%% "caliban-client-laminext" % "2.1.0"
 ```
 
 Add the following import to your code:

--- a/vuepress/docs/docs/laminext.md
+++ b/vuepress/docs/docs/laminext.md
@@ -4,7 +4,7 @@ If you are using the Scala.js framework [Laminar](https://laminar.dev), there is
 It is depending on [Laminext](https://laminext.dev), a library that provides nice little helpers for Laminar, in particular for using `Fetch` and `WebSocket`.
 
 To use it, import the `caliban-client-laminext` module:
-```
+```scala
 "com.github.ghostdogpr" %%% "caliban-client-laminext" % "2.1.0"
 ```
 

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -158,7 +158,7 @@ a federated graph:
       _fieldSet: FieldSet = FieldSet("")
     )
 
-    GraphQL.graphQL(RootResolver(Query(_service = _Service(original.render))), federationDirectives) |+| original
+    graphQL(RootResolver(Query(_service = _Service(original.render))), federationDirectives) |+| original
   }
 
   lazy val federated: GraphQLAspect[Nothing, Any] = 
@@ -202,7 +202,7 @@ case class Query(
 def allCharacterNames: UIO[List[String]] = ZIO.succeed(???)
 def getLines(name: String, offset: Int, limit: Int): UIO[List[String]] = ???
 
-val api = GraphQL.graphQL(RootResolver(Query(
+val api = graphQL(RootResolver(Query(
   characters = allCharacterNames.flatMap { 
     names => ZIO.foreach(names) { name =>
       val character = Character(

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -237,7 +237,7 @@ Caliban ships with support for OpenTelemetry tracing via integration with [zio-t
 In order to use tracing, first add `caliban-tracing` to your `built.sbt`.
 
 ```scala
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-tracing" % "2.1.0"
+"com.github.ghostdogpr" %% "caliban-tracing" % "2.1.0"
 ```
 
 Then add it to your schema as any other wrapper:

--- a/vuepress/docs/docs/middleware.md
+++ b/vuepress/docs/docs/middleware.md
@@ -237,7 +237,7 @@ Caliban ships with support for OpenTelemetry tracing via integration with [zio-t
 In order to use tracing, first add `caliban-tracing` to your `built.sbt`.
 
 ```scala
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-tracing" % "2.0.2"
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-tracing" % "2.1.0"
 ```
 
 Then add it to your schema as any other wrapper:

--- a/vuepress/docs/docs/relay-connections.md
+++ b/vuepress/docs/docs/relay-connections.md
@@ -80,7 +80,7 @@ case class Args(
 
 
 case class Query(connection: Args => ZIO[Any, CalibanError, ItemConnection])
-val api = GraphQL.graphQL(
+val api = graphQL(
   RootResolver(
     Query(args =>
       for {

--- a/vuepress/docs/docs/schema-comparison.md
+++ b/vuepress/docs/docs/schema-comparison.md
@@ -11,8 +11,7 @@ The output of `compare` is a `Task[List[SchemaComparisonChange]]`, with `SchemaC
 The following example will compare the schema obtained by Caliban with a schema defined in a string and print the differences.
 
 ```scala mdoc:silent
-import caliban.GraphQL.graphQL
-import caliban.RootResolver
+import caliban._
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 import caliban.tools._

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -178,7 +178,7 @@ implicit val schemaForMyClass: Schema[Any, MyClass] = Schema.gen
 ```scala
 import caliban.schema.Schema
 
-case class MyClass(field: String) derives Schema.SemiAuto
+case class MyClass(field: String) derives Schema.SemiAuto // you can also derive Schema.Auto to generate a Schema for nested types automatically
 
 // if you don't want to use the `derives` syntax, you can also use the following:
 given Schema[Any, MyClass] = Schema.gen

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -296,7 +296,7 @@ Caliban can automatically generate Scala code from a GraphQL schema.
 
 In order to use this feature, add the `caliban-codegen-sbt` sbt plugin to your `project/plugins.sbt` file:
 ```scala
-addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % "2.0.2")
+addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % "2.1.0")
 ```
 
 And enable it in your `build.sbt` file:

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -141,16 +141,16 @@ If you prefer to have a `Union` type instead of an `Enum`, even when the sealed 
 
 ## Case classes and sealed traits
 
-The transformation between Scala types and GraphQL types is handled by a typeclass named `Schema`. As mentioned earlier, caliban provides instances of `Schema` for all basic Scala types, but inevitably you will need to support your own types, in particular case classes and sealed traits.
+The transformation between Scala types and GraphQL types is handled by a typeclass named `Schema`. As mentioned earlier, Caliban provides instances of `Schema` for all basic Scala types, but inevitably you will need to support your own types, in particular case classes and sealed traits.
 
-Caliban is able to generate instances of `Schema` for case classes and sealed traits. You have 2 choices for doing that: auto derivation and semi-auto derivation.
+Caliban is able to generate instances of `Schema` for case classes and sealed traits. You have two choices for doing that: auto derivation and semi-auto derivation.
 
 ### Auto derivation
 Auto derivation is achieved easily by adding the following import:
 ```scala mdoc:silent
 import caliban.schema.Schema.auto._
 ```
-Using this import, caliban will generate a `Schema` instance for all the case classes and sealed traits that are found inside your resolver.
+Using this import, Caliban will generate `Schema` instances for all the case classes and sealed traits that are found inside your resolver.
 
 ::: warning Auto derivation limitations
 Auto derivation is the easiest way to get started, but it has some drawbacks:

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -3,41 +3,41 @@
 A GraphQL schema will be derived automatically at compile-time (no reflection) from the types present in your resolver.
 The table below shows how common Scala types are converted to GraphQL types.
 
-| Scala Type                                          | GraphQL Type                                                     |
-| --------------------------------------------------- | ---------------------------------------------------------------- |
-| Boolean                                             | Boolean                                                          |
-| Int                                                 | Int                                                              |
-| Float                                               | Float                                                            |
-| Double                                              | Float                                                            |
-| String                                              | String                                                           |
-| java.util.UUID                                      | ID                                                               |
-| Unit                                                | Unit (custom scalar)                                             |
-| Long                                                | Long (custom scalar)                                             |
-| BigInt                                              | BigInt (custom scalar)                                           |
-| BigDecimal                                          | BigDecimal (custom scalar)                                       |
-| java.time.Instant                                   | Instant (custom scalar)                                          |
-| java.time.LocalDate                                 | LocalDate (custom scalar)                                        |
-| java.time.LocalTime                                 | LocalTime (custom scalar)                                        |
-| java.time.LocalDateTime                             | LocalDateTime (custom scalar)                                    |
-| java.time.OffsetDateTime                            | OffsetDateTime (custom scalar)                                   |
-| java.time.ZonedDateTime                             | ZonedDateTime (custom scalar)                                    |
-| Case Class                                          | Object                                                           |
-| Sealed Trait                                        | Enum or Union                                                    |
-| Option[A]                                           | Nullable A                                                       |
-| List[A]                                             | List of A                                                        |
-| Set[A]                                              | List of A                                                        |
-| Seq[A]                                              | List of A                                                        |
-| Vector[A]                                           | List of A                                                        |
-| A => B                                              | A and B                                                          |
-| (A, B)                                              | Object with 2 fields `_1` and `_2`                               |
-| Either[A, B]                                        | Object with 2 nullable fields `left` and `right`                 |
-| Map[A, B]                                           | List of Object with 2 fields `key` and `value`                   |
-| ZIO[R, Nothing, A]                                  | A                                                                |
-| ZIO[R, Throwable, A]                                | Nullable A                                                       |
-| Future[A]                                           | Nullable A                                                       |
-| ZStream[R, Throwable, A]                            | A (subscription) or List of A (query, mutation)                  |
-| Json (from [Circe](https://github.com/circe/circe)) | Json (custom scalar, need `import caliban.interop.circe.json._`) |
-| Json (from [play-json](https://github.com/playframework/play-json)) | Json (custom scalar, need `import caliban.interop.play.json._`) |
+| Scala Type                                                          | GraphQL Type                                                     |
+|---------------------------------------------------------------------|------------------------------------------------------------------|
+| Boolean                                                             | Boolean                                                          |
+| Int                                                                 | Int                                                              |
+| Float                                                               | Float                                                            |
+| Double                                                              | Float                                                            |
+| String                                                              | String                                                           |
+| java.util.UUID                                                      | ID                                                               |
+| Unit                                                                | Unit (custom scalar)                                             |
+| Long                                                                | Long (custom scalar)                                             |
+| BigInt                                                              | BigInt (custom scalar)                                           |
+| BigDecimal                                                          | BigDecimal (custom scalar)                                       |
+| java.time.Instant                                                   | Instant (custom scalar)                                          |
+| java.time.LocalDate                                                 | LocalDate (custom scalar)                                        |
+| java.time.LocalTime                                                 | LocalTime (custom scalar)                                        |
+| java.time.LocalDateTime                                             | LocalDateTime (custom scalar)                                    |
+| java.time.OffsetDateTime                                            | OffsetDateTime (custom scalar)                                   |
+| java.time.ZonedDateTime                                             | ZonedDateTime (custom scalar)                                    |
+| Case Class                                                          | Object                                                           |
+| Sealed Trait                                                        | Enum or Union                                                    |
+| Option[A]                                                           | Nullable A                                                       |
+| List[A]                                                             | List of A                                                        |
+| Set[A]                                                              | List of A                                                        |
+| Seq[A]                                                              | List of A                                                        |
+| Vector[A]                                                           | List of A                                                        |
+| A => B                                                              | A and B                                                          |
+| (A, B)                                                              | Object with 2 fields `_1` and `_2`                               |
+| Either[A, B]                                                        | Object with 2 nullable fields `left` and `right`                 |
+| Map[A, B]                                                           | List of Object with 2 fields `key` and `value`                   |
+| ZIO[R, Nothing, A]                                                  | A                                                                |
+| ZIO[R, Throwable, A]                                                | Nullable A                                                       |
+| Future[A]                                                           | Nullable A                                                       |
+| ZStream[R, Throwable, A]                                            | A (subscription) or List of A (query, mutation)                  |
+| Json (from [Circe](https://github.com/circe/circe))                 | Json (custom scalar, need `import caliban.interop.circe.json._`) |
+| Json (from [play-json](https://github.com/playframework/play-json)) | Json (custom scalar, need `import caliban.interop.play.json._`)  |
 
 See the [Custom Types](#custom-types) section to find out how to support your own types.
 

--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -222,7 +222,7 @@ If you require a ZIO environment and use Scala 3, things are simpler since you d
 To make sure Caliban uses the proper environment, you need to specify it explicitly to `graphQL(...)`, unless you already have `Schema` instances for your root operations in scope.
 ```scala mdoc:silent
 val queries = Queries(ZIO.attempt(???), _ => ZIO.succeed(???))
-val api = GraphQL.graphQL[MyEnv, Queries, Unit, Unit](RootResolver(queries))
+val api = graphQL[MyEnv, Queries, Unit, Unit](RootResolver(queries))
 // or
 // implicit val queriesSchema: Schema[MyEnv, Queries] = Schema.gen
 // val api = graphQL(RootResolver(queries)) // it will infer MyEnv thanks to the instance above

--- a/vuepress/docs/docs/stitching.md
+++ b/vuepress/docs/docs/stitching.md
@@ -11,7 +11,7 @@ You should also be careful when using stitching since it's very easy to pull in 
 In order to use stitching, add `caliban-tools` to your dependencies:
 
 ```scala
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-tools" % "2.0.2"
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-tools" % "2.1.0"
 ```
 
 ## Stitching in Action

--- a/vuepress/docs/docs/stitching.md
+++ b/vuepress/docs/docs/stitching.md
@@ -35,7 +35,7 @@ object StitchingExample extends GenericSchema[Any] {
     GetUser: GetUserQuery => UIO[AppUser]
   )
 
-  val graphQL: GraphQL[Any] = GraphQL.graphQL(
+  val api: GraphQL[Any] = graphQL(
     RootResolver(
       Queries(
         GetUser = query =>

--- a/vuepress/docs/docs/stitching.md
+++ b/vuepress/docs/docs/stitching.md
@@ -11,7 +11,7 @@ You should also be careful when using stitching since it's very easy to pull in 
 In order to use stitching, add `caliban-tools` to your dependencies:
 
 ```scala
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-tools" % "2.1.0"
+"com.github.ghostdogpr" %% "caliban-tools" % "2.1.0"
 ```
 
 ## Stitching in Action

--- a/vuepress/docs/docs/tools.md
+++ b/vuepress/docs/docs/tools.md
@@ -9,5 +9,5 @@ Caliban comes with a module called `caliban-tools` that exposes some useful feat
 ## Dependency
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-tools" % "2.1.0"
+"com.github.ghostdogpr" %% "caliban-tools" % "2.1.0"
 ```

--- a/vuepress/docs/docs/tools.md
+++ b/vuepress/docs/docs/tools.md
@@ -9,5 +9,5 @@ Caliban comes with a module called `caliban-tools` that exposes some useful feat
 ## Dependency
 
 ```
-libraryDependencies += "com.github.ghostdogpr" %% "caliban-tools" % "2.0.2"
+libraryDependencies += "com.github.ghostdogpr" %% "caliban-tools" % "2.1.0"
 ```

--- a/vuepress/docs/docs/tools.md
+++ b/vuepress/docs/docs/tools.md
@@ -8,6 +8,6 @@ Caliban comes with a module called `caliban-tools` that exposes some useful feat
 
 ## Dependency
 
-```
+```scala
 "com.github.ghostdogpr" %% "caliban-tools" % "2.1.0"
 ```

--- a/vuepress/docs/faq/README.md
+++ b/vuepress/docs/faq/README.md
@@ -94,7 +94,6 @@ Caliban will automatically fill the error path and the error location inside `Ex
 
 If you have an interface that is not directly returned by any field, it will be missing from the schema. This is a constraint from the way the typeclass derivation works. A workaround is to use `withAdditionalTypes` on your `GraphQL` object to explicitly add the interface. See the following example:
 ```scala mdoc:silent
-import caliban.GraphQL._
 import caliban._
 import caliban.schema.Schema
 import caliban.schema.Annotations._

--- a/vuepress/docs/resources/README.md
+++ b/vuepress/docs/resources/README.md
@@ -1,6 +1,7 @@
 # Resources
 
 ## Talks
+- [Cost-effective and easy to maintain GraphQL integration tests](https://www.youtube.com/watch?v=pYfWq4GmObY) by Jules Ivanic at [Functional Scala](https://www.functionalscala.com/) in December 2022
 - [Zymposium episode on Caliban](https://youtu.be/mzqsXklbmfM) with Pierre Ricadat, Kit Langton and Adam Fraser in June 2021
 - [A Tour of Caliban](https://www.youtube.com/watch?v=lgxUKsOH65k) by Pierre Ricadat at [SF Scala](https://www.meetup.com/SF-Scala/) in April 2020
 - [Caliban: Designing a Functional GraphQL Library](https://www.youtube.com/watch?v=OC8PbviYUlQ) by Pierre Ricadat at [Functional Scala](https://www.functionalscala.com/) in December 2019 (slides available [here](https://www.slideshare.net/PierreRicadat/designing-a-functional-graphql-library-204680947))

--- a/vuepress/package.json
+++ b/vuepress/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "vuepress": "^1.1.0"
+    "vuepress": "^1.9.9"
   },
   "scripts": {
     "docs:dev": "vuepress dev docs",


### PR DESCRIPTION
To simplify things a little further, I moved the `graphQL` function to the `caliban` package. The old one is still there but deprecated.