### PR TITLE
Play 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.12 check
-      - run: sbt ++3.3.1 check
+      - run: sbt ++2.13.12 check ++3.3.1 check
       - save_cache:
           key: sbtcache
           paths:
@@ -24,7 +23,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.18 core/test http4s/test akkaHttp/test pekkoHttp/test play/test zioHttp/test examples/compile catsInterop/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test tracing/test
+      - run: sbt ++2.12.18 core/test http4s/test akkaHttp/test pekkoHttp/test zioHttp/test catsInterop/compile tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test tracing/test
       - save_cache:
           key: sbtcache
           paths:
@@ -99,7 +98,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.3.1 core/test catsInterop/compile benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile zioHttp/test tapirInterop/test pekkoHttp/test http4s/test federation/test tools/test reporting/test tracing/test
+      - run: sbt ++3.3.1 core/test catsInterop/compile benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile play/test zioHttp/test tapirInterop/test pekkoHttp/test http4s/test federation/test tools/test reporting/test tracing/test
       - save_cache:
           key: sbtcache
           paths:
@@ -114,7 +113,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.3.1 core/test catsInterop/compile benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile zioHttp/test tapirInterop/test pekkoHttp/test http4s/test federation/test tools/test reporting/test tracing/test
+      - run: sbt ++3.3.1 core/test catsInterop/compile benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile play/test zioHttp/test tapirInterop/test pekkoHttp/test http4s/test federation/test tools/test reporting/test tracing/test
       - save_cache:
           key: sbtcache
           paths:
@@ -146,7 +145,7 @@ jobs:
       - restore_cache:
           key: sbtcache
       - run: ./.circleci/install-native-deps.sh
-      - run: sbt ++3.3.1 clientJS/test clientLaminextJS/Test/fastLinkJS clientNative/Test/nativeLink
+      - run: sbt ++3.3.1 clientJS/test clientLaminextJS/Test/fastLinkJS clientNative/test
       - save_cache:
           key: sbtcache
           paths:
@@ -178,8 +177,8 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.12 http4s/mimaReportBinaryIssues akkaHttp/mimaReportBinaryIssues pekkoHttp/mimaReportBinaryIssues play/mimaReportBinaryIssues zioHttp/mimaReportBinaryIssues catsInterop/mimaReportBinaryIssues monixInterop/mimaReportBinaryIssues clientJVM/mimaReportBinaryIssues clientJS/mimaReportBinaryIssues clientLaminextJS/mimaReportBinaryIssues federation/mimaReportBinaryIssues reporting/mimaReportBinaryIssues tracing/mimaReportBinaryIssues tools/mimaReportBinaryIssues core/mimaReportBinaryIssues tapirInterop/mimaReportBinaryIssues
-      - run: sbt ++3.3.1 catsInterop/mimaReportBinaryIssues monixInterop/mimaReportBinaryIssues clientJVM/mimaReportBinaryIssues clientJS/mimaReportBinaryIssues clientLaminextJS/mimaReportBinaryIssues zioHttp/mimaReportBinaryIssues http4s/mimaReportBinaryIssues federation/mimaReportBinaryIssues reporting/mimaReportBinaryIssues tracing/mimaReportBinaryIssues tools/mimaReportBinaryIssues core/mimaReportBinaryIssues tapirInterop/mimaReportBinaryIssues pekkoHttp/mimaReportBinaryIssues
+      - run: sbt ++2.13.12 http4s/mimaReportBinaryIssues akkaHttp/mimaReportBinaryIssues pekkoHttp/mimaReportBinaryIssues zioHttp/mimaReportBinaryIssues catsInterop/mimaReportBinaryIssues monixInterop/mimaReportBinaryIssues clientJVM/mimaReportBinaryIssues clientJS/mimaReportBinaryIssues clientLaminextJS/mimaReportBinaryIssues federation/mimaReportBinaryIssues reporting/mimaReportBinaryIssues tracing/mimaReportBinaryIssues tools/mimaReportBinaryIssues core/mimaReportBinaryIssues tapirInterop/mimaReportBinaryIssues # play/mimaReportBinaryIssues
+      - run: sbt ++3.3.1 catsInterop/mimaReportBinaryIssues monixInterop/mimaReportBinaryIssues clientJVM/mimaReportBinaryIssues clientJS/mimaReportBinaryIssues clientLaminextJS/mimaReportBinaryIssues zioHttp/mimaReportBinaryIssues http4s/mimaReportBinaryIssues federation/mimaReportBinaryIssues reporting/mimaReportBinaryIssues tracing/mimaReportBinaryIssues tools/mimaReportBinaryIssues core/mimaReportBinaryIssues tapirInterop/mimaReportBinaryIssues pekkoHttp/mimaReportBinaryIssues # play/mimaReportBinaryIssues
       - save_cache:
           key: sbtcache
           paths:
@@ -203,7 +202,7 @@ jobs:
           chmod 600 ~/.gnupg/*
           echo RELOADAGENT | gpg-connect-agent
           echo $PGP_SECRET | base64 --decode | gpg --import --no-tty --batch --yes
-      - run: sbt clean ci-release
+      - run: sbt +clean ci-release
 
   microsite:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt codegenScriptedScala3
+      - run: sbt ++2.12.18 codegenScriptedScala3
       - save_cache:
           key: sbtcache
           paths:

--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -1,7 +1,5 @@
 package caliban
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
 import caliban.interop.tapir.TestData.sampleCharacters
 import caliban.interop.tapir.{
   FakeAuthorizationInterceptor,
@@ -13,10 +11,12 @@ import caliban.interop.tapir.{
   WebSocketInterpreter
 }
 import caliban.uploads.Uploads
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import play.api.Mode
 import play.api.routing._
 import play.api.routing.sird._
-import play.core.server.{ AkkaHttpServer, ServerConfig }
+import play.core.server.{ PekkoHttpServer, ServerConfig }
 import sttp.client3.UriContext
 import zio._
 import zio.test.{ Live, ZIOSpecDefault }
@@ -24,7 +24,7 @@ import zio.test.{ Live, ZIOSpecDefault }
 import scala.language.postfixOps
 
 object PlayAdapterSpec extends ZIOSpecDefault {
-  import sttp.tapir.json.circe._
+  import sttp.tapir.json.play._
 
   private val envLayer = TestService.make(sampleCharacters) ++ Uploads.empty
 
@@ -51,7 +51,7 @@ object PlayAdapterSpec extends ZIOSpecDefault {
                      }
       _           <- ZIO
                        .attempt(
-                         AkkaHttpServer.fromRouterWithComponents(
+                         PekkoHttpServer.fromRouterWithComponents(
                            ServerConfig(
                              mode = Mode.Dev,
                              port = Some(8088),

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@ val laminextVersion           = "0.16.2"
 val magnoliaScala2Version     = "1.1.6"
 val magnoliaScala3Version     = "1.3.4"
 val pekkoVersion              = "1.0.1"
-val playVersion               = "2.8.20"
-val playJsonVersion           = "2.10.2"
+val playVersion               = "3.0.0"
+val playJsonVersion           = "3.0.0"
 val scalafmtVersion           = "3.7.14"
 val sttpVersion               = "3.9.0"
-val tapirVersion              = "1.8.2"
+val tapirVersion              = "1.8.3"
 val zioVersion                = "2.0.18"
 val zioInteropCats2Version    = "22.0.0.0"
 val zioInteropCats3Version    = "23.0.0.8"
@@ -37,7 +37,7 @@ val zioPreludeVersion         = "1.0.0-RC21"
 
 inThisBuild(
   List(
-    scalaVersion             := scala212, // Change to control IntelliJ's highlighting
+    scalaVersion             := scala213, // Change to control IntelliJ's highlighting
     crossScalaVersions       := allScala,
     organization             := "com.github.ghostdogpr",
     homepage                 := Some(url("https://github.com/ghostdogpr/caliban")),
@@ -150,7 +150,7 @@ lazy val core = project
         "io.circe"                              %% "circe-parser"          % circeVersion    % Test,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % jsoniterVersion % Optional,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterVersion % Provided,
-        "com.typesafe.play"                     %% "play-json"             % playJsonVersion % Optional
+        "org.playframework"                     %% "play-json"             % playJsonVersion % Optional
       )
   )
   .dependsOn(macros)
@@ -393,20 +393,23 @@ lazy val play = project
   .settings(commonSettings)
   .settings(enableMimaSettingsJVM)
   .settings(
-    skip           := (scalaVersion.value == scala3),
-    ideSkipProject := (scalaVersion.value == scala3),
-    crossScalaVersions -= scala3,
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
+    skip               := (scalaVersion.value == scala212),
+    ideSkipProject     := (scalaVersion.value == scala212),
+    crossScalaVersions := Seq(scala213, scala3),
+    testFrameworks     := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
+    libraryDependencies ++= {
+      if (scalaVersion.value == scala3) Seq()
+      else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.2").cross(CrossVersion.full)))
+    },
     libraryDependencies ++= Seq(
-      "com.typesafe.play"             %% "play"                  % playVersion,
-      "com.softwaremill.sttp.tapir"   %% "tapir-play-server"     % tapirVersion,
-      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"      % tapirVersion % Test,
-      "dev.zio"                       %% "zio-test"              % zioVersion   % Test,
-      "dev.zio"                       %% "zio-test-sbt"          % zioVersion   % Test,
-      "com.typesafe.play"             %% "play-akka-http-server" % playVersion  % Test,
-      "io.circe"                      %% "circe-generic"         % circeVersion % Test,
-      "com.softwaremill.sttp.client3" %% "circe"                 % sttpVersion  % Test,
-      compilerPlugin(("org.typelevel" %% "kind-projector"        % "0.13.2").cross(CrossVersion.full))
+      "org.playframework"             %% "play"                   % playVersion,
+      "com.softwaremill.sttp.tapir"   %% "tapir-play-server"      % tapirVersion,
+      "com.softwaremill.sttp.tapir"   %% "tapir-json-play"        % tapirVersion % Test,
+      "dev.zio"                       %% "zio-test"               % zioVersion   % Test,
+      "dev.zio"                       %% "zio-test-sbt"           % zioVersion   % Test,
+      "org.playframework"             %% "play-pekko-http-server" % playVersion  % Test,
+      "io.circe"                      %% "circe-generic"          % circeVersion % Test,
+      "com.softwaremill.sttp.client3" %% "circe"                  % sttpVersion  % Test
     )
   )
   .dependsOn(core, tapirInterop % "compile->compile;test->test")
@@ -486,24 +489,24 @@ lazy val examples = project
     run / connectInput := true
   )
   .settings(
-    skip                                                 := (scalaVersion.value == scala3),
-    ideSkipProject                                       := (scalaVersion.value == scala3),
-    crossScalaVersions -= scala3,
+    skip                                                 := (scalaVersion.value != scala213),
+    ideSkipProject                                       := (scalaVersion.value != scala213),
+    crossScalaVersions                                   := Seq(scala213),
     libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % "always",
     libraryDependencies ++= Seq(
-      "org.typelevel"                         %% "cats-mtl"              % catsMtlVersion,
-      "org.http4s"                            %% "http4s-ember-server"   % http4sVersion,
-      "org.http4s"                            %% "http4s-dsl"            % http4sVersion,
-      "com.softwaremill.sttp.client3"         %% "zio"                   % sttpVersion,
-      "io.circe"                              %% "circe-generic"         % circeVersion,
-      "dev.zio"                               %% "zio-http"              % zioHttpVersion,
-      "com.typesafe.play"                     %% "play-akka-http-server" % playVersion,
-      "com.typesafe.akka"                     %% "akka-actor-typed"      % akkaVersion,
-      "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"  % tapirVersion,
-      "com.softwaremill.sttp.tapir"           %% "tapir-json-circe"      % tapirVersion,
-      "com.softwaremill.sttp.tapir"           %% "tapir-json-play"       % tapirVersion,
-      "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"  % tapirVersion,
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterVersion % Provided
+      "org.typelevel"                         %% "cats-mtl"               % catsMtlVersion,
+      "org.http4s"                            %% "http4s-ember-server"    % http4sVersion,
+      "org.http4s"                            %% "http4s-dsl"             % http4sVersion,
+      "com.softwaremill.sttp.client3"         %% "zio"                    % sttpVersion,
+      "io.circe"                              %% "circe-generic"          % circeVersion,
+      "dev.zio"                               %% "zio-http"               % zioHttpVersion,
+      "org.playframework"                     %% "play-pekko-http-server" % playVersion,
+      "com.typesafe.akka"                     %% "akka-actor-typed"       % akkaVersion,
+      "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"   % tapirVersion,
+      "com.softwaremill.sttp.tapir"           %% "tapir-json-circe"       % tapirVersion,
+      "com.softwaremill.sttp.tapir"           %% "tapir-json-play"        % tapirVersion,
+      "com.softwaremill.sttp.tapir"           %% "tapir-jsoniter-scala"   % tapirVersion,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"  % jsoniterVersion % Provided
     )
   )
   .dependsOn(

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/project/build.properties
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.9.7

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,13 +17,13 @@ libraryDependencies ++= Seq(
   "com.github.ghostdogpr"         %% "caliban-tapir"                 % calibanVersion,
   "com.github.ghostdogpr"         %% "caliban-client"                % calibanVersion,
   "com.github.ghostdogpr"         %% "caliban-tools"                 % calibanVersion,
-  "org.http4s"                    %% "http4s-ember-server"           % "0.23.16",
-  "org.http4s"                    %% "http4s-dsl"                    % "0.23.16",
-  "com.softwaremill.sttp.client3" %% "zio"                           % "3.3.18",
-  "io.circe"                      %% "circe-generic"                 % "0.14.1",
-  "com.typesafe.play"             %% "play-akka-http-server"         % "2.8.14",
+  "org.http4s"                    %% "http4s-ember-server"           % "0.23.23",
+  "org.http4s"                    %% "http4s-dsl"                    % "0.23.23",
+  "com.softwaremill.sttp.client3" %% "zio"                           % "3.9.0",
+  "io.circe"                      %% "circe-generic"                 % "0.14.6",
+  "org.playframework"             %% "play-pekko-http-server"        % "3.0.0",
   "com.typesafe.akka"             %% "akka-actor-typed"              % "2.6.18",
-  "com.softwaremill.sttp.tapir"   %% "tapir-jsoniter-scala"          % "1.2.2"
+  "com.softwaremill.sttp.tapir"   %% "tapir-jsoniter-scala"          % "1.8.3"
 )
 ```
 

--- a/examples/src/main/scala/example/play/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/play/AuthExampleApp.scala
@@ -1,19 +1,19 @@
 package example.play
 
-import akka.actor.ActorSystem
 import caliban._
-import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
 import caliban.interop.tapir.TapirAdapter.TapirResponse
+import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
 import caliban.schema.GenericSchema
+import org.apache.pekko.actor.ActorSystem
 import play.api.Mode
 import play.api.routing._
 import play.api.routing.sird._
-import play.core.server.{ AkkaHttpServer, ServerConfig }
+import play.core.server.{ PekkoHttpServer, ServerConfig }
 import sttp.model.StatusCode
 import sttp.tapir.json.play._
 import sttp.tapir.model.ServerRequest
 import zio.stream.ZStream
-import zio.{ FiberRef, RIO, Runtime, ULayer, Unsafe, ZIO, ZLayer }
+import zio.{ RIO, Runtime, Unsafe, ZIO, ZLayer }
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.io.StdIn.readLine
@@ -53,7 +53,7 @@ object AuthExampleApp extends App {
 
   val interpreter = Unsafe.unsafe(implicit u => runtime.unsafe.run(api.interpreter).getOrThrow())
 
-  val server = AkkaHttpServer.fromRouterWithComponents(
+  val server = PekkoHttpServer.fromRouterWithComponents(
     ServerConfig(
       mode = Mode.Dev,
       port = Some(8088),

--- a/examples/src/main/scala/example/play/ExampleApp.scala
+++ b/examples/src/main/scala/example/play/ExampleApp.scala
@@ -1,15 +1,15 @@
 package example.play
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
 import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
 import caliban.{ GraphQL, PlayAdapter }
 import example.ExampleData.sampleCharacters
 import example.{ ExampleApi, ExampleService }
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import play.api.Mode
 import play.api.routing._
 import play.api.routing.sird._
-import play.core.server.{ AkkaHttpServer, ServerConfig }
+import play.core.server.{ PekkoHttpServer, ServerConfig }
 import zio.{ Runtime, Scope, ZIO, ZIOAppDefault }
 
 object ExampleApp extends ZIOAppDefault {
@@ -23,7 +23,7 @@ object ExampleApp extends ZIOAppDefault {
       interpreter <- ZIO.serviceWithZIO[GraphQL[Any]](_.interpreter)
       _           <- ZIO.acquireRelease(
                        ZIO.attempt(
-                         AkkaHttpServer.fromRouterWithComponents(
+                         PekkoHttpServer.fromRouterWithComponents(
                            ServerConfig(
                              mode = Mode.Dev,
                              port = Some(8088),

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -483,7 +483,9 @@ object TapirAdapterSpec {
       fromMetadata(
         asStringAlways.map(error => Left(HttpError(error, StatusCode.UnprocessableEntity))),
         ConditionalResponseAs(
-          _.contentType.exists(_.startsWith("multipart/mixed")),
+          _.contentType.exists(
+            MediaType.unsafeParse(_).matches(ContentTypeRange("multipart", "mixed", ContentTypeRange.Wildcard))
+          ),
           asStream(ZioStreams)(readMultipartResponse)
             .mapRight(Right(_))
             .mapLeft(s => HttpError(s, StatusCode.UnprocessableEntity))

--- a/sbt
+++ b/sbt
@@ -34,8 +34,8 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.9.0"
-declare -r sbt_unreleased_version="1.9.0"
+declare -r sbt_release_version="1.9.7"
+declare -r sbt_unreleased_version="1.9.7"
 
 declare -r latest_dotty="3.3.1"
 declare -r latest_213="2.13.12"


### PR DESCRIPTION
This PR updates play and play-json to 3.0.0 and tapir to 1.8.3 (which supports play 3). Starting with v3, `play-pekko-http-server` has substituted `play-akka-http-server` 🎉. However, play has dropped support for Scala 2.12 which means we have to make some changes to CI to make things work:

1. We're now publishing `caliban-play` for Scala 2.13 and Scala 3 (instead of 2.12 and 2.13)
2. Default scala version in `build.sbt` is now Scala 2.13, which is the only one that can compile all the modules in IntelliJ. I tested publishing locally using `+publishLocal` and the sbt plugin was being published, but I'm not too sure whether we might see issues with `ci-release` - we'll have to see once this PR is merged in.
3. The examples work only with Scala 2.13 now. If we removed the akka adapter from the examples they'll work with Scala 3 as well
4. I had to disable mima checks for the play adapter because too many things are not bincompat anymore due to the akka -> pekko change 