### PR TITLE
Unify quick toApp implementations

### DIFF
--- a/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
@@ -18,13 +18,13 @@ final class QuickAdapter[-R, E] private (requestHandler: QuickRequestHandler[R, 
    * @param apiPath The path where the GraphQL API will be served.
    * @param graphiqlPath The path where the GraphiQL UI will be served. If None, GraphiQL will not be served.
    */
-  def toApp(apiPath: Path, graphiqlPath: Option[Path] = None): HttpApp[R] = {
+  def toApp(apiPath: String, graphiqlPath: Option[String] = None): HttpApp[R] = {
     val apiRoutes     = List(
       RoutePattern(Method.POST, apiPath) -> handler,
       RoutePattern(Method.GET, apiPath)  -> handler
     )
     val graphiqlRoute = graphiqlPath.fold(List.empty[Route[R, Nothing]]) { uiPath =>
-      val uiHandler = GraphiQLHandler.handler(apiPath.toString(), uiPath.toString)
+      val uiHandler = GraphiQLHandler.handler(apiPath, uiPath)
       List(RoutePattern(Method.GET, uiPath) -> uiHandler)
     }
 
@@ -43,7 +43,7 @@ final class QuickAdapter[-R, E] private (requestHandler: QuickRequestHandler[R, 
     trace: Trace
   ): RIO[R, Nothing] =
     Server
-      .serve[R](toApp(Path.decode(apiPath), graphiqlPath.map(Path.decode)))
+      .serve[R](toApp(apiPath, graphiqlPath))
       .provideSomeLayer[R](Server.defaultWithPort(port))
 
   def configure(config: ExecutionConfiguration)(implicit trace: Trace): QuickAdapter[R, E] =

--- a/adapters/quick/src/main/scala/caliban/quick/package.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/package.scala
@@ -30,7 +30,7 @@ package object quick {
     def toApp(apiPath: String, graphiqlPath: Option[String] = None)(implicit
       trace: Trace
     ): RIO[R, HttpApp[R]] =
-      gql.interpreter.map(QuickAdapter(_).toApp(Path.decode(apiPath), graphiqlPath.map(Path.decode)))
+      gql.interpreter.map(QuickAdapter(_).toApp(apiPath, graphiqlPath))
 
     /**
      * Creates a zio-http handler for the GraphQL API

--- a/build.sbt
+++ b/build.sbt
@@ -679,7 +679,8 @@ lazy val enableMimaSettingsJVM =
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("caliban.schema.Step#ObjectStep*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.schema.Annotations*"),
       ProblemFilters.exclude[MissingTypesProblem]("caliban.schema.Annotations*"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("caliban.schema.Annotations*")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("caliban.schema.Annotations*"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("caliban.QuickAdapter.toApp")
     )
   )
 


### PR DESCRIPTION
It's a bit weird that we require a string in syntax methods and Path in the QuickAdapter method. This PR unifies the implementation by requiring a String in both cases