### PR TITLE
Auto enum field derivation [Scala 3]

### DIFF
--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -22,7 +22,7 @@ trait CommonArgBuilderDerivation {
           (
             constValue[name].toString,
             Macros.annotations[t], {
-            if (Macros.isEnumField[P, t])
+              if (Macros.isEnumField[P, t])
                 if (!Macros.implicitExists[ArgBuilder[t]]) derived[t]
                 else summonInline[ArgBuilder[t]]
               else summonInline[ArgBuilder[t]]

--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -21,8 +21,12 @@ trait CommonArgBuilderDerivation {
         recurse[names, ts](
           (
             constValue[name].toString,
-            Macros.annotations[t],
-            summonInline[ArgBuilder[t]].asInstanceOf[ArgBuilder[Any]]
+            Macros.annotations[t], {
+              if (Macros.isEnumField[t])
+                if (!Macros.implicitExists[ArgBuilder[t]]) derived[t]
+                else summonInline[ArgBuilder[t]]
+              else summonInline[ArgBuilder[t]]
+            }.asInstanceOf[ArgBuilder[Any]]
           ) :: values
         )
     }

--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -12,17 +12,17 @@ import scala.compiletime.*
 import scala.util.NotGiven
 
 trait CommonArgBuilderDerivation {
-  inline def recurse[Label, A <: Tuple](
+  inline def recurse[P, Label, A <: Tuple](
     inline values: List[(String, List[Any], ArgBuilder[Any])] = Nil
   ): List[(String, List[Any], ArgBuilder[Any])] =
     inline erasedValue[(Label, A)] match {
       case (_: EmptyTuple, _)                 => values.reverse
       case (_: (name *: names), _: (t *: ts)) =>
-        recurse[names, ts](
+        recurse[P, names, ts](
           (
             constValue[name].toString,
             Macros.annotations[t], {
-              if (Macros.isEnumField[t])
+            if (Macros.isEnumField[P, t])
                 if (!Macros.implicitExists[ArgBuilder[t]]) derived[t]
                 else summonInline[ArgBuilder[t]]
               else summonInline[ArgBuilder[t]]
@@ -35,13 +35,13 @@ trait CommonArgBuilderDerivation {
     inline summonInline[Mirror.Of[A]] match {
       case m: Mirror.SumOf[A] =>
         makeSumArgBuilder[A](
-          recurse[m.MirroredElemLabels, m.MirroredElemTypes](),
+          recurse[A, m.MirroredElemLabels, m.MirroredElemTypes](),
           constValue[m.MirroredLabel]
         )
 
       case m: Mirror.ProductOf[A] =>
         makeProductArgBuilder(
-          recurse[m.MirroredElemLabels, m.MirroredElemTypes](),
+          recurse[A, m.MirroredElemLabels, m.MirroredElemTypes](),
           Macros.paramAnnotations[A].to(Map)
         )(m.fromProduct)
     }

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -48,7 +48,7 @@ trait CommonSchemaDerivation {
             (
               constValue[name].toString,
               Macros.annotations[t], {
-                if (Macros.isEnumField[t])
+                if (Macros.isEnumField[P, t])
                   if (!Macros.implicitExists[Schema[R, t]]) derived[R, t]
                   else summonInline[Schema[R, t]]
                 else summonInline[Schema[R, t]]

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -47,8 +47,12 @@ trait CommonSchemaDerivation {
           else
             (
               constValue[name].toString,
-              Macros.annotations[t],
-              summonInline[Schema[R, t]].asInstanceOf[Schema[R, Any]],
+              Macros.annotations[t], {
+                if (Macros.isEnumField[t])
+                  if (!Macros.implicitExists[Schema[R, t]]) derived[R, t]
+                  else summonInline[Schema[R, t]]
+                else summonInline[Schema[R, t]]
+              }.asInstanceOf[Schema[R, Any]],
               index
             ) :: values
         }(index + 1)

--- a/core/src/main/scala-3/caliban/schema/macros/Macros.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/Macros.scala
@@ -13,7 +13,7 @@ private[caliban] object Macros {
   inline def paramAnnotations[T]: List[(String, List[Any])] = ${ paramAnnotationsImpl[T] }
   inline def typeInfo[T]: TypeInfo                          = ${ typeInfoImpl[T] }
   inline def isFieldExcluded[P, T]: Boolean                 = ${ isFieldExcludedImpl[P, T] }
-  inline def isEnumField[T]: Boolean                        = ${ isEnumFieldImpl[T] }
+  inline def isEnumField[P, T]: Boolean                     = ${ isEnumFieldImpl[P, T] }
   inline def implicitExists[T]: Boolean                     = ${ implicitExistsImpl[T] }
 
   def annotationsImpl[T: Type](using qctx: Quotes): Expr[List[Any]] = {
@@ -83,9 +83,9 @@ private[caliban] object Macros {
     }
   }
 
-  def isEnumFieldImpl[T: Type](using q: Quotes): Expr[Boolean] = {
+  def isEnumFieldImpl[P: Type, T: Type](using q: Quotes): Expr[Boolean] = {
     import q.reflect.*
-    Expr(TypeRepr.of[T].termSymbol.flags.is(Flags.Enum))
+    Expr(TypeRepr.of[P].typeSymbol.flags.is(Flags.Enum) && TypeRepr.of[T].typeSymbol.flags.is(Flags.Enum))
   }
 
 }

--- a/core/src/main/scala-3/caliban/schema/macros/Macros.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/Macros.scala
@@ -13,6 +13,8 @@ private[caliban] object Macros {
   inline def paramAnnotations[T]: List[(String, List[Any])] = ${ paramAnnotationsImpl[T] }
   inline def typeInfo[T]: TypeInfo                          = ${ typeInfoImpl[T] }
   inline def isFieldExcluded[P, T]: Boolean                 = ${ isFieldExcludedImpl[P, T] }
+  inline def isEnumField[T]: Boolean                        = ${ isEnumFieldImpl[T] }
+  inline def implicitExists[T]: Boolean                     = ${ implicitExistsImpl[T] }
 
   def annotationsImpl[T: Type](using qctx: Quotes): Expr[List[Any]] = {
     import qctx.reflect.*
@@ -72,4 +74,18 @@ private[caliban] object Macros {
       && v.annotations.exists(_.tpe =:= TypeRepr.of[GQLExcluded])
     })
   }
+
+  def implicitExistsImpl[T: Type](using q: Quotes): Expr[Boolean] = {
+    import quotes.reflect._
+    Implicits.search(TypeRepr.of[T]) match {
+      case _: ImplicitSearchSuccess => Expr(true)
+      case _: ImplicitSearchFailure => Expr(false)
+    }
+  }
+
+  def isEnumFieldImpl[T: Type](using q: Quotes): Expr[Boolean] = {
+    import q.reflect.*
+    Expr(TypeRepr.of[T].termSymbol.flags.is(Flags.Enum))
+  }
+
 }

--- a/core/src/test/scala-3/caliban/schema/EnumFieldAutoDerivation.scala
+++ b/core/src/test/scala-3/caliban/schema/EnumFieldAutoDerivation.scala
@@ -1,0 +1,97 @@
+package caliban.schema
+
+import caliban.Macros.gqldoc
+import caliban.{ graphQL, RootResolver }
+import zio.{ Unsafe, ZIO }
+import zio.test.*
+
+object EnumFieldAutoDerivation extends ZIOSpecDefault {
+  import caliban.schema.Schema.*
+
+  override def spec = suite("EnumFieldAutoDerivation")(
+    test("A schema & argbuilder is created automatically for enums") {
+      val expected =
+        """schema {
+          |  query: Query
+          |}
+          |
+          |enum Bar {
+          |  BarA
+          |  BarB
+          |}
+          |
+          |enum Foo {
+          |  FooA
+          |  FooB
+          |}
+          |
+          |type Query {
+          |  foo(value: Bar): Value!
+          |}
+          |
+          |type Value {
+          |  value: Foo!
+          |}""".stripMargin
+
+      given Schema[Any, Foo]   = Schema.derived
+      given Schema[Any, Bar]   = Schema.derived
+      given Schema[Any, Value] = Schema.derived
+      given ArgBuilder[Bar]    = ArgBuilder.derived
+
+      given Schema[Any, Query] = Schema.Auto.derived
+
+      val resolver = RootResolver(Query(_ => Value(Foo.FooA)))
+      val gql      = graphQL(resolver)
+
+      assertTrue(gql.render == expected)
+    },
+    test("A provided Schema take priority over auto-derivation") {
+      given Schema[Any, Foo.FooB.type] = throw TestError
+      given Schema[Any, Foo]           = Schema.derived
+      given Schema[Any, Value]         = Schema.derived
+      given Schema[Any, Bar]           = Schema.derived
+      given ArgBuilder[Bar]            = ArgBuilder.derived
+      given Schema[Any, Query]         = Schema.derived
+      val resolver                     = RootResolver(Query(_ => Value(Foo.FooA)))
+
+      try {
+        graphQL(resolver).render
+        assertNever("Should have errored")
+      } catch {
+        case TestError => assertCompletes
+        case _         => assertNever("Invalid error")
+      }
+    },
+    test("A provided ArgBuilder take priority over auto-derivation") {
+      given Schema[Any, Foo]          = Schema.derived
+      given Schema[Any, Bar]          = Schema.derived
+      given Schema[Any, Value]        = Schema.derived
+      given ArgBuilder[Bar.BarA.type] = throw TestError
+      given ArgBuilder[Bar]           = ArgBuilder.derived
+      given Schema[Any, Query]        = Schema.derived
+
+      val resolver = RootResolver(Query(_ => Value(Foo.FooA)))
+      val gql      = graphQL(resolver)
+
+      val q = """query { foo(value: BarB) { value } }"""
+      gql.interpreter.flatMap(_.execute(q)).catchAllDefect(ZIO.fail(_)).either.flatMap {
+        case Right(_)                                 => assertNever("Should have errored")
+        case Left(e) if e.getMessage.contains("boom") => assertCompletes
+        case _                                        => assertNever("wrong error")
+      }
+    }
+  )
+
+  enum Foo {
+    case FooA, FooB
+  }
+
+  enum Bar {
+    case BarA, BarB
+  }
+
+  case class Value(value: Foo)
+  case class Query(foo: Option[Bar] => Value)
+
+  case object TestError extends Throwable("boom")
+}

--- a/core/src/test/scala-3/caliban/schema/EnumFieldAutoDerivation.scala
+++ b/core/src/test/scala-3/caliban/schema/EnumFieldAutoDerivation.scala
@@ -1,8 +1,7 @@
 package caliban.schema
 
-import caliban.Macros.gqldoc
 import caliban.{ graphQL, RootResolver }
-import zio.{ Unsafe, ZIO }
+import zio.ZIO
 import zio.test.*
 
 object EnumFieldAutoDerivation extends ZIOSpecDefault {


### PR DESCRIPTION
Not sure if this is a good or bad idea, but I thought it might be worth to discuss it at least.

With semi-auto derivation, we need to create a custom schema for each of the enum fields. e.g.,

Example 1:
```scala
enum Foo {
  case A, B
}

given Schema[Any, Foo]          = Schema.derived
given Schema[Any, Foo.A.type]   = Schema.derived
given Schema[Any, Foo.B.type]   = Schema.derived
```

In a perfect world, this would be allowed, but unfortunately Scala 3 doesn't allow the use of the `derives` keyword on enum fields:

```scala
enum Foo derives Schema.SemiAuto {
  case A derives Schema.SemiAuto
  case B derives Schema.SemiAuto
}
```
One alternative is to use auto-derivation for enums, but this already becomes a bit annoying when there are many enums in the schema:

```scala
given Schema[Any, Foo] = {
  import Schema.auto.*
  Schema.derived
}
```

Where this becomes problematic is when enums are used as unions instead. In the case below, auto-derivation will generate a schema for `FooInner` too, which is something we don't want if we're using semi-auto derivation.

Example 2:
```scala
case class FooInner(value: String)

@GQLUnion
enum Foo {
  case A()
  case B(value: FooInner)
}
```

The changes in this PR automatically generate a schema for enum fields, but not for any of their child fields (if applicable).

Schema definition then becomes:

```scala
// Example 1:
given Schema[Any, Foo] = Schema.derived

// Example 2:
given Schema[Any, Foo]    = Schema.derived
given Schema[Any, FooInner] = Schema.derived
```

What are your thoughts on this? Do you think that this is simplifying creation of schemas for enums or it might be making things unnecessarily complex?