### PR TITLE
Allow skipping `ValidationWrapper` for introspection queries

### DIFF
--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -58,12 +58,11 @@ object Wrapper {
    */
   trait ValidationWrapper[-R] extends SimpleWrapper[R, ValidationError, ExecutionRequest, Document] { self =>
 
+    /**
+     * Returns a new wrapper which skips the [[wrap]] function if the query is an introspection query.
+     */
     final def skipForIntrospection: ValidationWrapper[R] = new ValidationWrapper[R] {
       override val priority: Int = self.priority
-
-      override def apply[R1 <: R](that: GraphQL[R1]): GraphQL[R1] = self.apply(that)
-
-      override def |+|[R1 <: R](that: Wrapper[R1]): Wrapper[R1] = self |+| that
 
       override def wrap[R1 <: R](
         f: Document => ZIO[R1, ValidationError, ExecutionRequest]

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -5,7 +5,7 @@ import caliban.Value.NullValue
 import caliban.execution.{ ExecutionRequest, Field }
 import caliban.parsing.adt.Document
 import caliban.wrappers.Wrapper.{ OverallWrapper, ValidationWrapper }
-import caliban.{ CalibanError, Configurator, GraphQL, GraphQLRequest, GraphQLResponse }
+import caliban.{ CalibanError, Configurator, GraphQLRequest, GraphQLResponse }
 import zio.Console.{ printLine, printLineError }
 import zio._
 import zio.metrics.MetricKeyType.Histogram

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -99,10 +99,17 @@ object Wrappers {
 
   /**
    * Returns a wrapper that checks that the query's depth is under a given max
+   * @param maxDepth             the max allowed depth
+   */
+  def maxDepth(maxDepth: Int): ValidationWrapper[Any] =
+    this.maxDepth(maxDepth, skipForIntrospection = false)
+
+  /**
+   * Returns a wrapper that checks that the query's depth is under a given max
    * @param maxDepth the max allowed depth
    * @param skipForIntrospection whether to skip validation for introspection queries
    */
-  def maxDepth(maxDepth: Int, skipForIntrospection: Boolean = false): ValidationWrapper[Any] =
+  def maxDepth(maxDepth: Int, skipForIntrospection: Boolean): ValidationWrapper[Any] =
     new ValidationWrapper[Any] {
       def wrap[R1 <: Any](
         process: Document => ZIO[R1, ValidationError, ExecutionRequest]
@@ -134,10 +141,17 @@ object Wrappers {
 
   /**
    * Returns a wrapper that checks that the query has a limited number of fields
+   * @param maxFields            the max allowed number of fields
+   */
+  def maxFields(maxFields: Int): ValidationWrapper[Any] =
+    this.maxFields(maxFields, skipForIntrospection = false)
+
+  /**
+   * Returns a wrapper that checks that the query has a limited number of fields
    * @param maxFields the max allowed number of fields
    * @param skipForIntrospection whether to skip validation for introspection queries
    */
-  def maxFields(maxFields: Int, skipForIntrospection: Boolean = false): ValidationWrapper[Any] =
+  def maxFields(maxFields: Int, skipForIntrospection: Boolean): ValidationWrapper[Any] =
     new ValidationWrapper[Any] {
       def wrap[R1 <: Any](
         process: Document => ZIO[R1, ValidationError, ExecutionRequest]

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -591,7 +591,7 @@ object TestUtils {
   }
 
   val introspectionQuery =
-      """
+    """
       query IntrospectionQuery {
         __schema {
           queryType { name }

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -589,4 +589,99 @@ object TestUtils {
 
     val resolverQueryNoObject = RootResolver(Map("a" -> "b"))
   }
+
+  val introspectionQuery =
+      """
+      query IntrospectionQuery {
+        __schema {
+          queryType { name }
+          mutationType { name }
+          subscriptionType { name }
+          types {
+            ...FullType
+          }
+          directives {
+            name
+            description
+            locations
+            args {
+              ...InputValue
+            }
+          }
+        }
+      }
+
+      fragment FullType on __Type {
+        kind
+        name
+        description
+        fields(includeDeprecated: true) {
+          name
+          description
+          args {
+            ...InputValue
+          }
+          type {
+            ...TypeRef
+          }
+          isDeprecated
+          deprecationReason
+        }
+        inputFields {
+          ...InputValue
+        }
+        interfaces {
+          ...TypeRef
+        }
+        enumValues(includeDeprecated: true) {
+          name
+          description
+          isDeprecated
+          deprecationReason
+        }
+        possibleTypes {
+          ...TypeRef
+        }
+      }
+
+      fragment InputValue on __InputValue {
+        name
+        description
+        type { ...TypeRef }
+        defaultValue
+      }
+
+      fragment TypeRef on __Type {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
 }

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -414,6 +414,15 @@ object WrappersSpec extends ZIOSpecDefault {
         interpreter.flatMap(_.execute(query)).map { response =>
           assertTrue(response.data.toString == """true""")
         }
+      },
+      test("skipping validation wrappers for introspection") {
+        case class Test(test: String)
+        val gql = graphQL(RootResolver(Test("ok")))
+
+        for {
+          interpreter <- (gql @@ (maxFields(5).skipForIntrospection |+| maxDepth(1).skipForIntrospection)).interpreter
+          result      <- interpreter.executeRequest(GraphQLRequest(query = Some(TestUtils.introspectionQuery)))
+        } yield assertTrue(result.asJson.hcursor.downField("errors").failed)
       }
     )
 }


### PR DESCRIPTION
~~Introspection queries are relatively large + deep, so in order for introspection to be allowed we need for these wrappers to allow 250+ fields and 12 levels depth. With this PR, we can disable these checks for introspection queries.~~

~~One other way that this could be implemented is to be able to set a separate limit for introspections, e.g.,:~~

```scala
def maxFields(maxFields: Int, maxIntrospectionFields: Option[Int] = None): ValidationWrapper[Any] = ???
```

~~Thoughts?~~

EDIT: This PR now adds the `skipForIntrospection` method which returns a new ValidationWrapper that is skipped for introspection queries.