### PR TITLE
Don't include pure object fields in ZQuery collection

### DIFF
--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmarkSchema.scala
@@ -50,8 +50,8 @@ object NestedZQueryBenchmarkSchema {
   case class MultifieldRoot(entities: Query[List[MultifieldEntity]])
   case class MultifieldEntity(
     id: Int,
-    nested0: Query[Int],
-    nested1: Query[Int],
+    nested0: Int,
+    nested1: Int,
     nested2: Query[Int],
     nested3: Query[Int],
     nested4: Query[Int],
@@ -167,8 +167,8 @@ object NestedZQueryBenchmarkSchema {
       val qi = ZQuery.succeed(i)
       MultifieldEntity(
         i,
-        qi,
-        qi,
+        i + 1,
+        i + 2,
         qi,
         qi,
         qi,

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -15,6 +15,7 @@ import zio.query.{ Cache, ZQuery }
 import zio.stream.ZStream
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 object Executor {
@@ -157,20 +158,48 @@ object Executor {
               val q = if (isPure && !wrapper.wrapPureValues) query else wrapper.wrap(query, fieldInfo)
               loop(q, tail)
           }
-        if (isPure && !wrapPureValues) query
-        else loop(query, wrappers)
+        loop(query, wrappers)
+      }
+
+      def objectFieldQuery(name: String, step: ReducedStep[R], info: FieldInfo) = {
+        val q = wrap(loop(step), step.isPure)(fieldWrappers, info)
+        if (info.details.fieldType.isNullable) q.catchAll(handleError).map((name, _))
+        else q.map((name, _))
       }
 
       def loop(step: ReducedStep[R]): ZQuery[R, ExecutionError, ResponseValue] =
         step match {
           case PureStep(value)                               => ZQuery.succeed(value)
           case ReducedStep.ObjectStep(steps)                 =>
-            val queries = steps.map { case (name, step, info) =>
-              val q = wrap(loop(step), step.isPure)(fieldWrappers, info)
-              (if (info.details.fieldType.isNullable) q.catchAll(handleError) else q)
-                .map(name -> _)
+            var resolved: mutable.HashMap[String, ResponseValue] = null
+
+            val queries =
+              if (wrapPureValues) steps.map((objectFieldQuery _).tupled)
+              else {
+                val queries = List.newBuilder[ZQuery[R, ExecutionError, (String, ResponseValue)]]
+
+                var remaining = steps
+                while (!remaining.isEmpty) {
+                  remaining.head match {
+                    case (name, PureStep(value), _) =>
+                      if (null == resolved) { resolved = new mutable.HashMap[String, ResponseValue]() }
+                      resolved.update(name, value)
+                    case (name, step, info)         =>
+                      queries.addOne(objectFieldQuery(name, step, info))
+                  }
+                  remaining = remaining.tail
+                }
+
+                queries.result()
+              }
+
+            collectAll(queries).map { results =>
+              if (null == resolved) ObjectValue(results)
+              else {
+                results.foreach(kv => resolved.update(kv._1, kv._2))
+                ObjectValue(steps.map { case (name, _, _) => name -> resolved(name) })
+              }
             }
-            collectAll(queries).map(ObjectValue.apply)
           case ReducedStep.QueryStep(step)                   =>
             step.flatMap(loop)
           case ReducedStep.ListStep(steps, areItemsNullable) =>

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -15,7 +15,7 @@ import zio.query.{ Cache, ZQuery }
 import zio.stream.ZStream
 
 import scala.annotation.tailrec
-import scala.collection.immutable.HashMap
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 object Executor {
@@ -171,8 +171,7 @@ object Executor {
         step match {
           case PureStep(value)                               => ZQuery.succeed(value)
           case ReducedStep.ObjectStep(steps)                 =>
-            var useMapBuilder = false
-            val mapBuilder    = HashMap.newBuilder[String, ResponseValue]
+            var resolved: mutable.HashMap[String, ResponseValue] = null
 
             val queries =
               if (wrapPureValues) steps.map((objectFieldQuery _).tupled)
@@ -183,25 +182,22 @@ object Executor {
                 while (!remaining.isEmpty) {
                   remaining.head match {
                     case (name, PureStep(value), _) =>
-                      useMapBuilder = true
-                      mapBuilder += name -> value
+                      if (null == resolved) resolved = new mutable.HashMap[String, ResponseValue]()
+                      resolved.update(name, value)
                     case (name, step, info)         =>
                       queries += objectFieldQuery(name, step, info)
                   }
                   remaining = remaining.tail
                 }
-
                 queries.result()
               }
 
-            collectAll(queries).map { results =>
-              if (useMapBuilder) ObjectValue(results)
-              else {
-                results.foreach(mapBuilder += _)
-                val resolved = mapBuilder.result()
+            if (null == resolved) collectAll(queries).map(ObjectValue.apply)
+            else
+              collectAll(queries).map { results =>
+                results.foreach(kv => resolved.update(kv._1, kv._2))
                 ObjectValue(steps.map { case (name, _, _) => name -> resolved(name) })
               }
-            }
           case ReducedStep.QueryStep(step)                   =>
             step.flatMap(loop)
           case ReducedStep.ListStep(steps, areItemsNullable) =>


### PR DESCRIPTION
As discussed on Discord, I gave this a go. Seems to offer a fairly good performance increase whenever we have a mix of pure and effectful fields.

series/2.x:
```shell
[info] Benchmark                                           Mode  Cnt    Score   Error  Units
[info] NestedZQueryBenchmark.multifieldBatchedQuery1000   thrpt    5  551.735 ± 8.117  ops/s
[info] NestedZQueryBenchmark.multifieldBatchedQuery10000  thrpt    5   45.115 ± 1.188  ops/s
```

PR:
```shell
[info] Benchmark                                           Mode  Cnt    Score   Error  Units
[info] NestedZQueryBenchmark.multifieldBatchedQuery1000   thrpt    5  633.503 ± 8.756  ops/s
[info] NestedZQueryBenchmark.multifieldBatchedQuery10000  thrpt    5   54.862 ± 0.919  ops/s
```

I also did some rough testing for cases that we don't have any pure fields, and it seems that the performance was roughly identical to what we had previously