### PR TITLE
Resolve queried fields only in object schemas

### DIFF
--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
@@ -163,38 +163,18 @@ object NestedZQueryBenchmarkSchema {
   }
 
   private def generateMulti(n: Int) = {
-    val entities = (1 to n)
-      .map(i =>
-        MultifieldEntity(
-          i,
-          ZQuery.succeed(i),
-          ZQuery.succeed(i),
-          ZQuery.succeed(i),
-          ZQuery.succeed(i),
-          ZQuery.succeed(i),
-          ZQuery.succeed(
-            NestedObject(
-              i,
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i),
-              ZQuery.succeed(i)
-            )
-          )
-        )
+    val entities = (1 to n).map { i =>
+      val qi = ZQuery.succeed(i)
+      MultifieldEntity(
+        i,
+        qi,
+        qi,
+        qi,
+        qi,
+        qi,
+        ZQuery.succeed(NestedObject(i, qi, qi, qi, qi, qi, qi, qi, qi, qi, qi, qi, qi, qi, qi, qi))
       )
-      .toList
+    }.toList
     MultifieldRoot(ZQuery.succeed(entities))
   }
 

--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
@@ -12,6 +12,7 @@ object NestedZQueryBenchmarkSchema {
 
   type Query[A] = ZQuery[Any, Throwable, A]
 
+  implicit val nestedObjSchema: Schema[Any, NestedObject]          = Schema.gen
   implicit val simpleEntitySchema: Schema[Any, SimpleEntity]       = Schema.gen
   implicit val multipleEntitySchema: Schema[Any, MultifieldEntity] = Schema.gen
 
@@ -53,8 +54,29 @@ object NestedZQueryBenchmarkSchema {
     nested1: Query[Int],
     nested2: Query[Int],
     nested3: Query[Int],
-    nested4: Query[Int]
+    nested4: Query[Int],
+    nestedObject: Query[NestedObject]
   )
+
+  case class NestedObject(
+    id: Int,
+    nested0: Query[Int],
+    nested1: Query[Int],
+    nested2: Query[Int],
+    nested3: Query[Int],
+    nested4: Query[Int],
+    nested5: Query[Int],
+    nested6: Query[Int],
+    nested7: Query[Int],
+    nested8: Query[Int],
+    nested9: Query[Int],
+    nested10: Query[Int],
+    nested11: Query[Int],
+    nested12: Query[Int],
+    nested13: Query[Int],
+    nested14: Query[Int]
+  )
+
   case class DeepRoot(entities: Query[List[DeepEntity]])
   case class DeepEntity(next: Query[Option[DeepEntity]], nested: Query[Int])
   case class DeepWithArgsRoot(entities: Query[List[DeepWithArgsEntity]])
@@ -84,6 +106,7 @@ object NestedZQueryBenchmarkSchema {
       nested2
       nested3
       nested4
+      nestedObject { id }
     }
   }""".stripMargin
 
@@ -148,7 +171,27 @@ object NestedZQueryBenchmarkSchema {
           ZQuery.succeed(i),
           ZQuery.succeed(i),
           ZQuery.succeed(i),
-          ZQuery.succeed(i)
+          ZQuery.succeed(i),
+          ZQuery.succeed(
+            NestedObject(
+              i,
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i),
+              ZQuery.succeed(i)
+            )
+          )
         )
       )
       .toList

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -95,8 +95,6 @@ trait CommonSchemaDerivation[R] {
         )
     }
 
-    override private[schema] lazy val resolveFieldLazily: Boolean = !(ctx.isObject || _isValueType)
-
     override def resolve(value: T): Step[R] =
       if (ctx.isObject) PureStep(EnumValue(getName(ctx)))
       else if (_isValueType) resolveValueType(value)

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -107,14 +107,12 @@ trait CommonSchemaDerivation[R] {
       head.typeclass.resolve(head.dereference(value))
     }
 
-    private def resolveObject(value: T): Step[R] = {
+    private def resolveObject(value: T): Step[R] = MetadataFunctionStep[R] { field =>
       val fieldsBuilder = Map.newBuilder[String, Step[R]]
-      fields.foreach { case (name, schema, dereference) =>
-        fieldsBuilder += name -> {
-          lazy val step = schema.resolve(dereference(value))
-          if (schema.resolveFieldLazily) FunctionStep(_ => step)
-          else step
-        }
+      fields.foreach {
+        case (name, schema, dereference) if field.fieldNames.contains(name) =>
+          fieldsBuilder += name -> schema.resolve(dereference(value))
+        case _                                                              => ()
       }
       ObjectStep(getName(ctx), fieldsBuilder.result())
     }

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -107,10 +107,9 @@ trait CommonSchemaDerivation[R] {
 
     private def resolveObject(value: T, queriedFields: Set[String]): Step[R] = {
       val fieldsBuilder = Map.newBuilder[String, Step[R]]
-      fields.foreach {
-        case (name, schema, dereference) if queriedFields.contains(name) =>
+      fields.foreach { case (name, schema, dereference) =>
+        if (queriedFields.contains(name))
           fieldsBuilder += name -> schema.resolve(dereference(value))
-        case _                                                           => ()
       }
       ObjectStep(getName(ctx), fieldsBuilder.result())
     }

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -183,10 +183,9 @@ trait CommonSchemaDerivation {
 
     private def resolveObject(value: A, queriedFields: Set[String]): Step[R] = {
       val fieldsBuilder = Map.newBuilder[String, Step[R]]
-      fields.foreach {
-        case (name, _, schema, index) if queriedFields.contains(name) =>
+      fields.foreach { (name, _, schema, index) =>
+        if (queriedFields.contains(name))
           fieldsBuilder += name -> schema.resolve(value.asInstanceOf[Product].productElement(index))
-        case _                                                        => ()
       }
       ObjectStep(name, fieldsBuilder.result())
     }

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -171,8 +171,6 @@ trait CommonSchemaDerivation {
       else if (isInput) mkInputObject[R](annotations, fields, info)(isInput, isSubscription)
       else mkObject[R](annotations, fields, info)(isInput, isSubscription)
 
-    override private[schema] lazy val resolveFieldLazily: Boolean = (!isValueType) && fields.isEmpty
-
     def resolve(value: A): Step[R] =
       if (fields.isEmpty) PureStep(EnumValue(name))
       else if (isValueType) resolveValueType(value)

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -43,6 +43,9 @@ case class Field(
 ) { self =>
   lazy val locationInfo: LocationInfo = _locationInfo()
 
+  private[caliban] val fieldNames: Set[String] =
+    fields.foldLeft(Set.newBuilder[String]) { case (sb, f) => sb += f.name }.result()
+
   private[caliban] val aliasedName: String = alias.getOrElse(name)
 
   def combine(other: Field): Field =

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -43,7 +43,7 @@ case class Field(
 ) { self =>
   lazy val locationInfo: LocationInfo = _locationInfo()
 
-  private[caliban] val fieldNames: Set[String] =
+  private[caliban] lazy val fieldNames: Set[String] =
     fields.foldLeft(Set.newBuilder[String]) { case (sb, f) => sb += f.name }.result()
 
   private[caliban] val aliasedName: String = alias.getOrElse(name)

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -115,6 +115,7 @@ trait Schema[-R, T] { self =>
         case ObjectStep(_, fields)   => ObjectStep(name, fields)
         case PureStep(EnumValue(_))  => PureStep(EnumValue(name))
         case MetadataFunctionStep(s) => MetadataFunctionStep(field => loop(s(field)))
+        case FunctionStep(s)         => FunctionStep(args => loop(s(args)))
         case other                   => other
       }
 

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -81,9 +81,6 @@ trait Schema[-R, T] { self =>
    */
   def arguments: List[__InputValue] = Nil
 
-  @deprecated("No longer needed")
-  private[schema] def resolveFieldLazily: Boolean = false
-
   /**
    * Builds a new `Schema` of `A` from an existing `Schema` of `T` and a function from `A` to `T`.
    * @param f a function from `A` to `T`.

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -179,9 +179,9 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
 
       override def resolve(value: A): Step[R1] = MetadataFunctionStep[R1] { field =>
         val fieldsBuilder = Map.newBuilder[String, Step[R1]]
-        fieldsForResolve.foreach {
-          case (f, plan) if field.fieldNames.contains(f.name) => fieldsBuilder += f.name -> plan(value)
-          case _                                              => ()
+        fieldsForResolve.foreach { case (f, plan) =>
+          if (field.fieldNames.contains(f.name))
+            fieldsBuilder += f.name -> plan(value)
         }
         ObjectStep(name, fieldsBuilder.result())
       }

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -81,13 +81,7 @@ trait Schema[-R, T] { self =>
    */
   def arguments: List[__InputValue] = Nil
 
-  /**
-   * Boolean flag indicating whether the [[resolve]] method should be wrapped in a [[FunctionStep]] when resolving
-   * object fields.
-   *
-   * Should be `false` except for objects or wrappers of objects. This prevents fields of case classes to be resolved when they're not
-   * requested in the query, which significantly improves performance in larger schemas
-   */
+  @deprecated("No longer needed")
   private[schema] def resolveFieldLazily: Boolean = false
 
   /**
@@ -99,7 +93,6 @@ trait Schema[-R, T] { self =>
     override def arguments: List[__InputValue]                             = self.arguments
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = self.toType_(isInput, isSubscription)
     override def resolve(value: A): Step[R]                                = self.resolve(f(value))
-    override private[schema] def resolveFieldLazily: Boolean               = self.resolveFieldLazily
   }
 
   /**
@@ -120,16 +113,17 @@ trait Schema[-R, T] { self =>
       case _                                                         => true
     }
 
-    override private[schema] def resolveFieldLazily: Boolean = self.resolveFieldLazily
-    override def resolve(value: T): Step[R]                  =
-      self.resolve(value) match {
-        case o @ ObjectStep(_, fields)  =>
-          if (renameTypename) ObjectStep(name, fields) else o
-        case p @ PureStep(EnumValue(_)) =>
-          if (renameTypename) PureStep(EnumValue(name)) else p
-        case other                      =>
-          other
+    override def resolve(value: T): Step[R] = {
+      def loop(step: Step[R]): Step[R] = step match {
+        case ObjectStep(_, fields)   => ObjectStep(name, fields)
+        case PureStep(EnumValue(_))  => PureStep(EnumValue(name))
+        case MetadataFunctionStep(s) => MetadataFunctionStep(field => loop(s(field)))
+        case other                   => other
       }
+
+      val step = self.resolve(value)
+      if (renameTypename) loop(step) else step
+    }
   }
 }
 
@@ -185,10 +179,12 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
 
       private lazy val fieldsForResolve = fields(false, false)
 
-      override private[schema] def resolveFieldLazily: Boolean = true
-      override def resolve(value: A): Step[R1]                 = {
+      override def resolve(value: A): Step[R1] = MetadataFunctionStep[R1] { field =>
         val fieldsBuilder = Map.newBuilder[String, Step[R1]]
-        fieldsForResolve.foreach { case (f, plan) => fieldsBuilder += f.name -> plan(value) }
+        fieldsForResolve.foreach {
+          case (f, plan) if field.fieldNames.contains(f.name) => fieldsBuilder += f.name -> plan(value)
+          case _                                              => ()
+        }
         ObjectStep(name, fieldsBuilder.result())
       }
     }
@@ -336,8 +332,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     override def optional: Boolean                                         = true
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
 
-    override private[schema] def resolveFieldLazily: Boolean = ev.resolveFieldLazily
-    override def resolve(value: Option[A]): Step[R0]         =
+    override def resolve(value: Option[A]): Step[R0] =
       value match {
         case Some(value) => ev.resolve(value)
         case None        => NullStep
@@ -349,8 +344,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
       (if (ev.optional) t else t.nonNull).list
     }
 
-    override private[schema] def resolveFieldLazily: Boolean = ev.resolveFieldLazily
-    override def resolve(value: List[A]): Step[R0]           = ListStep(value.map(ev.resolve))
+    override def resolve(value: List[A]): Step[R0] = ListStep(value.map(ev.resolve))
   }
   implicit def setSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Set[A]]                                        = listSchema[R0, A].contramap(_.toList)
   implicit def seqSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Seq[A]]                                        = listSchema[R0, A].contramap(_.toList)
@@ -436,7 +430,6 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         kvSchema.toType_(isInput, isSubscription).nonNull.list
 
-      override private[schema] def resolveFieldLazily: Boolean = evA.resolveFieldLazily || evB.resolveFieldLazily
       override def resolve(value: Map[A, B]): Step[RA with RB] = ListStep(value.toList.map(kvSchema.resolve))
     }
   implicit def functionSchema[RA, RB, A, B](implicit

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -28,10 +28,15 @@ object Step {
    * Merge 2 root steps. Root steps are supposed to be objects so we ignore other cases.
    */
   def mergeRootSteps[R](step1: Step[R], step2: Step[R]): Step[R] = (step1, step2) match {
-    case (ObjectStep(name, fields1), ObjectStep(_, fields2)) =>
-      ObjectStep(name, fields1 ++ fields2) // fields2 override fields1 in case of conflict
-    case (ObjectStep(_, _), _) => step1 // if only step1 is an object, keep it
-    case _                     => step2 // otherwise keep step2
+    case (MetadataFunctionStep(l), MetadataFunctionStep(r))  => MetadataFunctionStep(f => mergeRootSteps(l(f), r(f)))
+    case (MetadataFunctionStep(l), r)                        => MetadataFunctionStep(f => mergeRootSteps(l(f), r))
+    case (l, MetadataFunctionStep(r))                        => MetadataFunctionStep(f => mergeRootSteps(l, r(f)))
+    // fields2 override fields1 in case of conflict
+    case (ObjectStep(name, fields1), ObjectStep(_, fields2)) => ObjectStep(name, fields1 ++ fields2)
+    // if only step1 is an object, keep it
+    case (ObjectStep(_, _), _)                               => step1
+    // otherwise keep step2
+    case _                                                   => step2
   }
 }
 

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -31,6 +31,9 @@ object Step {
     case (MetadataFunctionStep(l), MetadataFunctionStep(r))  => MetadataFunctionStep(f => mergeRootSteps(l(f), r(f)))
     case (MetadataFunctionStep(l), r)                        => MetadataFunctionStep(f => mergeRootSteps(l(f), r))
     case (l, MetadataFunctionStep(r))                        => MetadataFunctionStep(f => mergeRootSteps(l, r(f)))
+    case (FunctionStep(l), FunctionStep(r))                  => FunctionStep(args => mergeRootSteps(l(args), r(args)))
+    case (FunctionStep(l), r)                                => FunctionStep(args => mergeRootSteps(l(args), r))
+    case (l, FunctionStep(r))                                => FunctionStep(args => mergeRootSteps(l, r(args)))
     // fields2 override fields1 in case of conflict
     case (ObjectStep(name, fields1), ObjectStep(_, fields2)) => ObjectStep(name, fields1 ++ fields2)
     // if only step1 is an object, keep it


### PR DESCRIPTION
As discussed on Discord, in large schemas we currently see a big amount of CPU time being spent on resolving fields that are not queried. This PR fixes this (and by proxy, #1918) by using a `MetadataFieldStep` when resolving object schemas. This way, we only resolve fields that have been queried instead of every field in the object