### PR TITLE
Iterate through queried fields instead of object fields

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -4,7 +4,7 @@ import caliban.Value._
 import caliban.introspection.adt._
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations._
-import caliban.schema.Step.{PureStep => _}
+import caliban.schema.Step.{ PureStep => _ }
 import caliban.schema.Types._
 import magnolia1._
 

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -43,9 +43,6 @@ case class Field(
 ) { self =>
   lazy val locationInfo: LocationInfo = _locationInfo()
 
-  private[caliban] lazy val fieldNames: Set[String] =
-    fields.foldLeft(Set.newBuilder[String]) { case (sb, f) => sb += f.name }.result()
-
   private[caliban] val aliasedName: String = alias.getOrElse(name)
 
   def combine(other: Field): Field =

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -45,6 +45,8 @@ case class Field(
 
   private[caliban] val aliasedName: String = alias.getOrElse(name)
 
+  private[caliban] lazy val distinctFieldNames: List[String] = fields.map(_.name).distinct
+
   def combine(other: Field): Field =
     self.copy(
       fields = self.fields ::: other.fields,

--- a/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
+++ b/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
@@ -16,7 +16,7 @@ final private class ObjectFieldResolver[R, A](
     map
   }
 
-  def resolve(value: A): MetadataFunctionStep[R] = MetadataFunctionStep(resolveForField(value, _))
+  def resolve(value: A): Step[R] = MetadataFunctionStep(resolveForField(value, _))
 
   private def resolveForField(
     value: A,

--- a/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
+++ b/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
@@ -1,0 +1,35 @@
+package caliban.schema
+
+import caliban.execution.Field
+import caliban.schema.Step.{ MetadataFunctionStep, ObjectStep }
+
+import scala.collection.immutable.HashMap
+
+final private class ObjectFieldResolver[R, A](
+  objectName: String,
+  fields: Iterable[(String, A => Step[R])]
+) {
+
+  private val fieldsMap: java.util.HashMap[String, A => Step[R]] = {
+    val map = new java.util.HashMap[String, A => Step[R]]()
+    fields.foreach { case (name, resolve) => map.put(name, resolve) }
+    map
+  }
+
+  def resolve(value: A): MetadataFunctionStep[R] = MetadataFunctionStep(resolveForField(value, _))
+
+  private def resolveForField(
+    value: A,
+    field: Field
+  ): Step[R] = {
+    val fieldsBuilder = HashMap.newBuilder[String, Step[R]]
+    var remaining     = field.fields
+    while (!remaining.isEmpty) {
+      val name    = remaining.head.name
+      val resolve = fieldsMap.get(name)
+      if (!(resolve eq null)) fieldsBuilder += name -> resolve(value)
+      remaining = remaining.tail
+    }
+    ObjectStep(objectName, fieldsBuilder.result())
+  }
+}

--- a/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
+++ b/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
@@ -23,11 +23,12 @@ final private class ObjectFieldResolver[R, A](
     field: Field
   ): Step[R] = {
     val fieldsBuilder = HashMap.newBuilder[String, Step[R]]
-    var remaining     = field.fields
+    var remaining     = field.distinctFieldNames
     while (!remaining.isEmpty) {
-      val name    = remaining.head.name
+      val name    = remaining.head
       val resolve = fieldsMap.get(name)
-      if (!(resolve eq null)) fieldsBuilder += name -> resolve(value)
+      if (resolve eq null) ()
+      else fieldsBuilder += name -> resolve(value)
       remaining = remaining.tail
     }
     ObjectStep(objectName, fieldsBuilder.result())

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -188,16 +188,10 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
           )
         } else makeObject(Some(name), description, fields(isInput, isSubscription).map(_._1), directives)
 
-      private lazy val fieldsForResolve = fields(false, false)
+      private lazy val resolver =
+        new ObjectFieldResolver[R1, A](name, fields(false, false).map(f => (f._1.name, f._2)))
 
-      override def resolve(value: A): Step[R1] = MetadataFunctionStep[R1] { field =>
-        val fieldsBuilder = Map.newBuilder[String, Step[R1]]
-        fieldsForResolve.foreach { case (f, plan) =>
-          if (field.fieldNames.contains(f.name))
-            fieldsBuilder += f.name -> plan(value)
-        }
-        ObjectStep(name, fieldsBuilder.result())
-      }
+      override def resolve(value: A): Step[R1] = resolver.resolve(value)
     }
 
   /**


### PR DESCRIPTION
I don't know why this only just now occurred to me, but iterating through the queried fields is much more efficient than iterating through all the fields when resolving objects. This way, we don't need to create the `fieldNames` Set, plus we don't need to iterate through every single possible object field just so that we only use the ones that have been queried.

Also, I managed to extract this logic and reuse it across all 3 places that we were using it.