### PR TITLE
Add type alias for `ArgBuilder.Auto` and cleanup `Schema.Auto`

### DIFF
--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -95,10 +95,20 @@ trait ArgBuilderDerivation extends CommonArgBuilderDerivation {
 
   object Auto {
     inline def derived[A]: Auto[A] = new {
-      private val impl = ArgBuilder.gen[A]
+      private val impl = ArgBuilder.derived[A]
       export impl.*
     }
   }
+
+  /**
+   * Due to a Scala 3 compiler bug, it's not possible to derive two type classes of the same name. For example, the following fails to compile:
+   *
+   * `case class Foo(value: String) derives Schema.Auto, ArgBuilder.Auto`
+   *
+   * Until the issue is resolved, we can use this type alias as a workaround by replacing `ArgBuilder.Auto` with `ArgBuilder.GenAuto`
+   */
+  final type GenAuto[A] = Auto[A]
+
 }
 
 trait AutoArgBuilderDerivation extends ArgBuilderInstances with LowPriorityDerivedArgBuilder

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -325,7 +325,7 @@ trait SchemaDerivation[R] extends CommonSchemaDerivation {
     }
   }
 
-  sealed trait Auto[A] extends Schema[R, A], GenericSchema[R] {
+  sealed trait Auto[A] extends Schema[R, A] {
     inline given genAuto[T](using NotGiven[Schema[R, T]]): Schema[R, T] = derived[R, T]
   }
 

--- a/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
@@ -58,14 +58,8 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
 
         assertTrue(gql.render == expected)
       },
-      test("ArgBuilder derivation - default") {
-        final case class Foo(s: String) derives Schema.SemiAuto, ArgBuilder
-        final case class Bar(foo: Foo) derives Schema.SemiAuto
-        final case class Query(f: Foo => Bar) derives Schema.SemiAuto
-
-        val gql = graphQL(RootResolver(Query(Bar(_))))
-
-        val expected2 =
+      suite("ArgBuilder derivation") {
+        val expected =
           """schema {
             |  query: Query
             |}
@@ -82,7 +76,26 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
             |  f(s: String!): Bar!
             |}""".stripMargin
 
-        assertTrue(gql.render == expected2)
+        List(
+          test("SemiAuto") {
+            final case class Foo(s: String) derives Schema.SemiAuto, ArgBuilder
+            final case class Bar(foo: Foo) derives Schema.SemiAuto
+            final case class Query(f: Foo => Bar) derives Schema.SemiAuto
+
+            val gql = graphQL(RootResolver(Query(Bar(_))))
+
+            assertTrue(gql.render == expected)
+          },
+          test("Auto") {
+            final case class Foo(s: String) derives Schema.Auto, ArgBuilder.GenAuto
+            final case class Bar(foo: Foo) derives Schema.SemiAuto
+            final case class Query(f: Foo => Bar) derives Schema.SemiAuto
+
+            val gql = graphQL(RootResolver(Query(Bar(_))))
+
+            assertTrue(gql.render == expected)
+          }
+        )
       }
     )
   }

--- a/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
@@ -1,16 +1,15 @@
 package caliban.schema
 
 import java.util.UUID
-import caliban._
+import caliban.*
 import caliban.introspection.adt.{ __DeprecatedArgs, __Type, __TypeKind }
 import caliban.schema.Annotations.{ GQLExcluded, GQLInterface, GQLUnion, GQLValueType }
-import caliban.schema.Schema._
-import caliban.schema.ArgBuilder.auto._
+import caliban.schema.ArgBuilder.auto.*
 import zio.query.ZQuery
 import zio.stream.ZStream
-import zio.test.Assertion._
-import zio.test._
-import zio._
+import zio.test.Assertion.*
+import zio.test.*
+import zio.*
 
 import scala.concurrent.Future
 
@@ -35,7 +34,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
       },
       test("tricky case with R") {
         case class Field(value: ZQuery[Console, Nothing, String])
-        object MySchema extends GenericSchema[Console with Clock]
+        object MySchema extends SchemaDerivation[Console with Clock]
         case class Queries(field: ZQuery[Clock, Nothing, Field]) derives MySchema.Auto
 
         assert(
@@ -76,7 +75,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
         )
       },
       test("nested types with explicit schema in companion object") {
-        object consoleSchema extends GenericSchema[Console] {
+        object consoleSchema extends SchemaDerivation[Console] {
           case class A(s: String)
           object A {
             implicit val aSchema: Schema[Console, A] = gen
@@ -305,7 +304,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
             case class A(a: Int)
 
             given Schema[Any, A] = Schema.obj[Any, A]("A") { case given FieldAttributes =>
-              List(field("a")(_.a.toString))
+              List(Schema.field("a")(_.a.toString))
             }
 
             case class Queries(as: List[A]) derives Schema.Auto
@@ -321,7 +320,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
             case class A(a: Int)
 
             given Schema[Any, A] = Schema.obj[Any, A]("A") { case given FieldAttributes =>
-              List(field("a")(_.a.toString))
+              List(Schema.field("a")(_.a.toString))
             }
 
             case class Queries(as: List[A]) derives FooSchema.Auto


### PR DESCRIPTION
Leaving this as draft until we hear back whether this is indeed a bug with the Scala 3 compiler.

I've also removed the extension of `GenericSchema` from `Schema.Auto`. This doesn't seem to be needed now that we're using `using NotGiven[...]`.