### PR TITLE
Add `pre-commit` config with scalafmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: local
+    hooks:
+      - id: scalafmt
+        name: scalafmt fix formatting
+        entry: scalafmt
+        args: [ --exclude=target, --mode=changed, --reportError ]
+        language: system
+        stages: [ commit, push ]
+        always_run: true
+        pass_filenames: false
+        minimum_pre_commit_version: '2.8.0'


### PR DESCRIPTION
Adds pre-commit config that runs scalafmt when committing new changes. I've started using everywhere that I can recently because I find it quite annoying to submit a PR only to find out that the checks failed due to formatting.

In case you've never used pre-commit before, it's [pretty easy to install](https://pre-commit.com/#installation). Once installed, you only need to run `pre-commit install` at the root of the repo to install the hooks.

Note that if the user doesn't have pre-commit installed or never runs `pre-commit install` in this repo, the hooks just won't be run (i.e., no errors or anything)