### PR TITLE
Optimize `VariableCoercer`

### DIFF
--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
@@ -3,7 +3,7 @@ package caliban.execution
 import caliban.InputValue
 import caliban.InputValue.ObjectValue
 import caliban.Value.IntValue
-import caliban.schema.{ ArgBuilder, FieldAttributes, GenericSchema, Schema }
+import caliban.schema.{ ArgBuilder, Schema }
 import zio.query.ZQuery
 
 object NestedZQueryBenchmarkSchema {
@@ -14,14 +14,14 @@ object NestedZQueryBenchmarkSchema {
 
   implicit val simpleEntitySchema: Schema[Any, SimpleEntity]       = Schema.gen
   implicit val multipleEntitySchema: Schema[Any, MultifieldEntity] = Schema.gen
-  lazy implicit val deepEntitySchema: Schema[Any, DeepEntity]      = obj[Any, DeepEntity]("DeepEntity") { implicit fa =>
+
+  implicit val deepArgsBuilder: ArgBuilder[DeepArgs]          = ArgBuilder.gen
+  lazy implicit val deepEntitySchema: Schema[Any, DeepEntity] = obj[Any, DeepEntity]("DeepEntity") { implicit fa =>
     List(
       field[DeepEntity]("next")(_.next),
       field[DeepEntity]("nested")(_.nested)
     )
   }
-
-  implicit val deepArgsBuilder: ArgBuilder[DeepArgs] = ArgBuilder.derived
 
   lazy implicit val deepArgsSchema: Schema[Any, DeepArgs] =
     obj[Any, DeepArgs]("DeepArgs") { implicit fa =>
@@ -109,11 +109,11 @@ object NestedZQueryBenchmarkSchema {
     }
   }""".stripMargin
 
-  val deepWithArgs100Elements: DeepWithArgsRoot   = generateDeepWithArgs(100)
-  val deepWithArgs1000Elements: DeepWithArgsRoot  = generateDeepWithArgs(1000)
+  val deepWithArgs100Elements: DeepWithArgsRoot  = generateDeepWithArgs(100)
+  val deepWithArgs1000Elements: DeepWithArgsRoot = generateDeepWithArgs(1000)
 
-  val deepArgs100Elements: Map[String, InputValue] = generateDeepArgs(100)
-  val deepArgs1000Elements:  Map[String, InputValue] = generateDeepArgs(1000)
+  val deepArgs100Elements: Map[String, InputValue]  = generateDeepArgs(100)
+  val deepArgs1000Elements: Map[String, InputValue] = generateDeepArgs(1000)
 
   val deepWithArgsQuery: String =
     """query IntrospectionQuery($args: DeepArgsInput!) {

--- a/benchmarks/src/main/scala/caliban/execution/ValidationBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/execution/ValidationBenchmark.scala
@@ -1,7 +1,6 @@
 package caliban.execution
 
-import caliban.*
-import caliban.Value.IntValue
+import caliban._
 import caliban.parsing.{ Parser, VariablesCoercer }
 import caliban.schema.RootType
 import caliban.validation.Validator
@@ -18,7 +17,7 @@ import org.openjdk.jmh.annotations.{
 }
 
 import java.util.concurrent.TimeUnit
-import zio.*
+import zio._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -105,7 +105,9 @@ trait GraphQL[-R] { self =>
                                                           }
                   typeToValidate                        = if (intro) introspectionRootType else rootType
                   schemaToExecute                       = if (intro) introspectionRootSchema else schema
-                  validatedReq                         <- VariablesCoercer.coerceVariables(request, doc, typeToValidate, skipValidation)
+                  validatedVariables                   <-
+                    VariablesCoercer
+                      .coerceVariables(request.variables.getOrElse(Map.empty), doc, typeToValidate, skipValidation)
                   validate                              = (doc: Document) =>
                                                             for {
                                                               config       <- Configurator.configuration
@@ -113,8 +115,8 @@ trait GraphQL[-R] { self =>
                                                                                 doc,
                                                                                 typeToValidate,
                                                                                 schemaToExecute,
-                                                                                validatedReq.operationName,
-                                                                                validatedReq.variables.getOrElse(Map.empty),
+                                                                                request.operationName,
+                                                                                validatedVariables,
                                                                                 config.skipValidation,
                                                                                 config.validations
                                                                               )

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -105,9 +105,8 @@ trait GraphQL[-R] { self =>
                                                           }
                   typeToValidate                        = if (intro) introspectionRootType else rootType
                   schemaToExecute                       = if (intro) introspectionRootSchema else schema
-                  validatedVariables                   <-
-                    VariablesCoercer
-                      .coerceVariables(request.variables.getOrElse(Map.empty), doc, typeToValidate, skipValidation)
+                  unsafeVars                            = request.variables.getOrElse(Map.empty)
+                  coercedVars                          <- VariablesCoercer.coerceVariables(unsafeVars, doc, typeToValidate, skipValidation)
                   validate                              = (doc: Document) =>
                                                             for {
                                                               config       <- Configurator.configuration
@@ -116,7 +115,7 @@ trait GraphQL[-R] { self =>
                                                                                 typeToValidate,
                                                                                 schemaToExecute,
                                                                                 request.operationName,
-                                                                                validatedVariables,
+                                                                                coercedVars,
                                                                                 config.skipValidation,
                                                                                 config.validations
                                                                               )


### PR DESCRIPTION
Seems that when we refactored the `Validator` to use `ZPure` we forgot(?) to do it with the `VariableCoercer`. Reality is that in most cases the variables will be a small / shallow object so this doesn't _really_ provide much performance benefits for most users, except perhaps in cases where the inputs are deeply nested JSON files.

In this PR there are 2 different optimizations:

1. Use ZPure in favour of ZIO effects when recursing
2. Make `context` a by-name argument. This prevents us building the error context except when we need to fail the validation

### Benchmarking results

Before:
```
[info] Benchmark                              Mode  Cnt      Score     Error  Units
[info] ValidationBenchmark.variableCoercer100   thrpt    5  14006.365 ± 180.586  ops/s
[info] ValidationBenchmark.variableCoercer1000  thrpt    5    518.925 ±  18.125  ops/s
```

After:
```
[info] Benchmark                                 Mode  Cnt      Score     Error  Units
[info] ValidationBenchmark.variableCoercer100   thrpt    5  87682.811 ± 661.300  ops/s
[info] ValidationBenchmark.variableCoercer1000  thrpt    5   8429.327 ±  28.180  ops/s
```