### PR TITLE
Fix schema derivation on Interfaces when renamed via `.rename`

### DIFF
--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -105,18 +105,16 @@ trait Schema[-R, T] { self =>
       val newName = if (isInput) inputName.getOrElse(Schema.customizeInputTypeName(name)) else name
       val newTpe  = tpe.copy(name = Some(newName))
 
-      if (tpe.kind != __TypeKind.INTERFACE) newTpe
-      else {
-        val pt = tpe.possibleTypes.map(_.map { t =>
-          val newInterfaces = t
-            .interfaces()
-            .map(_.map { tt =>
-              if (tt.name == tpe.name) tt.copy(name = Some(newName))
-              else tt
-            })
-          t.copy(interfaces = () => newInterfaces)
-        })
-        newTpe.copy(possibleTypes = pt)
+      tpe.kind match {
+        case __TypeKind.INTERFACE =>
+          val pt = tpe.possibleTypes.map(_.map { t0 =>
+            val newInterfaces = t0
+              .interfaces()
+              .map(_.map(t1 => if (t1.name == tpe.name && t1.name.isDefined) t1.copy(name = Some(newName)) else t1))
+            t0.copy(interfaces = () => newInterfaces)
+          })
+          newTpe.copy(possibleTypes = pt)
+        case _                    => newTpe
       }
     }
 

--- a/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
@@ -1,5 +1,6 @@
 package caliban.schema
 
+import caliban.schema.Annotations.{ GQLInterface, GQLUnion }
 import zio.Chunk
 import zio.test.ZIOSpecDefault
 import zio.test._
@@ -41,11 +42,42 @@ object SchemaDerivationIssuesSpec extends ZIOSpecDefault {
             |  param: ASTParameter!
             |}""".stripMargin
       )
+    },
+    test("i1977") {
+      import i1977._
+
+      assertTrue(
+        schema ==
+          """schema {
+            |  query: Queries
+            |}
+            |
+            |union ASTValue = ASTValueBoolean | ASTValueList
+            |
+            |interface ASTParameter
+            |
+            |type ASTValueBoolean implements ASTParameter {
+            |  value: Boolean!
+            |}
+            |
+            |type ASTValueList implements ASTParameter {
+            |  values: [ASTValue!]!
+            |}
+            |
+            |type ASTVariable implements ASTParameter {
+            |  name: String!
+            |}
+            |
+            |type Queries {
+            |  param: ASTParameter!
+            |}""".stripMargin
+      )
     }
   )
 }
 
 private object i1972_i1973 {
+  @GQLUnion
   sealed trait Parameter
   object Parameter {
     implicit lazy val schema: Schema[Any, Parameter] = Schema.gen[Any, Parameter].rename("ASTParameter")
@@ -82,4 +114,42 @@ private object i1972_i1973 {
     val queries = Queries(param = Variable("temp"))
     graphQL(RootResolver(queries))
   }
+}
+
+private object i1977 {
+  @GQLInterface
+  sealed trait Parameter
+  object Parameter {
+    implicit lazy val schema: Schema[Any, Parameter] = Schema.gen[Any, Parameter].rename("ASTParameter")
+  }
+
+  case class Variable(name: String) extends Parameter
+  object Variable {
+    implicit val schema: Schema[Any, Variable] = Schema.gen[Any, Variable].rename("ASTVariable")
+  }
+
+  sealed trait Value extends Parameter
+  object Value {
+    case class Boolean(value: scala.Boolean) extends Value
+    object Boolean {
+      implicit val schema: Schema[Any, Boolean] = Schema.gen[Any, Boolean].rename("ASTValueBoolean")
+    }
+
+    case class List(values: Chunk[Value]) extends Value
+    object List {
+      implicit lazy val schema: Schema[Any, List] = Schema.gen[Any, List].rename("ASTValueList")
+    }
+
+    implicit lazy val schema: Schema[Any, Value] = Schema.gen[Any, Value].rename("ASTValue")
+  }
+
+  case class Queries(param: Parameter)
+  object Queries {
+    implicit val schema: Schema[Any, Queries] = Schema.gen
+  }
+
+  val schema = {
+    val queries = Queries(param = Variable("temp"))
+    graphQL(RootResolver(queries))
+  }.render
 }


### PR DESCRIPTION
Fixes #1977

Also, apologies for the (very) gnarly code, zooming into so many collections is never pretty 🥲 