### PR TITLE
Fix execution of nested `Sum` types

### DIFF
--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -30,7 +30,7 @@ trait CommonSchemaDerivation {
     List[Schema[R, Any]]
   ) =
     inline erasedValue[(Label, A)] match {
-      case (_: EmptyTuple, _)                 => (types.reverse, schemas.reverse)
+      case (_: EmptyTuple, _)                 => (types, schemas.reverse)
       case (_: (name *: names), _: (t *: ts)) =>
         val schema = {
           inline if (Macros.isEnumField[P, t])

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -23,27 +23,31 @@ trait CommonSchemaDerivation {
   export DerivationUtils.customizeInputTypeName
 
   inline def recurseSum[R, P, Label, A <: Tuple](
-    inline values: List[(String, List[Any], Schema[R, Any])] = Nil
-  ): List[(String, List[Any], Schema[R, Any])] =
+    inline types: List[(String, __Type, List[Any])] = Nil,
+    inline schemas: List[Schema[R, Any]] = Nil
+  ): (
+    List[(String, __Type, List[Any])],
+    List[Schema[R, Any]]
+  ) =
     inline erasedValue[(Label, A)] match {
-      case (_: EmptyTuple, _)                 => values.reverse
+      case (_: EmptyTuple, _)                 => (types.reverse, schemas.reverse)
       case (_: (name *: names), _: (t *: ts)) =>
-        recurseSum[R, P, names, ts] {
-          inline summonInline[Mirror.Of[t]] match {
+        val schema = {
+          inline if (Macros.isEnumField[P, t])
+            inline if (!Macros.implicitExists[Schema[R, t]]) derived[R, t]
+            else summonInline[Schema[R, t]]
+          else summonInline[Schema[R, t]]
+        }.asInstanceOf[Schema[R, Any]]
+
+        recurseSum[R, P, names, ts](
+          types = inline summonInline[Mirror.Of[t]] match {
             case m: Mirror.SumOf[t] =>
-              recurseSum[R, t, m.MirroredElemLabels, m.MirroredElemTypes](values)
+              recurseSum[R, t, m.MirroredElemLabels, m.MirroredElemTypes](types)._1
             case _                  =>
-              (
-                constValue[name].toString,
-                MagnoliaMacro.anns[t], {
-                  inline if (Macros.isEnumField[P, t])
-                    inline if (!Macros.implicitExists[Schema[R, t]]) derived[R, t]
-                    else summonInline[Schema[R, t]]
-                  else summonInline[Schema[R, t]]
-                }.asInstanceOf[Schema[R, Any]]
-              ) :: values
-          }
-        }
+              (constValue[name].toString, schema.toType_(), MagnoliaMacro.anns[t]) :: types
+          },
+          schemas = schema :: schemas
+        )
 
     }
 

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -84,24 +84,27 @@ trait CommonSchemaDerivation {
         )(m.ordinal)
 
       case m: Mirror.ProductOf[A] =>
-        inline if (!Macros.hasParams[A])
-          new EnumValueSchema[R, A](
-            MagnoliaMacro.typeInfo[A],
-            MagnoliaMacro.anns[A]
-          )
-        else inline if (Macros.hasAnnotation[A, GQLValueType])
-          new ValueTypeSchema[R, A](
-            valueTypeSchema[R, m.MirroredElemLabels, m.MirroredElemTypes],
-            MagnoliaMacro.typeInfo[A],
-            MagnoliaMacro.anns[A]
-          )
-        else
-          new ObjectSchema[R, A](
-            recurseProduct[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
-            MagnoliaMacro.typeInfo[A],
-            MagnoliaMacro.anns[A],
-            MagnoliaMacro.paramAnns[A].toMap
-          )
+        inline erasedValue[m.MirroredElemLabels] match {
+          case _: EmptyTuple                              =>
+            new EnumValueSchema[R, A](
+              MagnoliaMacro.typeInfo[A],
+              MagnoliaMacro.anns[A]
+            )
+          case _ if Macros.hasAnnotation[A, GQLValueType] =>
+            new ValueTypeSchema[R, A](
+              valueTypeSchema[R, m.MirroredElemLabels, m.MirroredElemTypes],
+              MagnoliaMacro.typeInfo[A],
+              MagnoliaMacro.anns[A]
+            )
+          case _                                          =>
+            new ObjectSchema[R, A](
+              recurseProduct[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
+              MagnoliaMacro.typeInfo[A],
+              MagnoliaMacro.anns[A],
+              MagnoliaMacro.paramAnns[A].toMap
+            )
+        }
+
     }
 }
 

--- a/core/src/main/scala-3/caliban/schema/SumSchema.scala
+++ b/core/src/main/scala-3/caliban/schema/SumSchema.scala
@@ -7,18 +7,16 @@ import caliban.schema.Types.makeUnion
 import magnolia1.TypeInfo
 
 final private class SumSchema[R, A](
-  _members: => List[(String, List[Any], Schema[R, Any])],
+  _members: => (List[(String, __Type, List[Any])], List[Schema[R, Any]]),
   info: TypeInfo,
   annotations: List[Any]
 )(ordinal: A => Int)
     extends Schema[R, A] {
-  private lazy val members = _members
 
-  private lazy val subTypes = members.map { (label, subTypeAnnotations, schema) =>
-    (label, schema.toType_(), subTypeAnnotations)
-  }.sortBy(_._1)
-
-  private lazy val schemas = members.map(_._3).toVector // Vector's .apply is O(1) vs List's O(N)
+  private lazy val (subTypes, schemas) = {
+    val (m, s) = _members
+    (m.sortBy(_._1), s.toVector)
+  }
 
   private lazy val isEnum = subTypes.forall((_, t, _) => t.allFields.isEmpty && t.allInputFields.isEmpty)
   private val isInterface = annotations.contains(GQLInterface())

--- a/core/src/main/scala-3/caliban/schema/macros/Macros.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/Macros.scala
@@ -1,6 +1,6 @@
 package caliban.schema.macros
 
-import caliban.schema.Annotations.{ GQLExcluded, GQLValueType }
+import caliban.schema.Annotations.GQLExcluded
 
 import scala.quoted.*
 
@@ -11,7 +11,6 @@ object Macros {
   inline def isEnumField[P, T]: Boolean     = ${ isEnumFieldImpl[P, T] }
   inline def implicitExists[T]: Boolean     = ${ implicitExistsImpl[T] }
   inline def hasAnnotation[T, Ann]: Boolean = ${ hasAnnotationImpl[T, Ann] }
-  inline def hasParams[T]: Boolean          = ${ hasParamsImpl[T] }
 
   /**
    * Tests whether type argument [[FieldT]] in [[Parent]] is annotated with [[GQLExcluded]]
@@ -25,18 +24,13 @@ object Macros {
     })
   }
 
-  private def hasParamsImpl[T: Type](using qctx: Quotes): Expr[Boolean] = {
-    import qctx.reflect.*
-    Expr(TypeRepr.of[T].typeSymbol.primaryConstructor.paramSymss.flatten.nonEmpty)
-  }
-
   private def hasAnnotationImpl[T: Type, Ann: Type](using qctx: Quotes): Expr[Boolean] = {
     import qctx.reflect.*
     Expr(TypeRepr.of[T].typeSymbol.annotations.exists(_.tpe =:= TypeRepr.of[Ann]))
   }
 
   private def implicitExistsImpl[T: Type](using q: Quotes): Expr[Boolean] = {
-    import quotes.reflect.*
+    import q.reflect.*
     Implicits.search(TypeRepr.of[T]) match {
       case _: ImplicitSearchSuccess => Expr(true)
       case _: ImplicitSearchFailure => Expr(false)

--- a/core/src/test/scala-3/caliban/Scala3SpecificSpec.scala
+++ b/core/src/test/scala-3/caliban/Scala3SpecificSpec.scala
@@ -1,15 +1,19 @@
 package caliban
 
 import caliban.schema.Annotations.GQLInterface
-import caliban.schema.Schema.auto._
-import zio._
-import zio.test._
-import zio.test.Assertion._
+import caliban.schema.Schema.auto.*
+import zio.*
+import zio.test.*
+import zio.test.Assertion.*
 
 object Scala3SpecificSpec extends ZIOSpecDefault {
 
   enum MyEnum {
     case A, B, C
+  }
+
+  enum EnumWithVal(val foo: String) {
+    case A extends EnumWithVal("a")
   }
 
   enum MyADT {
@@ -28,6 +32,18 @@ object Scala3SpecificSpec extends ZIOSpecDefault {
       test("Scala 3 enum") {
         case class Queries(item: MyEnum)
         val api         = graphQL(RootResolver(Queries(MyEnum.A)))
+        val interpreter = api.interpreter
+        val query       =
+          """query {
+            |  item
+            |}""".stripMargin
+        interpreter.flatMap(_.execute(query)).map { response =>
+          assertTrue(response.data.toString == """{"item":"A"}""")
+        }
+      },
+      test("Scala 3 enum with val") {
+        case class Query(item: EnumWithVal)
+        val api         = graphQL(RootResolver(Query(EnumWithVal.A)))
         val interpreter = api.interpreter
         val query       =
           """query {


### PR DESCRIPTION
With this PR, we resolve using the top-level schemas instead of the exploded leaf ones, otherwise the index returned by `.ordinal` doesn't match the index in the list