### PR TITLE
Fix Schema renaming on recursive types & Scala 3 nested union schema derivation

### DIFF
--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -123,7 +123,7 @@ trait CommonSchemaDerivation {
         makeUnion(
           Some(getName(annotations, info)),
           getDescription(annotations),
-          subTypes.map((_, t, _) => fixEmptyUnionObject(t)),
+          subTypes.flatMap((_, t, _) => unpackLeafTypes(t)).map(fixEmptyUnionObject),
           Some(info.full),
           Some(getDirectives(annotations))
         )
@@ -190,6 +190,12 @@ trait CommonSchemaDerivation {
       ObjectStep(name, fieldsBuilder.result())
     }
   }
+
+  private def unpackLeafTypes(t: __Type): List[__Type] =
+    t.possibleTypes match {
+      case None | Some(Nil) => List(t)
+      case Some(tpes)       => tpes.flatMap(unpackLeafTypes)
+    }
 
   // see https://github.com/graphql/graphql-spec/issues/568
   private def fixEmptyUnionObject(t: __Type): __Type =

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -105,7 +105,7 @@ trait Schema[-R, T] { self =>
       self.toType_(isInput, isSubscription).copy(name = Some(newName))
     }
 
-    private val renameTypename: Boolean = self.toType_().kind match {
+    private lazy val renameTypename: Boolean = self.toType_().kind match {
       case __TypeKind.UNION | __TypeKind.ENUM | __TypeKind.INTERFACE => false
       case _                                                         => true
     }

--- a/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
@@ -1,0 +1,85 @@
+package caliban.schema
+
+import zio.Chunk
+import zio.test.ZIOSpecDefault
+import zio.test._
+import caliban.{ graphQL, RootResolver }
+
+object SchemaDerivationIssuesSpec extends ZIOSpecDefault {
+  def spec = suite("SchemaDerivationIssuesSpec")(
+    test("i1972 & i1973") {
+      import i1972_i1973._
+
+      val schema = {
+        val queries = Queries(param = Variable("temp"))
+        graphQL(RootResolver(queries))
+      }.render
+
+      assertTrue(
+        schema ==
+          """schema {
+            |  query: Queries
+            |}
+            |
+            |union ASTParameter = ASTValueBoolean | ASTValueList | ASTVariable
+            |
+            |union ASTValue = ASTValueBoolean | ASTValueList
+            |
+            |type ASTValueBoolean {
+            |  value: Boolean!
+            |}
+            |
+            |type ASTValueList {
+            |  values: [ASTValue!]!
+            |}
+            |
+            |type ASTVariable {
+            |  name: String!
+            |}
+            |
+            |type Queries {
+            |  param: ASTParameter!
+            |}""".stripMargin
+      )
+    }
+  )
+}
+
+private object i1972_i1973 {
+  sealed trait Parameter
+  object Parameter {
+    implicit lazy val schema: Schema[Any, Parameter] = Schema.gen[Any, Parameter].rename("ASTParameter")
+  }
+
+  case class Variable(name: String) extends Parameter
+  object Variable {
+    implicit val schema: Schema[Any, Variable] = Schema.gen[Any, Variable].rename("ASTVariable")
+  }
+
+  sealed trait Value extends Parameter
+  object Value   {
+    case class Boolean(value: scala.Boolean) extends Value
+    object Boolean {
+      implicit val schema: Schema[Any, Boolean] = Schema.gen[Any, Boolean].rename("ASTValueBoolean")
+    }
+
+    case class List(values: Chunk[Value]) extends Value
+    object List {
+      implicit lazy val schema: Schema[Any, List] = Schema.gen[Any, List].rename("ASTValueList")
+    }
+
+    implicit lazy val schema: Schema[Any, Value] = Schema.gen[Any, Value].rename("ASTValue")
+  }
+
+  case class Queries(
+    param: Parameter
+  )
+  object Queries {
+    implicit val schema: Schema[Any, Queries] = Schema.gen
+  }
+
+  val schema = {
+    val queries = Queries(param = Variable("temp"))
+    graphQL(RootResolver(queries))
+  }
+}


### PR DESCRIPTION
Closes #1972 by unpacking possibleTypes when creating union schemas for Scala 3. @ghostdogpr let me know if you agree with this approach, perhaps there's a simper / better one

Also closes #1973 which was caused by a regression in 2.4.0 where the `lazy val` was mistakenly changed to a `val`