### PR TITLE
Add `apply` method to Schema

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -249,6 +249,7 @@ trait CommonSchemaDerivation[R] {
 }
 
 trait SchemaDerivation[R] extends CommonSchemaDerivation[R] {
+  def apply[A](implicit ev: Schema[R, A]): Schema[R, A] = ev
 
   /**
    * Returns an instance of `Schema` for the given type T.

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -115,6 +115,8 @@ trait CommonSchemaDerivation {
 }
 
 trait SchemaDerivation[R] extends CommonSchemaDerivation {
+  inline def apply[A]: Schema[R, A] = summonInline[Schema[R, A]]
+
   inline def gen[R, A]: Schema[R, A] = derived[R, A]
 
   inline def genDebug[R, A]: Schema[R, A] = PrintDerived(derived[R, A])

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -79,6 +79,8 @@ trait ArgBuilder[T] { self =>
 }
 
 object ArgBuilder extends ArgBuilderInstances {
+  def apply[T](implicit ev: ArgBuilder[T]): ArgBuilder[T] = ev
+
   object auto extends AutoArgBuilderDerivation
 }
 

--- a/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/SchemaDerivesAutoSpec.scala
@@ -38,7 +38,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
         case class Queries(field: ZQuery[Clock, Nothing, Field]) derives MySchema.Auto
 
         assert(
-          summon[Schema[Console & Clock, Queries]]
+          MySchema[Queries]
             .toType_()
             .fields(__DeprecatedArgs())
             .toList
@@ -84,7 +84,7 @@ object SchemaDerivesAutoSpec extends ZIOSpecDefault {
         }
         case class B(a: List[Option[consoleSchema.A]]) derives consoleSchema.Auto
 
-        assert(Types.collectTypes(summon[Schema[Console, B]].toType_()).map(_.name.getOrElse("")))(
+        assert(Types.collectTypes(consoleSchema[B].toType_()).map(_.name.getOrElse("")))(
           not(contains("SomeA")) && not(contains("OptionA")) && not(contains("None"))
         )
       },


### PR DESCRIPTION
This PR adds helper methods to "summon" a schema of type A. This is particularly useful in Scala 3 when schemas are derived via the `derives` keyword. e.g.,:

```scala
case class Foo(x: Int) derives Schema.SemiAuto
case class Bar(x: Int)

// Before
given Schema[Any, Bar] = summon[Schema[Any, Foo]].contramap(???)

// Now
given Schema[Any, Bar] = Schema[Foo].contramap(???)
```

Also works with custom schemas:
```scala
trait Env
object MySchema extends SchemaDerivation[Env]
case class Foo(x: Int) derives MySchema.SemiAuto
case class Bar(x: Int)

given Schema[Env, Bar] = MySchema[Foo].contramap(???)
```

Another option would be to have the apply method defined on `object Schema` directly as below, but I thought it might be a bit annoying having to add the environment parameter each time

```scala
def apply[R, A](implicit ev: Schema[R, A]): Schema[R, A] = ev
```