### PR TITLE
Resolve fields of objects lazily

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -85,7 +85,7 @@ trait CommonSchemaDerivation[R] {
           Some(ctx.typeName.full)
         )
 
-    override def resolveFieldLazily: Boolean = !ctx.isObject
+    override private[schema] def resolveFieldLazily: Boolean = !ctx.isObject
 
     override def resolve(value: T): Step[R] =
       if (ctx.isObject) PureStep(EnumValue(getName(ctx)))

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -4,7 +4,7 @@ import caliban.Value.EnumValue
 import caliban.introspection.adt.*
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations.*
-import caliban.schema.Step.ObjectStep
+import caliban.schema.Step.{ FunctionStep, ObjectStep }
 import caliban.schema.Types.*
 import caliban.schema.macros.{ Macros, TypeInfo }
 

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -154,7 +154,7 @@ trait CommonSchemaDerivation {
       else if (isInput) mkInputObject[R](annotations, fields, info, paramAnnotations)(isInput, isSubscription)
       else mkObject[R](annotations, fields, info, paramAnnotations)(isInput, isSubscription)
 
-    override def resolveFieldLazily: Boolean = fields.nonEmpty
+    override private[schema] lazy val resolveFieldLazily: Boolean = fields.nonEmpty
 
     def resolve(value: A): Step[R] =
       if (fields.isEmpty) PureStep(EnumValue(name))
@@ -165,8 +165,8 @@ trait CommonSchemaDerivation {
         val fieldsBuilder = Map.newBuilder[String, Step[R]]
         fields.foreach { case (label, _, schema, index) =>
           val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
+          lazy val step        = schema.resolve(value.asInstanceOf[Product].productElement(index))
           fieldsBuilder += getName(fieldAnnotations, label) -> {
-            lazy val step = schema.resolve(value.asInstanceOf[Product].productElement(index))
             if (schema.resolveFieldLazily) FunctionStep(_ => step)
             else step
           }

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -154,6 +154,8 @@ trait CommonSchemaDerivation {
       else if (isInput) mkInputObject[R](annotations, fields, info, paramAnnotations)(isInput, isSubscription)
       else mkObject[R](annotations, fields, info, paramAnnotations)(isInput, isSubscription)
 
+    override def resolveFieldLazily: Boolean = fields.nonEmpty
+
     def resolve(value: A): Step[R] =
       if (fields.isEmpty) PureStep(EnumValue(name))
       else if (isValueType) {
@@ -163,9 +165,11 @@ trait CommonSchemaDerivation {
         val fieldsBuilder = Map.newBuilder[String, Step[R]]
         fields.foreach { case (label, _, schema, index) =>
           val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
-          fieldsBuilder += getName(fieldAnnotations, label) -> schema.resolve(
-            value.asInstanceOf[Product].productElement(index)
-          )
+          fieldsBuilder += getName(fieldAnnotations, label) -> {
+            lazy val step = schema.resolve(value.asInstanceOf[Product].productElement(index))
+            if (schema.resolveFieldLazily) FunctionStep(_ => step)
+            else step
+          }
         }
         ObjectStep(name, fieldsBuilder.result())
       }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -393,7 +393,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         kvSchema.toType_(isInput, isSubscription).nonNull.list
 
-      override def resolveFieldLazily                          = true
+      override def resolveFieldLazily: Boolean                 = evA.resolveFieldLazily || evB.resolveFieldLazily
       override def resolve(value: Map[A, B]): Step[RA with RB] = ListStep(value.toList.map(kvSchema.resolve))
     }
   implicit def functionSchema[RA, RB, A, B](implicit


### PR DESCRIPTION
From Discord thread:

>I came across an interesting "issue". I was looking at some profiling results, and saw a rather significant amount of CPU time spent on the Schema.resolve method for rather small queries (~10% of the CPU time). After some investigation, it seems to happen when the query resolves to a rather big case class with many fields, where some of them have other nested fields etc. Even if the query doesn't request those fields, it seems that we're still resolving them, which can be quite expensive especially in the presence of many pure values. A solution to it was to make nested fields lazy () => SomeType, but even so we're still resolving a lot of fields that were not queried unnecessarily.

With this PR, we resolve fields that are pure objects (or pure objects wrapped in a collection) lazily. We do this because we want to avoid wrapping all fields in a `FunctionStep`, which requires packing/unpacking pure values / primitives during runtime.

With this PR, the resolving changes to:

```scala

case class Foo(valueA: String, valueB: Int)

case class Queries(
  string: String,             // Resolves eagerly (same behaviour)
  stringList: List[String],   // Resolves eagerly (same behaviour)
  args: String => String,     // Resolves lazily (same behaviour)
  effString: Task[String],    // Resolves lazily (same behaviour)
  obj: Foo,                   // Resolves lazily (changed)
  optObj: Option[Foo],        // Resolves lazily (changed)
  listObj: List[Foo],         // Resolves lazily (changed)
  // And so on
)
```