### PR TITLE
Fix #1352 using magnolia macros

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,9 @@ jobs:
             - "~/.ivy2/cache"
             - "~/.sbt"
             - "~/.m2"
-  test213_jdk21:
+  test213_jdk17:
     docker:
-      - image: cimg/openjdk:21.0-node
+      - image: cimg/openjdk:17.0-node
     resource_class: large
     steps:
       - checkout
@@ -106,9 +106,9 @@ jobs:
             - "~/.ivy2/cache"
             - "~/.sbt"
             - "~/.m2"
-  test3_jdk21:
+  test3_jdk17:
     docker:
-      - image: cimg/openjdk:21.0-node
+      - image: cimg/openjdk:17.0-node
     resource_class: large
     steps:
       - checkout
@@ -269,7 +269,7 @@ workflows:
           filters:
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - test213_jdk21:
+      - test213_jdk17:
           requires:
             - lint
           filters:
@@ -287,7 +287,7 @@ workflows:
           filters:
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-      - test3_jdk21:
+      - test3_jdk17:
           requires:
             - lint
           filters:
@@ -306,11 +306,11 @@ workflows:
             - scripted212_jdk
             - scripted3_jdk
             - test213_jdk
-            - test213_jdk21
+            - test213_jdk17
             - test213_js_native
             - test213_docs
             - test3_jdk
-            - test3_jdk21
+            - test3_jdk17
             - test3_js_native
             - test_mima
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,39 @@ jobs:
             - "~/.ivy2/cache"
             - "~/.sbt"
             - "~/.m2"
+  test213_jdk21:
+    docker:
+      - image: cimg/openjdk:21.0-node
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          key: sbtcache
+      - run: sbt ++2.13.12 core/test http4s/test akkaHttp/test pekkoHttp/test play/test zioHttp/test examples/compile catsInterop/compile benchmarks/compile monixInterop/compile tapirInterop/test clientJVM/test tools/test federation/test reporting/test tracing/test
+      - save_cache:
+          key: sbtcache
+          paths:
+            - "~/.ivy2/cache"
+            - "~/.sbt"
+            - "~/.m2"
   test3_jdk:
     docker:
       - image: cimg/openjdk:11.0-node
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          key: sbtcache
+      - run: sbt ++3.3.1 core/test catsInterop/compile benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile zioHttp/test tapirInterop/test pekkoHttp/test http4s/test federation/test tools/test reporting/test tracing/test
+      - save_cache:
+          key: sbtcache
+          paths:
+            - "~/.ivy2/cache"
+            - "~/.sbt"
+            - "~/.m2"
+  test3_jdk21:
+    docker:
+      - image: cimg/openjdk:21.0-node
     resource_class: large
     steps:
       - checkout
@@ -149,7 +179,7 @@ jobs:
       - restore_cache:
           key: sbtcache
       - run: sbt ++2.13.12 http4s/mimaReportBinaryIssues akkaHttp/mimaReportBinaryIssues pekkoHttp/mimaReportBinaryIssues play/mimaReportBinaryIssues zioHttp/mimaReportBinaryIssues catsInterop/mimaReportBinaryIssues monixInterop/mimaReportBinaryIssues clientJVM/mimaReportBinaryIssues clientJS/mimaReportBinaryIssues clientLaminextJS/mimaReportBinaryIssues federation/mimaReportBinaryIssues reporting/mimaReportBinaryIssues tracing/mimaReportBinaryIssues tools/mimaReportBinaryIssues core/mimaReportBinaryIssues tapirInterop/mimaReportBinaryIssues
-      - run: sbt ++3.3.0 catsInterop/mimaReportBinaryIssues monixInterop/mimaReportBinaryIssues clientJVM/mimaReportBinaryIssues clientJS/mimaReportBinaryIssues clientLaminextJS/mimaReportBinaryIssues zioHttp/mimaReportBinaryIssues http4s/mimaReportBinaryIssues federation/mimaReportBinaryIssues reporting/mimaReportBinaryIssues tracing/mimaReportBinaryIssues tools/mimaReportBinaryIssues core/mimaReportBinaryIssues tapirInterop/mimaReportBinaryIssues pekkoHttp/mimaReportBinaryIssues
+      - run: sbt ++3.3.1 catsInterop/mimaReportBinaryIssues monixInterop/mimaReportBinaryIssues clientJVM/mimaReportBinaryIssues clientJS/mimaReportBinaryIssues clientLaminextJS/mimaReportBinaryIssues zioHttp/mimaReportBinaryIssues http4s/mimaReportBinaryIssues federation/mimaReportBinaryIssues reporting/mimaReportBinaryIssues tracing/mimaReportBinaryIssues tools/mimaReportBinaryIssues core/mimaReportBinaryIssues tapirInterop/mimaReportBinaryIssues pekkoHttp/mimaReportBinaryIssues
       - save_cache:
           key: sbtcache
           paths:
