### PR TITLE
Modify rendering spec to parse the rendered schema and compare definitions

### DIFF
--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -238,7 +238,7 @@ object Rendering {
         s"(${list.map(a => s"${renderDescription(a.description, newline = false)}${a.name}: ${renderTypeName(a.`type`())}${renderDefaultValue(a)}${renderDirectives(a.directives)}").mkString(", ")})"
     }
 
-  private def isBuiltinScalar(name: String): Boolean =
+  private[caliban] def isBuiltinScalar(name: String): Boolean =
     name == "Int" || name == "Float" || name == "String" || name == "Boolean" || name == "ID"
 
   private[caliban] def renderTypeName(fieldType: __Type): String = {

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -1,297 +1,160 @@
-//package caliban
-//
-//import caliban.TestUtils._
-//import caliban.introspection.adt.{ __Type, __TypeKind }
-//import caliban.parsing.adt.Directive
-//import caliban.schema.Schema.auto._
-//import caliban.schema.ArgBuilder.auto._
-//import zio.test.Assertion._
-//import zio.test._
-//
-//object RenderingSpec extends ZIOSpecDefault {
-//
-//  val tripleQuote                              = "\"\"\""
-//  private val expectedDirectiveRenderingResult =
-//    """"Test directive"
-//      |directive @test(foo: Int) on FIELD_DEFINITION
-//      |
-//      |"Repeatable test directive"
-//      |directive @repeatable(bar: Int) repeatable on FIELD_DEFINITION
-//      |
-//      |schema @link(url: "https://example.com", import: ["@key", {name: "@provides", as: "@self"}]) {
-//      |  query: Query
-//      |}
-//      |
-//      |"Description of custom scalar emphasizing proper captain ship names"
-//      |scalar CaptainShipName @specifiedBy(url: "http://someUrl")
-//      |
-//      |union Role @uniondirective = Captain | Engineer | Mechanic | Pilot
-//      |
-//      |enum Origin @enumdirective {
-//      |  BELT
-//      |  EARTH
-//      |  MARS
-//      |  MOON @deprecated(reason: "Use: EARTH | MARS | BELT")
-//      |}
-//      |
-//      |input CharacterInput @inputobjdirective {
-//      |  name: String! @external
-//      |  nicknames: [String!]! @required
-//      |  origin: Origin!
-//      |}
-//      |
-//      |interface Human {
-//      |  name: String! @external
-//      |}
-//      |
-//      |type Captain {
-//      |  shipName: CaptainShipName!
-//      |}
-//      |
-//      |type Character implements Human @key(name: "name") {
-//      |  name: String! @external
-//      |  nicknames: [String!]! @required
-//      |  origin: Origin!
-//      |  role: Role
-//      |}
-//      |
-//      |type Engineer {
-//      |  shipName: String!
-//      |}
-//      |
-//      |type Mechanic {
-//      |  shipName: String!
-//      |}
-//      |
-//      |type Narrator implements Human {
-//      |  name: String!
-//      |}
-//      |
-//      |type Pilot {
-//      |  shipName: String!
-//      |}
-//      |
-//      |"Queries"
-//      |type Query {
-//      |  "Return all characters from a given origin"
-//      |  characters(origin: Origin): [Character!]!
-//      |  character(name: String!): Character @deprecated(reason: "Use `characters`")
-//      |  charactersIn(names: [String!]!): [Character!]!
-//      |  exists(character: CharacterInput!): Boolean!
-//      |  human: Human!
-//      |}"""
-//
-//  override def spec =
-//    suite("rendering")(
-//      test("it should render directives") {
-//        assert(
-//          graphQL(
-//            resolver,
-//            directives = List(Directives.Test, Directives.Repeatable),
-//            schemaDirectives = List(SchemaDirectives.Link)
-//          ).render.trim
-//        )(
-//          equalTo(
-//            expectedDirectiveRenderingResult.stripMargin.trim.replace(
-//              "\n\"Repeatable test directive\"",
-//              "\"Repeatable test directive\""
-//            ) // dirty trick to fix a scala bug
-//          )
-//        )
-//      },
-//      test("it should render descriptions") {
-//        import RenderingSpecSchema._
-//        val generated = graphQL(resolverSchema).render.trim
-//        assertTrue(generated == """|schema {
-//                                   |  query: QueryTest
-//                                   |  mutation: MutationTest
-//                                   |}
-//                                   |
-//                                   |input UserTestInput {
-//                                   |  name: String!
-//                                   |  "field-description"
-//                                   |  age: Int!
-//                                   |}
-//                                   |
-//                                   |type MutationTest {
-//                                   |  id(id: Int!, user: UserTestInput!): Boolean!
-//                                   |  fetch(nameLike: String!, "is user active currently" active: Boolean!): Boolean!
-//                                   |}
-//                                   |
-//                                   |type QueryTest {
-//                                   |  allUsers: [UserTest!]!
-//                                   |}
-//                                   |
-//                                   |type UserTest {
-//                                   |  name: String!
-//                                   |  "field-description"
-//                                   |  age: Int!
-//                                   |}""".stripMargin.trim)
-//      },
-//      test("it should render empty objects without field list") {
-//        assertTrue(graphQL(InvalidSchemas.Object.resolverEmpty).render.trim == """schema {
-//                                                                                 |  query: TestEmptyObject
-//                                                                                 |}
-//                                                                                 |
-//                                                                                 |type EmptyObject
-//                                                                                 |
-//                                                                                 |type TestEmptyObject {
-//                                                                                 |  o: EmptyObject!
-//                                                                                 |}""".stripMargin.trim)
-//      },
-//      test("it should not render a schema in no queries, mutations, or subscription") {
-//        assert(graphQL(InvalidSchemas.resolverEmpty).render.trim)(
-//          equalTo("")
-//        )
-//      },
-//      test("it should render object arguments in type directives") {
-//        val testType     = __Type(
-//          __TypeKind.OBJECT,
-//          name = Some("TestType"),
-//          directives = Some(
-//            List(
-//              Directive(
-//                name = "testdirective",
-//                arguments = Map(
-//                  "object" -> InputValue.ObjectValue(
-//                    Map(
-//                      "key1" -> Value.StringValue("value1"),
-//                      "key2" -> Value.StringValue("value2")
-//                    )
-//                  )
-//                )
-//              )
-//            )
-//          )
-//        )
-//        val renderedType = Rendering.renderTypes(List(testType))
-//        assert(renderedType)(equalTo("type TestType @testdirective(object: {key1: \"value1\",key2: \"value2\"})"))
-//      },
-//      test(
-//        "it should escape \", \\, backspace, linefeed, carriage-return and tab inside a normally quoted description string"
-//      ) {
-//        val testType     = __Type(
-//          __TypeKind.OBJECT,
-//          name = Some("TestType"),
-//          description = Some("A \"TestType\" description with \\, \b, \f, \r and \t")
-//        )
-//        val renderedType = Rendering.renderTypes(List(testType))
-//        assert(renderedType)(
-//          equalTo("\"A \\\"TestType\\\" description with \\\\, \\b, \\f, \\r and \\t\"\ntype TestType")
-//        )
-//      },
-//      test("it should escape \"\"\" inside a triple-quoted description string") {
-//        val testType     = __Type(
-//          __TypeKind.OBJECT,
-//          name = Some("TestType"),
-//          description = Some("A multiline \"TestType\" description\ngiven inside \"\"\"-quotes\n")
-//        )
-//        val renderedType = Rendering.renderTypes(List(testType))
-//        assert(renderedType)(
-//          equalTo("\"\"\"\nA multiline \"TestType\" description\ngiven inside \\\"\"\"-quotes\n\n\"\"\"\ntype TestType")
-//        )
-//      },
-//      test("it should render single line descriptions") {
-//        import RenderingSpecSchemaSingleLineDescription.resolver
-//        val expected =
-//          """schema {
-//            |  query: Query
-//            |}
-//            |
-//            |"type description in a single line"
-//            |type OutputValue {
-//            |  "field description in a single line"
-//            |  r: Int!
-//            |}
-//            |
-//            |type Query {
-//            |  "query description in a single line"
-//            |  q("argument description in a single line" in: Int!): OutputValue!
-//            |}
-//            |""".stripMargin
-//        assert(graphQL(resolver).render.trim)(equalTo(expected.trim))
-//      },
-//      test("it should render multiple line descriptions") {
-//        import RenderingSpecSchemaMultiLineDescription.resolver
-//        val expected =
-//          s"""schema {
-//             |  query: Query
-//             |}
-//             |
-//             |$tripleQuote
-//             |type description in
-//             |Multiple lines
-//             |$tripleQuote
-//             |type OutputValue {
-//             |  $tripleQuote
-//             |field description in
-//             |Multiple lines
-//             |$tripleQuote
-//             |  r: Int!
-//             |}
-//             |
-//             |type Query {
-//             |  $tripleQuote
-//             |query description in
-//             |Multiple lines
-//             |$tripleQuote
-//             |  q(${tripleQuote}argument description in
-//             |Multiple lines${tripleQuote} in: Int!): OutputValue!
-//             |}
-//             |""".stripMargin
-//
-//        val api = graphQL(resolver)
-//        assert(api.render.trim)(equalTo(expected.trim))
-//      },
-//      test("it should render single line descriptions ending in quote") {
-//        import RenderingSpecSchemaSingleLineEndingInQuoteDescription.resolver
-//        val expected =
-//          """schema {
-//            |  query: Query
-//            |}
-//            |
-//            |"type description in a single line \"ending in quote\""
-//            |type OutputValue {
-//            |  "field description in a single line \"ending in quote\""
-//            |  r: Int!
-//            |}
-//            |
-//            |type Query {
-//            |  "query description in a single line \"ending in quote\""
-//            |  q("argument description in a single line \"ending in quote\"" in: Int!): OutputValue!
-//            |}
-//            |""".stripMargin
-//        assert(graphQL(resolver).render.trim)(equalTo(expected.trim))
-//      },
-//      test("it should render multi line descriptions ending in quote") {
-//        import RenderingSpecSchemaMultiLineEndingInQuoteDescription.resolver
-//        val expected =
-//          s"""schema {
-//             |  query: Query
-//             |}
-//             |
-//             |$tripleQuote
-//             |type description in multiple lines
-//             |\"ending in quote\"
-//             |$tripleQuote
-//             |type OutputValue {
-//             |  $tripleQuote
-//             |field description in multiple lines
-//             |\"ending in quote\"
-//             |$tripleQuote
-//             |  r: Int!
-//             |}
-//             |
-//             |type Query {
-//             |  $tripleQuote
-//             |query description in multiple lines
-//             |\"ending in quote\"
-//             |$tripleQuote
-//             |  q(${tripleQuote}argument description in multiple lines
-//             |\"ending in quote\" ${tripleQuote} in: Int!): OutputValue!
-//             |}
-//             |""".stripMargin
-//        assert(graphQL(resolver).render.trim)(equalTo(expected.trim))
-//      }
-//    )
-//}
+package caliban
+
+import caliban.CalibanError.ParsingError
+import caliban.TestUtils._
+import caliban.introspection.adt.{ __Type, __TypeKind }
+import caliban.parsing.Parser
+import caliban.parsing.adt.Definition.TypeSystemDefinition
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.{
+  EnumValueDefinition,
+  FieldDefinition,
+  InputValueDefinition
+}
+import caliban.parsing.adt.{ Definition, Directive }
+import caliban.schema.Schema.auto._
+import caliban.schema.ArgBuilder.auto._
+import zio.IO
+import zio.test.Assertion._
+import zio.test._
+
+object RenderingSpec extends ZIOSpecDefault {
+  def fixDirectives(directives: List[Directive]): List[Directive] =
+    directives.map(_.copy(index = 0))
+
+  def fixFields(fields: List[FieldDefinition]): List[FieldDefinition] =
+    fields.map(field => field.copy(args = fixInputValues(field.args), directives = fixDirectives(field.directives)))
+
+  def fixInputValues(ivs: List[InputValueDefinition]): List[InputValueDefinition] =
+    ivs.map(iv => iv.copy(directives = fixDirectives(iv.directives)))
+
+  def fixEnumValues(evs: List[EnumValueDefinition]): List[EnumValueDefinition] =
+    evs.map(ev => ev.copy(directives = fixDirectives(ev.directives)))
+
+  def fixDefinitions(definitions: List[Definition]): List[Definition] =
+    definitions.map {
+      case t: TypeSystemDefinition.SchemaDefinition                         =>
+        t.copy(directives = fixDirectives(t.directives))
+      case t: TypeDefinition.ObjectTypeDefinition                           =>
+        t.copy(directives = fixDirectives(t.directives), fields = fixFields(t.fields))
+      case t: TypeSystemDefinition.TypeDefinition.InterfaceTypeDefinition   =>
+        t.copy(directives = fixDirectives(t.directives), fields = fixFields(t.fields))
+      case t: TypeSystemDefinition.TypeDefinition.InputObjectTypeDefinition =>
+        t.copy(directives = fixDirectives(t.directives), fields = fixInputValues(t.fields))
+      case t: TypeSystemDefinition.TypeDefinition.EnumTypeDefinition        =>
+        t.copy(directives = fixDirectives(t.directives), enumValuesDefinition = fixEnumValues(t.enumValuesDefinition))
+      case t: TypeSystemDefinition.TypeDefinition.UnionTypeDefinition       =>
+        t.copy(directives = fixDirectives(t.directives))
+      case t: TypeSystemDefinition.TypeDefinition.ScalarTypeDefinition      =>
+        t.copy(directives = fixDirectives(t.directives))
+      case other                                                            => other
+    }
+
+  def checkApi[R](api: GraphQL[R]): IO[ParsingError, TestResult] = {
+    val definitions = fixDefinitions(api.toDocument.definitions.filter {
+      case d: Definition.TypeSystemDefinition.TypeDefinition.ScalarTypeDefinition =>
+        !Rendering.isBuiltinScalar(d.name)
+      case _                                                                      => true
+    })
+
+    for {
+      definitionsFromRender <- Parser.parseQuery(api.render).map(doc => fixDefinitions(doc.definitions))
+    } yield assert(definitions)(Assertion.hasSameElements(definitionsFromRender))
+  }
+
+  override def spec =
+    suite("rendering")(
+      test("it should render directives") {
+        val api = graphQL(
+          resolver,
+          directives = List(Directives.Test, Directives.Repeatable),
+          schemaDirectives = List(SchemaDirectives.Link)
+        )
+        checkApi(api)
+      },
+      test("it should render descriptions") {
+        import RenderingSpecSchema._
+        val api = graphQL(resolverSchema)
+        checkApi(api)
+      },
+      test("it should render empty objects without field list") {
+        assertTrue(graphQL(InvalidSchemas.Object.resolverEmpty).render.trim == """schema {
+                                                                                 |  query: TestEmptyObject
+                                                                                 |}
+                                                                                 |
+                                                                                 |type EmptyObject
+                                                                                 |
+                                                                                 |type TestEmptyObject {
+                                                                                 |  o: EmptyObject!
+                                                                                 |}""".stripMargin.trim)
+      },
+      test("it should not render a schema in no queries, mutations, or subscription") {
+        assert(graphQL(InvalidSchemas.resolverEmpty).render.trim)(
+          equalTo("")
+        )
+      },
+      test("it should render object arguments in type directives") {
+        val testType     = __Type(
+          __TypeKind.OBJECT,
+          name = Some("TestType"),
+          directives = Some(
+            List(
+              Directive(
+                name = "testdirective",
+                arguments = Map(
+                  "object" -> InputValue.ObjectValue(
+                    Map(
+                      "key1" -> Value.StringValue("value1"),
+                      "key2" -> Value.StringValue("value2")
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        val renderedType = Rendering.renderTypes(List(testType))
+        assert(renderedType)(equalTo("type TestType @testdirective(object: {key1: \"value1\",key2: \"value2\"})"))
+      },
+      test(
+        "it should escape \", \\, backspace, linefeed, carriage-return and tab inside a normally quoted description string"
+      ) {
+        val testType     = __Type(
+          __TypeKind.OBJECT,
+          name = Some("TestType"),
+          description = Some("A \"TestType\" description with \\, \b, \f, \r and \t")
+        )
+        val renderedType = Rendering.renderTypes(List(testType))
+        assert(renderedType)(
+          equalTo("\"A \\\"TestType\\\" description with \\\\, \\b, \\f, \\r and \\t\"\ntype TestType")
+        )
+      },
+      test("it should escape \"\"\" inside a triple-quoted description string") {
+        val testType     = __Type(
+          __TypeKind.OBJECT,
+          name = Some("TestType"),
+          description = Some("A multiline \"TestType\" description\ngiven inside \"\"\"-quotes\n")
+        )
+        val renderedType = Rendering.renderTypes(List(testType))
+        assert(renderedType)(
+          equalTo("\"\"\"\nA multiline \"TestType\" description\ngiven inside \\\"\"\"-quotes\n\n\"\"\"\ntype TestType")
+        )
+      },
+      test("it should render single line descriptions") {
+        val api = graphQL(resolver)
+        checkApi(api)
+      },
+      test("it should render multiple line descriptions") {
+        val api = graphQL(resolver)
+        checkApi(api)
+      },
+      test("it should render single line descriptions ending in quote") {
+        val api = graphQL(resolver)
+        checkApi(api)
+      },
+      test("it should render multi line descriptions ending in quote") {
+        val api = graphQL(resolver)
+        checkApi(api)
+      }
+    )
+}


### PR DESCRIPTION
Closes #1637
Here's a rough idea
 - First render API
 - Parse rendered API
 - Compare parsed API with original API

To do this, we need to fix `index` of `Directive` because values are set differently when we parse rendered API.
`fixDefinitions` is a helper function for that work.