### PR TITLE
Use `NoStackTrace` as the base of `CalibanError`s

### DIFF
--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -8,10 +8,12 @@ import caliban.interop.play.{ IsPlayJsonReads, IsPlayJsonWrites }
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 import caliban.parsing.adt.LocationInfo
 
+import scala.util.control.NoStackTrace
+
 /**
  * The base type for all Caliban errors.
  */
-sealed trait CalibanError extends Throwable with Product with Serializable {
+sealed trait CalibanError extends NoStackTrace with Product with Serializable {
   def msg: String
   override def getMessage: String = msg
 


### PR DESCRIPTION
As discussed [here](https://github.com/ghostdogpr/caliban/pull/1909#discussion_r1346713883)

We probably want to make this change as we want to avoid pushing the entire stacktrace each time we create an error