### PR TITLE
FS2 Stream interop

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,1 @@
+OrganizeImports.preset = INTELLIJ_2020_3

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val akkaVersion               = "2.6.20"
 val catsEffect3Version        = "3.5.0"
 val catsMtlVersion            = "1.3.0"
 val circeVersion              = "0.14.5"
+val fs2Version                = "3.7.0"
 val http4sVersion             = "0.23.19"
 val javaTimeVersion           = "2.5.0"
 val jsoniterVersion           = "2.23.1"
@@ -263,6 +264,7 @@ lazy val catsInterop = project
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.2").cross(CrossVersion.full)))
     } ++ Seq(
       "org.typelevel" %% "cats-effect"      % catsEffect3Version,
+      "co.fs2"        %% "fs2-core"         % fs2Version,
       "dev.zio"       %% "zio-interop-cats" % zioInteropCats3Version,
       "dev.zio"       %% "zio-test"         % zioVersion % Test,
       "dev.zio"       %% "zio-test-sbt"     % zioVersion % Test

--- a/examples/src/main/scala/example/interop/cats/ExampleCatsInterop.scala
+++ b/examples/src/main/scala/example/interop/cats/ExampleCatsInterop.scala
@@ -1,47 +1,93 @@
 package example.interop.cats
 
+import caliban.ResponseValue.{ ObjectValue, StreamValue }
 import caliban._
+import caliban.interop.cats.ToEffect
+import caliban.interop.cats.implicits._
+import caliban.interop.fs2.implicits._
 import caliban.schema.Schema.auto._
+import cats.effect.std.{ Console, Dispatcher, Random }
+import cats.effect.syntax.all._
+import cats.effect.{ ExitCode, IO, IOApp, LiftIO }
+import fs2.Stream
+import zio.ZIO
+import zio.interop.catz._
+import zio.stream.ZStream
+import zio.stream.interop.fs2z._
 
-import cats.effect.{ ExitCode, IO, IOApp }
-import cats.effect.std.Dispatcher
-import zio.Runtime
+import scala.concurrent.duration._
 
-object ExampleCatsInterop extends IOApp {
+object ExampleCatsInterop extends IOApp.Simple {
 
-  import caliban.interop.cats.implicits._
+  implicit val zioRuntime: zio.Runtime[Any] = zio.Runtime.default
 
-  implicit val zioRuntime: Runtime[Any] = Runtime.default
+  val console = Console[IO]
+  val random  = Random.javaUtilConcurrentThreadLocalRandom[IO]
 
   case class Number(value: Int)
 
-  case class Queries(numbers: List[Number], randomNumber: IO[Number])
+  case class Queries(numbers: List[Number], randomNumber: IO[Number], moreRandomNumbers: Stream[IO, Number])
 
-  val numbers      = List(1, 2, 3, 4).map(Number)
-  val randomNumber = IO(scala.util.Random.nextInt()).map(Number)
+  case class Subscriptions(numbers: Stream[IO, Number])
 
-  val queries = Queries(numbers, randomNumber)
+  val numbers             = List(1, 2, 3, 4).map(Number)
+  val randomNumber        = random.nextInt.map(Number)
+  val moreRandomNumbers   = Stream.repeatEval(randomNumber).take(5)
+  val subscriptionNumbers = Stream.emits(5 to 8).covary[IO].spaced(500.millis).map(Number)
 
-  val query = """
-  {
-    numbers {
-      value
-    }
+  val queries       = Queries(numbers, randomNumber, moreRandomNumbers)
+  val subscriptions = Subscriptions(subscriptionNumbers)
 
-    randomNumber {
-      value
-    }
-  }"""
+  val query =
+    """|{
+       |  numbers {
+       |    value
+       |  }
+       |
+       |  randomNumber {
+       |    value
+       |  }
+       |
+       |  moreRandomNumbers {
+       |    value
+       |  }
+       |}
+       |""".stripMargin
 
-  override def run(args: List[String]): IO[ExitCode] =
+  val subscription =
+    """|subscription {
+       |  numbers {
+       |    value
+       |  }
+       |}
+       |""".stripMargin
+
+  override def run: IO[Unit] =
     Dispatcher.parallel[IO].use { implicit dispatcher => // required for a derivation of the schema
-      val api = graphQL(RootResolver(queries))
+      val api = graphQL(RootResolver(Some(queries), Option.empty[Unit], Some(subscriptions)))
 
       for {
         interpreter <- api.interpreterAsync[IO]
-        _           <- interpreter.checkAsync[IO](query)
-        result      <- interpreter.executeAsync[IO](query)
-        _           <- IO(println(result.data))
-      } yield ExitCode.Success
+
+        _      <- console.println("execute a query:")
+        _      <- interpreter.checkAsync[IO](query)
+        result <- interpreter.executeAsync[IO](query)
+        _      <- console.println(result.data)
+
+        _      <- console.println("subscribe to a stream:")
+        _      <- interpreter.checkAsync[IO](subscription)
+        result <- interpreter.executeAsync[IO](subscription)
+
+        _ <- result.data match {
+               case ObjectValue(("numbers", StreamValue(zstream)) :: Nil) =>
+                 zstream.toFs2Stream
+                   .translate(ToEffect[IO, Any].toEffectK)
+                   .foreach(console.println)
+                   .compile
+                   .drain
+
+               case _ => console.println(s"Wrong result: ${result.data}")
+             }
+      } yield ()
     }
 }

--- a/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
@@ -1,0 +1,22 @@
+package caliban.interop.fs2
+
+import caliban.introspection.adt.__Type
+import caliban.schema.Schema
+import caliban.schema.Step
+import fs2.Stream
+import zio.RIO
+import zio.stream.ZStream
+import zio.stream.interop.fs2z._
+
+object Fs2Interop {
+  def schemaStreamRIO[R, A](implicit ev: Schema[R, ZStream[R, Throwable, A]]): Schema[R, Stream[RIO[R, *], A]] =
+    new Schema[R, Stream[RIO[R, *], A]] {
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
+        ev.toType_(isInput, isSubscription)
+
+      override def optional: Boolean = ev.optional
+
+      override def resolve(value: Stream[RIO[R, *], A]): Step[R] =
+        ev.resolve(value.toZStream())
+    }
+}

--- a/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
@@ -2,13 +2,11 @@ package caliban.interop.fs2
 
 import caliban.interop.cats.FromEffect
 import caliban.introspection.adt.__Type
-import caliban.schema.Schema
-import caliban.schema.Step
+import caliban.schema.{ Schema, Step }
 import fs2.Stream
-import zio.RIO
-import zio.Task
 import zio.stream.ZStream
 import zio.stream.interop.fs2z._
+import zio.{ RIO, Task }
 
 object Fs2Interop {
   def schemaStreamRIO[R, A](implicit ev: Schema[R, ZStream[R, Throwable, A]]): Schema[R, Stream[RIO[R, *], A]] =

--- a/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
@@ -1,10 +1,12 @@
 package caliban.interop.fs2
 
+import caliban.interop.cats.FromEffect
 import caliban.introspection.adt.__Type
 import caliban.schema.Schema
 import caliban.schema.Step
 import fs2.Stream
 import zio.RIO
+import zio.Task
 import zio.stream.ZStream
 import zio.stream.interop.fs2z._
 
@@ -18,5 +20,19 @@ object Fs2Interop {
 
       override def resolve(value: Stream[RIO[R, *], A]): Step[R] =
         ev.resolve(value.toZStream())
+    }
+
+  def schemaStreamF[F[_], R, A](implicit
+    interop: FromEffect[F, R],
+    ev: Schema[R, Stream[RIO[R, *], A]]
+  ): Schema[R, Stream[F, A]] =
+    new Schema[R, Stream[F, A]] {
+      override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
+        ev.toType_(isInput, isSubscription)
+
+      override def optional: Boolean = ev.optional
+
+      override def resolve(value: Stream[F, A]): Step[R] =
+        ev.resolve(value.translate(interop.fromEffectK))
     }
 }

--- a/interop/cats/src/main/scala/caliban/interop/fs2/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/fs2/implicits/package.scala
@@ -1,7 +1,7 @@
 package caliban.interop.fs2
 
 import caliban.interop.cats.FromEffect
-import caliban.schema.Schema
+import caliban.schema.{ Schema, SubscriptionSchema }
 import fs2.Stream
 import zio.RIO
 import zio.stream.ZStream
@@ -18,4 +18,7 @@ package object implicits {
     ev: Schema[R, Stream[RIO[R, *], A]]
   ): Schema[R, Stream[F, A]] =
     Fs2Interop.schemaStreamF
+
+  implicit def fs2SubscriptionSchemaStreamF[F[_], A]: SubscriptionSchema[Stream[F, A]] =
+    new SubscriptionSchema[Stream[F, A]] {}
 }

