### PR TITLE
Optimize Scala3's codegen

### DIFF
--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -11,7 +11,6 @@ import caliban.schema.macros.{ Macros, TypeInfo }
 import scala.compiletime.*
 import scala.deriving.Mirror
 import scala.util.NotGiven
-import scala.quoted.*
 
 object PrintDerived {
   import scala.quoted.*


### PR DESCRIPTION
Seems that we were still creating a bit too much redundant code during Schema derivation in Scala 3.

With these changes, we avoid creating any methods / lambdas during while we're inlining to reduce the size of the generated code. Tested the changes by compiling an API at work which has a medium-sized schema and the generated code size was down by ~10%

I also tried to cleanup a bit of the derived code in ArgBuilder's derivation (see last commit). Let me know if you prefer I rollback those changes