### PR TITLE
Fix return type of ZHttpAdapter.makeHttpService

### DIFF
--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -17,8 +17,10 @@ object ZHttpAdapter {
 
   def makeHttpService[R, E](interpreter: HttpInterpreter[R, E])(implicit
     serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
-  ): HttpApp[R, Throwable] =
-    ZioHttpInterpreter(serverOptions).toHttp(interpreter.serverEndpoints[R, ZioStreams](ZioStreams))
+  ): App[R] =
+    ZioHttpInterpreter(serverOptions)
+      .toHttp(interpreter.serverEndpoints[R, ZioStreams](ZioStreams))
+      .withDefaultErrorResponse
 
   def makeWebSocketService[R, E](
     interpreter: WebSocketInterpreter[R, E]

--- a/adapters/zio-http/src/test/scala/caliban/ZHttpAdapterSpec.scala
+++ b/adapters/zio-http/src/test/scala/caliban/ZHttpAdapterSpec.scala
@@ -37,7 +37,6 @@ object ZHttpAdapterSpec extends ZIOSpecDefault {
                 case _ -> !! / "ws" / "graphql"  =>
                   ZHttpAdapter.makeWebSocketService(WebSocketInterpreter(interpreter))
               }
-              .withDefaultErrorResponse
           )
           .forkScoped
       _           <- Live.live(Clock.sleep(3 seconds))

--- a/examples/src/main/scala/example/federation/v2/FederatedApp.scala
+++ b/examples/src/main/scala/example/federation/v2/FederatedApp.scala
@@ -20,7 +20,6 @@ object FederatedApp extends ZIOAppDefault {
             .collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
               ZHttpAdapter.makeHttpService(HttpInterpreter(interpreter))
             }
-            .withDefaultErrorResponse
         )
         .provideSome[CharacterService](Server.live, config)
   } yield ()
@@ -35,7 +34,6 @@ object FederatedApp extends ZIOAppDefault {
             .collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
               ZHttpAdapter.makeHttpService(HttpInterpreter(interpreter))
             }
-            .withDefaultErrorResponse
         )
         .provideSome[EpisodeService](Server.live, config)
   } yield ()

--- a/examples/src/main/scala/example/stitching/ExampleApp.scala
+++ b/examples/src/main/scala/example/stitching/ExampleApp.scala
@@ -105,7 +105,7 @@ import caliban.ZHttpAdapter
 object ExampleApp extends ZIOAppDefault {
   import sttp.tapir.json.circe._
 
-  private val graphiql = Handler.fromStream(ZStream.fromResource("graphiql.html")).toHttp
+  private val graphiql = Handler.fromStream(ZStream.fromResource("graphiql.html")).toHttp.withDefaultErrorResponse
 
   override def run =
     (for {
@@ -120,7 +120,6 @@ object ExampleApp extends ZIOAppDefault {
                 case _ -> !! / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(WebSocketInterpreter(interpreter))
                 case _ -> !! / "graphiql"        => graphiql
               }
-              .withDefaultErrorResponse
           )
     } yield ())
       .provide(

--- a/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
@@ -82,7 +82,7 @@ object Authed extends GenericSchema[Auth] {
 }
 
 object AuthExampleApp extends ZIOAppDefault {
-  private val graphiql = Handler.fromStream(ZStream.fromResource("graphiql.html")).toHttp
+  private val graphiql = Handler.fromStream(ZStream.fromResource("graphiql.html")).toHttp.withDefaultErrorResponse
 
   override def run: URIO[Any, ExitCode] =
     (for {
@@ -97,7 +97,6 @@ object AuthExampleApp extends ZIOAppDefault {
                              case _ -> !! / "ws" / "graphql"  => Auth.WebSockets.live(interpreter)
                              case _ -> !! / "graphiql"        => graphiql
                            }
-                           .withDefaultErrorResponse
                        )
       _           <- ZIO.logInfo(s"Server started on port $port")
       _           <- ZIO.never

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -11,7 +11,7 @@ import zio.http._
 object ExampleApp extends ZIOAppDefault {
   import sttp.tapir.json.circe._
 
-  private val graphiql = Handler.fromStream(ZStream.fromResource("graphiql.html")).toHttp
+  private val graphiql = Handler.fromStream(ZStream.fromResource("graphiql.html")).toHttp.withDefaultErrorResponse
 
   override def run: ZIO[Any, Throwable, Unit] =
     (for {
@@ -25,7 +25,6 @@ object ExampleApp extends ZIOAppDefault {
                 case _ -> !! / "ws" / "graphql"  => ZHttpAdapter.makeWebSocketService(WebSocketInterpreter(interpreter))
                 case _ -> !! / "graphiql"        => graphiql
               }
-              .withDefaultErrorResponse
           )
       _           <- Console.printLine("Server online at http://localhost:8088/")
       _           <- Console.printLine("Press RETURN to stop...") *> Console.readLine


### PR DESCRIPTION
`makeHttpService` was returning `HttpApp[R, Throwable]` while `makeWebSocketService` returned `HttpApp[R, Response]` aka `App[R]`. Considering `serve` expects an `App[R]`, it would be better to fix `makeHttpService`.