### PR TITLE
Add `ArgBuilder.Auto` and prioritise local implicits when using `Schema.Auto`

### DIFF
--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -2,13 +2,14 @@ package caliban.schema
 
 import caliban.CalibanError.ExecutionError
 import caliban.InputValue
-import caliban.Value._
+import caliban.Value.*
 import caliban.schema.macros.Macros
 import caliban.schema.Annotations.GQLDefault
 import caliban.schema.Annotations.GQLName
 
 import scala.deriving.Mirror
-import scala.compiletime._
+import scala.compiletime.*
+import scala.util.NotGiven
 
 trait CommonArgBuilderDerivation {
   inline def recurse[Label, A <: Tuple](
@@ -87,6 +88,17 @@ trait CommonArgBuilderDerivation {
 
 trait ArgBuilderDerivation extends CommonArgBuilderDerivation {
   inline def gen[A]: ArgBuilder[A] = derived
+
+  sealed trait Auto[A] extends ArgBuilder[A] {
+    inline given genAuto[T](using NotGiven[ArgBuilder[T]]): ArgBuilder[T] = derived
+  }
+
+  object Auto {
+    inline def derived[A]: Auto[A] = new {
+      private val impl = ArgBuilder.gen[A]
+      export impl.*
+    }
+  }
 }
 
 trait AutoArgBuilderDerivation extends ArgBuilderInstances with LowPriorityDerivedArgBuilder

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -10,6 +10,7 @@ import caliban.schema.macros.{ Macros, TypeInfo }
 
 import scala.compiletime.*
 import scala.deriving.Mirror
+import scala.util.NotGiven
 import scala.quoted.*
 
 object PrintDerived {
@@ -324,7 +325,10 @@ trait SchemaDerivation[R] extends CommonSchemaDerivation {
     }
   }
 
-  sealed trait Auto[A] extends Schema[R, A], GenericSchema[R], LowPriorityDerivedSchema
+  sealed trait Auto[A] extends Schema[R, A], GenericSchema[R] {
+    inline given genAuto[T](using NotGiven[Schema[R, T]]): Schema[R, T] = derived[R, T]
+  }
+
   object Auto {
     inline def derived[A]: Auto[A] = new {
       private val impl = Schema.derived[R, A]

--- a/core/src/test/scala-3/caliban/schema/ArgBuilderDerivesAutoSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/ArgBuilderDerivesAutoSpec.scala
@@ -1,0 +1,64 @@
+package caliban.schema
+
+import caliban.CalibanError.ExecutionError
+import caliban.InputValue
+import caliban.InputValue.{ ListValue, ObjectValue }
+import caliban.schema.ArgBuilder
+import caliban.schema.ArgBuilder.*
+import caliban.Value.{ IntValue, NullValue, StringValue }
+import zio.test.Assertion.*
+import zio.test.*
+
+import java.time.*
+import scala.annotation.experimental
+
+object ArgBuilderDerivesAutoSpec extends ZIOSpecDefault {
+  def spec = suite("ArgBuilderDerivesAutoSpec")(
+    suite("buildMissing")(
+      test("works with derived case class ArgBuilders") {
+        sealed abstract class Nullable[+T]
+        case class SomeNullable[+T](t: T) extends Nullable[T]
+        case object NullNullable          extends Nullable[Nothing]
+        case object MissingNullable       extends Nullable[Nothing]
+
+        given [A](using ev: ArgBuilder[A]): ArgBuilder[Nullable[A]] =
+          new ArgBuilder[Nullable[A]] {
+            def build(input: InputValue): Either[ExecutionError, Nullable[A]] = input match {
+              case NullValue => Right(NullNullable)
+              case _         => ev.build(input).map(SomeNullable(_))
+            }
+
+            override def buildMissing(default: Option[String]): Either[ExecutionError, Nullable[A]] =
+              Right(MissingNullable)
+          }
+
+        case class Wrapper(a: Nullable[String]) derives ArgBuilder.Auto
+
+        val derivedAB = summon[ArgBuilder[Wrapper]]
+
+        assertTrue(
+          derivedAB.build(ObjectValue(Map())) == Right(Wrapper(MissingNullable)),
+          derivedAB.build(ObjectValue(Map("a" -> NullValue))) == Right(Wrapper(NullNullable)),
+          derivedAB.build(ObjectValue(Map("a" -> StringValue("x")))) == Right(Wrapper(SomeNullable("x")))
+        )
+      }
+    ),
+    test("reuses implicits defined in ArgBuilder") {
+      case class InputArgs[A](value: A, list: List[A])
+
+      case class Wrapper(ints: InputArgs[Int], strings: InputArgs[String]) derives ArgBuilder.Auto
+
+      val derivedAB = summon[ArgBuilder[Wrapper]]
+
+      val ints    = ObjectValue(Map("value" -> IntValue(1), "list" -> ListValue(List(IntValue(1), IntValue(2)))))
+      val strings =
+        ObjectValue(Map("value" -> StringValue("x"), "list" -> ListValue(List(StringValue("x"), StringValue("y")))))
+
+      val expected = Wrapper(
+        InputArgs(1, List(1, 2)),
+        InputArgs("x", List("x", "y"))
+      )
+      assertTrue(derivedAB.build(ObjectValue(Map("ints" -> ints, "strings" -> strings))) == Right(expected))
+    }
+  )
+}

--- a/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
@@ -314,6 +314,22 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
             val gql      = graphQL(resolver)
 
             assertTrue(gql.render == expected)
+          },
+          test("from local scope when using a custom schema") {
+            trait Foo
+            object FooSchema extends SchemaDerivation[Foo]
+            case class A(a: Int)
+
+            given Schema[Any, A] = Schema.obj[Any, A]("A") { case given FieldAttributes =>
+              List(field("a")(_.a.toString))
+            }
+
+            case class Queries(as: List[A]) derives FooSchema.Auto
+
+            val resolver = RootResolver(Queries(List(A(1), A(2))))
+            val gql      = graphQL[Foo, Queries, Unit, Unit](resolver)
+
+            assertTrue(gql.render == expected)
           }
         )
       }

--- a/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
@@ -280,9 +280,21 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
             |  as: [A!]!
             |}""".stripMargin
         List(
-          test("from GenericSchema") {
+          test("from GenericSchema[Any]") {
             case class A(a: String)
             case class Queries(as: List[A]) derives Schema.Auto
+
+            val resolver = RootResolver(Queries(List(A("a"), A("b"))))
+            val gql      = graphQL(resolver)
+
+            assertTrue(gql.render == expected)
+          },
+          test("from GenericSchema[T]") {
+            trait Foo
+            object FooSchema extends SchemaDerivation[Foo]
+
+            case class A(a: String)
+            case class Queries(as: List[A]) derives FooSchema.Auto
 
             val resolver = RootResolver(Queries(List(A("a"), A("b"))))
             val gql      = graphQL(resolver)

--- a/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
@@ -160,7 +160,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
         case class Something(b: Int)
         case class Query(something: Something) derives Schema.Auto
 
-        implicit val somethingSchema: Schema[Any, Something] = Schema.gen[Any, Something].rename("SomethingElse")
+        given Schema[Any, Something] = Schema.gen[Any, Something].rename("SomethingElse")
 
         assertTrue(Types.innerType(introspectSubscription[Something]).name.get == "SomethingElse")
       },
@@ -266,13 +266,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
                          |}""".stripMargin
         assertTrue(gql.render == expected)
       },
