### PR TITLE
Stop filtering directives on inputs and input fields

### DIFF
--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -164,8 +164,9 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
             Some(customizeInputTypeName(name)),
             description,
             fields(isInput, isSubscription).map { case (f, _) =>
-              __InputValue(f.name, f.description, f.`type`, None)
-            }
+              __InputValue(f.name, f.description, f.`type`, None, f.directives)
+            },
+            directives = Some(directives)
           )
         } else makeObject(Some(name), description, fields(isInput, isSubscription).map(_._1), directives)
 


### PR DESCRIPTION
This is another difference between federation 1 and federation 2.

https://www.apollographql.com/docs/graphos/delivery/contracts/#valid-tag-locations

In federation 2 input types and their fields can and should be tagged when using contract graphs. We were previously filtering out their directives. I suspect this is so that a type that is both a normal type and an input type would not need to be defined by library users twice, but it is problematic in Federation 2.

I am not sure how Caliban normally handles these sort of splits or if it does or if we just say that the latest version doesn't work for Fed 1 but this seems like a breaking change without some mechanism to mitigate it.