### PR TITLE
Cache creation of interpreter

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -80,8 +80,8 @@ trait GraphQL[-R] { self =>
    * adding some middleware around the query execution.
    * Fails with a [[caliban.CalibanError.ValidationError]] if the schema is invalid.
    */
-  final def interpreter(implicit trace: Trace): IO[ValidationError, GraphQLInterpreter[R, CalibanError]] =
-    ZIO.fromEither(validatedRootSchemaCached).map { schema =>
+  final def interpreter(implicit trace: Trace): IO[ValidationError, GraphQLInterpreter[R, CalibanError]] = {
+    val validated = validatedRootSchemaCached.map { schema =>
       lazy val rootType =
         RootType(
           schema.query.opType,
@@ -154,6 +154,8 @@ trait GraphQL[-R] { self =>
           }
       }
     }
+    ZIO.fromEither(validated)
+  }
 
   /**
    * Attaches a function that will wrap one of the stages of query processing

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -77,8 +77,10 @@ trait GraphQL[-R] { self =>
    * adding some middleware around the query execution.
    * Fails with a [[caliban.CalibanError.ValidationError]] if the schema is invalid.
    */
-  final def interpreter(implicit trace: Trace): IO[ValidationError, GraphQLInterpreter[R, CalibanError]] =
-    ZIO.fromEither(cachedInterpreter)
+  final def interpreter(implicit trace: Trace): IO[ValidationError, GraphQLInterpreter[R, CalibanError]] = {
+    val i = cachedInterpreter
+    ZIO.fromEither(i)
+  }
 
   private lazy val cachedInterpreter =
     Validator.validateSchemaEither(schemaBuilder).map { schema =>

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -80,7 +80,7 @@ trait GraphQL[-R] { self =>
    * adding some middleware around the query execution.
    * Fails with a [[caliban.CalibanError.ValidationError]] if the schema is invalid.
    */
-  final def interpreter(implicit trace: Trace): IO[ValidationError, GraphQLInterpreter[R, CalibanError]] = {
+  final def interpreter(implicit trace: Trace): IO[ValidationError, GraphQLInterpreter[R, CalibanError]] =
     ZIO.fromEither(validatedRootSchemaCached).map { schema =>
       lazy val rootType =
         RootType(
@@ -154,7 +154,6 @@ trait GraphQL[-R] { self =>
           }
       }
     }
-  }
 
   /**
    * Attaches a function that will wrap one of the stages of query processing


### PR DESCRIPTION
With this PR, the validation of the root schema returns an `Either` instead of an `IO`. This in turn allows us to cache the creation of the interpreter, to avoid accidentally recreating it per-request which would be very detrimental to performance.

For example, the code below would previously recreate the interpreter on each request, whereas with the changes in this PR the interpreter would be created only on the first request, and then be memoized.

```scala
    val apiRoutes = (??? : GraphQL[Any]).interpreter.map { interpreter =>
      ZHttpAdapter.makeHttpService(HttpInterpreter(interpreter))
    }
    
    Http.fromHttpZIO[Request] {
      case (GET | POST) -> !! / "api" / "graphql" => apiRoutes
      case _ => Http.empty
    }
```
At the moment, `cachedInterpreter` is private, but we could potentially make it public as well. Note that some of the methods (see comments) are no longer used, but kept for binary and source compatibility