### PR TITLE
Validate that root types are objects

### DIFF
--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -586,5 +586,7 @@ object TestUtils {
 
     case class WrongFieldName(@GQLName("bool: Boolean\n  num") num: Int)
     val resolverBadFieldName = RootResolver(WrongFieldName(1))
+
+    val resolverQueryNoObject = RootResolver(Map("a" -> "b"))
   }
 }

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -492,7 +492,7 @@ object ExecutionSpec extends ZIOSpecDefault {
         case class Queries(test: Int)
         case class Subscriptions(test: ZStream[Any, Throwable, Int])
         val interpreter =
-          graphQL(RootResolver(Queries(1), Option.empty[Unit], Subscriptions(ZStream(1, 2, 3)))).interpreter
+          graphQL(RootResolver(Some(Queries(1)), Option.empty[Unit], Some(Subscriptions(ZStream(1, 2, 3))))).interpreter
         val query       = gqldoc("""
              subscription {
                test
@@ -506,7 +506,9 @@ object ExecutionSpec extends ZIOSpecDefault {
         case class Queries(test: Int)
         case class Subscriptions(test: Int => ZStream[Any, Throwable, Int])
         val interpreter =
-          graphQL(RootResolver(Queries(1), Option.empty[Unit], Subscriptions(_ => ZStream(1, 2, 3)))).interpreter
+          graphQL(
+            RootResolver(Some(Queries(1)), Option.empty[Unit], Some(Subscriptions(_ => ZStream(1, 2, 3))))
+          ).interpreter
         val query       = gqldoc("""
              subscription {
                test(value: 1)

--- a/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
@@ -320,6 +320,12 @@ object ValidationSchemaSpec extends ZIOSpecDefault {
               graphQL(resolverBadFieldName),
               "Field 'bool: Boolean\n  num' of Object 'WrongFieldName' is not a valid name."
             )
+          },
+          test("query root type not an object") {
+            check(
+              graphQL(resolverQueryNoObject),
+              "The query root operation is not an object type."
+            )
           }
         )
       }


### PR DESCRIPTION
Prevent doing something like `RootResolver(Map("a" -> "b"))` (poke @kubukoz)