### PR TITLE
Add benchmarks for Grackle + configurable project scalaVersion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.18 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test tracing/test
+      - run: sbt ++2.12.18 core/test http4s/test akkaHttp/test play/test zioHttp/test examples/compile catsInterop/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test tracing/test
       - save_cache:
           key: sbtcache
           paths:

--- a/benchmarks/src/main/scala/caliban/Data.scala
+++ b/benchmarks/src/main/scala/caliban/Data.scala
@@ -7,6 +7,13 @@ object Data {
     case object EARTH extends Origin
     case object MARS  extends Origin
     case object BELT  extends Origin
+
+    def fromString(s: String): Option[Origin] = s match {
+      case "EARTH" => Some(EARTH)
+      case "MARS"  => Some(MARS)
+      case "BELT"  => Some(BELT)
+      case _       => None
+    }
   }
 
   sealed trait Role

--- a/benchmarks/src/main/scala/caliban/Data.scala
+++ b/benchmarks/src/main/scala/caliban/Data.scala
@@ -7,13 +7,6 @@ object Data {
     case object EARTH extends Origin
     case object MARS  extends Origin
     case object BELT  extends Origin
-
-    def fromString(s: String): Option[Origin] = s match {
-      case "EARTH" => Some(EARTH)
-      case "MARS"  => Some(MARS)
-      case "BELT"  => Some(BELT)
-      case _       => None
-    }
   }
 
   sealed trait Role

