### PR TITLE
Optionally disable tracing of pure fields in `ApolloTracing` wrapper

### DIFF
--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmark.scala
@@ -77,7 +77,7 @@ class NestedZQueryBenchmark {
     run(
       graphQL[Any, MultifieldRoot, Unit, Unit](
         RootResolver(NestedZQueryBenchmarkSchema.multifield1000Elements)
-      ).withWrapper(ApolloTracing.apolloTracing).interpreter
+      ).withWrapper(ApolloTracing.apolloTracing()).interpreter
     )
 
   @Benchmark

--- a/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
@@ -20,7 +20,8 @@ object ApolloTracing {
    * following Apollo Tracing format: https://github.com/apollographql/apollo-tracing.
    *
    * @param excludePureFields Optionally disable tracing of pure fields.
-   *                          Setting this to true can help improve performance at the cost of generating incomplete traces
+   *                          Setting this to true can help improve performance at the cost of generating incomplete traces.
+   *                          WARNING: Use this with caution as it could potentially cause issues if the tracing client expects all queried fields to be included in the traces
    */
   def apolloTracing(excludePureFields: Boolean = false): EffectfulWrapper[Any] =
     EffectfulWrapper(

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -96,7 +96,7 @@ object ExampleApi {
       timeout(3 seconds) @@           // wrapper that fails slow queries
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
-      apolloTracing @@                // wrapper for https://github.com/apollographql/apollo-tracing
+      apolloTracing() @@                // wrapper for https://github.com/apollographql/apollo-tracing
       DeferSupport.defer              // wrapper that enables @defer directive support
   }
 

--- a/examples/src/main/scala/example/federation/FederatedApi.scala
+++ b/examples/src/main/scala/example/federation/FederatedApi.scala
@@ -22,7 +22,7 @@ object FederatedApi {
       maxDepth(30) |+|                 // query analyzer that limit query depth
       timeout(3 seconds) |+|           // wrapper that fails slow queries
       printSlowQueries(500 millis) |+| // wrapper that logs slow queries
-      ApolloFederatedTracing.wrapper   // wrapper for https://github.com/apollographql/apollo-tracing
+      ApolloFederatedTracing.wrapper()   // wrapper for https://github.com/apollographql/apollo-tracing
 
   object Characters extends GenericSchema[CharacterService] {
     import example.federation.FederationData.characters._

--- a/examples/src/main/scala/example/federation/v2/FederatedApi.scala
+++ b/examples/src/main/scala/example/federation/v2/FederatedApi.scala
@@ -22,7 +22,7 @@ object FederatedApi {
       maxDepth(30) |+|                 // query analyzer that limit query depth
       timeout(3 seconds) |+|           // wrapper that fails slow queries
       printSlowQueries(500 millis) |+| // wrapper that logs slow queries
-      ApolloFederatedTracing.wrapper   // wrapper for https://github.com/apollographql/apollo-tracing
+      ApolloFederatedTracing.wrapper() // wrapper for https://github.com/apollographql/apollo-tracing
 
   object Characters extends GenericSchema[CharacterService] {
     import FederationData.characters._

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
@@ -65,6 +65,6 @@ object TestApi extends GenericSchema[TestService with Uploads] {
       timeout(3 seconds) @@           // wrapper that fails slow queries
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
-      apolloTracing @@                // wrapper for https://github.com/apollographql/apollo-tracing
+      apolloTracing() @@              // wrapper for https://github.com/apollographql/apollo-tracing
       DeferSupport.defer
 }

--- a/vuepress/docs/docs/federation.md
+++ b/vuepress/docs/docs/federation.md
@@ -98,7 +98,7 @@ Federated tracing is slightly different from standard apollo-tracing thus it com
 import caliban.federation.tracing.ApolloFederatedTracing
 
 
-val api = schema @@ federated(resolver, additionalResolvers: _*) @@ ApolloFederatedTracing.wrapper
+val api = schema @@ federated(resolver, additionalResolvers: _*) @@ ApolloFederatedTracing.wrapper()
 ```
 In federated tracing the gateway communicates with the implementing service via a header `apollo-federation-include-trace`,
 for now the only value it can send is `ftv1`. Thus if you detect this header then you should enable tracing otherwise you can disable it.


### PR DESCRIPTION
We previously discussed on Discord that it might be good to expose this as an option where users might prefer performance over correctness