### PR TITLE
Improved execution field merging

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -320,7 +320,7 @@ object Executor {
       f._condition.isEmpty || f._condition.get.contains(typeName)
 
     def mergeFields(fields: List[Field]) = {
-      val map       = new java.util.LinkedHashMap[String, Field]((fields.size / 0.75d).toInt + 1)
+      val map       = new java.util.LinkedHashMap[String, Field](calculateMapCapacity(fields.size))
       var remaining = fields
       while (!remaining.isEmpty) {
         val h = remaining.head
@@ -386,4 +386,17 @@ object Executor {
       (l.result(), r.result())
     }
   }
+
+  /**
+   * The behaviour of mutable Maps (both Java and Scala) is to resize once the number of entries exceeds
+   * the capacity * loadFactor (default of 0.75d) threshold in order to prevent hash collisions.
+   *
+   * This method is a helper method to estimate the initial map size depending on the number of elements the Map is
+   * expected to hold
+   *
+   * NOTE: This method is the same as java.util.HashMap.calculateHashMapCapacity on JDK19+
+   */
+  private def calculateMapCapacity(nMappings: Int): Int =
+    Math.ceil(nMappings / 0.75d).toInt
+
 }

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -309,11 +309,11 @@ object Executor {
     field.fields match {
       // Shortcut if all the fields have the same condition, which means we don't need to dedup
       // as that's been handled in Field.apply
-      case fields @ head :: tail if tail.forall(_._condition == head._condition) =>
-        if (head._condition.forall(_.contains(typeName))) fields
+      case head :: tail if tail.forall(_._condition == head._condition) =>
+        if (head._condition.forall(_.contains(typeName))) field.fields
         else Nil
-      case Nil                                                                   => Nil
-      case fields                                                                =>
+      case Nil                                                          => Nil
+      case fields                                                       =>
         val map = new java.util.LinkedHashMap[String, Field]()
         fields.foreach { field =>
           if (field._condition.forall(_.contains(typeName))) {


### PR DESCRIPTION
In many cases, there's would be only a single condition on fields (either None or Set(Something)). In these cases, the field merging has already been handled within `Field.apply`, which means we don't need to do it again.

For these cases, we up to 15% improvement in execution time depending on the number of fields in the object