### PR TITLE
Render schema directives even if no queries/mutations/subscriptions

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -43,7 +43,7 @@ trait GraphQL[-R] { self =>
     val flattenedParts   = parts.flatten.mkString("\n")
     val schema           = (flattenedParts, schemaDirectives) match {
       case ("", "")                      => ""
-      case ("", schemaDirectives)        => s"extend schema $schemaDirectives\n"
+      case ("", schemaDirectives)        => s"extend schema $schemaDirectives"
       case (something, schemaDirectives) => s"""schema $schemaDirectives{
                                                |$something
                                                |}""".stripMargin

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -42,7 +42,7 @@ trait GraphQL[-R] { self =>
     val schemaDirectives = renderSchemaDirectives(schemaBuilder.schemaDirectives)
 
     val schema = parts.flatten.mkString("\n") match {
-      case ""        => ""
+      case ""        => s"extend schema $schemaDirectives\n"
       case something => s"""schema $schemaDirectives{
                            |$something
                            |}""".stripMargin

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -40,12 +40,13 @@ trait GraphQL[-R] { self =>
       schemaBuilder.subscription.flatMap(_.opType.name).map(n => s"  subscription: $n")
     )
     val schemaDirectives = renderSchemaDirectives(schemaBuilder.schemaDirectives)
-
-    val schema = parts.flatten.mkString("\n") match {
-      case ""        => s"extend schema $schemaDirectives\n"
-      case something => s"""schema $schemaDirectives{
-                           |$something
-                           |}""".stripMargin
+    val flattenedParts   = parts.flatten.mkString("\n")
+    val schema           = (flattenedParts, schemaDirectives) match {
+      case ("", "")                      => ""
+      case ("", schemaDirectives)        => s"extend schema $schemaDirectives\n"
+      case (something, schemaDirectives) => s"""schema $schemaDirectives{
+                                               |$something
+                                               |}""".stripMargin
     }
 
     val directivesPrefix = renderDirectives(additionalDirectives) match {

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -4,7 +4,7 @@ import caliban.CalibanError.ParsingError
 import caliban.TestUtils._
 import caliban.introspection.adt.{ __Type, __TypeKind }
 import caliban.parsing.Parser
-import caliban.parsing.adt.Definition.{TypeSystemDefinition, TypeSystemExtension}
+import caliban.parsing.adt.Definition.{ TypeSystemDefinition, TypeSystemExtension }
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.{
   EnumValueDefinition,
@@ -90,15 +90,22 @@ object RenderingSpec extends ZIOSpecDefault {
                                                                                  |  o: EmptyObject!
                                                                                  |}""".stripMargin.trim)
       },
-      test("it should not render a schema definition without schema directives if no queries, mutations, or subscription") {
+      test(
+        "it should not render a schema definition without schema directives if no queries, mutations, or subscription"
+      ) {
         assert(graphQL(InvalidSchemas.resolverEmpty).render.trim)(
           equalTo("")
         )
       },
-      test("it should render a schema extension with schema directives even if no queries, mutations, or subscription") {
-        val renderedType = graphQL(InvalidSchemas.resolverEmpty, schemaDirectives = List(SchemaDirectives.Link)).render.trim
+      test(
+        "it should render a schema extension with schema directives even if no queries, mutations, or subscription"
+      ) {
+        val renderedType =
+          graphQL(InvalidSchemas.resolverEmpty, schemaDirectives = List(SchemaDirectives.Link)).render.trim
         assert(renderedType)(
-          equalTo("""extend schema @link(url: "https://example.com", import: ["@key", {name: "@provides", as: "@self"}])""")
+          equalTo(
+            """extend schema @link(url: "https://example.com", import: ["@key", {name: "@provides", as: "@self"}])"""
+          )
         )
       },
       test("it should render object arguments in type directives") {


### PR DESCRIPTION
Per discord chat. The current behavior is problematic for Apollo federation subgraphs that only have entity resolvers. This changes rendering to include an extend schema statement.

Rendering tests seem commented out so didn't mess with that but tested with a local example I was running into and it works as expected.