### PR TITLE
Adjust tracing span name to adhere to semantic guidelines

### DIFF
--- a/core/src/main/scala/caliban/execution/ExecutionRequest.scala
+++ b/core/src/main/scala/caliban/execution/ExecutionRequest.scala
@@ -4,5 +4,6 @@ import caliban.parsing.adt.OperationType
 
 case class ExecutionRequest(
   field: Field,
-  operationType: OperationType
+  operationType: OperationType,
+  operationName: Option[String]
 )

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -143,7 +143,8 @@ object Validator {
                 op.directives,
                 rootType
               ),
-              op.operationType
+              op.operationType,
+              operationName
             )
           )
       }

--- a/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
@@ -44,8 +44,8 @@ object SchemaTracer {
 
   private def spanName(request: ExecutionRequest): String = {
     val operationTypeString = request.operationType match {
-      case OperationType.Query => "query"
-      case OperationType.Mutation => "mutation"
+      case OperationType.Query        => "query"
+      case OperationType.Mutation     => "mutation"
       case OperationType.Subscription => "subscription"
     }
 

--- a/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
@@ -43,7 +43,7 @@ object SchemaTracer {
 
   private def attributes[T, R](
     field: Field
-  ) = List("query" -> graphQLQuery(field))
+  ) = List("document" -> graphQLQuery(field))
 
   private def graphQLQuery(field: Field): String =
     RemoteQuery.apply(maskField(field)).toGraphQLRequest.query.getOrElse("")

--- a/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
@@ -10,6 +10,7 @@ import caliban.Value.IntValue.IntNumber
 import caliban.Value.StringValue
 import caliban.execution.ExecutionRequest
 import caliban.execution.Field
+import caliban.parsing.adt.OperationType
 import caliban.tools.stitching.RemoteQuery
 import caliban.wrappers.Wrapper.ExecutionWrapper
 import io.opentelemetry.api.trace.SpanKind
@@ -30,7 +31,7 @@ object SchemaTracer {
         else
           ZIO.serviceWithZIO[Tracing](tracer =>
             tracer.span[R, Nothing, GraphQLResponse[CalibanError]](
-              "query",
+              spanName(request),
               SpanKind.INTERNAL
             ) {
               ZIO.foreach(attributes(request.field)) { case (k, v) =>
@@ -39,6 +40,20 @@ object SchemaTracer {
             }
           )
       }
+  }
+
+  private def spanName(request: ExecutionRequest): String = {
+    val operationTypeString = request.operationType match {
+      case OperationType.Query => "query"
+      case OperationType.Mutation => "mutation"
+      case OperationType.Subscription => "subscription"
+    }
+
+    // The span name MUST be of the format <graphql.operation.type> <graphql.operation.name>
+    // provided that graphql.operation.type and graphql.operation.name are available. If
+    // graphql.operation.name is not available, the span SHOULD be named <graphql.operation.type>.
+    // When <graphql.operation.type> is not available, GraphQL Operation MAY be used as span name.
+    Seq(Some(operationTypeString), request.operationName).flatten.mkString(" ")
   }
 
   private def attributes[T, R](


### PR DESCRIPTION
Adjusts the tracing span name to adhere to [the published OpenTelemetry semantic guidelines for GraphQL](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/graphql.md). Mostly, this was just two things:

1. Renaming the `"query"` attribute to `"document"`, and
2. Renaming the span from the generic `"query"` to `"<operationType>[ <operationName>]"`

To achieve 2, I had to modify the `ExecutionRequest` type to include the `operationName` as an argument. This wasn't too hard, as `ExecutionRequest` is only constructed in one spot.