@@ -239,6 +269,12 @@ workflows:
           filters:
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+      - test213_jdk21:
+          requires:
+            - lint
+          filters:
+            tags:
+              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
       - test213_docs:
           requires:
             - lint
@@ -246,6 +282,12 @@ workflows:
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
       - test3_jdk:
+          requires:
+            - lint
+          filters:
+            tags:
+              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+      - test3_jdk21:
           requires:
             - lint
           filters:
@@ -264,9 +306,11 @@ workflows:
             - scripted212_jdk
             - scripted3_jdk
             - test213_jdk
+            - test213_jdk21
             - test213_js_native
             - test213_docs
             - test3_jdk
+            - test3_jdk21
             - test3_js_native
             - test_mima
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,9 @@ workflows:
           requires:
             - lint
           filters:
+            branches:
+              only:
+                - series/2.x
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
       - test213_docs:
@@ -291,6 +294,9 @@ workflows:
           requires:
             - lint
           filters:
+            branches:
+              only:
+                - series/2.x
             tags:
               only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
       - test_mima:

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -37,23 +37,37 @@ trait CommonSchemaDerivation {
       case _                 => s"${name}Input"
     }
 
-  inline def recurse[R, P, Label, A <: Tuple](
-    inline values: List[(String, List[Any], Schema[R, Any], Int)] = Nil
-  )(inline index: Int = 0): List[(String, List[Any], Schema[R, Any], Int)] =
+  inline def recurseSum[R, P, Label, A <: Tuple](
+    inline values: List[(String, List[Any], Schema[R, Any])] = Nil
+  ): List[(String, List[Any], Schema[R, Any])] =
     inline erasedValue[(Label, A)] match {
       case (_: EmptyTuple, _)                 => values.reverse
       case (_: (name *: names), _: (t *: ts)) =>
-        recurse[R, P, names, ts] {
+        recurseSum[R, P, names, ts] {
+          (
+            constValue[name].toString,
+            MagnoliaMacro.anns[t], {
+              if (Macros.isEnumField[P, t])
+                if (!Macros.implicitExists[Schema[R, t]]) derived[R, t]
+                else summonInline[Schema[R, t]]
+              else summonInline[Schema[R, t]]
+            }.asInstanceOf[Schema[R, Any]]
+          ) :: values
+        }
+    }
+
+  inline def recurseProduct[R, P, Label, A <: Tuple](
+    inline values: List[(String, Schema[R, Any], Int)] = Nil
+  )(inline index: Int = 0): List[(String, Schema[R, Any], Int)] =
+    inline erasedValue[(Label, A)] match {
+      case (_: EmptyTuple, _)                 => values.reverse
+      case (_: (name *: names), _: (t *: ts)) =>
+        recurseProduct[R, P, names, ts] {
           inline if (Macros.isFieldExcluded[P, name]) values
           else
             (
               constValue[name].toString,
-              Macros.annotations[t], {
-                if (Macros.isEnumField[P, t])
-                  if (!Macros.implicitExists[Schema[R, t]]) derived[R, t]
-                  else summonInline[Schema[R, t]]
-                else summonInline[Schema[R, t]]
-              }.asInstanceOf[Schema[R, Any]],
+              summonInline[Schema[R, t]].asInstanceOf[Schema[R, Any]],
               index
             ) :: values
         }(index + 1)
@@ -63,29 +77,29 @@ trait CommonSchemaDerivation {
     inline summonInline[Mirror.Of[A]] match {
       case m: Mirror.SumOf[A] =>
         makeSumSchema[R, A](
-          recurse[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
+          recurseSum[R, A, m.MirroredElemLabels, m.MirroredElemTypes](),
           MagnoliaMacro.typeInfo[A],
-          Macros.annotations[A]
+          MagnoliaMacro.anns[A]
         )(m.ordinal)
 
       case m: Mirror.ProductOf[A] =>
         makeProductSchema[R, A](
-          recurse[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
+          recurseProduct[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
           MagnoliaMacro.typeInfo[A],
-          Macros.annotations[A],
-          Macros.paramAnnotations[A].toMap
+          MagnoliaMacro.anns[A],
+          MagnoliaMacro.paramAnns[A].toMap
         )
     }
 
   private def makeSumSchema[R, A](
-    _members: => List[(String, List[Any], Schema[R, Any], Int)],
+    _members: => List[(String, List[Any], Schema[R, Any])],
     info: TypeInfo,
     annotations: List[Any]
   )(ordinal: A => Int): Schema[R, A] = new Schema[R, A] {
 
     private lazy val members = _members.toVector // Vector's .apply is O(1) vs List's O(N)
 
-    private lazy val subTypes = members.map { case (label, subTypeAnnotations, schema, _) =>
+    private lazy val subTypes = members.map { case (label, subTypeAnnotations, schema) =>
       (label, schema.toType_(), subTypeAnnotations)
     }.sortBy { case (label, _, _) => label }.toList
 
@@ -119,19 +133,19 @@ trait CommonSchemaDerivation {
       }
 
     def resolve(value: A): Step[R] = {
-      val (label, _, schema, _) = members(ordinal(value))
+      val (label, _, schema) = members(ordinal(value))
       if (isEnum) PureStep(EnumValue(label)) else schema.resolve(value)
     }
   }
 
   private def makeProductSchema[R, A](
-    _fields: => List[(String, List[Any], Schema[R, Any], Int)],
+    _fields: => List[(String, Schema[R, Any], Int)],
     info: TypeInfo,
     annotations: List[Any],
     paramAnnotations: Map[String, List[Any]]
   ): Schema[R, A] = new Schema[R, A] {
 
-    private lazy val fields = _fields.map { case (label, _, schema, index) =>
+    private lazy val fields = _fields.map { case (label, schema, index) =>
       val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
       (getName(fieldAnnotations, label), fieldAnnotations, schema, index)
     }

--- a/core/src/main/scala-3/caliban/schema/macros/Macros.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/Macros.scala
@@ -7,42 +7,18 @@ import scala.quoted.*
 export magnolia1.TypeInfo
 
 object Macros {
-  inline def annotations[T]: List[Any]                      = ${ annotationsImpl[T] }
-  inline def paramAnnotations[T]: List[(String, List[Any])] = ${ paramAnnotationsImpl[T] }
-  inline def isFieldExcluded[P, T]: Boolean                 = ${ isFieldExcludedImpl[P, T] }
-  inline def isEnumField[P, T]: Boolean                     = ${ isEnumFieldImpl[P, T] }
-  inline def implicitExists[T]: Boolean                     = ${ implicitExistsImpl[T] }
-
-  private def annotationsImpl[T: Type](using qctx: Quotes): Expr[List[Any]] = {
-    import qctx.reflect.*
-    val tpe = TypeRepr.of[T]
-    Expr.ofList {
-      tpe.typeSymbol.annotations.filter { a =>
-        a.tpe.typeSymbol.maybeOwner.isNoSymbol || (a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" && a.tpe.typeSymbol.owner.fullName != "jdk.internal")
-      }.map(_.asExpr.asInstanceOf[Expr[Any]])
-    }
-  }
-
-  private def paramAnnotationsImpl[T: Type](using qctx: Quotes): Expr[List[(String, List[Any])]] = {
-    import qctx.reflect.*
-    val tpe = TypeRepr.of[T]
-    Expr.ofList {
-      tpe.typeSymbol.primaryConstructor.paramSymss.flatten.map { field =>
-        Expr(field.name) -> field.annotations.filter { a =>
-          a.tpe.typeSymbol.maybeOwner.isNoSymbol ||
-          (a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" && a.tpe.typeSymbol.owner.fullName != "jdk.internal")
-        }.map(_.asExpr.asInstanceOf[Expr[Any]])
-      }.filter(_._2.nonEmpty).map((name, anns) => Expr.ofTuple(name, Expr.ofList(anns)))
-    }
-  }
+  inline def isFieldExcluded[P, T]: Boolean = ${ isFieldExcludedImpl[P, T] }
+  inline def isEnumField[P, T]: Boolean     = ${ isEnumFieldImpl[P, T] }
+  inline def implicitExists[T]: Boolean     = ${ implicitExistsImpl[T] }
 
   /**
    * Tests whether type argument [[FieldT]] in [[Parent]] is annotated with [[GQLExcluded]]
    */
   private def isFieldExcludedImpl[Parent: Type, FieldT: Type](using qctx: Quotes): Expr[Boolean] = {
     import qctx.reflect.*
+    val fieldName = Type.valueOfConstant[FieldT]
     Expr(TypeRepr.of[Parent].typeSymbol.primaryConstructor.paramSymss.flatten.exists { v =>
-      Type.valueOfConstant[FieldT].map(_ == v.name).getOrElse(false)
+      fieldName.map(_ == v.name).getOrElse(false)
       && v.annotations.exists(_.tpe =:= TypeRepr.of[GQLExcluded])
     })
   }


### PR DESCRIPTION
The main issue seems to be when using `Macro.anns` to inspect the annotations of parameters for Product types within the `recurse` method. After taking a closer look at the code, it seems that we are unnecessarily double-extracting the parameter annotations for Product due to reusing the same `recurse` method for both Sum and Product types.

With this PR, we use different recurse methods for Product and Sum types. This solves this issue since the parameter annotations are now extracted via `Macro.paramAnns` which works fine on JDK17+. To demonstrate, I added 2 unit tests for it and added test workflows for JDK17 for Scala 3 (also for Scala 2.13 for completeness).

While the underlying issue with Magnolia still exists (see [here](https://github.com/softwaremill/magnolia/issues/493)), I think we should still do the separation as now macros that are specific to product/sum types are only executed when needed, which results in reduced compilation time + codegen size