### PR TITLE
Add SBT plugin to help manage 3rd-party dependency versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,7 @@ lazy val root = project
     clientLaminext,
     tools,
     codegenSbt,
+    buildinfoSbt,
     federation,
     reporting,
     tracing
@@ -245,6 +246,38 @@ lazy val codegenSbt = project
     }
   )
   .dependsOn(tools)
+
+lazy val buildinfoSbt = project
+  .in(file(".buildinfo-sbt"))
+  .settings(name := "caliban-build-info")
+  .enablePlugins(BuildInfoPlugin, SbtPlugin)
+  .settings(
+    skip             := (scalaVersion.value != scala212),
+    ideSkipProject   := (scalaVersion.value != scala212),
+    buildInfoKeys    := Seq[BuildInfoKey](
+      "caliban"     -> version.value,
+      "akka"        -> akkaVersion,
+      "cats"        -> catsEffect3Version,
+      "circe"       -> circeVersion,
+      "fs2"         -> fs2Version,
+      "http4s"      -> http4sVersion,
+      "jsoniter"    -> jsoniterVersion,
+      "pekko"       -> pekkoVersion,
+      "play"        -> playVersion,
+      "`play-json`" -> playJsonVersion,
+      "sttp"        -> sttpVersion,
+      "tapir"       -> tapirVersion,
+      "zio"         -> zioVersion,
+      "`zio-http`"  -> zioHttpVersion,
+      "`zio-query`" -> zqueryVersion
+    ),
+    buildInfoPackage := "caliban",
+    buildInfoObject  := "BuildVersions"
+  )
+  .settings(
+    sbtPlugin          := true,
+    crossScalaVersions := Seq(scala212)
+  )
 
 lazy val catsInterop = project
   .in(file("interop/cats"))

--- a/vuepress/docs/.vuepress/config.js
+++ b/vuepress/docs/.vuepress/config.js
@@ -87,6 +87,10 @@ module.exports = {
           {
             title: 'Examples',
             path: 'examples'
+          },
+          {
+            title: 'Managing Dependencies',
+            path: 'managing-dependencies'
           }]
         }
       }

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -52,6 +52,11 @@ import sttp.tapir.json.zio._
 
 For more info on the adapters and the JSON implementations, see [here](adapters.md#json-handling).
 
+::: tip Managing dependency versions
+Starting with version 2.4.2, Caliban provides an SBT plugin to help manage dependency versions.
+Check out the [Managing Dependencies](managing-dependencies.md) section for more info!
+:::
+
 ## A simple example
 
 Creating a GraphQL API with Caliban is as simple as creating a case class. Indeed, the whole GraphQL schema will be derived from a case class structure (its fields and the other types it references), and the resolver is just an instance of that case class.

--- a/vuepress/docs/docs/managing-dependencies.md
+++ b/vuepress/docs/docs/managing-dependencies.md
@@ -1,0 +1,44 @@
+# Managing Dependencies
+
+Caliban provides integrations with many 3rd-party libraries.
+In some cases, users might need to include additional modules from one of these integrations.
+
+Let's use the `caliban-http4s` module as an example, where a user needs to include the server implementation:
+
+```scala mdoc:silent
+val calibanVersion  = "2.4.1"
+val http4sVersion   = ??? // what version should we use?
+
+libraryDependencies ++= Seq(
+  "com.github.ghostdogpr" %% "caliban-http4s"       % calibanVersion,
+  "org.http4s"            %% "http4s-ember-server"  % http4sVersion,
+)
+```
+
+One sensible choice for this example would be to choose the latest `http4s` version. However, in some rare cases where
+the versioning scheme is not strictly adhered to, this might lead to unexpected runtime errors if there is a mismatch
+between the version of `http4s` that Caliban was build against for and the user-defined version.
+
+## Caliban build-info SBT plugin
+
+Starting with version 2.4.2, Caliban provides an SBT plugin that can be used to retrieve the versions of the libraries
+that the current version of Caliban was built against. This makes it easier to manage additional dependencies from
+libraries caliban integrates with.
+
+To use the SBT plugin, add the following in the `project/plugins.sbt` file:
+
+```scala
+addSbtPlugin("com.github.ghostdogpr" % "caliban-build-info" % "2.4.2")
+```
+
+The dependency versions that caliban was build against can then be extracted in `build.sbt` as:
+
+```scala
+val calibanVersion  = _root_.caliban.BuildVersions.caliban
+val http4sVersion   = _root_.caliban.BuildVersions.http4s
+
+libraryDependencies ++= Seq(
+  "com.github.ghostdogpr" %% "caliban-http4s"       % calibanVersion,
+  "org.http4s"            %% "http4s-ember-server"  % http4sVersion
+)
+```

--- a/vuepress/docs/docs/managing-dependencies.md
+++ b/vuepress/docs/docs/managing-dependencies.md
@@ -5,7 +5,7 @@ In some cases, users might need to include additional modules from one of these 
 
 Let's use the `caliban-http4s` module as an example, where a user needs to include the server implementation:
 
-```scala mdoc:silent
+```scala
 val calibanVersion  = "2.4.1"
 val http4sVersion   = ??? // what version should we use?
 


### PR DESCRIPTION
With this PR, we publish a lightweight SBT plugin that contains the versions of the libraries that Caliban was built against.

The motivation behind adding this is that in many cases a user will need to include additional dependencies from one of the integrations (e.g., tapir). Currently, the user needs to specify the version of tapir / http4s / etc. manually.

In some cases, this might cause binary incompatibility issues if the 3rd-party library doesn't strictly adhere to their versioning scheme, which makes dependency management more difficult as they need to manually keep library versions in-sync with what Caliban uses.

Let me know what you think about adding this plugin. Also, happy to hear any recommendations for the plugin name!