-      test("Auto derivation reuses implicit derivations in GenericSchema") {
-        case class A(a: String)
-        case class Queries(as: List[A]) derives Schema.Auto
-
-        val resolver = RootResolver(Queries(List(A("a"), A("b"))))
-        val gql      = graphQL(resolver)
-
+      suite("Auto derivation reuses implicits") {
         val expected =
           """schema {
             |  query: Queries
@@ -285,8 +279,31 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
             |type Queries {
             |  as: [A!]!
             |}""".stripMargin
+        List(
+          test("from GenericSchema") {
+            case class A(a: String)
+            case class Queries(as: List[A]) derives Schema.Auto
 
-        assertTrue(gql.render == expected)
+            val resolver = RootResolver(Queries(List(A("a"), A("b"))))
+            val gql      = graphQL(resolver)
+
+            assertTrue(gql.render == expected)
+          },
+          test("from local scope") {
+            case class A(a: Int)
+
+            given Schema[Any, A] = Schema.obj[Any, A]("A") { case given FieldAttributes =>
+              List(field("a")(_.a.toString))
+            }
+
+            case class Queries(as: List[A]) derives Schema.Auto
+
+            val resolver = RootResolver(Queries(List(A(1), A(2))))
+            val gql      = graphQL(resolver)
+
+            assertTrue(gql.render == expected)
+          }
+        )
       }
     )
 


### PR DESCRIPTION
In this PR:

1. Added support for `... derives ArgBuilder.Auto`
2. Fixed an issue with `... derives Schema.Auto` where previously it would prioritise auto-derivation over implicits in the local scope. The added test case would previously fail