### PR TITLE
Revert "Use Magnolia's macros for Scala 3 (#1930)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,7 @@ val http4sVersion             = "0.23.23"
 val javaTimeVersion           = "2.5.0"
 val jsoniterVersion           = "2.24.1"
 val laminextVersion           = "0.16.2"
-val magnoliaScala2Version     = "1.1.6"
-val magnoliaScala3Version     = "1.3.3"
+val magnoliaVersion           = "1.1.6"
 val pekkoVersion              = "1.0.1"
 val playVersion               = "2.8.20"
 val playJsonVersion           = "2.10.1"
@@ -110,12 +109,10 @@ lazy val macros = project
   .settings(
     libraryDependencies ++= {
       if (scalaVersion.value == scala3) {
-        Seq(
-          "com.softwaremill.magnolia1_3" %% "magnolia" % magnoliaScala3Version
-        )
+        Seq.empty
       } else {
         Seq(
-          "com.softwaremill.magnolia1_2" %% "magnolia"      % magnoliaScala2Version,
+          "com.softwaremill.magnolia1_2" %% "magnolia"      % magnoliaVersion,
           "org.scala-lang"                % "scala-reflect" % scalaVersion.value
         )
       }

--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -6,7 +6,6 @@ import caliban.Value.*
 import caliban.schema.Annotations.GQLDefault
 import caliban.schema.Annotations.GQLName
 import caliban.schema.macros.Macros
-import magnolia1.Macro as MagnoliaMacro
 
 import scala.deriving.Mirror
 import scala.compiletime.*
@@ -22,7 +21,7 @@ trait CommonArgBuilderDerivation {
         recurse[P, names, ts](
           (
             constValue[name].toString,
-            MagnoliaMacro.anns[t], {
+            Macros.annotations[t], {
               if (Macros.isEnumField[P, t])
                 if (!Macros.implicitExists[ArgBuilder[t]]) derived[t]
                 else summonInline[ArgBuilder[t]]
@@ -43,7 +42,7 @@ trait CommonArgBuilderDerivation {
       case m: Mirror.ProductOf[A] =>
         makeProductArgBuilder(
           recurse[A, m.MirroredElemLabels, m.MirroredElemTypes](),
-          MagnoliaMacro.paramAnns[A].to(Map)
+          Macros.paramAnnotations[A].to(Map)
         )(m.fromProduct)
     }
 

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -6,8 +6,7 @@ import caliban.parsing.adt.Directive
 import caliban.schema.Annotations.*
 import caliban.schema.Step.{ FunctionStep, ObjectStep }
 import caliban.schema.Types.*
-import caliban.schema.macros.Macros
-import magnolia1.{ Macro as MagnoliaMacro, TypeInfo }
+import caliban.schema.macros.{ Macros, TypeInfo }
 
 import scala.compiletime.*
 import scala.deriving.Mirror
@@ -48,7 +47,7 @@ trait CommonSchemaDerivation {
           else
             (
               constValue[name].toString,
-              MagnoliaMacro.anns[t], {
+              Macros.annotations[t], {
                 if (Macros.isEnumField[P, t])
                   if (!Macros.implicitExists[Schema[R, t]]) derived[R, t]
                   else summonInline[Schema[R, t]]
@@ -64,16 +63,16 @@ trait CommonSchemaDerivation {
       case m: Mirror.SumOf[A] =>
         makeSumSchema[R, A](
           recurse[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
-          MagnoliaMacro.typeInfo[A],
-          MagnoliaMacro.anns[A]
+          Macros.typeInfo[A],
+          Macros.annotations[A]
         )(m.ordinal)
 
       case m: Mirror.ProductOf[A] =>
         makeProductSchema[R, A](
           recurse[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
-          MagnoliaMacro.typeInfo[A],
-          MagnoliaMacro.anns[A],
-          MagnoliaMacro.paramAnns[A].toMap
+          Macros.typeInfo[A],
+          Macros.annotations[A],
+          Macros.paramAnnotations[A].toMap
         )
     }
 

--- a/core/src/main/scala-3/caliban/schema/macros/Macros.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/Macros.scala
@@ -4,12 +4,64 @@ import caliban.schema.Annotations.GQLExcluded
 
 import scala.quoted.*
 
-export magnolia1.TypeInfo
-
 object Macros {
-  inline def isFieldExcluded[P, T]: Boolean = ${ isFieldExcludedImpl[P, T] }
-  inline def isEnumField[P, T]: Boolean     = ${ isEnumFieldImpl[P, T] }
-  inline def implicitExists[T]: Boolean     = ${ implicitExistsImpl[T] }
+  // this code was inspired from WIP in magnolia
+  // https://github.com/propensive/magnolia/blob/b937cf2c7dabebb8236e7e948f37a354777fa9b7/src/core/macro.scala
+
+  inline def annotations[T]: List[Any]                      = ${ annotationsImpl[T] }
+  inline def paramAnnotations[T]: List[(String, List[Any])] = ${ paramAnnotationsImpl[T] }
+  inline def typeInfo[T]: TypeInfo                          = ${ typeInfoImpl[T] }
+  inline def isFieldExcluded[P, T]: Boolean                 = ${ isFieldExcludedImpl[P, T] }
+  inline def isEnumField[P, T]: Boolean                     = ${ isEnumFieldImpl[P, T] }
+  inline def implicitExists[T]: Boolean                     = ${ implicitExistsImpl[T] }
+
+  private def annotationsImpl[T: Type](using qctx: Quotes): Expr[List[Any]] = {
+    import qctx.reflect.*
+    val tpe = TypeRepr.of[T]
+    Expr.ofList {
+      tpe.typeSymbol.annotations.filter { a =>
+        a.tpe.typeSymbol.maybeOwner.isNoSymbol || (a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" && a.tpe.typeSymbol.owner.fullName != "jdk.internal")
+      }.map(_.asExpr.asInstanceOf[Expr[Any]])
+    }
+  }
+
+  private def paramAnnotationsImpl[T: Type](using qctx: Quotes): Expr[List[(String, List[Any])]] = {
+    import qctx.reflect.*
+    val tpe = TypeRepr.of[T]
+    Expr.ofList {
+      tpe.typeSymbol.primaryConstructor.paramSymss.flatten.map { field =>
+        Expr(field.name) -> field.annotations.filter { a =>
+          a.tpe.typeSymbol.maybeOwner.isNoSymbol ||
+          (a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" && a.tpe.typeSymbol.owner.fullName != "jdk.internal")
+        }.map(_.asExpr.asInstanceOf[Expr[Any]])
+      }.filter(_._2.nonEmpty).map((name, anns) => Expr.ofTuple(name, Expr.ofList(anns)))
+    }
+  }
+
+  private def typeInfoImpl[T: Type](using qctx: Quotes): Expr[TypeInfo] = {
+    import qctx.reflect.*
+
+    def normalizedName(s: Symbol): String = if (s.flags.is(Flags.Module)) s.name.stripSuffix("$") else s.name
+    def name(tpe: TypeRepr): Expr[String] = Expr(normalizedName(tpe.typeSymbol))
+
+    def ownerNameChain(sym: Symbol): List[String] =
+      if (sym.isNoSymbol) List.empty
+      else if (sym == defn.EmptyPackageClass) List.empty
+      else if (sym == defn.RootPackage) List.empty
+      else if (sym == defn.RootClass) List.empty
+      else ownerNameChain(sym.owner) :+ normalizedName(sym)
+
+    def owner(tpe: TypeRepr): Expr[String] = Expr(ownerNameChain(tpe.typeSymbol.maybeOwner).mkString("."))
+
+    def typeInfo(tpe: TypeRepr): Expr[TypeInfo] = tpe match {
+      case AppliedType(tpe, args) =>
+        '{ TypeInfo(${ owner(tpe) }, ${ name(tpe) }, ${ Expr.ofList(args.map(typeInfo)) }) }
+      case _                      =>
+        '{ TypeInfo(${ owner(tpe) }, ${ name(tpe) }, Nil) }
+    }
+
+    typeInfo(TypeRepr.of[T])
+  }
 
   /**
    * Tests whether type argument [[FieldT]] in [[Parent]] is annotated with [[GQLExcluded]]

--- a/core/src/main/scala-3/caliban/schema/macros/TypeInfo.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/TypeInfo.scala
@@ -1,0 +1,5 @@
+package caliban.schema.macros
+
+case class TypeInfo(owner: String, short: String, typeParams: Iterable[TypeInfo]) {
+  def full: String = s"$owner.$short"
+}


### PR DESCRIPTION
That change re-introduced https://github.com/ghostdogpr/caliban/issues/1352 so rolling it back.