--- a/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
+++ b/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
@@ -227,6 +227,7 @@ class GraphQLBenchmarks {
 
   object Caliban {
     import caliban.schema.Schema
+    import caliban.schema.Schema._
     import caliban.schema.ArgBuilder.auto._
     import caliban.schema.Schema.auto._
 

--- a/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
+++ b/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
@@ -2,16 +2,13 @@ package caliban
 
 import caliban.Data._
 import caliban.parsing.Parser
-import io.circe.Json
+import io.circe.{ Encoder, Json }
 import org.openjdk.jmh.annotations._
 import sangria.execution._
-import sangria.macros.derive._
 import sangria.marshalling.circe._
+import cats.effect.IO
+import edu.gemini.grackle.generic.GenericMapping
 import sangria.parser.QueryParser
-import caliban.schema.{ Schema => CSchema }
-import caliban.schema.Schema.auto._
-import caliban.schema.ArgBuilder.auto._
-import sangria.schema._
 import zio.{ Runtime, Task, UIO, Unsafe, ZIO }
 
 import java.util.concurrent.TimeUnit
@@ -26,12 +23,13 @@ import scala.language.postfixOps
 @Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 class GraphQLBenchmarks {
-  import CSchema._
+  implicit val executionContext: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
 
   val simpleQuery: String =
     """{
           characters{
             name
+            origin
           }
        }""".stripMargin
 
@@ -227,122 +225,245 @@ class GraphQLBenchmarks {
               }
                 """
 
-  private val runtime = Runtime.default
+  object Caliban {
+    import caliban.schema.Schema
+    import caliban.schema.ArgBuilder.auto._
+    import caliban.schema.Schema.auto._
 
-  case class CharactersArgs(origin: Option[Origin])
-  case class CharacterArgs(name: String)
+    private val runtime = Runtime.default
 
-  case class Query(
-    characters: CharactersArgs => UIO[List[Character]],
-    character: CharacterArgs => UIO[Option[Character]]
-  )
+    case class CharactersArgs(origin: Option[Origin])
+    case class CharacterArgs(name: String)
 
-  implicit val originSchema: CSchema[Any, Origin]       = CSchema.gen
-  implicit val characterSchema: CSchema[Any, Character] = CSchema.gen
-
-  val resolver: RootResolver[Query, Unit, Unit] = RootResolver(
-    Query(
-      args => ZIO.succeed(Data.characters.filter(c => args.origin.forall(c.origin == _))),
-      args => ZIO.succeed(Data.characters.find(c => c.name == args.name))
+    case class Query(
+      characters: CharactersArgs => UIO[List[Character]],
+      character: CharacterArgs => UIO[Option[Character]]
     )
-  )
 
-  def run[A](zio: Task[A]): A = Unsafe.unsafe(implicit u => runtime.unsafe.run(zio).getOrThrow())
+    implicit val originSchema: Schema[Any, Origin]       = Schema.gen
+    implicit val characterSchema: Schema[Any, Character] = Schema.gen
 
-  val interpreter: GraphQLInterpreter[Any, CalibanError] = run(graphQL(resolver).interpreter)
+    val resolver: RootResolver[Query, Unit, Unit] = RootResolver(
+      Query(
+        args => ZIO.succeed(Data.characters.filter(c => args.origin.forall(c.origin == _))),
+        args => ZIO.succeed(Data.characters.find(c => c.name == args.name))
+      )
+    )
+
+    val interpreter: GraphQLInterpreter[Any, CalibanError] = run(graphQL(resolver).interpreter)
+
+    def run[A](zio: Task[A]): A = Unsafe.unsafe(implicit u => runtime.unsafe.run(zio).getOrThrow())
+  }
+
+  object Sangria {
+    import sangria.macros.derive._
+    import sangria.schema._
+
+    implicit val OriginEnum: EnumType[Origin]                  = deriveEnumType[Origin](IncludeValues("EARTH", "MARS", "BELT"))
+    implicit val CaptainType: ObjectType[Unit, Role.Captain]   = deriveObjectType[Unit, Role.Captain]()
+    implicit val PilotType: ObjectType[Unit, Role.Pilot]       = deriveObjectType[Unit, Role.Pilot]()
+    implicit val EngineerType: ObjectType[Unit, Role.Engineer] = deriveObjectType[Unit, Role.Engineer]()
+    implicit val MechanicType: ObjectType[Unit, Role.Mechanic] = deriveObjectType[Unit, Role.Mechanic]()
+    implicit val RoleType: UnionType[Unit]                     = UnionType(
+      "Role",
+      types = List(PilotType, EngineerType, MechanicType, CaptainType)
+    )
+    implicit val CharacterType: ObjectType[Unit, Character]    = ObjectType(
+      "Character",
+      fields[Unit, Character](
+        Field(
+          "name",
+          StringType,
+          resolve = _.value.name
+        ),
+        Field(
+          "nicknames",
+          ListType(StringType),
+          resolve = _.value.nicknames
+        ),
+        Field(
+          "origin",
+          OriginEnum,
+          resolve = _.value.origin
+        ),
+        Field(
+          "role",
+          OptionType(RoleType),
+          resolve = _.value.role
+        )
+      )
+    )
+
+    val OriginArg: Argument[Option[Origin]] = Argument("origin", OptionInputType(OriginEnum))
+    val NameArg: Argument[String]           = Argument("name", StringType)
+
+    val QueryType: ObjectType[Unit, Unit] = ObjectType(
+      "Query",
+      fields[Unit, Unit](
+        Field(
+          "characters",
+          ListType(CharacterType),
+          arguments = OriginArg :: Nil,
+          resolve = args => Future.successful(Data.characters.filter(c => (args arg OriginArg).forall(c.origin == _)))
+        ),
+        Field(
+          "character",
+          OptionType(CharacterType),
+          arguments = NameArg :: Nil,
+          resolve = args => Future.successful(Data.characters.find(c => c.name == (args arg NameArg)))
+        )
+      )
+    )
+
+    val schema: Schema[Unit, Unit] = Schema(QueryType)
+
+  }
+
+  object Grackle extends GenericMapping[IO] {
+    import edu.gemini.grackle.Predicate._
+    import edu.gemini.grackle.Query._
+    import edu.gemini.grackle.QueryCompiler._
+    import edu.gemini.grackle.Value._
+    import edu.gemini.grackle.Cursor.{ Context, Env }
+    import edu.gemini.grackle._
+    import edu.gemini.grackle.generic._
+    import edu.gemini.grackle.syntax._
+    import semiauto._
+
+    val schema =
+      schema"""
+          type Query {
+              character(id: String!): Character
+              characters(origin: Origin): [Character!]!
+            }
+          enum Origin {
+            EARTH
+            MARS
+            BELT
+          }
+          type Captain {
+            shipName: String!
+          }
+          type Pilot {
+            shipName: String!
+          }
+          type Engineer {
+            shipName: String!
+          }
+          type Mechanic {
+            shipName: String!
+          }
+          union Role = Captain | Pilot | Engineer | Mechanic
+          type Character {
+            name: String!
+            nicknames: [String!]!
+            origin: Origin!
+            role: Role
+          }
+        """
+
+    val QueryType     = schema.ref("Query")
+    val OriginType    = schema.ref("Origin")
+    val CharacterType = schema.ref("Character")
+    val CaptainType   = schema.ref("Captain")
+    val PilotType     = schema.ref("Pilot")
+    val EngineerType  = schema.ref("Engineer")
+    val RoleType      = schema.ref("Role")
+    val MechanicType  = schema.ref("Mechanic")
+
+    implicit val earthCursorBuilder: CursorBuilder[Origin] = {
+      case class OriginCursor(context: Context, focus: Origin, parent: Option[Cursor], env: Env)
+          extends PrimitiveCursor[Origin] {
+        def withEnv(env0: Env): Cursor    = copy(env = env.add(env0))
+        override def asLeaf: Result[Json] = Json.fromString(focus.toString).success
+      }
+      new CursorBuilder[Origin]           {
+        val tpe = EnumType("Origin", None, List("EARTH", "MARS", "BELT").map(EnumValue(_, None)))
+
+        def build(context: Context, focus: Origin, parent: Option[Cursor], env: Env): Result[Cursor] =
+          OriginCursor(context.asType(tpe), focus, parent, env).success
+      }
+    }
+    implicit val roleEncoder: Encoder[Role]                = Encoder.encodeString.contramap(_.toString)
+
+    implicit val captainCursorBuiler: CursorBuilder[Role.Captain]   =
+      deriveObjectCursorBuilder[Role.Captain](CaptainType)
+    implicit val pilotCursorBuiler: CursorBuilder[Role.Pilot]       =
+      deriveObjectCursorBuilder[Role.Pilot](PilotType)
+    implicit val engineerCursorBuiler: CursorBuilder[Role.Engineer] =
+      deriveObjectCursorBuilder[Role.Engineer](EngineerType)
+    implicit val mechanicCursorBuiler: CursorBuilder[Role.Mechanic] =
+      deriveObjectCursorBuilder[Role.Mechanic](MechanicType)
+    implicit val roleCursorBuilder: CursorBuilder[Role]             =
+      CursorBuilder.deriveLeafCursorBuilder[Role](RoleType)
+    implicit val characterCursorBuiler: CursorBuilder[Character]    =
+      deriveObjectCursorBuilder[Character](CharacterType)
+
+    val typeMappings =
+      List(
+        ObjectMapping(
+          tpe = QueryType,
+          fieldMappings = List(
+            GenericField("character", Data.characters),
+            GenericField("characters", Data.characters)
+          )
+        )
+      )
+
+    implicit val eq: cats.Eq[Origin] = cats.Eq.fromUniversalEquals[Origin]
+
+    // #elaborator
+    override val selectElaborator = new SelectElaborator(
+      Map(
+        QueryType -> {
+          case Select(f @ "character", List(Binding("id", IDValue(id))), child)        =>
+            Select(f, Nil, Unique(Filter(Eql(CharacterType / "id", Const(id)), child))).success
+          case Select("characters", List(Binding("origin", TypedEnumValue(e))), child) =>
+            Origin
+              .fromString(e.name)
+              .map { origin =>
+                Select("characters", Nil, Unique(Filter(Eql(CharacterType / "origin", Const(origin)), child))).success
+              }
+              .getOrElse(Result.failure(s"Unknown origin '${e.name}'"))
+        }
+      )
+    )
+
+    def run[A](io: IO[A]): A = io.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
+  }
 
   @Benchmark
   def simpleCaliban(): Unit = {
-    val io = interpreter.execute(simpleQuery)
-    run(io)
+    val io = Caliban.interpreter.execute(simpleQuery)
+    Caliban.run(io)
     ()
   }
 
   @Benchmark
   def introspectCaliban(): Unit = {
-    val io = interpreter.execute(fullIntrospectionQuery)
-    run(io)
+    val io = Caliban.interpreter.execute(fullIntrospectionQuery)
+    Caliban.run(io)
     ()
   }
 
   @Benchmark
   def fragmentsCaliban(): Unit = {
-    val io = interpreter.execute(fragmentsQuery)
-    run(io)
+    val io = Caliban.interpreter.execute(fragmentsQuery)
+    Caliban.run(io)
     ()
   }
 
   @Benchmark
   def parserCaliban(): Unit = {
     val io = Parser.parseQuery(fullIntrospectionQuery)
-    run(io)
+    Caliban.run(io)
     ()
   }
-
-  implicit val OriginEnum: EnumType[Origin]                  = deriveEnumType[Origin](IncludeValues("EARTH", "MARS", "BELT"))
-  implicit val CaptainType: ObjectType[Unit, Role.Captain]   = deriveObjectType[Unit, Role.Captain]()
-  implicit val PilotType: ObjectType[Unit, Role.Pilot]       = deriveObjectType[Unit, Role.Pilot]()
-  implicit val EngineerType: ObjectType[Unit, Role.Engineer] = deriveObjectType[Unit, Role.Engineer]()
-  implicit val MechanicType: ObjectType[Unit, Role.Mechanic] = deriveObjectType[Unit, Role.Mechanic]()
-  implicit val RoleType: UnionType[Unit]                     = UnionType(
-    "Role",
-    types = List(PilotType, EngineerType, MechanicType, CaptainType)
-  )
-  implicit val CharacterType: ObjectType[Unit, Character]    = ObjectType(
-    "Character",
-    fields[Unit, Character](
-      Field(
-        "name",
-        StringType,
-        resolve = _.value.name
-      ),
-      Field(
-        "nicknames",
-        ListType(StringType),
-        resolve = _.value.nicknames
-      ),
-      Field(
-        "origin",
-        OriginEnum,
-        resolve = _.value.origin
-      ),
-      Field(
-        "role",
-        OptionType(RoleType),
-        resolve = _.value.role
-      )
-    )
-  )
-
-  val OriginArg: Argument[Option[Origin]] = Argument("origin", OptionInputType(OriginEnum))
-  val NameArg: Argument[String]           = Argument("name", StringType)
-
-  val QueryType: ObjectType[Unit, Unit] = ObjectType(
-    "Query",
-    fields[Unit, Unit](
-      Field(
-        "characters",
-        ListType(CharacterType),
-        arguments = OriginArg :: Nil,
-        resolve = args => Future.successful(Data.characters.filter(c => (args arg OriginArg).forall(c.origin == _)))
-      ),
-      Field(
-        "character",
-        OptionType(CharacterType),
-        arguments = NameArg :: Nil,
-        resolve = args => Future.successful(Data.characters.find(c => c.name == (args arg NameArg)))
-      )
-    )
-  )
-
-  val schema: Schema[Unit, Unit] = Schema(QueryType)
-
-  implicit val executionContext: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
 
   @Benchmark
   def simpleSangria(): Unit = {
     val future: Future[Json] =
-      Future.fromTry(QueryParser.parse(simpleQuery)).flatMap(queryAst => Executor.execute(schema, queryAst))
+      Future.fromTry(QueryParser.parse(simpleQuery)).flatMap(queryAst => Executor.execute(Sangria.schema, queryAst))
     Await.result(future, 1 minute)
     ()
   }
@@ -350,7 +471,9 @@ class GraphQLBenchmarks {
   @Benchmark
   def introspectSangria(): Unit = {
     val future: Future[Json] =
-      Future.fromTry(QueryParser.parse(fullIntrospectionQuery)).flatMap(queryAst => Executor.execute(schema, queryAst))
+      Future
+        .fromTry(QueryParser.parse(fullIntrospectionQuery))
+        .flatMap(queryAst => Executor.execute(Sangria.schema, queryAst))
     Await.result(future, 1 minute)
     ()
   }
@@ -360,7 +483,7 @@ class GraphQLBenchmarks {
     val future: Future[Json] =
       Future
         .fromTry(QueryParser.parse(fragmentsQuery))
-        .flatMap(queryAst => Executor.execute(schema, queryAst))
+        .flatMap(queryAst => Executor.execute(Sangria.schema, queryAst))
     Await.result(future, 1 minute)
     ()
   }
@@ -369,6 +492,33 @@ class GraphQLBenchmarks {
   def parserSangria(): Unit = {
     val future = Future.fromTry(QueryParser.parse(fullIntrospectionQuery))
     Await.result(future, 1 minute)
+    ()
+  }
+
+  @Benchmark
+  def simpleGrackle(): Unit = {
+    val io = Grackle.compileAndRun(simpleQuery)
+    Grackle.run(io)
+    ()
+  }
+
+  @Benchmark
+  def introspectGrackle(): Unit = {
+    val io = Grackle.compileAndRun(fullIntrospectionQuery)
+    Grackle.run(io)
+    ()
+  }
+
+  @Benchmark
+  def fragmentsGrackle(): Unit = {
+    val io = Grackle.compileAndRun(fragmentsQuery)
+    Grackle.run(io)
+    ()
+  }
+
+  @Benchmark
+  def parserGrackle(): Unit = {
+    Grackle.compiler.compile(fullIntrospectionQuery)
     ()
   }
 }

--- a/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
+++ b/benchmarks/src/main/scala/caliban/GraphQLBenchmarks.scala
@@ -251,7 +251,7 @@ class GraphQLBenchmarks {
       )
     )
 
-    val interpreter: GraphQLInterpreter[Any, CalibanError] = run(graphQL(resolver).interpreter)
+    val interpreter: GraphQLInterpreter[Any, CalibanError] = run(graphQL[Any, Query, Unit, Unit](resolver).interpreter)
 
     def run[A](zio: Task[A]): A = Unsafe.unsafe(implicit u => runtime.unsafe.run(zio).getOrThrow())
   }

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ val zioPreludeVersion         = "1.0.0-RC19"
 
 inThisBuild(
   List(
-    scalaVersion             := scala212,
+    scalaVersion             := scala212, // Change to control IntelliJ's highlighting
     crossScalaVersions       := allScala,
     organization             := "com.github.ghostdogpr",
     homepage                 := Some(url("https://github.com/ghostdogpr/caliban")),
@@ -216,6 +216,8 @@ lazy val codegenSbt = project
   .settings(commonSettings)
   .enablePlugins(BuildInfoPlugin)
   .settings(
+    skip             := (scalaVersion.value != scala212),
+    ideSkipProject   := (scalaVersion.value != scala212),
     buildInfoKeys    := Seq[BuildInfoKey](version),
     buildInfoPackage := "caliban.codegen",
     buildInfoObject  := "BuildInfo"
@@ -353,6 +355,8 @@ lazy val akkaHttp = project
   .settings(commonSettings)
   .settings(enableMimaSettingsJVM)
   .settings(
+    skip           := (scalaVersion.value == scala3),
+    ideSkipProject := (scalaVersion.value == scala3),
     crossScalaVersions -= scala3,
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
@@ -371,6 +375,8 @@ lazy val play = project
   .settings(commonSettings)
   .settings(enableMimaSettingsJVM)
   .settings(
+    skip           := (scalaVersion.value == scala3),
+    ideSkipProject := (scalaVersion.value == scala3),
     crossScalaVersions -= scala3,
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
@@ -462,6 +468,8 @@ lazy val examples = project
     run / connectInput := true
   )
   .settings(
+    skip                                                 := (scalaVersion.value == scala3),
+    ideSkipProject                                       := (scalaVersion.value == scala3),
     crossScalaVersions -= scala3,
     libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % "always",
     libraryDependencies ++= Seq(
@@ -512,13 +520,20 @@ lazy val reporting = project
 lazy val benchmarks = project
   .in(file("benchmarks"))
   .settings(commonSettings)
-  .settings(publish / skip := true)
-  .dependsOn(core)
+  .settings(
+    skip               := (scalaVersion.value == scala212),
+    ideSkipProject     := (scalaVersion.value == scala212),
+    publish / skip     := true,
+    crossScalaVersions := Seq(scala213, scala3)
+  )
+  .dependsOn(core % "compile->compile")
   .enablePlugins(JmhPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "org.sangria-graphql"                   %% "sangria"             % "3.4.1",
+      "org.sangria-graphql"                   %% "sangria"             % "4.0.1",
       "org.sangria-graphql"                   %% "sangria-circe"       % "1.3.2",
+      "edu.gemini"                            %% "gsp-graphql-core"    % "0.13.0",
+      "edu.gemini"                            %% "gsp-graphql-generic" % "0.13.0",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % jsoniterVersion,
       "io.circe"                              %% "circe-parser"        % circeVersion,
       "dev.zio"                               %% "zio-json"            % zioJsonVersion
@@ -551,6 +566,8 @@ lazy val docs = project
   .enablePlugins(MdocPlugin)
   .settings(commonSettings)
   .settings(
+    skip               := (scalaVersion.value == scala3),
+    ideSkipProject     := (scalaVersion.value == scala3),
     crossScalaVersions := Seq(scala212, scala213),
     name               := "caliban-docs",
     mdocIn             := (ThisBuild / baseDirectory).value / "vuepress" / "docs",

--- a/build.sbt
+++ b/build.sbt
@@ -663,3 +663,5 @@ lazy val apiMappingSettings = Def.settings(
     ).flatten.toMap
   }
 )
+
+Global / excludeLintKeys += ideSkipProject

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,5 +12,7 @@ addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"                 % "0.11.0")
 addSbtPlugin("org.scalameta"      % "sbt-mdoc"                      % "2.3.7")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"               % "1.1.3")
 
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.1")
+
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13"
 addDependencyTreePlugin


### PR DESCRIPTION
Benchmarking results across Caliban 2.3.0, Sangria 4.0.1 and Grackle 0.13.0:

```
[info] Benchmark                             Mode  Cnt      Score      Error  Units
[info] GraphQLBenchmarks.fragmentsCaliban   thrpt    5    127.584 ±    0.576  ops/s
[info] GraphQLBenchmarks.fragmentsGrackle   thrpt    5     68.214 ±    0.915  ops/s
[info] GraphQLBenchmarks.fragmentsSangria   thrpt    5     79.630 ±    1.145  ops/s
[info] GraphQLBenchmarks.introspectCaliban  thrpt    5   4588.751 ±  107.401  ops/s
[info] GraphQLBenchmarks.introspectGrackle  thrpt    5   1814.529 ±    9.122  ops/s
[info] GraphQLBenchmarks.introspectSangria  thrpt    5   1613.585 ±   12.726  ops/s
[info] GraphQLBenchmarks.parserCaliban      thrpt    5  34136.881 ±  675.789  ops/s
[info] GraphQLBenchmarks.parserGrackle      thrpt    5   4484.088 ±   26.300  ops/s
[info] GraphQLBenchmarks.parserSangria      thrpt    5  22734.408 ±  123.280  ops/s
[info] GraphQLBenchmarks.simpleCaliban      thrpt    5  62526.730 ± 1452.906  ops/s
[info] GraphQLBenchmarks.simpleGrackle      thrpt    5  14730.999 ± 1568.441  ops/s
[info] GraphQLBenchmarks.simpleSangria      thrpt    5  16663.193 ±  615.734  ops/s
```