### PR TITLE
Add test for HTTP `GET` method

### DIFF
--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -35,7 +35,7 @@ object PlayAdapterSpec extends ZIOSpecDefault {
       runtime     <- ZIO.runtime[TestService with Uploads]
       interpreter <- TestApi.api.interpreter
       router       = Router.from {
-                       case req @ POST(p"/api/graphql")    =>
+                       case req @ (GET(p"/api/graphql") | POST(p"/api/graphql"))    =>
                          PlayAdapter
                            .makeHttpService(
                              HttpInterpreter(interpreter)

--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -35,18 +35,18 @@ object PlayAdapterSpec extends ZIOSpecDefault {
       runtime     <- ZIO.runtime[TestService with Uploads]
       interpreter <- TestApi.api.interpreter
       router       = Router.from {
-                       case req @ (GET(p"/api/graphql") | POST(p"/api/graphql"))    =>
+                       case req @ (GET(p"/api/graphql") | POST(p"/api/graphql")) =>
                          PlayAdapter
                            .makeHttpService(
                              HttpInterpreter(interpreter)
                                .intercept(FakeAuthorizationInterceptor.bearer[TestService & Uploads])
                            )(runtime, mat)
                            .apply(req)
-                       case req @ POST(p"/upload/graphql") =>
+                       case req @ POST(p"/upload/graphql")                       =>
                          PlayAdapter
                            .makeHttpUploadService(HttpUploadInterpreter(interpreter))(runtime, mat, implicitly, implicitly)
                            .apply(req)
-                       case req @ GET(p"/ws/graphql")      =>
+                       case req @ GET(p"/ws/graphql")                            =>
                          PlayAdapter.makeWebSocketService(WebSocketInterpreter(interpreter))(runtime, mat).apply(req)
                      }
       _           <- ZIO


### PR DESCRIPTION
Saw some time ago that we don't have a test against HTTP `GET` methods. Adding this as an extra precaution now that we're going to use a different tapir version for core / zio-http