### PR TITLE
Run stream of deferred queries sequentially

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -231,7 +231,7 @@ object Executor {
             ZStream.succeed(resp) ++ makeDeferStream(more, cache)
         })
 
-      ZStream.mergeAllUnbounded()(defers.map(run): _*)
+      ZStream.mergeAll(1)(defers.map(run): _*)
     }
 
     def runIncrementalQuery(

--- a/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
@@ -2,10 +2,10 @@ package caliban.execution
 
 import caliban.Macros.gqldoc
 import caliban.ResponseValue.StreamValue
-import caliban.TestUtils.{Character, characters}
-import caliban.{CalibanError, GraphQLResponse, ResponseValue, Value}
+import caliban.TestUtils.{ characters, Character }
+import caliban.{ CalibanError, GraphQLResponse, ResponseValue, Value }
 import zio.test.Assertion.hasSameElements
-import zio.test.{TestAspect, TestClock, ZIOSpecDefault, assert, assertTrue}
+import zio.test.{ assert, assertTrue, TestAspect, TestClock, ZIOSpecDefault }
 import zio._
 
 trait CharacterService {

--- a/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
@@ -2,11 +2,11 @@ package caliban.execution
 
 import caliban.Macros.gqldoc
 import caliban.ResponseValue.StreamValue
-import caliban.TestUtils.{ characters, Character }
-import caliban.{ CalibanError, GraphQLResponse, ResponseValue, Value }
+import caliban.TestUtils.{Character, characters}
+import caliban.{CalibanError, GraphQLResponse, ResponseValue, Value}
 import zio.test.Assertion.hasSameElements
-import zio.test.{ assert, assertTrue, TestAspect, ZIOSpecDefault }
-import zio.{ Chunk, UIO, ZIO, ZLayer }
+import zio.test.{TestAspect, TestClock, ZIOSpecDefault, assert, assertTrue}
+import zio._
 
 trait CharacterService {
   def characterBy(pred: Character => Boolean): UIO[List[Character]]
@@ -188,7 +188,32 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
           """{"hasNext":false}"""
         )
       )
-    }
+    },
+    test("deferred fields backed by a datasource") {
+      import TestDatasourceDeferredSchema._
+      val query = gqldoc("""
+        {
+          foo {
+            bar { ... @defer { value } }
+          }
+        }""")
+
+      for {
+        resp <- interpreter.flatMap(_.execute(query))
+        rest <- runIncrementalResponses(resp)
+        head  = rest.head.toString
+        mid   = rest.tail.init.toList.map(_.toString)
+        last  = rest.last.toString
+      } yield assertTrue(
+        head == """{"foo":{"bar":[{},{},{}]}}""",
+        mid.sorted == List(
+          """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",0]}],"hasNext":true}""",
+          """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",1]}],"hasNext":true}""",
+          """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",2]}],"hasNext":true}"""
+        ),
+        last == """{"hasNext":false}"""
+      )
+    } @@ TestAspect.nonFlaky(50)
   ).provide(CharacterService.test)
 
   def runIncrementalResponses(response: GraphQLResponse[CalibanError]) =


### PR DESCRIPTION
Fixes #1980.

Note that we probably want to figure out a way to run the stream in parallel, but I believe that would require changes in zio-query. I can open an issue there and see what can be done