### PR TITLE
Add a simple wrapper to check directives

### DIFF
--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -2,14 +2,15 @@ package caliban.wrappers
 
 import caliban.CalibanError.{ ExecutionError, ValidationError }
 import caliban.Value.NullValue
-import caliban.execution.{ ExecutionRequest, Field }
-import caliban.parsing.adt.Document
-import caliban.wrappers.Wrapper.{ OverallWrapper, ValidationWrapper }
-import caliban.{ CalibanError, Configurator, GraphQLRequest, GraphQLResponse }
+import caliban.execution.{ ExecutionRequest, Field, FieldInfo }
+import caliban.parsing.adt.{ Directive, Document }
+import caliban.wrappers.Wrapper.{ FieldWrapper, OverallWrapper, ValidationWrapper }
+import caliban.{ CalibanError, Configurator, GraphQLRequest, GraphQLResponse, ResponseValue }
 import zio.Console.{ printLine, printLineError }
 import zio._
 import zio.metrics.MetricKeyType.Histogram
 import zio.metrics.MetricLabel
+import zio.query.ZQuery
 
 import scala.annotation.tailrec
 
@@ -172,4 +173,18 @@ object Wrappers {
   private def innerFields(fields: List[Field]): UIO[Int] =
     ZIO.foreach(fields)(countFields).map(_.sum + fields.length)
 
+  /**
+   * Returns a wrapper that check directives on fields and can potentially fail the query
+   * @param check a function from directives to a ZIO that can fail
+   */
+  def checkDirectives[R](check: List[Directive] => ZIO[R, ExecutionError, Unit]): FieldWrapper[R] =
+    new FieldWrapper[R]() {
+      def wrap[R1 <: R](
+        query: ZQuery[R1, ExecutionError, ResponseValue],
+        info: FieldInfo
+      ): ZQuery[R1, ExecutionError, ResponseValue] = {
+        val directives = info.parent.flatMap(_.allFields.find(_.name == info.name)).flatMap(_.directives).getOrElse(Nil)
+        ZQuery.fromZIO(check(directives)) *> query
+      }
+    }
 }


### PR DESCRIPTION
It can be useful if you want to use an annotation to control permissions at the field level. Even if not super useful, it is a good example of what you can do with wrappers, and users can use that as a base to make their own.