### PR TITLE
Add new library to benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -553,7 +553,7 @@ lazy val benchmarks = project
       "org.sangria-graphql"                   %% "sangria-circe"       % "1.3.2",
       "edu.gemini"                            %% "gsp-graphql-core"    % "0.13.0",
       "edu.gemini"                            %% "gsp-graphql-generic" % "0.13.0",
-      "io.github.valdemargr"                  %% "gql-server"          % "0.3.2",
+      "io.github.valdemargr"                  %% "gql-server"          % "0.3.3",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % jsoniterVersion,
       "io.circe"                              %% "circe-parser"        % circeVersion,
       "dev.zio"                               %% "zio-json"            % zioJsonVersion

--- a/build.sbt
+++ b/build.sbt
@@ -553,6 +553,7 @@ lazy val benchmarks = project
       "org.sangria-graphql"                   %% "sangria-circe"       % "1.3.2",
       "edu.gemini"                            %% "gsp-graphql-core"    % "0.13.0",
       "edu.gemini"                            %% "gsp-graphql-generic" % "0.13.0",
+      "io.github.valdemargr"                  %% "gql-server"          % "0.3.2",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % jsoniterVersion,
       "io.circe"                              %% "circe-parser"        % circeVersion,
       "dev.zio"                               %% "zio-json"            % zioJsonVersion


### PR DESCRIPTION
Add benchmarks for https://valdemargr.github.io/gql/

```
[info] Benchmark                             Mode  Cnt       Score       Error  Units
[info] GraphQLBenchmarks.fragmentsCaliban   thrpt    5      37.354 ±    13.488  ops/s
[info] GraphQLBenchmarks.fragmentsGql       thrpt    5       0.681 ±     0.107  ops/s
[info] GraphQLBenchmarks.fragmentsGrackle   thrpt    5      13.997 ±     1.471  ops/s
[info] GraphQLBenchmarks.fragmentsSangria   thrpt    5      15.968 ±     2.336  ops/s
[info] GraphQLBenchmarks.introspectCaliban  thrpt    5     497.500 ±   109.747  ops/s
[info] GraphQLBenchmarks.introspectGql      thrpt    5      13.772 ±     2.406  ops/s
[info] GraphQLBenchmarks.introspectGrackle  thrpt    5     279.773 ±    27.783  ops/s
[info] GraphQLBenchmarks.introspectSangria  thrpt    5     262.946 ±    51.054  ops/s
[info] GraphQLBenchmarks.parserCaliban      thrpt    5    9660.458 ±  1480.212  ops/s
[info] GraphQLBenchmarks.parserGql          thrpt    5    4025.805 ±   936.090  ops/s
[info] GraphQLBenchmarks.parserGrackle      thrpt    5    1371.776 ±   357.871  ops/s
[info] GraphQLBenchmarks.parserSangria      thrpt    5    5262.416 ±  1498.741  ops/s
[info] GraphQLBenchmarks.simpleCaliban      thrpt    5   12087.981 ±  6046.116  ops/s
[info] GraphQLBenchmarks.simpleGql          thrpt    5     507.348 ±   190.618  ops/s
[info] GraphQLBenchmarks.simpleGrackle      thrpt    5    3390.703 ±  1115.016  ops/s
[info] GraphQLBenchmarks.simpleSangria      thrpt    5    3286.516 ±  2024.055  ops/s
```