### PR TITLE
Improve codegen

### DIFF
--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -164,7 +164,7 @@ object SchemaWriter {
 
     def writeInterface(interface: InterfaceTypeDefinition, impls: List[ObjectTypeDefinition]): String =
       s"""@GQLInterface
-        ${writeDescription(interface.description)}sealed trait ${interface.name} extends scala.Product with scala.Serializable {
+        ${writeDescription(interface.description)}sealed trait ${interface.name} extends scala.Product with scala.Serializable $derivesSchema {
          ${interface.fields.map(field => "def " + writeField(field, interface)).mkString("\n")}
         }
 

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -649,22 +649,19 @@ object SchemaWriterSpec extends ZIOSpecDefault {
       """import caliban.schema.Annotations._
         |
         |object Types {
-        |  final case class HumanFriendsConnectionArgs(first: scala.Option[Int], after: scala.Option[ID])
-        |      derives caliban.schema.Schema.SemiAuto,
-        |        caliban.schema.ArgBuilder
-        |  final case class DroidFriendsConnectionArgs(first: scala.Option[Int], after: scala.Option[ID])
+        |  final case class CharacterFriendsConnectionArgs(first: scala.Option[Int], after: scala.Option[ID])
         |      derives caliban.schema.Schema.SemiAuto,
         |        caliban.schema.ArgBuilder
         |
         |  @GQLInterface
         |  sealed trait Character extends scala.Product with scala.Serializable {
-        |    def friendsConnection: FriendsConnection
+        |    def friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection
         |  }
         |
         |  object Character {
-        |    final case class Human(friendsConnection: HumanFriendsConnectionArgs => FriendsConnection) extends Character
+        |    final case class Human(friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection) extends Character
         |        derives caliban.schema.Schema.SemiAuto
-        |    final case class Droid(friendsConnection: DroidFriendsConnectionArgs => FriendsConnection) extends Character
+        |    final case class Droid(friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection) extends Character
         |        derives caliban.schema.Schema.SemiAuto
         |  }
         |

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -280,23 +280,20 @@ object SchemaWriterSpec extends ZIOSpecDefault {
          |
          |object Types {
          |
+         |  final case class Captain(
+         |    @GQLDescription(\"ship\")
+         |    shipName: String
+         |  ) extends Role
+         |      with Role2
+         |  final case class Pilot(shipName: String)   extends Role with Role2
+         |  final case class Stewart(shipName: String) extends Role2
+         |
          |  @GQLDescription(\"\"\"role
          |Captain or Pilot\"\"\")
          |  sealed trait Role extends scala.Product with scala.Serializable
          |  @GQLDescription(\"\"\"role2
          |Captain or Pilot or Stewart\"\"\")
          |  sealed trait Role2 extends scala.Product with scala.Serializable
-         |
-         |  object Role2 {
-         |    final case class Stewart(shipName: String) extends Role2
-         |  }
-         |
-         |  final case class Captain(
-         |    @GQLDescription("ship")
-         |    shipName: String
-         |  ) extends Role
-         |      with Role2
-         |  final case class Pilot(shipName: String) extends Role with Role2
          |
          |}"""
     ),
@@ -555,6 +552,14 @@ object SchemaWriterSpec extends ZIOSpecDefault {
          |
          |object Types {
          |
+         |  final case class Admin(
+         |    id: java.util.UUID,
+         |    @GQLDescription(\"firstName\")
+         |    firstName: String,
+         |    lastName: String
+         |  ) extends Person
+         |  final case class Customer(id: java.util.UUID, firstName: String, lastName: String, email: String) extends Person
+         |
          |  @GQLInterface
          |  @GQLDescription(\"\"\"person
          |Admin or Customer\"\"\")
@@ -562,16 +567,6 @@ object SchemaWriterSpec extends ZIOSpecDefault {
          |    def id: java.util.UUID
          |    def firstName: String
          |    def lastName: String
-         |  }
-         |
-         |  object Person {
-         |    final case class Admin(
-         |      id: java.util.UUID,
-         |      @GQLDescription("firstName")
-         |      firstName: String,
-         |      lastName: String
-         |    ) extends Person
-         |    final case class Customer(id: java.util.UUID, firstName: String, lastName: String, email: String) extends Person
          |  }
          |
          |}"""
@@ -652,17 +647,14 @@ object SchemaWriterSpec extends ZIOSpecDefault {
         |  final case class CharacterFriendsConnectionArgs(first: scala.Option[Int], after: scala.Option[ID])
         |      derives caliban.schema.Schema.SemiAuto,
         |        caliban.schema.ArgBuilder
+        |  final case class Human(friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection) extends Character
+        |      derives caliban.schema.Schema.SemiAuto
+        |  final case class Droid(friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection) extends Character
+        |      derives caliban.schema.Schema.SemiAuto
         |
         |  @GQLInterface
         |  sealed trait Character extends scala.Product with scala.Serializable derives caliban.schema.Schema.SemiAuto {
         |    def friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection
-        |  }
-        |
-        |  object Character {
-        |    final case class Human(friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection) extends Character
-        |        derives caliban.schema.Schema.SemiAuto
-        |    final case class Droid(friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection) extends Character
-        |        derives caliban.schema.Schema.SemiAuto
         |  }
         |
         |}""".stripMargin

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -630,6 +630,45 @@ object SchemaWriterSpec extends ZIOSpecDefault {
         |  ) derives caliban.schema.Schema.SemiAuto
         |
         |}""".stripMargin
+    ),
+    (
+      "inherits field with args",
+      gen(
+        """
+        |interface Character {
+        |    friendsConnection(first: Int, after: ID): FriendsConnection!
+        |}
+        |type Human implements Character {
+        |    friendsConnection(first: Int, after: ID): FriendsConnection!
+        |}
+        |type Droid implements Character {
+        |    friendsConnection(first: Int, after: ID): FriendsConnection!
+        |}""",
+        addDerives = true
+      ),
+      """import caliban.schema.Annotations._
+        |
+        |object Types {
+        |  final case class HumanFriendsConnectionArgs(first: scala.Option[Int], after: scala.Option[ID])
+        |      derives caliban.schema.Schema.SemiAuto,
+        |        caliban.schema.ArgBuilder
+        |  final case class DroidFriendsConnectionArgs(first: scala.Option[Int], after: scala.Option[ID])
+        |      derives caliban.schema.Schema.SemiAuto,
+        |        caliban.schema.ArgBuilder
+        |
+        |  @GQLInterface
+        |  sealed trait Character extends scala.Product with scala.Serializable {
+        |    def friendsConnection: FriendsConnection
+        |  }
+        |
+        |  object Character {
+        |    final case class Human(friendsConnection: HumanFriendsConnectionArgs => FriendsConnection) extends Character
+        |        derives caliban.schema.Schema.SemiAuto
+        |    final case class Droid(friendsConnection: DroidFriendsConnectionArgs => FriendsConnection) extends Character
+        |        derives caliban.schema.Schema.SemiAuto
+        |  }
+        |
+        |}""".stripMargin
     )
   )
 

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -654,7 +654,7 @@ object SchemaWriterSpec extends ZIOSpecDefault {
         |        caliban.schema.ArgBuilder
         |
         |  @GQLInterface
-        |  sealed trait Character extends scala.Product with scala.Serializable {
+        |  sealed trait Character extends scala.Product with scala.Serializable derives caliban.schema.Schema.SemiAuto {
         |    def friendsConnection: CharacterFriendsConnectionArgs => FriendsConnection
         |  }
         |


### PR DESCRIPTION
Hi there

I'm trying out caliban, and found that the codegen had some bugs, particularly related to interfaces. Here are some tests and rather quick and dirty patches for the problems I saw.

## inheriting fields with arguments from interface
I guess this was never tried. now it doesn't infer new `Args` types for the subtypes but reuses the one from the interface. Or well, there were none for the interface, but let's add those instead

## Missing prefix in scala code for object type namespaced by one type union

I don't like the logic for putting object types in namespaces and would prefer it all at the top-level with multiple extends, honestly. But the logic being what it is, this replicates some computation of prefixes from interfaces for type unions

## Missing `derives` for interface type
Scala 3 complained about this, so here is a fix.


--- 

I can break this up into consecutive PR's if needed, but since the first attempt gave conflicts I bundled them together


