### PR TITLE
fixes inline escape character handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,8 +181,9 @@ lazy val tools = project
       "com.softwaremill.sttp.client3" %% "zio"                 % sttpVersion,
       "dev.zio"                       %% "zio-config"          % zioConfigVersion,
       "dev.zio"                       %% "zio-config-magnolia" % zioConfigVersion,
-      "dev.zio"                       %% "zio-test"            % zioVersion % Test,
-      "dev.zio"                       %% "zio-test-sbt"        % zioVersion % Test
+      "dev.zio"                       %% "zio-test"            % zioVersion     % Test,
+      "dev.zio"                       %% "zio-test-sbt"        % zioVersion     % Test,
+      "dev.zio"                       %% "zio-json"            % zioJsonVersion % Test
     )
   )
   .dependsOn(core, clientJVM)

--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -108,7 +108,9 @@ object DocumentRenderer extends Renderer[Document] {
             newlineOrSpace(indent, writer)
           case value                         =>
             pad(indent, writer)
-            unsafeFastEscape(value, writer)
+            writer append '"'
+            Renderer.escapedString.unsafeRender(value, indent, writer)
+            writer append '"'
             newlineOrSpace(indent, writer)
         }
     }
@@ -665,25 +667,6 @@ object DocumentRenderer extends Renderer[Document] {
     if (indentation.isDefined) writer append '\n' else writer append ','
 
   private def increment(indentation: Option[Int]): Option[Int] = indentation.map(_ + 1)
-
-  private def unsafeFastEscape(value: String, writer: StringBuilder) = {
-    writer.append('"')
-    var i = 0
-    while (i < value.length) {
-      (value.charAt(i): @switch) match {
-        case '\\' => writer.append("\\\\")
-        case '\b' => writer.append("\\b")
-        case '\f' => writer.append("\\f")
-        case '\n' => writer.append("\\n")
-        case '\r' => writer.append("\\r")
-        case '\t' => writer.append("\\t")
-        case '"'  => writer.append("\\\"")
-        case c    => writer.append(c)
-      }
-      i += 1
-    }
-    writer.append('"')
-  }
 
   /**
    * A zero allocation version of triple quote escaping.

--- a/core/src/main/scala/caliban/rendering/Renderer.scala
+++ b/core/src/main/scala/caliban/rendering/Renderer.scala
@@ -1,5 +1,7 @@
 package caliban.rendering
 
+import scala.annotation.switch
+
 /**
  * The inverse of a `Parser` over some type A.
  * A renderer can be used to render a value of type A to a string in either a regular or compact format.
@@ -126,6 +128,28 @@ object Renderer {
   lazy val string: Renderer[String] = new Renderer[String] {
     override def unsafeRender(value: String, indent: Option[Int], write: StringBuilder): Unit =
       write.append(value)
+  }
+
+  lazy val escapedString: Renderer[String] = new Renderer[String] {
+    override def unsafeRender(value: String, indent: Option[Int], write: StringBuilder): Unit =
+      unsafeFastEscape(value, write)
+
+    private def unsafeFastEscape(value: String, writer: StringBuilder): Unit = {
+      var i = 0
+      while (i < value.length) {
+        (value.charAt(i): @switch) match {
+          case '\\' => writer.append("\\\\")
+          case '\b' => writer.append("\\b")
+          case '\f' => writer.append("\\f")
+          case '\n' => writer.append("\\n")
+          case '\r' => writer.append("\\r")
+          case '\t' => writer.append("\\t")
+          case '"'  => writer.append("\\\"")
+          case c    => writer.append(c)
+        }
+        i += 1
+      }
+    }
   }
 
   /**

--- a/core/src/main/scala/caliban/rendering/ValueRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/ValueRenderer.scala
@@ -19,9 +19,9 @@ object ValueRenderer {
           write ++= name
         case StringValue(str)               =>
           write += '"'
-          unsafeFastEscape(str, write)
+          Renderer.escapedString.unsafeRender(str, indent, write)
           write += '"'
-        case Value.EnumValue(value)         => unsafeFastEscape(value, write)
+        case Value.EnumValue(value)         => Renderer.escapedString.unsafeRender(value, indent, write)
         case Value.BooleanValue(value)      => write append value
         case Value.NullValue                => write ++= "null"
         case IntNumber(value)               => write append value
@@ -54,7 +54,7 @@ object ValueRenderer {
       indent: Option[Int],
       write: StringBuilder
     ): Unit =
-      unsafeFastEscape(value.value, write)
+      Renderer.escapedString.unsafeRender(value.value, indent, write)
   }
 
   lazy val responseValueRenderer: Renderer[ResponseValue] = new Renderer[ResponseValue] {
@@ -70,11 +70,11 @@ object ValueRenderer {
           responseObjectValueRenderer.unsafeRender(in, indent, write)
         case StringValue(str)                =>
           write += '"'
-          unsafeFastEscape(str, write)
+          Renderer.escapedString.unsafeRender(str, indent, write)
           write += '"'
         case Value.EnumValue(value)          =>
           write += '"'
-          unsafeFastEscape(value, write)
+          Renderer.escapedString.unsafeRender(value, indent, write)
           write += '"'
         case Value.BooleanValue(value)       => write append value
         case Value.NullValue                 => write append "null"
@@ -115,18 +115,6 @@ object ValueRenderer {
         responseValueRenderer.unsafeRender(field._2, indent, write)
       }
       write += '}'
-    }
-  }
-
-  private def unsafeFastEscape(str: String, write: StringBuilder): Unit = {
-    var i = 0
-    while (i < str.length) {
-      (str.charAt(i): @switch) match {
-        case '"'  => write ++= "\\\""
-        case '\n' => write ++= "\\n"
-        case c    => write += c
-      }
-      i += 1
     }
   }
 


### PR DESCRIPTION
Closes #1794

Fixes an issue with inline escaped characters not getting properly rendered when writing back documents.

I unified the `unsafeFastEscape` methods that existed under both `DocumentRenderer` and `ValueRenderer` as well (since one didn't escape the complete set of characters)