### PR TITLE
Move `new {...}` outside of inline method in `SemiAuto` derivation

### DIFF
--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -319,9 +319,10 @@ trait SchemaDerivation[R] extends CommonSchemaDerivation {
   final lazy val auto = new AutoSchemaDerivation[Any] {}
 
   sealed trait SemiAuto[A] extends Schema[R, A]
+
   object SemiAuto {
-    inline def derived[A]: SemiAuto[A] = new {
-      private val impl = Schema.derived[R, A]
+    inline def derived[A]: SemiAuto[A] = exported(Schema.derived[R, A])
+    private def exported[A](impl: Schema[R, A]): SemiAuto[A] = new {
       export impl.*
     }
   }

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -319,9 +319,8 @@ trait SchemaDerivation[R] extends CommonSchemaDerivation {
   final lazy val auto = new AutoSchemaDerivation[Any] {}
 
   sealed trait SemiAuto[A] extends Schema[R, A]
-
   object SemiAuto {
-    inline def derived[A]: SemiAuto[A] = exported(Schema.derived[R, A])
+    inline def derived[A]: SemiAuto[A]                       = exported(Schema.derived[R, A])
     private def exported[A](impl: Schema[R, A]): SemiAuto[A] = new {
       export impl.*
     }


### PR DESCRIPTION
I've been playing abit with code derivation lately, and it seems that having `new Foo{ ... }` used in inline methods can be fairly bad especially when used alongside derivation. What happens is that the call to `new { ... }` is inlined at every callsite, which causes a new anonymous class to be created, which can lead to a big increase in the number of generated classes, potentially killing the JIT code cache (see [somewhat related issue](https://github.com/lampepfl/dotty/issues/16723)).

In the case here, since we're only exporting 2 methods it's not particularly bad. However, I tested these changes in a medium/small-sized application and the number of classes in the final JAR was reduced from 800 to 700, and the size was reduced from 2.2MB down to 1.9MB.

Unfortunately, we can't do the same with `Auto` as I can't figure out a way to get the auto-derivation to work. However that's not as big of an issue since only the top-level derivation will use the implementation of `Auto.derived`, whereas any child nodes will be derived using `Schema.derived` which already uses a non-inlined method to create the `Schema`s.