--- a/interop/cats/src/main/scala/caliban/interop/fs2/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/fs2/implicits/package.scala
@@ -1,5 +1,6 @@
 package caliban.interop.fs2
 
+import caliban.interop.cats.FromEffect
 import caliban.schema.Schema
 import fs2.Stream
 import zio.RIO
@@ -11,4 +12,10 @@ package object implicits {
     ev: Schema[R, ZStream[R, Throwable, A]]
   ): Schema[R, Stream[RIO[R, *], A]] =
     Fs2Interop.schemaStreamRIO
+
+  implicit def fs2SchemaStreamF[F[_], R, A](implicit
+    interop: FromEffect[F, R],
+    ev: Schema[R, Stream[RIO[R, *], A]]
+  ): Schema[R, Stream[F, A]] =
+    Fs2Interop.schemaStreamF
 }

--- a/interop/cats/src/main/scala/caliban/interop/fs2/implicits/package.scala
+++ b/interop/cats/src/main/scala/caliban/interop/fs2/implicits/package.scala
@@ -1,0 +1,14 @@
+package caliban.interop.fs2
+
+import caliban.schema.Schema
+import fs2.Stream
+import zio.RIO
+import zio.stream.ZStream
+
+package object implicits {
+
+  implicit def fs2SchemaStreamRIO[R, A](implicit
+    ev: Schema[R, ZStream[R, Throwable, A]]
+  ): Schema[R, Stream[RIO[R, *], A]] =
+    Fs2Interop.schemaStreamRIO
+}

