### PR TITLE
fix a warning about impure expression

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CompileTimeCalibanPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CompileTimeCalibanPlugin.scala
@@ -266,7 +266,7 @@ object CompileTimeCalibanClientPlugin extends AutoPlugin {
                     clientsSettings
                       .flatTraverseT[File] { serverProject: Project =>
                         Def.taskDyn {
-                          ensureCompiled(serverProject).value
+                          val _ = ensureCompiled(serverProject).value
 
                           val serverMetadata = {
                             val serverTargetDir = (serverProject / target).value.getAbsolutePath


### PR DESCRIPTION
See details in [Discord](https://discord.com/channels/629491597070827530/633200096393166868/1167904836554072094)

Under some circumstances the build can start failing with the following error:
```
[error] .../ghostdogpr/caliban/codegen-sbt/src/main/scala/caliban/codegen/CompileTimeCalibanPlugin.scala:269:57: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
[error]                           ensureCompiled(serverProject).value
[error]                                                         ^
[error] No warnings can be incurred under -Xfatal-warnings.
[error] two errors found
[error] (codegenSbt / Compile / compileIncremental) Compilation failed
```

Usually it does not happen, however can show up if one uses [Metals](https://scalameta.org/metals) to work with the project (e.g. vscode).