### PR TITLE
More object field resolution / reduction optimizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.tools.mima.core.{ IncompatibleMethTypeProblem, IncompatibleResultTypeProblem, ProblemFilters }
 import org.scalajs.linker.interface.ModuleSplitStyle
 import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 
@@ -671,7 +672,10 @@ lazy val enableMimaSettingsJVM =
   Def.settings(
     mimaFailOnProblem     := enforceMimaCompatibility,
     mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet,
-    mimaBinaryIssueFilters ++= Seq()
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("caliban.schema.Step#ObjectStep*"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("caliban.schema.Step#ObjectStep*")
+    )
   )
 
 lazy val enableMimaSettingsJS =

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -33,7 +33,9 @@ object Executor {
     queryExecution: QueryExecution = QueryExecution.Parallel,
     featureSet: Set[Feature] = Set.empty
   )(implicit trace: Trace): URIO[R, GraphQLResponse[CalibanError]] = {
-    val wrapPureValues = fieldWrappers.exists(_.wrapPureValues)
+    val wrapPureValues    = fieldWrappers.exists(_.wrapPureValues)
+    val isDeferredEnabled = featureSet(Feature.Defer)
+
     type ExecutionQuery[+A] = ZQuery[R, ExecutionError, A]
 
     val execution = request.operationType match {
@@ -57,32 +59,32 @@ object Executor {
       path: List[Either[String, Int]]
     ): ReducedStep[R] = {
 
-      def reduceObjectStep(objectName: String, fields: Map[String, Step[R]]) = {
+      def reduceObjectStep(objectName: String, fields: collection.Map[String, Step[R]]): ReducedStep[R] = {
         val filteredFields    = mergeFields(currentField, objectName)
         val (deferred, eager) = filteredFields.partitionMap {
           case f @ Field("__typename", _, _, _, _, _, _, directives, _, _, _)   =>
             Right((f.aliasedName, PureStep(StringValue(objectName)), fieldInfo(f, path, directives)))
           case f @ Field(name, _, _, _, _, _, args, directives, _, _, fragment) =>
-            val aliasedName = f.aliasedName
-            val field       = fields
-              .get(name)
-              .fold(NullStep: ReducedStep[R])(reduceStep(_, f, args, Left(aliasedName) :: path))
+            val field = fields.get(name) match {
+              case Some(step) => reduceStep(step, f, args, Left(f.aliasedName) :: path)
+              case _          => NullStep
+            }
+            val entry = (f.aliasedName, field, fieldInfo(f, path, directives))
 
-            val info = fieldInfo(f, path, directives)
-
-            fragment.collectFirst {
+            fragment match {
               // The defer spec provides some latitude on how we handle responses. Since it is more performant to return
               // pure fields rather than spin up the defer machinery we return pure fields immediately to the caller.
-              case IsDeferred(label) if featureSet(Feature.Defer) && !field.isPure =>
-                (label, (aliasedName, field, info))
-            }.toLeft((aliasedName, field, info))
+              case Some(IsDeferred(label)) if isDeferredEnabled && !field.isPure => Left(label, entry)
+              case _                                                             => Right(entry)
+            }
         }
 
+        val eagerReduced = reduceObject(eager, wrapPureValues)
         deferred match {
-          case Nil => reduceObject(eager, wrapPureValues)
+          case Nil => eagerReduced
           case d   =>
             DeferStep(
-              reduceObject(eager, wrapPureValues),
+              eagerReduced,
               d.groupBy(_._1).toList.map { case (label, labelAndFields) =>
                 val (_, fields) = labelAndFields.unzip
                 reduceObject(fields, wrapPureValues) -> label

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -74,7 +74,7 @@ object Executor {
             fragment match {
               // The defer spec provides some latitude on how we handle responses. Since it is more performant to return
               // pure fields rather than spin up the defer machinery we return pure fields immediately to the caller.
-              case Some(IsDeferred(label)) if isDeferredEnabled && !field.isPure => Left(label, entry)
+              case Some(IsDeferred(label)) if isDeferredEnabled && !field.isPure => Left((label, entry))
               case _                                                             => Right(entry)
             }
         }

--- a/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
+++ b/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
@@ -3,7 +3,7 @@ package caliban.schema
 import caliban.execution.Field
 import caliban.schema.Step.{ MetadataFunctionStep, ObjectStep }
 
-import scala.collection.immutable.HashMap
+import scala.collection.mutable
 
 final private class ObjectFieldResolver[R, A](
   objectName: String,
@@ -22,15 +22,15 @@ final private class ObjectFieldResolver[R, A](
     value: A,
     field: Field
   ): Step[R] = {
-    val fieldsBuilder = HashMap.newBuilder[String, Step[R]]
-    var remaining     = field.distinctFieldNames
+    val fieldsBuilder = new mutable.HashMap[String, Step[R]]()
+
+    var remaining = field.distinctFieldNames
     while (!remaining.isEmpty) {
       val name    = remaining.head
       val resolve = fieldsMap.get(name)
-      if (resolve eq null) ()
-      else fieldsBuilder += name -> resolve(value)
+      if (resolve ne null) fieldsBuilder.update(name, resolve(value))
       remaining = remaining.tail
     }
-    ObjectStep(objectName, fieldsBuilder.result())
+    ObjectStep(objectName, fieldsBuilder)
   }
 }

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -4,18 +4,18 @@ import caliban.CalibanError.ExecutionError
 import caliban.Value.NullValue
 import caliban.execution.{ Field, FieldInfo }
 import caliban.{ InputValue, ResponseValue }
-import zio.stream.ZStream
 import zio.query.ZQuery
+import zio.stream.ZStream
 
 sealed trait Step[-R]
 
 object Step {
-  case class ListStep[-R](steps: List[Step[R]])                         extends Step[R]
-  case class FunctionStep[-R](step: Map[String, InputValue] => Step[R]) extends Step[R]
-  case class MetadataFunctionStep[-R](step: Field => Step[R])           extends Step[R]
-  case class ObjectStep[-R](name: String, fields: Map[String, Step[R]]) extends Step[R]
-  case class QueryStep[-R](query: ZQuery[R, Throwable, Step[R]])        extends Step[R]
-  case class StreamStep[-R](inner: ZStream[R, Throwable, Step[R]])      extends Step[R]
+  case class ListStep[-R](steps: List[Step[R]])                                    extends Step[R]
+  case class FunctionStep[-R](step: Map[String, InputValue] => Step[R])            extends Step[R]
+  case class MetadataFunctionStep[-R](step: Field => Step[R])                      extends Step[R]
+  case class ObjectStep[-R](name: String, fields: collection.Map[String, Step[R]]) extends Step[R]
+  case class QueryStep[-R](query: ZQuery[R, Throwable, Step[R]])                   extends Step[R]
+  case class StreamStep[-R](inner: ZStream[R, Throwable, Step[R]])                 extends Step[R]
 
   // PureStep is both a Step and a ReducedStep so it is defined outside this object
   // This is to avoid boxing/unboxing pure values during step reduction

--- a/interop/cats/src/test/scala/caliban/interop/fs2/Fs2InteropSchemaSpec.scala
+++ b/interop/cats/src/test/scala/caliban/interop/fs2/Fs2InteropSchemaSpec.scala
@@ -120,7 +120,7 @@ object Fs2InteropSchemaSpec extends ZIOSpecDefault {
     isSubtype[ObjectStep[Any]](
       hasField(
         "fields",
-        _.fields,
+        _.fields.toMap,
         hasKey(
           "bar",
           isSubtype[StreamStep[Any]](


### PR DESCRIPTION
There are 2 main optimizations in this PR:

1. Avoid usages of FunctionX and the number of branches within `reduceObjectStep`
2. Use a `mutable.HashMap` in ObjectFieldResolver

Now, I'm somewhat conflicted about (2). For _some_ reason, Scala's immutable HashMapBuilder is much slower than using a mutable Map. I realised this inefficiency after looking at some profiling graphs, where a lot of time was spend on the `+=` method of the HashMapBuilder. It seems that even if the HashMapBuilder is mutable, the implementation copies the underlying arrays on each new entry (no idea why).

Since this is in our _very_ hot path and we probably can't go changing the Scala std library, one way to optimize for it is to use a mutable HashMap, and change the Map type on ObjectStep from Map (i.e., `immutable.Map`) to `collection.Map` which is the base type for both mutable and immutable collections. This change is binary incompatible but largely source-compatible so most users should not need to do any changes to their code.

As I said though, I'm fairly conflicted about this change. It does offer a fairly sizeable performance improvement over the current implementation, but it could potentially leak mutability if misused; even if `collection.Map` doesn't expose any mutable APIs a user _could potentially_ pattern match and get the mutable instance. Having said that, I don't know how much of an issue this actually is

series/2.x:
```
[info] Benchmark                                              Mode  Cnt    Score    Error  Units
[info] NestedZQueryBenchmark.multifieldSequentialQuery1000   thrpt    5  686.416 ± 30.976  ops/s
[info] NestedZQueryBenchmark.multifieldSequentialQuery10000  thrpt    5   61.166 ±  1.555  ops/s
```

PR (~10% improvement):
```
[info] Benchmark                                              Mode  Cnt    Score    Error  Units
[info] NestedZQueryBenchmark.multifieldSequentialQuery1000   thrpt    5  746.585 ± 21.516  ops/s
[info] NestedZQueryBenchmark.multifieldSequentialQuery10000  thrpt    5   65.220 ±  1.478  ops/s
```