### PR TITLE
Exclude fields with different arguments from interfaces

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -155,8 +155,10 @@ trait CommonSchemaDerivation[R] {
             .filter { case (_, list) => list.lengthCompare(impl.size) == 0 }
             .collect { case (_, list) =>
               Types
-                .unify(list.map(_.`type`()))
-                .flatMap(t => list.headOption.map(_.copy(`type` = () => t)))
+                .unifyFieldTypes(list)
+                .flatMap { t =>
+                  list.headOption.map(_.copy(`type` = () => t))
+                }
             }
             .flatten
             .toList

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -155,7 +155,7 @@ trait CommonSchemaDerivation[R] {
             .filter { case (_, list) => list.lengthCompare(impl.size) == 0 }
             .collect { case (_, list) =>
               Types
-                .unifyFieldTypes(list)
+                .unify(list)
                 .flatMap(t => list.headOption.map(_.copy(`type` = () => t)))
             }
             .flatten

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -156,9 +156,7 @@ trait CommonSchemaDerivation[R] {
             .collect { case (_, list) =>
               Types
                 .unifyFieldTypes(list)
-                .flatMap { t =>
-                  list.headOption.map(_.copy(`type` = () => t))
-                }
+                .flatMap(t => list.headOption.map(_.copy(`type` = () => t)))
             }
             .flatten
             .toList

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -239,7 +239,7 @@ trait CommonSchemaDerivation {
         .collect {
           case (_, list) if list.lengthCompare(impl.size) == 0 =>
             Types
-              .unifyFieldTypes(list)
+              .unify(list)
               .flatMap(t => list.headOption.map(_.copy(`type` = () => t)))
         }
         .flatten

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -239,7 +239,7 @@ trait CommonSchemaDerivation {
         .collect {
           case (_, list) if list.lengthCompare(impl.size) == 0 =>
             Types
-              .unify(list.map(_.`type`()))
+              .unifyFieldTypes(list)
               .flatMap(t => list.headOption.map(_.copy(`type` = () => t)))
         }
         .flatten

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -153,19 +153,13 @@ object Types {
     }
 
   /**
-   * Tries to find a common widened type among a list of types.
+   * Tries to find a common widened type among a list of fields.
    *
    * @example {{{unify(List(string, makeNonNull(string))) // => Some(__Type(SCALAR, Some("String")))}}}
-   * @param l a list of types to unify
+   * @param l a list of fields to unify
    * @return the unified type if one could be found
    */
-  def unify(l: List[__Type]): Option[__Type] =
-    l.headOption.flatMap(first => l.drop(1).foldLeft(Option(first))((acc, t) => acc.flatMap(unify(_, t))))
-
-  /**
-   * Similar to `unify` with the difference that it takes into account field arguments
-   */
-  def unifyFieldTypes(l: List[__Field]): Option[__Type] =
+  def unify(l: List[__Field]): Option[__Type] =
     l.headOption.flatMap { first =>
       val args                            = first.args.map(_.`type`())
       def _unify(f2: __Field)(t1: __Type) =

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -163,6 +163,23 @@ object Types {
     l.headOption.flatMap(first => l.drop(1).foldLeft(Option(first))((acc, t) => acc.flatMap(unify(_, t))))
 
   /**
+   * Similar to [[unify]] with the difference that it takes into account field arguments
+   */
+  def unifyFieldTypes(l: List[__Field]): Option[__Type] =
+    l.headOption.flatMap { first =>
+      val args                            = first.args.map(_.`type`())
+      def _unify(f2: __Field)(t1: __Type) =
+        if (
+          args.length == f2.args.length &&
+          args.zip(f2.args.map(_.`type`())).forall(v => same(v._1, v._2))
+        )
+          unify(t1, f2.`type`())
+        else None
+
+      l.drop(1).foldLeft(Option(first.`type`()))((acc, t) => acc.flatMap(_unify(t)))
+    }
+
+  /**
    * Tries to unify two types by widening them to a common supertype.
    *
    * @example {{{unify(string, makeNonNull(string)) // => Some(__Type(SCALAR, Some("String")))}}}

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -155,7 +155,6 @@ object Types {
   /**
    * Tries to find a common widened type among a list of fields.
    *
-   * @example {{{unify(List(string, makeNonNull(string))) // => Some(__Type(SCALAR, Some("String")))}}}
    * @param l a list of fields to unify
    * @return the unified type if one could be found
    */

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -163,7 +163,7 @@ object Types {
     l.headOption.flatMap(first => l.drop(1).foldLeft(Option(first))((acc, t) => acc.flatMap(unify(_, t))))
 
   /**
-   * Similar to [[unify]] with the difference that it takes into account field arguments
+   * Similar to `unify` with the difference that it takes into account field arguments
    */
   def unifyFieldTypes(l: List[__Field]): Option[__Type] =
     l.headOption.flatMap { first =>

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -86,7 +86,7 @@ object SchemaSpec extends ZIOSpecDefault {
         )
       },
       test("interface only take fields that return the same type") {
-        assertTrue(introspect[MyInterface].fields(__DeprecatedArgs()).toList.flatten.map(_.name) == List("common"))
+        assertTrue(introspect[MyInterface].fields(__DeprecatedArgs()).toList.flatten.map(_.name) == List("c2", "c1"))
       },
       test("enum-like sealed traits annotated with GQLUnion") {
         assert(introspect[EnumLikeUnion])(
@@ -267,8 +267,8 @@ object SchemaSpec extends ZIOSpecDefault {
   @GQLInterface
   sealed trait MyInterface
   object MyInterface   {
-    case class A(common: Int, different: String)  extends MyInterface
-    case class B(common: Int, different: Boolean) extends MyInterface
+    case class A(c1: Int, c2: Int => Int, d1: Int, d2: Int => Int, d3: Int => Int)      extends MyInterface
+    case class B(c1: Int, c2: Int => Int, d1: Boolean, d2: Int, d3: Option[Int] => Int) extends MyInterface
   }
 
   @GQLUnion


### PR DESCRIPTION
There seems to be a bug with the schema generation for interfaces; When fields have the same underlying type, the arguments are not considered. For example, with the code below we would include the `different` field in the definition of the `MyInterface` interface.

With the changes in this PR we ensure that the arguments of `__Field` are identical when merging the types

```scala
  @GQLInterface
  sealed trait MyInterface

  object MyInterface   {
    case class A(common: String, different: String)           extends MyInterface
    case class B(common: String, different: String => String) extends MyInterface
  }
```

@ghostdogpr the `Types.unify` method is not used anywhere anymore. Is it possible that users are using this method? I haven't removed it just to maintain bin compatibility