### PR TITLE
Validation optimizations

### DIFF
--- a/core/src/main/scala/caliban/Rendering.scala
+++ b/core/src/main/scala/caliban/Rendering.scala
@@ -214,12 +214,12 @@ object Rendering {
     }
 
   private def renderField(field: __Field): String =
-    s"${field.name}${renderArguments(field.args)}: ${renderTypeName(field.`type`())}${if (field.isDeprecated)
+    s"${field.name}${renderArguments(field.args)}: ${renderTypeName(field._type)}${if (field.isDeprecated)
       s" @deprecated${field.deprecationReason.fold("")(reason => s"""(reason: "$reason")""")}"
     else ""}${renderDirectives(field.directives)}"
 
   private def renderInputValue(inputValue: __InputValue): String =
-    s"${inputValue.name}: ${renderTypeName(inputValue.`type`())}${renderDefaultValue(inputValue)}${renderDirectives(inputValue.directives)}"
+    s"${inputValue.name}: ${renderTypeName(inputValue._type)}${renderDefaultValue(inputValue)}${renderDirectives(inputValue.directives)}"
 
   private def renderEnumValue(v: __EnumValue): String =
     s"${renderDescription(v.description)}${v.name}${if (v.isDeprecated)
@@ -232,7 +232,7 @@ object Rendering {
     arguments match {
       case Nil  => ""
       case list =>
-        s"(${list.map(a => s"${renderDescription(a.description, newline = false)}${a.name}: ${renderTypeName(a.`type`())}${renderDefaultValue(a)}${renderDirectives(a.directives)}").mkString(", ")})"
+        s"(${list.map(a => s"${renderDescription(a.description, newline = false)}${a.name}: ${renderTypeName(a._type)}${renderDefaultValue(a)}${renderDirectives(a.directives)}").mkString(", ")})"
     }
 
   private[caliban] def isBuiltinScalar(name: String): Boolean =

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -205,7 +205,7 @@ object Field {
         case Some(tpes) =>
           tpes.foreach(_.name.foreach(name => loop(sb += name, rootType.types.get(name))))
           sb
-        case _                => sb
+        case _          => sb
       }
 
     val tpe = rootType.types.get(typeName)

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -81,7 +81,7 @@ object Field {
         map.compute(key, (_, existing) => if (existing == null) f else existing.combine(f))
       }
 
-      val innerType = Types.innerType(fieldType)
+      val innerType = fieldType.innerType
 
       selectionSet.foreach {
         case F(alias, name, arguments, directives, selectionSet, index) =>
@@ -92,7 +92,7 @@ object Field {
             (directives ::: schemaDirectives).map(resolveDirectiveVariables(variableValues, variableDefinitions))
 
           if (checkDirectives(resolvedDirectives)) {
-            val t = selected.fold(Types.string)(_.`type`()) // default only case where it's not found is __typename
+            val t = selected.fold(Types.string)(_._type) // default only case where it's not found is __typename
 
             val fields =
               if (selectionSet.nonEmpty) loop(selectionSet, t, None)

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -9,6 +9,7 @@ import caliban.parsing.adt.{ Directive, LocationInfo, Selection, VariableDefinit
 import caliban.schema.{ RootType, Types }
 import caliban.{ InputValue, Value }
 
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 /**
@@ -73,11 +74,11 @@ object Field {
     val memoizedFragments = collection.mutable.Map.empty[FragmentSpread, (List[Field], Option[String])]
 
     def loop(selectionSet: List[Selection], fieldType: __Type, fragment: Option[Fragment]): List[Field] = {
-      val map = new java.util.LinkedHashMap[(String, String), Field](selectionSet.length)
+      val map = new java.util.LinkedHashMap[(String, Option[String]), Field](selectionSet.length)
 
       def addField(f: Field, condition: Option[String]): Unit = {
         val name = f.alias.getOrElse(f.name)
-        val key  = (name, condition.getOrElse(""))
+        val key  = (name, condition)
         map.compute(key, (_, existing) => if (existing == null) f else existing.combine(f))
       }
 
@@ -198,15 +199,18 @@ object Field {
     arguments.flatMap { case (k, v) => resolveVariable(v).map(k -> _) }
   }
 
-  private def subtypeNames(typeName: String, rootType: RootType): Option[Set[String]] =
-    rootType.types
-      .get(typeName)
-      .map(t =>
-        t.possibleTypes
-          .fold(Set.empty[String])(
-            _.map(_.name.map(subtypeNames(_, rootType).getOrElse(Set.empty))).toSet.flatten.flatten
-          ) + typeName
-      )
+  private def subtypeNames(typeName: String, rootType: RootType): Option[Set[String]] = {
+    def loop(sb: mutable.Builder[String, Set[String]], `type`: Option[__Type]): mutable.Builder[String, Set[String]] =
+      `type`.flatMap(_.possibleTypes) match {
+        case Some(tpes) =>
+          tpes.foreach(_.name.foreach(name => loop(sb += name, rootType.types.get(name))))
+          sb
+        case _                => sb
+      }
+
+    val tpe = rootType.types.get(typeName)
+    tpe.map(_ => loop(Set.newBuilder[String] += typeName, tpe).result())
+  }
 
   private def checkDirectives(directives: List[Directive]): Boolean =
     directives.isEmpty ||

--- a/core/src/main/scala/caliban/introspection/adt/__Field.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Field.scala
@@ -27,4 +27,6 @@ case class __Field(
 
   def toInputValueDefinition: InputValueDefinition =
     InputValueDefinition(description, name, `type`().toType(), None, directives.getOrElse(Nil))
+
+  private[caliban] lazy val _type: __Type = `type`()
 }

--- a/core/src/main/scala/caliban/introspection/adt/__Field.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Field.scala
@@ -22,11 +22,11 @@ case class __Field(
                              )
                            )
                          else Nil) ++ directives.getOrElse(Nil)
-    FieldDefinition(description, name, args.map(_.toInputValueDefinition), `type`().toType(), allDirectives)
+    FieldDefinition(description, name, args.map(_.toInputValueDefinition), _type.toType(), allDirectives)
   }
 
   def toInputValueDefinition: InputValueDefinition =
-    InputValueDefinition(description, name, `type`().toType(), None, directives.getOrElse(Nil))
+    InputValueDefinition(description, name, _type.toType(), None, directives.getOrElse(Nil))
 
   private[caliban] lazy val _type: __Type = `type`()
 }

--- a/core/src/main/scala/caliban/introspection/adt/__InputValue.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__InputValue.scala
@@ -13,6 +13,8 @@ case class __InputValue(
 ) {
   def toInputValueDefinition: InputValueDefinition = {
     val default = defaultValue.flatMap(v => Parser.parseInputValue(v).toOption)
-    InputValueDefinition(description, name, `type`().toType(), default, directives.getOrElse(Nil))
+    InputValueDefinition(description, name, _type.toType(), default, directives.getOrElse(Nil))
   }
+
+  private[caliban] lazy val _type: __Type = `type`()
 }

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -5,6 +5,7 @@ import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
 import caliban.parsing.adt.Type.{ ListType, NamedType }
 import caliban.parsing.adt.{ Directive, Type }
+import caliban.schema.Types
 
 case class __Type(
   kind: __TypeKind,
@@ -121,4 +122,6 @@ case class __Type(
 
   lazy val allFields: List[__Field] =
     fields(__DeprecatedArgs(Some(true))).getOrElse(Nil)
+
+  lazy val innerType: __Type = Types.innerType(this)
 }

--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -137,7 +137,7 @@ object VariablesCoercer {
               .foreach(fields) { case (k, v) =>
                 defs
                   .find(_.name == k)
-                  .map(field => coerceValues(v, field.`type`(), s"$context at field '${field.name}'").map(k -> _))
+                  .map(field => coerceValues(v, field._type, s"$context at field '${field.name}'").map(k -> _))
                   .getOrElse {
                     ZIO.fail(ValidationError(s"$context field '$k' does not exist", coercionDescription))
                   }

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -160,16 +160,16 @@ object Types {
    */
   def unify(l: List[__Field]): Option[__Type] =
     l.headOption.flatMap { first =>
-      val args                            = first.args.map(_.`type`())
+      val args                            = first.args.map(_._type)
       def _unify(f2: __Field)(t1: __Type) =
         if (
           args.length == f2.args.length &&
-          args.zip(f2.args.map(_.`type`())).forall(v => same(v._1, v._2))
+          args.zip(f2.args.map(_._type)).forall(v => same(v._1, v._2))
         )
-          unify(t1, f2.`type`())
+          unify(t1, f2._type)
         else None
 
-      l.drop(1).foldLeft(Option(first.`type`()))((acc, t) => acc.flatMap(_unify(t)))
+      l.drop(1).foldLeft(Option(first._type))((acc, t) => acc.flatMap(_unify(t)))
     }
 
   /**

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -524,7 +524,7 @@ object Validator {
     currentType: __Type,
     context: Context
   ): EReader[Any, ValidationError, Unit] =
-    ZPure.foreachDiscard(f.args.filter(_.`type`().kind == __TypeKind.NON_NULL))(arg =>
+    ZPure.foreachDiscard(f.args.filter(_._type.kind == __TypeKind.NON_NULL))(arg =>
       (arg.defaultValue, field.arguments.get(arg.name)) match {
         case (None, None) | (None, Some(NullValue)) =>
           failValidation(
@@ -565,7 +565,7 @@ object Validator {
     context: Context,
     errorContext: String
   ): EReader[Any, ValidationError, Unit] = {
-    val t           = inputValue.`type`()
+    val t           = inputValue._type
     val inputType   = if (t.kind == __TypeKind.NON_NULL) t.ofType.getOrElse(t) else t
     val inputFields = inputType.inputFields.getOrElse(Nil)
 
@@ -589,7 +589,7 @@ object Validator {
         } *> ZPure.foreachDiscard(inputFields)(inputField =>
           ZPure.when(
             inputField.defaultValue.isEmpty &&
-              inputField.`type`().kind == __TypeKind.NON_NULL &&
+              inputField._type.kind == __TypeKind.NON_NULL &&
               fields.getOrElse(inputField.name, NullValue) == NullValue
           )(
             failValidation(
@@ -615,7 +615,7 @@ object Validator {
     variableDefinition: VariableDefinition,
     inputValue: __InputValue
   ): EReader[Any, ValidationError, Unit] = {
-    val locationType = inputValue.`type`()
+    val locationType = inputValue._type
     val variableType = variableDefinition.variableType
     if (!locationType.isNullable && !variableType.nonNull) {
       val hasNonNullVariableDefaultValue = variableDefinition.defaultValue.exists(_ != NullValue)
@@ -854,7 +854,7 @@ object Validator {
     for {
       _ <- ValueValidator.validateDefaultValue(inputValue, fieldContext)
       _ <- checkName(inputValue.name, fieldContext)
-      _ <- onlyInputType(inputValue.`type`(), fieldContext)
+      _ <- onlyInputType(inputValue._type, fieldContext)
     } yield ()
   }
 
@@ -924,18 +924,18 @@ object Validator {
             case Some(superField) =>
               val superArgs = superField.args.map(arg => (arg.name, arg)).toMap
               val extraArgs = objField.args.filter { arg =>
-                superArgs.get(arg.name).fold(true)(superArg => !Types.same(arg.`type`(), superArg.`type`()))
+                superArgs.get(arg.name).fold(true)(superArg => !Types.same(arg._type, superArg._type))
               }
 
-              def fieldTypeIsValid = isValidSubtype(superField.`type`(), objField.`type`())
+              def fieldTypeIsValid = isValidSubtype(superField._type, objField._type)
 
               def listItemTypeIsValid =
                 isListField(superField) && isListField(objField) && (for {
-                  superListItemType <- superField.`type`().ofType
-                  objListItemType   <- objField.`type`().ofType
+                  superListItemType <- superField._type.ofType
+                  objListItemType   <- objField._type.ofType
                 } yield isValidSubtype(superListItemType, objListItemType)).getOrElse(false)
 
-              def extraArgsAreValid = !extraArgs.exists(_.`type`().kind == __TypeKind.NON_NULL)
+              def extraArgsAreValid = !extraArgs.exists(_._type.kind == __TypeKind.NON_NULL)
 
               (fieldTypeIsValid, isListField(superField)) match {
                 case (_, true) if !listItemTypeIsValid =>
@@ -950,7 +950,7 @@ object Validator {
                     "An object field type must be equal to or a possible type of the interface field type."
                   )
                 case _ if !extraArgsAreValid           =>
-                  val argNames = extraArgs.filter(_.`type`().kind == __TypeKind.NON_NULL).map(_.name).mkString(", ")
+                  val argNames = extraArgs.filter(_._type.kind == __TypeKind.NON_NULL).map(_.name).mkString(", ")
                   failValidation(
                     s"$fieldContext with extra non-nullable arg(s) '$argNames' in $objectContext is invalid",
                     "Any additional field arguments must not be of a non-nullable type."
@@ -978,7 +978,7 @@ object Validator {
   }
 
   private def isListField(field: __Field) =
-    field.`type`().kind == __TypeKind.LIST
+    field._type.kind == __TypeKind.LIST
 
   private[caliban] def onlyInputType(`type`: __Type, errorContext: String): EReader[Any, ValidationError, Unit] = {
     // https://spec.graphql.org/June2018/#IsInputType()
@@ -1007,7 +1007,7 @@ object Validator {
         val fieldContext = s"Field '${field.name}' of $context"
         for {
           _ <- checkName(field.name, fieldContext)
-          _ <- onlyOutputType(field.`type`(), fieldContext)
+          _ <- onlyOutputType(field._type, fieldContext)
           _ <- ZPure.foreachDiscard(field.args)(validateInputValue(_, fieldContext))
         } yield ()
       }

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -35,7 +35,7 @@ object ValueValidator {
     argValue: InputValue,
     context: Context,
     errorContext: String
-  ): EReader[Any, ValidationError, Unit] = validateType(inputValue.`type`(), argValue, context, errorContext)
+  ): EReader[Any, ValidationError, Unit] = validateType(inputValue._type, argValue, context, errorContext)
 
   def validateType(
     inputType: __Type,
@@ -77,10 +77,10 @@ object ValueValidator {
                 inputType.inputFields.getOrElse(List.empty).forEach_ { f =>
                   fields.collectFirst { case (name, fieldValue) if name == f.name => fieldValue } match {
                     case Some(value) =>
-                      validateType(f.`type`(), value, context, s"Field ${f.name} in $errorContext")
+                      validateType(f._type, value, context, s"Field ${f.name} in $errorContext")
                     case None        =>
                       ZPure.when(f.defaultValue.isEmpty) {
-                        validateType(f.`type`(), NullValue, context, s"Field ${f.name} in $errorContext")
+                        validateType(f._type, NullValue, context, s"Field ${f.name} in $errorContext")
                       }
                   }
                 }

--- a/core/src/test/scala-2/caliban/Scala2SpecificSpec.scala
+++ b/core/src/test/scala-2/caliban/Scala2SpecificSpec.scala
@@ -12,7 +12,7 @@ object Scala2SpecificSpec extends ZIOSpecDefault {
     suite("Scala2SpecificSpec")(
       test("value classes should unwrap") {
         case class Queries(organizationId: OrganizationId, painter: WrappedPainter)
-        val fieldTypes = introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.map(_.`type`())
+        val fieldTypes = introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.map(_._type)
         assertTrue(fieldTypes.map(_.ofType.flatMap(_.name)) == Some("Long") :: Some("Painter") :: Nil)
       },
       test("value classes") {

--- a/core/src/test/scala-2/caliban/interop/play/SchemaSpec.scala
+++ b/core/src/test/scala-2/caliban/interop/play/SchemaSpec.scala
@@ -15,7 +15,7 @@ object SchemaSpec extends ZIOSpecDefault {
         import caliban.interop.play.json._
         case class Queries(to: JsValue, from: JsValue => Unit)
 
-        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, String]("to", _.ofType.flatMap(_.name).get, equalTo("Json")))
         )
       }

--- a/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
@@ -161,7 +161,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
 
         given Schema[Any, Something] = Schema.gen[Any, Something].rename("SomethingElse")
 
-        assertTrue(Types.innerType(introspectSubscription[Something]).name.get == "SomethingElse")
+        assertTrue(introspectSubscription[Something].innerType.name.get == "SomethingElse")
       },
       test("union redirect") {
         @GQLUnion

--- a/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
@@ -21,14 +21,14 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
       test("effectful field") {
         case class EffectfulFieldSchema(q: Task[Int]) derives Schema.Auto
 
-        assert(introspect[EffectfulFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[EffectfulFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR)))
         )
       },
       test("infallible effectful field") {
         case class InfallibleFieldSchema(q: UIO[Int]) derives Schema.Auto
 
-        assert(introspect[InfallibleFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[InfallibleFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL)))
         )
       },
@@ -44,7 +44,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
             .toList
             .flatten
             .headOption
-            .map(_.`type`())
+            .map(_._type)
         )(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL)))
         )
@@ -52,7 +52,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
       test("field with Future") {
         case class FutureFieldSchema(q: Future[Int]) derives Schema.Auto
 
-        assert(introspect[FutureFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[FutureFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR)))
         )
       },
@@ -91,7 +91,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
       test("UUID field should be converted to ID") {
         case class IDSchema(id: UUID) derives Schema.Auto
 
-        assert(introspect[IDSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[IDSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, String]("id", _.ofType.flatMap(_.name).get, equalTo("ID")))
         )
       },
@@ -133,7 +133,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
         import caliban.interop.circe.json._
         case class Queries(to: io.circe.Json, from: io.circe.Json => Unit) derives Schema.Auto
 
-        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, String]("to", _.ofType.flatMap(_.name).get, equalTo("Json")))
         )
       },
@@ -141,7 +141,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
         case class Query(a: ZStream[Any, Throwable, Int]) derives Schema.Auto
 
         assertTrue(
-          introspect[Query].fields(__DeprecatedArgs()).flatMap(_.headOption).map(_.`type`().kind).get == __TypeKind.LIST
+          introspect[Query].fields(__DeprecatedArgs()).flatMap(_.headOption).map(_._type.kind).get == __TypeKind.LIST
         )
       },
       test("ZStream in a Subscription doesn't return a list type") {
@@ -151,7 +151,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
           introspectSubscription[Query]
             .fields(__DeprecatedArgs())
             .flatMap(_.headOption)
-            .map(_.`type`().kind)
+            .map(_._type.kind)
             .get == __TypeKind.SCALAR
         )
       },
@@ -194,7 +194,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
         case class Wrapper(value: Int)
         case class Queries(test: Option[Wrapper]) derives Schema.Auto
 
-        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, Option[String]]("name", _.name, equalTo(Some("Int"))))
         )
       },
@@ -203,7 +203,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
         case class Wrapper(value: Int)
         case class Queries(test: Option[Wrapper]) derives Schema.Auto
 
-        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, Option[String]]("name", _.name, equalTo(Some("Wrapper"))))
         )
       },

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -21,12 +21,12 @@ object SchemaSpec extends ZIOSpecDefault {
   override def spec =
     suite("SchemaSpec")(
       test("effectful field") {
-        assert(introspect[EffectfulFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[EffectfulFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR)))
         )
       },
       test("infallible effectful field") {
-        assert(introspect[InfallibleFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[InfallibleFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL)))
         )
       },
@@ -37,12 +37,12 @@ object SchemaSpec extends ZIOSpecDefault {
           import auto._
           implicit lazy val queriesSchema: Schema[Console with Clock, Queries] = genAll
         }
-        assert(MySchema.queriesSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(MySchema.queriesSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL)))
         )
       },
       test("field with Future") {
-        assert(introspect[FutureFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[FutureFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR)))
         )
       },
@@ -81,7 +81,7 @@ object SchemaSpec extends ZIOSpecDefault {
         )
       },
       test("UUID field should be converted to ID") {
-        assert(introspect[IDSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[IDSchema].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, String]("id", _.ofType.flatMap(_.name).get, equalTo("ID")))
         )
       },
@@ -102,7 +102,7 @@ object SchemaSpec extends ZIOSpecDefault {
         import caliban.interop.circe.json._
         case class Queries(to: io.circe.Json, from: io.circe.Json => Unit)
 
-        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, String]("to", _.ofType.flatMap(_.name).get, equalTo("Json")))
         )
       },
@@ -110,7 +110,7 @@ object SchemaSpec extends ZIOSpecDefault {
         case class Query(a: ZStream[Any, Throwable, Int])
 
         assertTrue(
-          introspect[Query].fields(__DeprecatedArgs()).flatMap(_.headOption).map(_.`type`().kind).get == __TypeKind.LIST
+          introspect[Query].fields(__DeprecatedArgs()).flatMap(_.headOption).map(_._type.kind).get == __TypeKind.LIST
         )
       },
       test("ZStream in a Subscription doesn't return a list type") {
@@ -120,7 +120,7 @@ object SchemaSpec extends ZIOSpecDefault {
           introspectSubscription[Query]
             .fields(__DeprecatedArgs())
             .flatMap(_.headOption)
-            .map(_.`type`().kind)
+            .map(_._type.kind)
             .get == __TypeKind.SCALAR
         )
       },
@@ -155,7 +155,7 @@ object SchemaSpec extends ZIOSpecDefault {
         case class Wrapper(value: Int)
         case class Queries(test: Option[Wrapper])
 
-        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, Option[String]]("name", _.name, equalTo(Some("Int"))))
         )
       },
@@ -164,7 +164,7 @@ object SchemaSpec extends ZIOSpecDefault {
         case class Wrapper(value: Int)
         case class Queries(test: Option[Wrapper])
 
-        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_.`type`()))(
+        assert(introspect[Queries].fields(__DeprecatedArgs()).toList.flatten.headOption.map(_._type))(
           isSome(hasField[__Type, Option[String]]("name", _.name, equalTo(Some("Wrapper"))))
         )
       },

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -130,7 +130,7 @@ object SchemaSpec extends ZIOSpecDefault {
 
         implicit val somethingSchema: Schema[Any, Something] = Schema.gen[Any, Something].rename("SomethingElse")
 
-        assertTrue(Types.innerType(introspectSubscription[Something]).name.get == "SomethingElse")
+        assertTrue(introspectSubscription[Something].innerType.name.get == "SomethingElse")
       },
       test("union redirect") {
         case class Queries(union: RedirectingUnion)


### PR DESCRIPTION
I was playing around with IntelliJ's new profiler with in-editor hints, and I managed to identify a few places where the code could be optimized. The majority of the optimizations are for validation. 

With these changes, we get between 35-50% performance increase for validation, and about 6% for the fragments benchmark which also includes parsing + execution

Before:

```
[info] Benchmark                                       Mode  Cnt       Score      Error  Units
[info] GraphQLBenchmarks.fragmentsCaliban             thrpt    5     258.842 ±   16.625  ops/s
[info] execution.ValidationBenchmark.deep10000        thrpt    5  119928.824 ± 1033.349  ops/s
[info] execution.ValidationBenchmark.multifield10000  thrpt    5  166221.001 ± 1928.873  ops/s
[info] execution.ValidationBenchmark.simple10000      thrpt    5  270143.275 ± 3360.337  ops/s
```

After:

```
[info] Benchmark                                       Mode  Cnt       Score      Error  Units
[info] GraphQLBenchmarks.fragmentsCaliban             thrpt    5     275.328 ±    3.720  ops/s
[info] execution.ValidationBenchmark.deep10000        thrpt    5  181127.662 ±  915.815  ops/s
[info] execution.ValidationBenchmark.multifield10000  thrpt    5  231313.426 ± 5619.929  ops/s
[info] execution.ValidationBenchmark.simple10000      thrpt    5  360995.697 ± 3407.331  ops/s
```
