### PR TITLE
Add option to dynamically enable / disable `ApolloTracing`

### DIFF
--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -1,16 +1,16 @@
 package caliban.wrappers
 
 import caliban.CalibanError.{ ExecutionError, ParsingError, ValidationError }
+import caliban._
 import caliban.execution.{ ExecutionRequest, FieldInfo }
 import caliban.introspection.adt.__Introspection
 import caliban.parsing.adt.Document
 import caliban.wrappers.Wrapper.CombinedWrapper
-import caliban._
 import zio.query.ZQuery
-import zio.{ UIO, URIO, ZIO }
+import zio.{ UIO, ZIO }
 
 import scala.annotation.tailrec
-import scala.collection.mutable.{ ArrayBuffer, ListBuffer }
+import scala.collection.mutable.ListBuffer
 
 /**
  * A `Wrapper[-R]` represents an extra layer of computation that can be applied on top of Caliban's query handling.
@@ -29,7 +29,10 @@ import scala.collection.mutable.{ ArrayBuffer, ListBuffer }
 sealed trait Wrapper[-R] extends GraphQLAspect[Nothing, R] { self =>
   val priority: Int = 0
 
-  def |+|[R1 <: R](that: Wrapper[R1]): Wrapper[R1] = CombinedWrapper(List(self, that))
+  def |+|[R1 <: R](that: Wrapper[R1]): Wrapper[R1] = that match {
+    case Wrapper.Empty => self
+    case _             => CombinedWrapper(List(self, that))
+  }
 
   def apply[R1 <: R](that: GraphQL[R1]): GraphQL[R1] =
     that.withWrapper(self)
@@ -37,18 +40,19 @@ sealed trait Wrapper[-R] extends GraphQLAspect[Nothing, R] { self =>
 
 object Wrapper {
 
-  sealed trait SimpleWrapper[-R, E, A, Info] extends Wrapper[R] {
-    def wrap[R1 <: R](f: Info => ZIO[R1, E, A]): Info => ZIO[R1, E, A]
-  }
-
   /**
    * A wrapper that doesn't do anything.
    * Useful for cases where we want to programmatically decide whether we'll use a wrapper or not
    */
-  val empty: Wrapper[Any] = new OverallWrapper[Any] {
-    def wrap[R1 <: Any](
-      f: GraphQLRequest => URIO[R1, GraphQLResponse[CalibanError]]
-    ): GraphQLRequest => URIO[R1, GraphQLResponse[CalibanError]] = f
+  object Empty extends Wrapper[Any] {
+    override def |+|[R1 <: Any](that: Wrapper[R1]): Wrapper[R1]   = that
+    override def apply[R1 <: Any](that: GraphQL[R1]): GraphQL[R1] = that
+  }
+
+  def empty[R]: Wrapper[R] = Empty
+
+  sealed trait SimpleWrapper[-R, E, A, Info] extends Wrapper[R] {
+    def wrap[R1 <: R](f: Info => ZIO[R1, E, A]): Info => ZIO[R1, E, A]
   }
 
   /**
@@ -169,6 +173,7 @@ object Wrapper {
       case wrapper: IntrospectionWrapper[R] => ZIO.succeed(i append wrapper)
       case CombinedWrapper(wrappers)        => ZIO.foreachDiscard(wrappers)(loop)
       case EffectfulWrapper(wrapper)        => wrapper.flatMap(loop)
+      case Wrapper.Empty                    => ZIO.unit
     }
 
     def finalize[W <: Wrapper[R]](buffer: ListBuffer[W]): List[W] = buffer.sortBy(_.priority).result()

--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -7,7 +7,7 @@ import caliban.parsing.adt.Document
 import caliban.wrappers.Wrapper.CombinedWrapper
 import caliban._
 import zio.query.ZQuery
-import zio.{ UIO, ZIO }
+import zio.{ UIO, URIO, ZIO }
 
 import scala.annotation.tailrec
 import scala.collection.mutable.{ ArrayBuffer, ListBuffer }
@@ -39,6 +39,16 @@ object Wrapper {
 
   sealed trait SimpleWrapper[-R, E, A, Info] extends Wrapper[R] {
     def wrap[R1 <: R](f: Info => ZIO[R1, E, A]): Info => ZIO[R1, E, A]
+  }
+
+  /**
+   * A wrapper that doesn't do anything.
+   * Useful for cases where we want to programmatically decide whether we'll use a wrapper or not
+   */
+  val empty: Wrapper[Any] = new OverallWrapper[Any] {
+    def wrap[R1 <: Any](
+      f: GraphQLRequest => URIO[R1, GraphQLResponse[CalibanError]]
+    ): GraphQLRequest => URIO[R1, GraphQLResponse[CalibanError]] = f
   }
 
   /**

--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -44,7 +44,7 @@ object Wrapper {
    * A wrapper that doesn't do anything.
    * Useful for cases where we want to programmatically decide whether we'll use a wrapper or not
    */
-  object Empty extends Wrapper[Any] {
+  case object Empty extends Wrapper[Any] {
     override def |+|[R1 <: Any](that: Wrapper[R1]): Wrapper[R1]   = that
     override def apply[R1 <: Any](that: GraphQL[R1]): GraphQL[R1] = that
   }

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -186,7 +186,7 @@ object WrappersSpec extends ZIOSpecDefault {
             fiber       <- interpreter.execute(query).map(_.extensions.map(_.toString)).fork
             _           <- latch.await
             _           <- TestClock.adjust(4 seconds)
-            result      <- fiber.join.flatMap(ZIO.fromOption(_))
+            result      <- fiber.join.map(_.getOrElse("null"))
           } yield result
 
         List(
@@ -203,6 +203,18 @@ object WrappersSpec extends ZIOSpecDefault {
                 res == """{"tracing":{"version":1,"startTime":"1970-01-01T00:00:00.000Z","endTime":"1970-01-01T00:00:04.000Z","duration":4000000000,"parsing":{"startOffset":0,"duration":0},"validation":{"startOffset":0,"duration":0},"execution":{"resolvers":[{"path":["hero","name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":1000000000},{"path":["hero","friends",0,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":2000000000},{"path":["hero","friends",1,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":3000000000},{"path":["hero"],"parentType":"Query","fieldName":"hero","returnType":"Hero!","startOffset":0,"duration":4000000000},{"path":["hero","friends"],"parentType":"Hero","fieldName":"friends","returnType":"[Hero!]!","startOffset":0,"duration":4000000000},{"path":["hero","friends",2,"name"],"parentType":"Hero","fieldName":"name","returnType":"String!","startOffset":0,"duration":4000000000}]}}}"""
               )
             }
+          },
+          test("enabled") {
+            for {
+              r1 <- ZIO.scoped(ApolloTracing.enabled(false) *> test_(false))
+              r2 <- test_(false)
+            } yield assertTrue(r1 == "null", r2 != "null")
+          },
+          test("enabledWith") {
+            for {
+              r1 <- ApolloTracing.enabledWith(value = false)(test_(false))
+              r2 <- test_(false)
+            } yield assertTrue(r1 == "null", r2 != "null")
           }
         )
       },


### PR DESCRIPTION
The motivation behind this change is that tracing adds a significant overhead to requests, both in terms of execution time and response payload size.

With this change, the user can control dynamically whether tracing will be enabled for the current execution. This opens up possibilities to dynamically enable / disable tracing via the `HttpInterpreter` or HTTP middleware which optionally enable tracing based on HTTP headers.

~~PS: If we like this idea, should we also make it available for the federation tracing wrapper?~~

Actually I just realised that `ApolloFederatedTracing` is already controllable via the graphql extensions.