### PR TITLE
Another round of optimizations

### DIFF
--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -82,11 +82,11 @@ trait CommonSchemaDerivation {
     annotations: List[Any]
   )(ordinal: A => Int): Schema[R, A] = new Schema[R, A] {
 
-    private lazy val members = _members
+    private lazy val members = _members.toVector // Vector's .apply is O(1) vs List's O(N)
 
     private lazy val subTypes = members.map { case (label, subTypeAnnotations, schema, _) =>
       (label, schema.toType_(), subTypeAnnotations)
-    }.sortBy { case (label, _, _) => label }
+    }.sortBy { case (label, _, _) => label }.toList
 
     private lazy val isEnum = subTypes.forall { (_, t, _) =>
       t.fields(__DeprecatedArgs(Some(true))).forall(_.isEmpty)
@@ -131,48 +131,55 @@ trait CommonSchemaDerivation {
     paramAnnotations: Map[String, List[Any]]
   ): Schema[R, A] = new Schema[R, A] {
 
-    private lazy val fields = _fields
+    private lazy val fields = _fields.map { case (label, _, schema, index) =>
+      val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
+      (getName(fieldAnnotations, label), fieldAnnotations, schema, index)
+    }
 
-    private lazy val isValueType: Boolean =
+    private val isValueType: Boolean =
       annotations.exists {
         case GQLValueType(_) => true
         case _               => false
       }
 
-    private lazy val isScalarValueType: Boolean =
+    private def isScalarValueType: Boolean =
       annotations.exists {
         case GQLValueType(true) => true
         case _                  => false
       }
 
-    private lazy val name = getName(annotations, info)
+    private val name = getName(annotations, info)
 
     def toType(isInput: Boolean, isSubscription: Boolean): __Type =
       if (isValueType && fields.nonEmpty)
         if (isScalarValueType) makeScalar(name, getDescription(annotations))
         else fields.head._3.toType_(isInput, isSubscription)
-      else if (isInput) mkInputObject[R](annotations, fields, info, paramAnnotations)(isInput, isSubscription)
-      else mkObject[R](annotations, fields, info, paramAnnotations)(isInput, isSubscription)
+      else if (isInput) mkInputObject[R](annotations, fields, info)(isInput, isSubscription)
+      else mkObject[R](annotations, fields, info)(isInput, isSubscription)
 
-    override private[schema] lazy val resolveFieldLazily: Boolean = fields.nonEmpty
+    override private[schema] lazy val resolveFieldLazily: Boolean = (!isValueType) && fields.isEmpty
 
     def resolve(value: A): Step[R] =
       if (fields.isEmpty) PureStep(EnumValue(name))
-      else if (isValueType) {
-        val head = fields.head
-        head._3.resolve(value.asInstanceOf[Product].productElement(head._4))
-      } else {
-        val fieldsBuilder = Map.newBuilder[String, Step[R]]
-        fields.foreach { case (label, _, schema, index) =>
-          val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
-          lazy val step        = schema.resolve(value.asInstanceOf[Product].productElement(index))
-          fieldsBuilder += getName(fieldAnnotations, label) -> {
-            if (schema.resolveFieldLazily) FunctionStep(_ => step)
-            else step
-          }
+      else if (isValueType) resolveValueType(value)
+      else resolveObject(value)
+
+    private def resolveValueType(value: A): Step[R] = {
+      val head = fields.head
+      head._3.resolve(value.asInstanceOf[Product].productElement(head._4))
+    }
+
+    private def resolveObject(value: A): Step[R] = {
+      val fieldsBuilder = Map.newBuilder[String, Step[R]]
+      fields.foreach { case (name, _, schema, index) =>
+        lazy val step = schema.resolve(value.asInstanceOf[Product].productElement(index))
+        fieldsBuilder += name -> {
+          if (schema.resolveFieldLazily) FunctionStep(_ => step)
+          else step
         }
-        ObjectStep(name, fieldsBuilder.result())
       }
+      ObjectStep(name, fieldsBuilder.result())
+    }
   }
 
   // see https://github.com/graphql/graphql-spec/issues/568
@@ -271,15 +278,13 @@ trait CommonSchemaDerivation {
   private def mkInputObject[R](
     annotations: List[Any],
     fields: List[(String, List[Any], Schema[R, Any], Int)],
-    info: TypeInfo,
-    paramAnnotations: Map[String, List[Any]]
+    info: TypeInfo
   )(isInput: Boolean, isSubscription: Boolean) = makeInputObject(
     Some(getInputName(annotations).getOrElse(customizeInputTypeName(getName(annotations, info)))),
     getDescription(annotations),
-    fields.map { (label, _, schema, _) =>
-      val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
+    fields.map { (name, fieldAnnotations, schema, _) =>
       __InputValue(
-        getName(fieldAnnotations, label),
+        name,
         getDescription(fieldAnnotations),
         () =>
           if (schema.optional) schema.toType_(isInput, isSubscription)
@@ -295,19 +300,14 @@ trait CommonSchemaDerivation {
   private def mkObject[R](
     annotations: List[Any],
     fields: List[(String, List[Any], Schema[R, Any], Int)],
-    info: TypeInfo,
-    paramAnnotations: Map[String, List[Any]]
+    info: TypeInfo
   )(isInput: Boolean, isSubscription: Boolean) = makeObject(
     Some(getName(annotations, info)),
     getDescription(annotations),
-    fields.filterNot { case (label, _, _, _) =>
-      paramAnnotations.getOrElse(label, Nil).contains(GQLExcluded())
-    }.map { case (label, _, schema, _) =>
-      val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
+    fields.map { case (name, fieldAnnotations, schema, _) =>
       val deprecatedReason = getDeprecatedReason(fieldAnnotations)
-
       __Field(
-        getName(fieldAnnotations, label),
+        name,
         getDescription(fieldAnnotations),
         schema.arguments,
         () =>
@@ -321,6 +321,7 @@ trait CommonSchemaDerivation {
     getDirectives(annotations),
     Some(info.full)
   )
+
 }
 
 trait SchemaDerivation[R] extends CommonSchemaDerivation {

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -64,20 +64,20 @@ trait GraphQL[-R] { self =>
 
   private lazy val cachedInterpreter =
     Validator.validateSchemaEither(schemaBuilder).map { schema =>
-      lazy val rootType =
-        RootType(
-          schema.query.opType,
-          schema.mutation.map(_.opType),
-          schema.subscription.map(_.opType),
-          schemaBuilder.additionalTypes,
-          additionalDirectives,
-          schemaBuilder.schemaDescription
-        )
-
-      val introWrappers                               = wrappers.collect { case w: IntrospectionWrapper[R] => w }
-      lazy val introspectionRootSchema: RootSchema[R] = Introspector.introspect(rootType, introWrappers)
-
       new GraphQLInterpreter[R, CalibanError] {
+        private val rootType =
+          RootType(
+            schema.query.opType,
+            schema.mutation.map(_.opType),
+            schema.subscription.map(_.opType),
+            schemaBuilder.additionalTypes,
+            additionalDirectives,
+            schemaBuilder.schemaDescription
+          )
+
+        private val introWrappers                               = wrappers.collect { case w: IntrospectionWrapper[R] => w }
+        private lazy val introspectionRootSchema: RootSchema[R] = Introspector.introspect(rootType, introWrappers)
+
         override def check(query: String)(implicit trace: Trace): IO[CalibanError, Unit] =
           for {
             document      <- Parser.parseQuery(query)

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -4,8 +4,8 @@ import scala.util.Try
 import caliban.interop.circe._
 import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.jsoniter.IsJsoniterCodec
-import caliban.interop.play.{IsPlayJsonReads, IsPlayJsonWrites}
-import caliban.interop.zio.{IsZIOJsonDecoder, IsZIOJsonEncoder}
+import caliban.interop.play.{ IsPlayJsonReads, IsPlayJsonWrites }
+import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 import caliban.rendering.ValueRenderer
 import zio.stream.Stream
 

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -4,10 +4,12 @@ import scala.util.Try
 import caliban.interop.circe._
 import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.jsoniter.IsJsoniterCodec
-import caliban.interop.play.{ IsPlayJsonReads, IsPlayJsonWrites }
-import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
+import caliban.interop.play.{IsPlayJsonReads, IsPlayJsonWrites}
+import caliban.interop.zio.{IsZIOJsonDecoder, IsZIOJsonEncoder}
 import caliban.rendering.ValueRenderer
 import zio.stream.Stream
+
+import scala.util.hashing.MurmurHash3
 
 sealed trait InputValue { self =>
   def toInputString: String = ValueRenderer.inputValueRenderer.renderCompact(self)
@@ -71,10 +73,10 @@ object ResponseValue {
     override def toString: String =
       ValueRenderer.responseObjectValueRenderer.renderCompact(this)
 
-    override def hashCode: Int               = fields.toSet.hashCode()
+    override lazy val hashCode: Int          = MurmurHash3.unorderedHash(fields)
     override def equals(other: Any): Boolean =
       other match {
-        case o: ObjectValue => o.hashCode() == hashCode
+        case o: ObjectValue => o.hashCode == hashCode
         case _              => false
       }
   }

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -58,10 +58,10 @@ object Executor {
           value match {
             case EnumValue(v) =>
               // special case of an hybrid union containing case objects, those should return an object instead of a string
-              val obj = currentField.fields.collectFirst {
-                case f: Field if f.name == "__typename" =>
+              val obj = currentField.fields.view.filter(_._condition.forall(_.contains(v))).collectFirst {
+                case f if f.name == "__typename" =>
                   ObjectValue(List(f.aliasedName -> StringValue(v)))
-                case f: Field if f.name == "_"          =>
+                case f if f.name == "_"          =>
                   NullValue
               }
               obj.fold(s)(PureStep(_))

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -15,7 +15,7 @@ import zio.query.{ Cache, ZQuery }
 import zio.stream.ZStream
 
 import scala.annotation.tailrec
-import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
 
 object Executor {
 
@@ -33,6 +33,7 @@ object Executor {
     queryExecution: QueryExecution = QueryExecution.Parallel,
     featureSet: Set[Feature] = Set.empty
   )(implicit trace: Trace): URIO[R, GraphQLResponse[CalibanError]] = {
+    val wrapPureValues = fieldWrappers.exists(_.wrapPureValues)
 
     val execution                                                          = request.operationType match {
       case OperationType.Query        => queryExecution
@@ -57,7 +58,7 @@ object Executor {
           value match {
             case EnumValue(v) =>
               // special case of an hybrid union containing case objects, those should return an object instead of a string
-              val obj = mergeFields(currentField, v).collectFirst {
+              val obj = currentField.fields.collectFirst {
                 case f: Field if f.name == "__typename" =>
                   ObjectValue(List(f.aliasedName -> StringValue(v)))
                 case f: Field if f.name == "_"          =>
@@ -69,10 +70,8 @@ object Executor {
         case FunctionStep(step)             => reduceStep(step(arguments), currentField, Map(), path)
         case MetadataFunctionStep(step)     => reduceStep(step(currentField), currentField, arguments, path)
         case ListStep(steps)                =>
-          var i = -1
           reduceList(
-            steps.map { step =>
-              i += 1
+            steps.zipWithIndex.map { case (step, i) =>
               reduceStep(step, currentField, arguments, Right(i) :: path)
             },
             Types.listOf(currentField.fieldType).fold(false)(_.isNullable)
@@ -99,13 +98,13 @@ object Executor {
           }
 
           deferred match {
-            case Nil => reduceObject(eager, fieldWrappers)
+            case Nil => reduceObject(eager, wrapPureValues)
             case d   =>
               DeferStep(
-                reduceObject(eager, fieldWrappers),
+                reduceObject(eager, wrapPureValues),
                 d.groupBy(_._1).toList.map { case (label, labelAndFields) =>
                   val (_, fields) = labelAndFields.unzip
-                  reduceObject(fields, fieldWrappers) -> label
+                  reduceObject(fields, wrapPureValues) -> label
                 },
                 path
               )
@@ -270,60 +269,42 @@ object Executor {
 
   private[caliban] def mergeFields(field: Field, typeName: String): List[Field] = {
     // ugly mutable code but it's worth it for the speed ;)
-    val array    = ArrayBuffer.empty[Field]
-    val map      = collection.mutable.Map.empty[String, Int]
-    var index    = 0
+    val map      = new java.util.LinkedHashMap[String, Field]()
     var modified = false
 
     field.fields.foreach { field =>
       if (field._condition.forall(_.contains(typeName))) {
-        val name = field.aliasedName
-        map.get(name) match {
-          case None        =>
-            // first time we see this field, add it to the array
-            array += field
-            map.update(name, index)
-            index = index + 1
-          case Some(index) =>
-            modified = true
-            // field already existed, merge it
-            val f = array(index)
-            array(index) = f.copy(fields = f.fields ::: field.fields)
-        }
+        map.compute(
+          field.aliasedName,
+          (_, f) =>
+            if (f == null) field
+            else {
+              modified = true
+              f.copy(fields = f.fields ::: field.fields)
+            }
+        )
       } else {
         modified = true
       }
     }
 
-    // Avoid materializing the buffer if no modification took place
-    if (modified) array.toList else field.fields
+    // Avoid conversions if no modification took place
+    if (modified) map.values().asScala.toList else field.fields
   }
 
   private def fieldInfo(field: Field, path: List[Either[String, Int]], fieldDirectives: List[Directive]): FieldInfo =
     FieldInfo(field.aliasedName, field, path, fieldDirectives, field.parentType)
 
-  private def reduceList[R](list: List[ReducedStep[R]], areItemsNullable: Boolean): ReducedStep[R] = {
-    var allPure = true
-    val pures  = List.newBuilder[ResponseValue]
-    var tail   = list
-    while (allPure && tail.nonEmpty)
-      tail.head match {
-        case step: PureStep =>
-          pures += step.value
-          tail = tail.tail
-        case _              =>
-          allPure = false
-      }
-
-    if (allPure) PureStep(ListValue(pures.result()))
+  private def reduceList[R](list: List[ReducedStep[R]], areItemsNullable: Boolean): ReducedStep[R] =
+    if (list.forall(_.isInstanceOf[PureStep]))
+      PureStep(ListValue(list.asInstanceOf[List[PureStep]].map(_.value)))
     else ReducedStep.ListStep(list, areItemsNullable)
-  }
 
   private def reduceObject[R](
     items: List[(String, ReducedStep[R], FieldInfo)],
-    fieldWrappers: List[FieldWrapper[R]]
+    wrapPureValues: Boolean
   ): ReducedStep[R] =
-    if (!fieldWrappers.exists(_.wrapPureValues) && items.forall(_._2.isPure))
+    if (!wrapPureValues && items.forall(_._2.isPure))
       PureStep(ObjectValue(items.asInstanceOf[List[(String, PureStep, FieldInfo)]].map { case (k, v, _) =>
         (k, v.value)
       }))

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -43,6 +43,8 @@ case class Field(
 ) { self =>
   lazy val locationInfo: LocationInfo = _locationInfo()
 
+  private[caliban] lazy val aliasedName: String = alias.getOrElse(name)
+
   def combine(other: Field): Field =
     self.copy(
       fields = self.fields ::: other.fields,
@@ -121,11 +123,8 @@ object Field {
     def loop(selectionSet: List[Selection], fieldType: __Type, fragment: Option[Fragment]): List[Field] = {
       val map = new java.util.LinkedHashMap[(String, Option[String]), Field](selectionSet.length)
 
-      def addField(f: Field, condition: Option[String]): Unit = {
-        val name = f.alias.getOrElse(f.name)
-        val key  = (name, condition)
-        map.compute(key, (_, existing) => if (existing == null) f else existing.combine(f))
-      }
+      def addField(f: Field, condition: Option[String]): Unit =
+        map.compute((f.aliasedName, condition), (_, existing) => if (existing == null) f else existing.combine(f))
 
       val innerType = fieldType.innerType
 

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -43,7 +43,7 @@ case class Field(
 ) { self =>
   lazy val locationInfo: LocationInfo = _locationInfo()
 
-  private[caliban] lazy val aliasedName: String = alias.getOrElse(name)
+  private[caliban] val aliasedName: String = alias.getOrElse(name)
 
   def combine(other: Field): Field =
     self.copy(

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -219,8 +219,6 @@ object Field {
     if (directive.arguments.isEmpty) directive
     else directive.copy(arguments = resolveVariables(directive.arguments, variableDefinitions, variableValues))
 
-  private val emptyVariables = Map.empty[String, InputValue]
-
   private def resolveVariables(
     arguments: Map[String, InputValue],
     variableDefinitions: Map[String, VariableDefinition],
@@ -240,7 +238,7 @@ object Field {
         case value: Value                   =>
           Some(value)
       }
-    if (arguments.isEmpty) emptyVariables
+    if (arguments.isEmpty) Map.empty[String, InputValue]
     else arguments.flatMap { case (k, v) => resolveVariable(v).map(k -> _) }
   }
 

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -118,11 +118,11 @@ object Field {
     directives: List[Directive],
     rootType: RootType
   ): Field = {
-    val memoizedFragments      = new mutable.HashMap[String, (List[Field], Option[String])](fragments.size + 1, 1.0)
+    val memoizedFragments      = new mutable.HashMap[String, (List[Field], Option[String])]()
     val variableDefinitionsMap = variableDefinitions.map(v => v.name -> v).toMap
 
     def loop(selectionSet: List[Selection], fieldType: __Type, fragment: Option[Fragment]): List[Field] = {
-      val map = new java.util.LinkedHashMap[(String, Option[String]), Field](16, 1.0f)
+      val map = new java.util.LinkedHashMap[(String, Option[String]), Field]()
 
       def addField(f: Field, condition: Option[String]): Unit =
         map.compute((f.aliasedName, condition), (_, existing) => if (existing == null) f else existing.combine(f))

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -118,11 +118,14 @@ case class __Type(
       case _                   => true
     }
 
-  def list: __Type    = __Type(__TypeKind.LIST, ofType = Some(self))
-  def nonNull: __Type = __Type(__TypeKind.NON_NULL, ofType = Some(self))
+  lazy val list: __Type    = __Type(__TypeKind.LIST, ofType = Some(self))
+  lazy val nonNull: __Type = __Type(__TypeKind.NON_NULL, ofType = Some(self))
 
   lazy val allFields: List[__Field] =
     fields(__DeprecatedArgs(Some(true))).getOrElse(Nil)
+
+  private[caliban] lazy val allFieldsMap: Map[String, __Field] =
+    allFields.map(f => f.name -> f).toMap
 
   lazy val innerType: __Type = Types.innerType(this)
 }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -115,7 +115,7 @@ trait Schema[-R, T] { self =>
       self.toType_(isInput, isSubscription).copy(name = Some(newName))
     }
 
-    lazy val renameTypename: Boolean = self.toType_().kind match {
+    private val renameTypename: Boolean = self.toType_().kind match {
       case __TypeKind.UNION | __TypeKind.ENUM | __TypeKind.INTERFACE => false
       case _                                                         => true
     }
@@ -334,10 +334,10 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     evA: Schema[RA, A],
     evB: Schema[RB, B]
   ): Schema[RA with RB, Either[A, B]] = {
-    lazy val typeAName: String   = Types.name(evA.toType_())
-    lazy val typeBName: String   = Types.name(evB.toType_())
-    lazy val name: String        = s"Either${typeAName}Or$typeBName"
-    lazy val description: String = s"Either $typeAName or $typeBName"
+    val typeAName: String   = Types.name(evA.toType_())
+    val typeBName: String   = Types.name(evB.toType_())
+    val name: String        = s"Either${typeAName}Or$typeBName"
+    val description: String = s"Either $typeAName or $typeBName"
 
     implicit val leftSchema: Schema[RA, A]  = new Schema[RA, A] {
       override def optional: Boolean                                         = true
@@ -363,8 +363,8 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     evA: Schema[RA, A],
     evB: Schema[RB, B]
   ): Schema[RA with RB, (A, B)] = {
-    lazy val typeAName: String = Types.name(evA.toType_())
-    lazy val typeBName: String = Types.name(evB.toType_())
+    val typeAName: String = Types.name(evA.toType_())
+    val typeBName: String = Types.name(evB.toType_())
 
     obj[RA with RB, (A, B)](
       s"Tuple${typeAName}And$typeBName",
@@ -378,17 +378,18 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
   }
   implicit def mapSchema[RA, RB, A, B](implicit evA: Schema[RA, A], evB: Schema[RB, B]): Schema[RA with RB, Map[A, B]] =
     new Schema[RA with RB, Map[A, B]] {
-      lazy val typeAName: String   = Types.name(evA.toType_())
-      lazy val typeBName: String   = Types.name(evB.toType_())
-      lazy val name: String        = s"KV$typeAName$typeBName"
-      lazy val description: String = s"A key-value pair of $typeAName and $typeBName"
+      private lazy val typeAName: String   = Types.name(evA.toType_())
+      private lazy val typeBName: String   = Types.name(evB.toType_())
+      private lazy val name: String        = s"KV$typeAName$typeBName"
+      private lazy val description: String = s"A key-value pair of $typeAName and $typeBName"
 
-      lazy val kvSchema: Schema[RA with RB, (A, B)] = obj[RA with RB, (A, B)](name, Some(description))(implicit ft =>
-        List(
-          field("key", Some("Key"))(_._1),
-          field("value", Some("Value"))(_._2)
+      private lazy val kvSchema: Schema[RA with RB, (A, B)] =
+        obj[RA with RB, (A, B)](name, Some(description))(implicit ft =>
+          List(
+            field("key", Some("Key"))(_._1),
+            field("value", Some("Value"))(_._2)
+          )
         )
-      )
 
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         kvSchema.toType_(isInput, isSubscription).nonNull.list

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -36,13 +36,11 @@ object FieldMap {
     ): FieldMap = {
       val responseName = f.alias.getOrElse(f.name)
 
-      parentType.allFields.collectFirst {
-        case f1 if f1.name == f.name =>
-          val sf    = SelectedField(parentType, selection, f1)
-          val entry = self.get(responseName).map(_ + sf).getOrElse(Set(sf))
-          self + (responseName -> entry)
+      parentType.allFieldsMap.get(f.name).fold(self) { f1 =>
+        val sf    = SelectedField(parentType, selection, f1)
+        val entry = self.get(responseName).map(_ + sf).getOrElse(Set(sf))
+        self + (responseName -> entry)
       }
-        .getOrElse(self)
     }
   }
 

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -512,7 +512,7 @@ object Validator {
     ZPure
       .when(field.name != "__typename") {
         ZPure
-          .fromOption(currentType.allFields.find(_.name == field.name))
+          .fromOption(currentType.allFieldsMap.get(field.name))
           .orElseFail(
             ValidationError(
               s"Field '${field.name}' does not exist on type '${DocumentRenderer.renderTypeName(currentType)}'.",
@@ -883,8 +883,7 @@ object Validator {
     val objectContext = s"Object '${obj.name.getOrElse("")}'"
 
     def validateInterfaceFields(obj: __Type) = {
-      def fieldNames(t: __Type) =
-        t.allFields.map(_.name).toSet
+      def fieldNames(t: __Type) = t.allFieldsMap.keySet
 
       val supertype = obj.interfaces().toList.flatten
 

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -188,7 +188,7 @@ object Wrappers {
         query: ZQuery[R1, ExecutionError, ResponseValue],
         info: FieldInfo
       ): ZQuery[R1, ExecutionError, ResponseValue] = {
-        val directives = info.parent.flatMap(_.allFields.find(_.name == info.name)).flatMap(_.directives).getOrElse(Nil)
+        val directives = info.parent.flatMap(_.allFieldsMap.get(info.name)).flatMap(_.directives).getOrElse(Nil)
         ZQuery.fromZIO(check(directives)) *> query
       }
     }


### PR DESCRIPTION
## Main optimizations:

- [Scala 3] Use a `Vector` instead of a `List` in derived `Sum` schemas. The benefit of this is that the `.apply` method on Vectors is O(1) whereas on Lists is O(N). The benefit of this becomes obvious only in presence of enums with many values
- Avoid checking whether to wrap pure values each time we reduce an object
- Add `allFieldsMap` lazy val on `__Type` to replace `.find` calls. This provides benefits mostly to objects with large number of fields as it avoids iterating through them all
- Use `MurmurHash3.unorderedHash` to calculate the hashCode of `ResponseValue.ObjectValue` the conversion of to Set. I'm not sure about the total impact of this since it's hard to identify how much it's been used.

## Minor / ultra-minor:

- Avoid conversions in `Executor.mergeFields` when no modifications have been made
- [Scala 3] Avoid recalculating all the field names each time `resolve` is called
- Split `resolve` method of derived Schemas into individual methods to aid JDK code caching
- Convert methods in anonymous classes to `private`
- Add `aliasedName` val on `Field` to avoid repeated calls to `alias.getOrElse(name)`
- Probably a bunch more that I missed