### PR TITLE
Fix incorrect Scala 3 enum value renaming

### DIFF
--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -44,7 +44,12 @@ trait CommonSchemaDerivation {
             case m: Mirror.SumOf[t] =>
               recurseSum[R, t, m.MirroredElemLabels, m.MirroredElemTypes](types)._1
             case _                  =>
-              (constValue[name].toString, schema.toType_(), MagnoliaMacro.anns[t]) :: types
+              (
+                constValue[name].toString,
+                schema.toType_(),
+                // Workaround until we figure out why the macro uses the parent's annotations when the leaf is a Scala 3 enum
+                inline if (!MagnoliaMacro.isEnum[t]) MagnoliaMacro.anns[t] else Nil
+              ) :: types
           },
           schemas = schema :: schemas
         )
@@ -88,7 +93,8 @@ trait CommonSchemaDerivation {
           case _: EmptyTuple                              =>
             new EnumValueSchema[R, A](
               MagnoliaMacro.typeInfo[A],
-              MagnoliaMacro.anns[A]
+              // Workaround until we figure out why the macro uses the parent's annotations when the leaf is a Scala 3 enum
+              inline if (!MagnoliaMacro.isEnum[A]) MagnoliaMacro.anns[A] else Nil
             )
           case _ if Macros.hasAnnotation[A, GQLValueType] =>
             new ValueTypeSchema[R, A](

--- a/core/src/test/scala-3/caliban/Scala3SpecificSpec.scala
+++ b/core/src/test/scala-3/caliban/Scala3SpecificSpec.scala
@@ -1,6 +1,6 @@
 package caliban
 
-import caliban.schema.Annotations.GQLInterface
+import caliban.schema.Annotations.{ GQLInterface, GQLName }
 import caliban.schema.Schema.auto.*
 import zio.*
 import zio.test.*
@@ -8,6 +8,7 @@ import zio.test.Assertion.*
 
 object Scala3SpecificSpec extends ZIOSpecDefault {
 
+  @GQLName("FooEnum")
   enum MyEnum {
     case A, B, C
   }
@@ -29,6 +30,24 @@ object Scala3SpecificSpec extends ZIOSpecDefault {
 
   override def spec =
     suite("Scala3SpecificSpec")(
+      test("Scala 3 enum schema derivation") {
+        case class Queries(item: MyEnum)
+        val api      = graphQL(RootResolver(Queries(MyEnum.A)))
+        val rendered = api.render
+        assertTrue(rendered == """schema {
+                                 |  query: Queries
+                                 |}
+                                 |
+                                 |enum FooEnum {
+                                 |  A
+                                 |  B
+                                 |  C
+                                 |}
+                                 |
+                                 |type Queries {
+                                 |  item: FooEnum!
+                                 |}""".stripMargin)
+      },
       test("Scala 3 enum") {
         case class Queries(item: MyEnum)
         val api         = graphQL(RootResolver(Queries(MyEnum.A)))


### PR DESCRIPTION
For some reason, using `MagnoliaMacro.anns[t]` on an enum value returns the annotations of the enum. With this PR we don't return annotations for enum values as we know they'll be incorrect.

Just a small clarification on what constitutes as "enum value"

```scala
enum Foo {

 case A   // This is the only one affected by this change and the only one with incorrect behaviour
 case B()
 case C(value: STring)

}
```