### PR TITLE
Allow configurable filtering of directives from input

### DIFF
--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -219,7 +219,9 @@ object Rendering {
     else ""}${renderDirectives(field.directives)}"
 
   private def renderInputValue(inputValue: __InputValue): String =
-    s"${inputValue.name}: ${renderTypeName(inputValue._type)}${renderDefaultValue(inputValue)}${renderDirectives(inputValue.directives)}"
+    s"${inputValue.name}: ${renderTypeName(inputValue._type)}${renderDefaultValue(inputValue)}${renderDirectives(
+      inputValue.directives.map(_.filter(_.includeWithInputTypes))
+    )}"
 
   private def renderEnumValue(v: __EnumValue): String =
     s"${renderDescription(v.description)}${v.name}${if (v.isDeprecated)

--- a/core/src/main/scala/caliban/execution/Fragment.scala
+++ b/core/src/main/scala/caliban/execution/Fragment.scala
@@ -9,7 +9,7 @@ object Fragment {
   object IsDeferred {
     def unapply(fragment: Fragment): Option[Option[String]] =
       fragment.directives.collectFirst {
-        case Directive("defer", args, _) if args.get("if").forall {
+        case Directive("defer", args, _, _) if args.get("if").forall {
               case BooleanValue(v) => v
               case _               => true
             } =>
@@ -20,7 +20,7 @@ object Fragment {
 
 object IsStream {
   def unapply(field: Field): Option[(Option[String], Option[Int])] =
-    field.directives.collectFirst { case Directive("stream", args, _) =>
+    field.directives.collectFirst { case Directive("stream", args, _, _) =>
       (
         args.get("label").collect { case StringValue(v) => v },
         args.get("initialCount").collect { case v: IntValue => v.toInt }

--- a/core/src/main/scala/caliban/parsing/adt/Directive.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Directive.scala
@@ -2,7 +2,12 @@ package caliban.parsing.adt
 
 import caliban.{ InputValue, Value }
 
-case class Directive(name: String, arguments: Map[String, InputValue] = Map.empty, index: Int = 0)
+case class Directive(
+  name: String,
+  arguments: Map[String, InputValue] = Map.empty,
+  index: Int = 0,
+  includeWithInputTypes: Boolean = false
+)
 
 object Directives {
   def isDeprecated(directives: List[Directive]): Boolean =

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -166,9 +166,9 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
             Some(customizeInputTypeName(name)),
             description,
             fields(isInput, isSubscription).map { case (f, _) =>
-              __InputValue(f.name, f.description, f.`type`, None, f.directives)
+              __InputValue(f.name, f.description, f.`type`, None, f.directives.map(_.filter(_.includeWithInputTypes)))
             },
-            directives = Some(directives)
+            directives = Some(directives.filter(_.includeWithInputTypes))
           )
         } else makeObject(Some(name), description, fields(isInput, isSubscription).map(_._1), directives)
 

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2.scala
@@ -11,7 +11,7 @@ trait FederationDirectivesV2 {
 
   case class GQLInaccessible() extends GQLDirective(Inaccessible)
 
-  val Inaccessible = Directive("inaccessible")
+  val Inaccessible = Directive("inaccessible", includeWithInputTypes = true)
 
   case class GQLOverride(from: String) extends GQLDirective(Override(from))
 
@@ -24,7 +24,7 @@ trait FederationDirectivesV2 {
 
   object Tag {
     def apply(name: String): Directive =
-      Directive("tag", Map("name" -> StringValue(name)))
+      Directive("tag", Map("name" -> StringValue(name)), includeWithInputTypes = true)
   }
 
 }


### PR DESCRIPTION
I should add some tests but putting this up for feedback in case we don't like the overall approach.

I went with a default of not including because upon reflection most of the federation directives are not allowed on input objects. The only ones that are are `@tag` and `@inaccessible`:


```graphql
directive @external on FIELD_DEFINITION | OBJECT
directive @requires(fields: FieldSet!) on FIELD_DEFINITION
directive @provides(fields: FieldSet!) on FIELD_DEFINITION
directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
directive @shareable repeatable on OBJECT | FIELD_DEFINITION
directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
directive @override(from: String!) on FIELD_DEFINITION
directive @composeDirective(name: String!) repeatable on SCHEMA
directive @interfaceObject on OBJECT
```
> [Source](https://www.apollographql.com/docs/federation/subgraph-spec/#subgraph-schema-additions)

This does mean this should be considered a breaking change. Anyone that recently implemented their own directive and is depending on the current copying logic will run into problems until they set that to true with this change.