### PR TITLE
Alt http method validation implementation

### DIFF
--- a/core/src/main/scala/caliban/Configurator.scala
+++ b/core/src/main/scala/caliban/Configurator.scala
@@ -10,14 +10,12 @@ object Configurator {
    * Configuration for the execution of a GraphQL query.
    * @param skipValidation if true, the query will not be validated (in that case, the `validations` field is ignored). Default: false.
    * @param enableIntrospection if true, introspection queries are allowed. Default: true.
-   * @param allowMutationsOverGetRequests if true, mutations are allowed for GET requests. Note that this is highly discouraged as it goes against the recommended practices. Default: false.
    * @param queryExecution the execution strategy to use (sequential, parallel, batched). Default: parallel.
    * @param validations the validations to run on the query during the validation phase. Default: all available validations.
    */
   case class ExecutionConfiguration(
     skipValidation: Boolean = false,
     enableIntrospection: Boolean = true,
-    allowMutationsOverGetRequests: Boolean = false,
     queryExecution: QueryExecution = QueryExecution.Parallel,
     validations: List[QueryValidation] = AllValidations
   )
@@ -56,9 +54,4 @@ object Configurator {
   def setQueryExecution(queryExecution: QueryExecution): URIO[Scope, Unit] =
     configRef.locallyScopedWith(_.copy(queryExecution = queryExecution))
 
-  /**
-   * Enable or disable mutations for GET requests. See [[ExecutionConfiguration]] for more details
-   */
-  def setAllowMutationsOverGetRequests(allow: Boolean): URIO[Scope, Unit] =
-    configRef.locallyScopedWith(_.copy(allowMutationsOverGetRequests = allow))
 }

--- a/core/src/main/scala/caliban/HttpRequestMethod.scala
+++ b/core/src/main/scala/caliban/HttpRequestMethod.scala
@@ -1,21 +1,22 @@
 package caliban
 
 import caliban.CalibanError.ValidationError
-import zio.{ FiberRef, Scope, UIO, URIO, Unsafe, ZIO }
+import zio.{ FiberRef, UIO, Unsafe, ZIO }
 
-private[caliban] sealed trait HttpRequestMethod
+sealed trait HttpRequestMethod
 
-private[caliban] object HttpRequestMethod {
+object HttpRequestMethod {
   case object GET  extends HttpRequestMethod
   case object POST extends HttpRequestMethod
 
-  val MutationOverGetError: ValidationError = ValidationError("Mutations are not allowed for GET requests", "")
+  private[caliban] val MutationOverGetError: ValidationError =
+    ValidationError("Mutations are not allowed for GET requests", "")
 
   private val fiberRef: FiberRef[HttpRequestMethod] = Unsafe.unsafe(implicit u => FiberRef.unsafe.make(POST))
 
-  val get: UIO[HttpRequestMethod] = fiberRef.get
+  private[caliban] val get: UIO[HttpRequestMethod] = fiberRef.get
 
-  def setWith[R, E, B](method: HttpRequestMethod)(zio: ZIO[R, E, B]): ZIO[R, E, B] =
+  private[caliban] def setWith[R, E, B](method: HttpRequestMethod)(zio: ZIO[R, E, B]): ZIO[R, E, B] =
     method match {
       case POST => zio
       case GET  => fiberRef.locally(method)(zio)

--- a/core/src/main/scala/caliban/validation/package.scala
+++ b/core/src/main/scala/caliban/validation/package.scala
@@ -22,7 +22,9 @@ package object validation {
     operations: List[OperationDefinition],
     fragments: Map[String, FragmentDefinition],
     selectionSets: List[Selection],
-    variables: Map[String, InputValue]
+    variables: Map[String, InputValue],
+    httpMethod: Option[HttpRequestMethod],
+    isMutation: Boolean
   ) {
     lazy val variableDefinitions: Map[String, VariableDefinition] =
       operations.flatMap(_.variableDefinitions.map(d => d.name -> d)).toMap
@@ -30,6 +32,15 @@ package object validation {
 
   object Context {
     val empty: Context =
-      Context(Document(Nil, SourceMapper.empty), RootType(Types.boolean, None, None), Nil, Map.empty, Nil, Map.empty)
+      Context(
+        Document(Nil, SourceMapper.empty),
+        RootType(Types.boolean, None, None),
+        Nil,
+        Map.empty,
+        Nil,
+        Map.empty,
+        None,
+        isMutation = false
+      )
   }
 }

--- a/core/src/test/scala/caliban/execution/FieldSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldSpec.scala
@@ -65,7 +65,8 @@ object FieldSpec extends ZIOSpecDefault {
                  operationName = None,
                  Map.empty,
                  skipValidation = false,
-                 validations = AllValidations
+                 validations = AllValidations,
+                 requestMethod = HttpRequestMethod.POST
                )
   } yield req
 


### PR DESCRIPTION
After giving this a go, I don't think I like it. It requires too many breaking changes, as well as making `HttpRequestMethod` public, and the only _real_ benefit is that the validation now is now part of `AllValidations`. 

Leaving this here just to check whether we think this is worth it or not