### PR TITLE
Add helper method for creating custom enum schemas

### DIFF
--- a/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
@@ -26,3 +26,19 @@ case class __EnumValue(
        else Nil) ++ directives.getOrElse(Nil)
     )
 }
+
+object __EnumValue {
+  def apply(
+    name: String,
+    description: Option[String] = None,
+    isDeprecated: Boolean = false,
+    deprecationReason: Option[String] = None,
+    directives: List[Directive] = List.empty
+  ): __EnumValue = new __EnumValue(
+    name,
+    description,
+    isDeprecated,
+    deprecationReason,
+    if (directives.isEmpty) None else Some(directives)
+  )
+}

--- a/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
@@ -26,19 +26,3 @@ case class __EnumValue(
        else Nil) ++ directives.getOrElse(Nil)
     )
 }
-
-object __EnumValue {
-  def simple(
-    name: String,
-    description: Option[String] = None,
-    isDeprecated: Boolean = false,
-    deprecationReason: Option[String] = None,
-    directives: List[Directive] = List.empty
-  ): __EnumValue = new __EnumValue(
-    name,
-    description,
-    isDeprecated,
-    deprecationReason,
-    if (directives.isEmpty) None else Some(directives)
-  )
-}

--- a/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__EnumValue.scala
@@ -28,7 +28,7 @@ case class __EnumValue(
 }
 
 object __EnumValue {
-  def apply(
+  def simple(
     name: String,
     description: Option[String] = None,
     isDeprecated: Boolean = false,

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -200,6 +200,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
    * @param values       list of possible enum values
    * @param directives   the directives to add to the type
    * @param repr         function that defines how to convert A into a string. WARNING: The resulting string must be contained in the values list
+   * @see [[enumValue]]  convenience method for creating enum values required by this method
    */
   def enumSchema[A](
     name: String,
@@ -219,6 +220,20 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
       else QueryStep(ZQuery.fail(ExecutionError(s"Invalid enum value '$asString'")))
     }
   }
+
+  def enumValue(
+    name: String,
+    description: Option[String] = None,
+    isDeprecated: Boolean = false,
+    deprecationReason: Option[String] = None,
+    directives: List[Directive] = List.empty
+  ): __EnumValue = __EnumValue(
+    name,
+    description,
+    isDeprecated,
+    deprecationReason,
+    directives = if (directives.nonEmpty) Some(directives) else None
+  )
 
   /**
    * Manually defines a field from a name, a description, some directives and a resolver.

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -1270,7 +1270,7 @@ object ExecutionSpec extends ZIOSpecDefault {
           case object B extends MyEnum
         }
         implicit val enumSchema: Schema[Any, MyEnum] =
-          Schema.enumSchema("Foo", values = List(__EnumValue.simple("A")), repr = _.toString)
+          Schema.enumSchema("Foo", values = List(enumValue("A")), repr = _.toString)
 
         case class Query(valid: MyEnum, invalid: MyEnum)
 

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -1270,7 +1270,7 @@ object ExecutionSpec extends ZIOSpecDefault {
           case object B extends MyEnum
         }
         implicit val enumSchema: Schema[Any, MyEnum] =
-          Schema.enumSchema("Foo", values = List(__EnumValue("A")), repr = _.toString)
+          Schema.enumSchema("Foo", values = List(__EnumValue.simple("A")), repr = _.toString)
 
         case class Query(valid: MyEnum, invalid: MyEnum)
 

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -5,7 +5,7 @@ import caliban.CalibanError.ExecutionError
 import caliban.Macros.gqldoc
 import caliban.TestUtils._
 import caliban.Value.{ BooleanValue, IntValue, NullValue, StringValue }
-import caliban.introspection.adt.{ __EnumValue, __Type }
+import caliban.introspection.adt.__Type
 import caliban.parsing.adt.LocationInfo
 import caliban.schema.Annotations.{ GQLInterface, GQLName, GQLValueType }
 import caliban.schema._

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -299,7 +299,7 @@ object SchemaSpec extends ZIOSpecDefault {
         case class Query(myEnum: EnumLikeUnion)
 
         implicit val myEnumSchema: Schema[Any, EnumLikeUnion] =
-          Schema.enumSchema("Foo", Some("foo description"), List(__EnumValue("A")), repr = _.toString)
+          Schema.enumSchema("Foo", Some("foo description"), List(__EnumValue.simple("A")), repr = _.toString)
 
         val gql = graphQL(RootResolver(Query(EnumLikeUnion.A)))
         assertTrue(

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -3,7 +3,7 @@ package caliban.schema
 import java.util.UUID
 import caliban.Value.StringValue
 import caliban._
-import caliban.introspection.adt.{ __DeprecatedArgs, __EnumValue, __Type, __TypeKind }
+import caliban.introspection.adt.{ __DeprecatedArgs, __Type, __TypeKind }
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations.{ GQLDirective, GQLExcluded, GQLInterface, GQLUnion, GQLValueType }
 import caliban.schema.Schema.auto._

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -299,7 +299,7 @@ object SchemaSpec extends ZIOSpecDefault {
         case class Query(myEnum: EnumLikeUnion)
 
         implicit val myEnumSchema: Schema[Any, EnumLikeUnion] =
-          Schema.enumSchema("Foo", Some("foo description"), List(__EnumValue.simple("A")), repr = _.toString)
+          enumSchema("Foo", Some("foo description"), List(enumValue("A")), repr = _.toString)
 
         val gql = graphQL(RootResolver(Query(EnumLikeUnion.A)))
         assertTrue(


### PR DESCRIPTION
Currently, the only way for a user to create a custom enum schema is a bit verbose, and requires the user to look up the enum schema derivation in order to implement one:

```scala
trait Foo
object Foo {
  case object A extends Foo
  case object B extends Foo
}

implicit val fooSchema: Schema[Any, Foo] = new Schema[Any, Foo] {
  def toType(isInput: Boolean = false, isSubscription: Boolean = false): __Type =
    Types.makeEnum(
      Some("Foo"),
      None,
      List(__EnumValue("FooB", None, false, None, None),  __EnumValue("FooA", None, false, None, None)),
      None,
    )

  override def resolve(value: Foo): Step[R] = PureStep(StringValue("Foo" + value.toString))
}
```

With this PR, we add a helper method in the `Schema` companion object to make it easier to create one:

```scala
import Schema._

implicit val fooSchema: Schema[Any, Foo] = enumSchema[Foo](
  "Foo",
  values = List(enumValue("FooA"), enumValue("FooB")),
  repr = v => "Foo" + v.toString
)
```