### PR TITLE
Add a helper to easily render the schema for a type

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -31,7 +31,7 @@ trait GraphQL[-R] { self =>
     ZIO.fromEither(Validator.validateSchemaEither(schemaBuilder))
 
   /**
-   * Returns a string that renders the API types into the GraphQL format.
+   * Returns a string that renders the API types into the GraphQL SDL.
    */
   final def render: String = {
     val parts            = Seq(

--- a/core/src/main/scala/caliban/package.scala
+++ b/core/src/main/scala/caliban/package.scala
@@ -35,6 +35,16 @@ package object caliban {
     val features                                = Set.empty
   }
 
-  def render[T](implicit schema: Schema[Nothing, T]): String =
+  /**
+   * Returns a string that renders the given type into the GraphQL SDL.
+   */
+  def render[T](implicit schema: Schema[Any, T]): String =
+    renderEnv[Any, T]
+
+  /**
+   * Returns a string that renders the given type into the GraphQL SDL.
+   * This variant of the method allows specifying the environment type when it's not `Any`.
+   */
+  def renderEnv[R, T](implicit schema: Schema[R, T]): String =
     renderTypes(collectTypes(schema.toType_(), Nil))
 }

--- a/core/src/main/scala/caliban/package.scala
+++ b/core/src/main/scala/caliban/package.scala
@@ -39,7 +39,7 @@ package object caliban {
    * Returns a string that renders the given type into the GraphQL SDL.
    */
   def render[T](implicit schema: Schema[Any, T]): String =
-    renderEnv[Any, T]
+    renderWith[Any, T]
 
   /**
    * Returns a string that renders the given type into the GraphQL SDL.

--- a/core/src/main/scala/caliban/package.scala
+++ b/core/src/main/scala/caliban/package.scala
@@ -1,5 +1,7 @@
+import caliban.Rendering.renderTypes
 import caliban.introspection.adt.__Directive
 import caliban.parsing.adt.Directive
+import caliban.schema.Types.collectTypes
 import caliban.schema._
 import caliban.wrappers.Wrapper
 
@@ -32,4 +34,7 @@ package object caliban {
     val additionalDirectives: List[__Directive] = directives
     val features                                = Set.empty
   }
+
+  def render[T](implicit schema: Schema[Nothing, T]): String =
+    renderTypes(collectTypes(schema.toType_(), Nil))
 }

--- a/core/src/main/scala/caliban/package.scala
+++ b/core/src/main/scala/caliban/package.scala
@@ -45,6 +45,6 @@ package object caliban {
    * Returns a string that renders the given type into the GraphQL SDL.
    * This variant of the method allows specifying the environment type when it's not `Any`.
    */
-  def renderEnv[R, T](implicit schema: Schema[R, T]): String =
+  def renderWith[R, T](implicit schema: Schema[R, T]): String =
     renderTypes(collectTypes(schema.toType_(), Nil))
 }

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -246,6 +246,11 @@ object SchemaSpec extends ZIOSpecDefault {
             Directive("join__Graph", Map("name" -> StringValue("B")))
           )
         )
+      },
+      test("render can be called with a Schema where R is not any") {
+        object schema extends GenericSchema[Env]
+        import schema.auto._
+        assertTrue(caliban.render[EnvironmentSchema].nonEmpty)
       }
     )
 
@@ -253,6 +258,8 @@ object SchemaSpec extends ZIOSpecDefault {
   case class InfallibleFieldSchema(q: UIO[Int])
   case class FutureFieldSchema(q: Future[Int])
   case class IDSchema(id: UUID)
+  trait Env
+  case class EnvironmentSchema(test: RIO[Env, Int])
 
   @GQLInterface
   sealed trait MyInterface

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -253,7 +253,7 @@ object SchemaSpec extends ZIOSpecDefault {
       test("render can be called with a Schema where R is not any") {
         object schema extends GenericSchema[Env]
         import schema.auto._
-        assertTrue(caliban.renderEnv[Env, EnvironmentSchema].nonEmpty)
+        assertTrue(caliban.renderWith[Env, EnvironmentSchema].nonEmpty)
       }
     )
 

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -247,10 +247,13 @@ object SchemaSpec extends ZIOSpecDefault {
           )
         )
       },
+      test("render can be called with a Schema where R is any") {
+        assertTrue(caliban.render[EffectfulFieldSchema].nonEmpty)
+      },
       test("render can be called with a Schema where R is not any") {
         object schema extends GenericSchema[Env]
         import schema.auto._
-        assertTrue(caliban.render[EnvironmentSchema].nonEmpty)
+        assertTrue(caliban.renderEnv[Env, EnvironmentSchema].nonEmpty)
       }
     )
 


### PR DESCRIPTION
This allows checking the produced schema without having to provide a resolver.

```scala
println(render[Query])
println(renderWith[MyEnv, Query])
```