--- a/interop/cats/src/test/scala/caliban/interop/fs2/Fs2InteropSchemaSpec.scala
+++ b/interop/cats/src/test/scala/caliban/interop/fs2/Fs2InteropSchemaSpec.scala
@@ -1,0 +1,100 @@
+package caliban.interop.fs2
+
+import caliban.Value.IntValue
+import caliban.interop.fs2.implicits._
+import caliban.parsing.adt.Definition
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.FieldDefinition
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.ObjectTypeDefinition
+import caliban.parsing.adt.Type._
+import caliban.schema.PureStep
+import caliban.schema.Schema
+import caliban.schema.Schema.auto._
+import caliban.schema.Step
+import caliban.schema.Step.ObjectStep
+import caliban.schema.Step.StreamStep
+import fs2.Stream
+import zio.Chunk
+import zio.Exit
+import zio.Task
+import zio.Unsafe
+import zio.stream.ZStream
+import zio.test.Assertion._
+import zio.test._
+
+import scala.collection.immutable.Seq
+
+object Fs2InteropSchemaSpec extends ZIOSpecDefault {
+  case class Foo[F[_]](bar: Stream[F, Int])
+
+  override def spec = suite("Fs2InteropSchemaSpec")(
+    suiteAll("Stream of zio.Task") {
+      val testee: Schema[Any, Foo[Task]] = Schema.gen
+
+      test("should derive a correct schema type") {
+        assert(testee.toType_().toTypeDefinition) {
+          streamDerivedAsListOfInts
+        }
+      }
+      test("should resolve to a correct stream step") {
+        check(Gen.listOf(Gen.int)) { expectedValues =>
+          val foo = Foo(Stream.emits(expectedValues).covary[Task])
+
+          assert(testee.resolve(foo)) {
+            streamResolvesToCorrectValues(expectedValues)
+          }
+        }
+      }
+    }
+  )
+
+  private val streamDerivedAsListOfInts: Assertion[Option[TypeDefinition]] =
+    isSome(
+      isSubtype[ObjectTypeDefinition](
+        hasField(
+          "fields",
+          _.fields,
+          hasFirst[FieldDefinition](
+            hasField(
+              "ofType",
+              _.ofType,
+              isSubtype[ListType](
+                equalTo(
+                  ListType(NamedType("Int", true), false)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+
+  private def streamResolvesToCorrectValues(expectedValues: Seq[Int]): Assertion[Step[Any]] = {
+    val expectedChunk =
+      Chunk
+        .fromIterable(expectedValues)
+        .map(v => PureStep(IntValue(v)): Step[Any])
+
+    isSubtype[ObjectStep[Any]](
+      hasField(
+        "fields",
+        _.fields,
+        hasKey(
+          "bar",
+          isSubtype[StreamStep[Any]](
+            hasField(
+              "inner",
+              step =>
+                Unsafe.unsafe { implicit unsafe =>
+                  runtime.unsafe.run(step.inner.runCollect)
+                },
+              isSubtype[Exit.Success[Chunk[Step[Any]]]](
+                equalTo(Exit.Success(expectedChunk))
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+}

--- a/interop/cats/src/test/scala/caliban/interop/fs2/Fs2InteropSchemaSpec.scala
+++ b/interop/cats/src/test/scala/caliban/interop/fs2/Fs2InteropSchemaSpec.scala
@@ -3,30 +3,20 @@ package caliban.interop.fs2
 import caliban.Value.IntValue
 import caliban.interop.fs2.implicits._
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition
-import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.FieldDefinition
-import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.ObjectTypeDefinition
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.{ FieldDefinition, ObjectTypeDefinition }
 import caliban.parsing.adt.Type._
-import caliban.schema.PureStep
-import caliban.schema.Schema
 import caliban.schema.Schema.auto._
-import caliban.schema.Step
-import caliban.schema.Step.ObjectStep
-import caliban.schema.Step.StreamStep
-import cats.effect.IO
-import cats.effect.LiftIO
-import cats.effect.Resource
+import caliban.schema.Step.{ ObjectStep, StreamStep }
+import caliban.schema.{ PureStep, Schema, Step }
 import cats.effect.std.Dispatcher
 import cats.effect.unsafe.implicits._
+import cats.effect.{ IO, LiftIO, Resource }
 import fs2.Stream
-import zio.Chunk
-import zio.Exit
-import zio.Task
-import zio.Unsafe
-import zio.ZIO
 import zio.interop.catz._
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test._
+import zio.{ Chunk, Exit, Task, Unsafe, ZIO }
 
 import scala.collection.immutable.Seq
 

--- a/interop/cats/src/test/scala/caliban/interop/fs2/Fs2InteropSchemaSpec.scala
+++ b/interop/cats/src/test/scala/caliban/interop/fs2/Fs2InteropSchemaSpec.scala
@@ -2,7 +2,6 @@ package caliban.interop.fs2
 
 import caliban.Value.IntValue
 import caliban.interop.fs2.implicits._
-import caliban.parsing.adt.Definition
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.FieldDefinition
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.ObjectTypeDefinition
@@ -13,11 +12,18 @@ import caliban.schema.Schema.auto._
 import caliban.schema.Step
 import caliban.schema.Step.ObjectStep
 import caliban.schema.Step.StreamStep
+import cats.effect.IO
+import cats.effect.LiftIO
+import cats.effect.Resource
+import cats.effect.std.Dispatcher
+import cats.effect.unsafe.implicits._
 import fs2.Stream
 import zio.Chunk
 import zio.Exit
 import zio.Task
 import zio.Unsafe
+import zio.ZIO
+import zio.interop.catz._
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test._
@@ -26,6 +32,14 @@ import scala.collection.immutable.Seq
 
 object Fs2InteropSchemaSpec extends ZIOSpecDefault {
   case class Foo[F[_]](bar: Stream[F, Int])
+
+  // Generates the Schema when the `IO` type is visible at compile time to the deriver.
+  private def generateSchemaForIO(implicit dispatcher: Dispatcher[IO]): Schema[Any, Foo[IO]] =
+    Schema.gen
+
+  // Generates the Schema when a generic `F` type is visible at compile time to the deriver.
+  private def generateSchemaForF[F[_]](implicit dispatcher: Dispatcher[F]): Schema[Any, Foo[F]] =
+    Schema.gen
 
   override def spec = suite("Fs2InteropSchemaSpec")(
     suiteAll("Stream of zio.Task") {
@@ -42,6 +56,60 @@ object Fs2InteropSchemaSpec extends ZIOSpecDefault {
 
           assert(testee.resolve(foo)) {
             streamResolvesToCorrectValues(expectedValues)
+          }
+        }
+      }
+    },
+    suiteAll("Stream of IO") {
+
+      val testeeScoped =
+        Dispatcher
+          .sequential[IO]
+          .map(generateSchemaForIO(_))
+          .mapK(LiftIO.liftK[Task])
+          .toScopedZIO
+
+      test("should derive a correct schema type") {
+        testeeScoped.map { testee =>
+          assert(testee.toType_().toTypeDefinition) {
+            streamDerivedAsListOfInts
+          }
+        }
+      }
+      test("should resolve to a correct stream step") {
+        testeeScoped.flatMap { testee =>
+          check(Gen.listOf(Gen.int)) { expectedValues =>
+            val foo = Foo(Stream.emits(expectedValues).covary[IO])
+
+            assert(testee.resolve(foo)) {
+              streamResolvesToCorrectValues(expectedValues)
+            }
+          }
+        }
+      }
+    },
+    suiteAll("Stream of F") {
+      val testeeScoped =
+        Dispatcher
+          .sequential[Task]
+          .map(generateSchemaForF(_))
+          .toScopedZIO
+
+      test("should derive a correct schema type") {
+        testeeScoped.map { testee =>
+          assert(testee.toType_().toTypeDefinition) {
+            streamDerivedAsListOfInts
+          }
+        }
+      }
+      test("should resolve to a correct stream step") {
+        testeeScoped.flatMap { testee =>
+          check(Gen.listOf(Gen.int)) { expectedValues =>
+            val foo = Foo(Stream.emits(expectedValues).covary[Task])
+
+            assert(testee.resolve(foo)) {
+              streamResolvesToCorrectValues(expectedValues)
+            }
           }
         }
       }


### PR DESCRIPTION
Enables `Schema` derivation for the `fs2.Stream` type.
See also #138.