### PR TITLE
Avoid unnecessary mapping of steps to queries

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -192,7 +192,8 @@ object Executor {
             queries.result()
           }
 
-        val resolved = pures // Avoids placing of var into Function1 which will convert it to ObjectRef by the Scala compiler
+        val resolved =
+          pures // Avoids placing of var into Function1 which will convert it to ObjectRef by the Scala compiler
         collectAll(_steps)((objectFieldQuery _).tupled).map { results =>
           if (resolved eq null) ObjectValue(results)
           else {

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -172,7 +172,7 @@ object Executor {
       }
 
       def makeObjectQuery(steps: List[(String, ReducedStep[R], FieldInfo)]) = {
-        def newMap() = new java.util.HashMap[String, ResponseValue](Math.ceil(steps.size / 0.75d).toInt)
+        def newMap() = new java.util.HashMap[String, ResponseValue](calculateMapCapacity(steps.size))
 
         var pures: java.util.HashMap[String, ResponseValue] = null
         val _steps                                          =


### PR DESCRIPTION
By using ZQuery.foreach, we avoid the unnecessary extra `.map` to convert a list of steps to ZQueries