### PR TITLE
Optimize fragment validation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -668,20 +668,13 @@ lazy val commonSettings = Def.settings(
   })
 )
 
-lazy val enforceMimaCompatibility = true // Enable / disable failing CI on binary incompatibilities
+lazy val enforceMimaCompatibility = false // Enable / disable failing CI on binary incompatibilities
 
 lazy val enableMimaSettingsJVM =
   Def.settings(
     mimaFailOnProblem     := enforceMimaCompatibility,
     mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet,
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("caliban.schema.Step#ObjectStep*"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("caliban.schema.Step#ObjectStep*"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.schema.Annotations*"),
-      ProblemFilters.exclude[MissingTypesProblem]("caliban.schema.Annotations*"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("caliban.schema.Annotations*"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("caliban.QuickAdapter.toApp")
-    )
+    mimaBinaryIssueFilters ++= Seq()
   )
 
 lazy val enableMimaSettingsJS =

--- a/core/src/main/scala/caliban/introspection/adt/__Field.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Field.scala
@@ -14,6 +14,8 @@ case class __Field(
   deprecationReason: Option[String] = None,
   @GQLExcluded directives: Option[List[Directive]] = None
 ) {
+  final override lazy val hashCode: Int = super.hashCode()
+
   def toFieldDefinition: FieldDefinition = {
     val allDirectives = (if (isDeprecated)
                            List(

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -132,8 +132,18 @@ case class __Type(
   lazy val allEnumValues: List[__EnumValue] =
     enumValues(__DeprecatedArgs(Some(true))).getOrElse(Nil)
 
-  private[caliban] lazy val allFieldsMap: Map[String, __Field] =
-    allFields.map(f => f.name -> f).toMap
+  private[caliban] lazy val allFieldsMap: collection.Map[String, __Field] = {
+    val map = collection.mutable.HashMap.empty[String, __Field]
+    allFields.foreach(f => map.update(f.name, f))
+    map
+  }
 
   lazy val innerType: __Type = Types.innerType(this)
+
+  private[caliban] lazy val possibleTypeNames: Set[String] =
+    kind match {
+      case __TypeKind.OBJECT                       => name.fold(Set.empty[String])(Set(_))
+      case __TypeKind.INTERFACE | __TypeKind.UNION => possibleTypes.fold(Set.empty[String])(_.flatMap(_.name).toSet)
+      case _                                       => Set.empty
+    }
 }

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -22,6 +22,8 @@ case class __Type(
   @GQLExcluded directives: Option[List[Directive]] = None,
   @GQLExcluded origin: Option[String] = None
 ) { self =>
+  final override lazy val hashCode: Int = super.hashCode()
+
   def |+|(that: __Type): __Type = __Type(
     kind,
     (name ++ that.name).reduceOption((_, b) => b),

--- a/core/src/main/scala/caliban/parsing/adt/Selection.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Selection.scala
@@ -3,7 +3,9 @@ package caliban.parsing.adt
 import caliban.InputValue
 import caliban.parsing.adt.Type.NamedType
 
-sealed trait Selection
+sealed trait Selection {
+  final override lazy val hashCode: Int = super.hashCode()
+}
 
 object Selection {
 

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -7,7 +7,6 @@ import caliban.execution.{ ExecutionRequest, Field => F }
 import caliban.introspection.Introspector
 import caliban.introspection.adt._
 import caliban.introspection.adt.__TypeKind._
-import caliban.parsing.SourceMapper
 import caliban.parsing.adt.Definition.ExecutableDefinition.{ FragmentDefinition, OperationDefinition }
 import caliban.parsing.adt.Definition.TypeSystemDefinition.DirectiveDefinition
 import caliban.parsing.adt.Definition.{ TypeSystemDefinition, TypeSystemExtension }
@@ -15,14 +14,14 @@ import caliban.parsing.adt.OperationType._
 import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
 import caliban.parsing.adt.Type.NamedType
 import caliban.parsing.adt._
-import caliban.parsing.Parser
+import caliban.parsing.{ Parser, SourceMapper }
 import caliban.rendering.DocumentRenderer
 import caliban.schema._
 import caliban.validation.Utils.isObjectType
-import caliban.{ Configurator, InputValue, Value }
-import zio.{ IO, ZIO }
+import caliban.{ Configurator, InputValue }
 import zio.prelude._
 import zio.prelude.fx.ZPure
+import zio.{ IO, ZIO }
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -69,6 +68,8 @@ object Validator {
       validateRootQuery(schema)
   }.runEither
 
+  private val zunit = ZPure.unit[Unit]
+
   private[caliban] def validateType(t: __Type): EReader[Any, ValidationError, Unit] =
     ZPure.forEach(t.name)(name => checkName(name, s"Type '$name'")) *>
       (t.kind match {
@@ -77,7 +78,7 @@ object Validator {
         case __TypeKind.INTERFACE    => validateInterface(t)
         case __TypeKind.INPUT_OBJECT => validateInputObject(t)
         case __TypeKind.OBJECT       => validateObject(t)
-        case _                       => ZPure.unit
+        case _                       => zunit
       })
 
   def failValidation(msg: String, explanatoryText: String): EReader[Any, ValidationError, Nothing] =
@@ -161,7 +162,7 @@ object Validator {
     validateFragments(fragments).flatMap { fragmentMap =>
       val selectionSets = collectSelectionSets(operations.flatMap(_.selectionSet) ++ fragments.flatMap(_.selectionSet))
       val context       = Context(document, rootType, operations, fragmentMap, selectionSets, variables)
-      ZPure.foreachDiscard(validations)(identity).provideService(context) as fragmentMap
+      validateAll(validations)(identity).provideService(context) as fragmentMap
     }
   }
 
@@ -304,7 +305,7 @@ object Validator {
         // it's a minor optimization to short-circuit the length check on a List for the off-chance that list is long
         (v.lengthCompare(1) > 0) && !directiveDefinitions.get(n).exists(_.exists(_.isRepeatable))
       } match {
-      case None            => ZPure.unit
+      case None            => zunit
       case Some((name, _)) =>
         failValidation(
           s"Directive '$name' is defined more than once.",
@@ -315,7 +316,7 @@ object Validator {
   lazy val validateDirectives: QueryValidation = ZPure.serviceWithPure { context =>
     for {
       directives <- collectAllDirectives(context)
-      _          <- ZPure.foreachDiscard(directives) { case (d, location) =>
+      _          <- validateAll(directives) { case (d, location) =>
                       (context.rootType.additionalDirectives ::: Introspector.directives).find(_.name == d.name) match {
                         case None            =>
                           failValidation(
@@ -323,19 +324,19 @@ object Validator {
                             "GraphQL servers define what directives they support. For each usage of a directive, the directive must be available on that server."
                           )
                         case Some(directive) =>
-                          ZPure.foreachDiscard(d.arguments) { case (arg, argValue) =>
+                          validateAll(d.arguments) { case (arg, argValue) =>
                             directive.allArgs.find(_.name == arg) match {
-                              case None             =>
-                                failValidation(
-                                  s"Argument '$arg' is not defined on directive '${d.name}' ($location).",
-                                  "Every argument provided to a field or directive must be defined in the set of possible arguments of that field or directive."
-                                )
                               case Some(inputValue) =>
                                 validateInputValues(
                                   inputValue,
                                   argValue,
                                   context,
                                   s"InputValue '${inputValue.name}' of Directive '${d.name}'"
+                                )
+                              case None             =>
+                                failValidation(
+                                  s"Argument '$arg' is not defined on directive '${d.name}' ($location).",
+                                  "Every argument provided to a field or directive must be defined in the set of possible arguments of that field or directive."
                                 )
                             }
                           } *>
@@ -353,14 +354,14 @@ object Validator {
   lazy val validateVariables: QueryValidation =
     ZPure.serviceWithPure { context =>
       ZPure.foreachDiscard(context.operations)(op =>
-        ZPure.foreachDiscard(op.variableDefinitions.groupBy(_.name)) { case (name, variables) =>
+        validateAll(op.variableDefinitions.groupBy(_.name)) { case (name, variables) =>
           ZPure.when(variables.length > 1)(
             failValidation(
               s"Variable '$name' is defined more than once.",
               "If any operation defines more than one variable with the same name, it is ambiguous and invalid. It is invalid even if the type of the duplicate variable is the same."
             )
           )
-        } *> ZPure.foreachDiscard(op.variableDefinitions) { v =>
+        } *> validateAll(op.variableDefinitions) { v =>
           val t = Type.innerType(v.variableType)
           ZPure.whenCase(context.rootType.types.get(t).map(_.kind)) {
             case Some(__TypeKind.OBJECT) | Some(__TypeKind.UNION) | Some(__TypeKind.INTERFACE) =>
@@ -371,14 +372,14 @@ object Validator {
           }
         } *> {
           val variableUsages = collectVariablesUsed(context, op.selectionSet)
-          ZPure.foreachDiscard(variableUsages)(v =>
+          validateAll(variableUsages)(v =>
             ZPure.when(!op.variableDefinitions.exists(_.name == v))(
               failValidation(
                 s"Variable '$v' is not defined.",
                 "Variables are scoped on a per‐operation basis. That means that any variable used within the context of an operation must be defined at the top level of that operation"
               )
             )
-          ) *> ZPure.foreachDiscard(op.variableDefinitions)(v =>
+          ) *> validateAll(op.variableDefinitions)(v =>
             ZPure.when(!variableUsages.contains(v.name))(
               failValidation(
                 s"Variable '${v.name}' is not used.",
@@ -397,19 +398,18 @@ object Validator {
     ZPure.serviceWithPure { context =>
       val spreads     = collectFragmentSpreads(context.selectionSets)
       val spreadNames = spreads.map(_.name).toSet
-      ZPure.foreachDiscard(context.fragments.values)(f =>
+      validateAll(context.fragments.values)(f =>
         if (!spreadNames.contains(f.name))
           failValidation(
             s"Fragment '${f.name}' is not used in any spread.",
             "Defined fragments must be used within a document."
           )
-        else
-          ZPure.when(detectCycles(context, f))(
-            failValidation(
-              s"Fragment '${f.name}' forms a cycle.",
-              "The graph of fragment spreads must not form any cycles including spreading itself. Otherwise an operation could infinitely spread or infinitely execute on cycles in the underlying data."
-            )
+        else if (detectCycles(context, f))
+          failValidation(
+            s"Fragment '${f.name}' forms a cycle.",
+            "The graph of fragment spreads must not form any cycles including spreading itself. Otherwise an operation could infinitely spread or infinitely execute on cycles in the underlying data."
           )
+        else zunit
       )
     }
 
@@ -423,12 +423,11 @@ object Validator {
   }
 
   lazy val validateDocumentFields: QueryValidation = ZPure.serviceWithPure { context =>
-    ZPure.foreachDiscard(context.document.definitions) {
+    validateAll(context.document.definitions) {
       case OperationDefinition(opType, _, _, _, selectionSet) =>
         opType match {
-          case OperationType.Query =>
+          case OperationType.Query        =>
             validateSelectionSet(context, selectionSet, context.rootType.queryType)
-
           case OperationType.Mutation     =>
             context.rootType.mutationType.fold[EReader[Any, ValidationError, Unit]](
               failValidation("Mutation operations are not supported on this schema.", "")
@@ -438,9 +437,9 @@ object Validator {
               failValidation("Subscription operations are not supported on this schema.", "")
             )(validateSelectionSet(context, selectionSet, _))
         }
-      case _: FragmentDefinition                              => ZPure.unit
-      case _: TypeSystemDefinition                            => ZPure.unit
-      case _: TypeSystemExtension                             => ZPure.unit
+      case _: FragmentDefinition                              => zunit
+      case _: TypeSystemDefinition                            => zunit
+      case _: TypeSystemExtension                             => zunit
     }
   }
 
@@ -448,26 +447,28 @@ object Validator {
     context: Context,
     selectionSet: List[Selection],
     currentType: __Type
-  ): EReader[Any, ValidationError, Unit] =
-    validateFields(context, selectionSet, currentType) *>
-      FragmentValidator.findConflictsWithinSelectionSet(context, context.rootType.queryType, selectionSet)
+  ): EReader[Any, ValidationError, Unit] = {
+    val v1 = validateFields(context, selectionSet, currentType)
+    val v2 = FragmentValidator.findConflictsWithinSelectionSet(context, context.rootType.queryType, selectionSet)
+    v1 *> v2
+  }
 
   private def validateFields(
     context: Context,
     selectionSet: List[Selection],
     currentType: __Type
   ): EReader[Any, ValidationError, Unit] =
-    ZPure.foreachDiscard(selectionSet) {
+    validateAll(selectionSet) {
       case f: Field                                       => validateField(context, f, currentType)
       case FragmentSpread(name, _)                        =>
         context.fragments.get(name) match {
+          case Some(fragment) =>
+            validateSpread(context, Some(name), currentType, Some(fragment.typeCondition), fragment.selectionSet)
           case None           =>
             failValidation(
               s"Fragment spread '$name' is not defined.",
               "Named fragment spreads must refer to fragments defined within the document. It is a validation error if the target of a spread is not defined."
             )
-          case Some(fragment) =>
-            validateSpread(context, Some(name), currentType, Some(fragment.typeCondition), fragment.selectionSet)
         }
       case InlineFragment(typeCondition, _, selectionSet) =>
         validateSpread(context, None, currentType, typeCondition, selectionSet)
@@ -483,16 +484,16 @@ object Validator {
     typeCondition.fold[Option[__Type]](Some(currentType))(t => context.rootType.types.get(t.name)) match {
       case Some(fragmentType) =>
         validateFragmentType(name, fragmentType) *> {
-          val possibleTypes         = getPossibleTypeNames(currentType)
-          val possibleFragmentTypes = getPossibleTypeNames(fragmentType)
+          val possibleTypes         = currentType.possibleTypeNames
+          val possibleFragmentTypes = fragmentType.possibleTypeNames
           val applicableTypes       = possibleTypes intersect possibleFragmentTypes
-          ZPure.when(applicableTypes.isEmpty)(
+          if (applicableTypes.isEmpty)
             failValidation(
               s"${name.fold("Inline fragment spread")(n => s"Fragment spread '$n'")} is not possible: possible types are '${possibleTypes
                 .mkString(", ")}' and possible fragment types are '${possibleFragmentTypes.mkString(", ")}'.",
               "Fragments are declared on a type and will only apply when the runtime object type matches the type condition. They also are spread within the context of a parent type. A fragment spread is only valid if its type condition could ever apply within the parent type."
             )
-          ) *> validateFields(context, selectionSet, fragmentType)
+          else validateFields(context, selectionSet, fragmentType)
         }
       case None               =>
         lazy val typeConditionName = typeCondition.fold("?")(_.name)
@@ -502,30 +503,19 @@ object Validator {
         )
     }
 
-  private def getPossibleTypeNames(t: __Type): Set[String] =
-    t.kind match {
-      case __TypeKind.OBJECT                       => t.name.fold(Set.empty[String])(Set(_))
-      case __TypeKind.INTERFACE | __TypeKind.UNION => t.possibleTypes.fold(Set.empty[String])(_.flatMap(_.name).toSet)
-      case _                                       => Set.empty
-    }
-
   private def validateField(context: Context, field: Field, currentType: __Type): EReader[Any, ValidationError, Unit] =
-    ZPure
-      .when(field.name != "__typename") {
-        ZPure
-          .fromOption(currentType.allFieldsMap.get(field.name))
-          .orElseFail(
-            ValidationError(
-              s"Field '${field.name}' does not exist on type '${DocumentRenderer.renderTypeName(currentType)}'.",
-              "The target field of a field selection must be defined on the scoped type of the selection set. There are no limitations on alias names."
-            )
+    if (field.name != "__typename") {
+      currentType.allFieldsMap.get(field.name) match {
+        case Some(f) =>
+          validateFields(context, field.selectionSet, f._type.innerType) *>
+            validateArguments(field, f, currentType, context)
+        case None    =>
+          failValidation(
+            s"Field '${field.name}' does not exist on type '${DocumentRenderer.renderTypeName(currentType)}'.",
+            "The target field of a field selection must be defined on the scoped type of the selection set. There are no limitations on alias names."
           )
-          .flatMap { f =>
-            validateFields(context, field.selectionSet, f._type.innerType) *>
-              validateArguments(field, f, currentType, context)
-          }
       }
-      .unit
+    } else zunit
 
   private def validateArguments(
     field: Field,
@@ -533,7 +523,7 @@ object Validator {
     currentType: __Type,
     context: Context
   ): EReader[Any, ValidationError, Unit] =
-    ZPure.foreachDiscard(f.allArgs.filter(_._type.kind == __TypeKind.NON_NULL))(arg =>
+    validateAll(f.allArgs.filter(_._type.kind == __TypeKind.NON_NULL))(arg =>
       (arg.defaultValue, field.arguments.get(arg.name)) match {
         case (None, None) | (None, Some(NullValue)) =>
           failValidation(
@@ -541,32 +531,30 @@ object Validator {
               .getOrElse("")}'.",
             "Arguments can be required. An argument is required if the argument type is non‐null and does not have a default value. Otherwise, the argument is optional."
           )
-
-        case (Some(_), Some(NullValue)) =>
+        case (Some(_), Some(NullValue))             =>
           failValidation(
             s"Required argument '${arg.name}' is null on '${field.name}' of type '${currentType.name
               .getOrElse("")}'.",
             "Arguments can be required. An argument is required if the argument type is non‐null and does not have a default value. Otherwise, the argument is optional."
           )
-        case _                          => ZPure.unit[Unit]
+        case _                                      => zunit
       }
-    ) *>
-      ZPure.foreachDiscard(field.arguments) { case (arg, argValue) =>
-        f.allArgs.find(_.name == arg) match {
-          case None             =>
-            failValidation(
-              s"Argument '$arg' is not defined on field '${field.name}' of type '${currentType.name.getOrElse("")}'.",
-              "Every argument provided to a field or directive must be defined in the set of possible arguments of that field or directive."
-            )
-          case Some(inputValue) =>
-            validateInputValues(
-              inputValue,
-              argValue,
-              context,
-              s"InputValue '${inputValue.name}' of Field '${field.name}'"
-            )
-        }
+    ) *> validateAll(field.arguments) { case (arg, argValue) =>
+      f.allArgs.find(_.name == arg) match {
+        case Some(inputValue) =>
+          validateInputValues(
+            inputValue,
+            argValue,
+            context,
+            s"InputValue '${inputValue.name}' of Field '${field.name}'"
+          )
+        case None             =>
+          failValidation(
+            s"Argument '$arg' is not defined on field '${field.name}' of type '${currentType.name.getOrElse("")}'.",
+            "Every argument provided to a field or directive must be defined in the set of possible arguments of that field or directive."
+          )
       }
+    }
 
   private[caliban] def validateInputValues(
     inputValue: __InputValue,
@@ -580,7 +568,7 @@ object Validator {
 
     argValue match {
       case InputValue.ObjectValue(fields) if inputType.kind == __TypeKind.INPUT_OBJECT =>
-        ZPure.foreachDiscard(fields) { case (k, v) =>
+        validateAll(fields) { case (k, v) =>
           inputFields.find(_.name == k) match {
             case None        =>
               failValidation(
@@ -595,7 +583,7 @@ object Validator {
                 s"InputValue '${inputValue.name}' of Field '$k' of InputObject '${t.name.getOrElse("")}'"
               )
           }
-        } *> ZPure.foreachDiscard(inputFields)(inputField =>
+        } *> validateAll(inputFields)(inputField =>
           ZPure.when(
             inputField.defaultValue.isEmpty &&
               inputField._type.kind == __TypeKind.NON_NULL &&
@@ -616,7 +604,7 @@ object Validator {
               "Variables are scoped on a per‐operation basis. That means that any variable used within the context of an operation must be defined at the top level of that operation"
             )
         }
-      case _                                                                           => ZPure.unit[Unit]
+      case _                                                                           => zunit
     }
   } *> ValueValidator.validateInputTypes(inputValue, argValue, context, errorContext)
 
@@ -709,7 +697,7 @@ object Validator {
           s"Field selection is mandatory on type '${currentType.name.getOrElse("")}'.",
           "Leaf selections on objects, interfaces, and unions without subfields are disallowed."
         )
-      case _                                                                                 => ZPure.unit
+      case _                                                                                 => zunit
     }
 
   lazy val validateOperationNameUniqueness: QueryValidation = ZPure.serviceWithPure { context =>
@@ -793,7 +781,7 @@ object Validator {
 
   private def validateFragmentType(name: Option[String], targetType: __Type): EReader[Any, ValidationError, Unit] =
     targetType.kind match {
-      case __TypeKind.UNION | __TypeKind.INTERFACE | __TypeKind.OBJECT => ZPure.unit
+      case __TypeKind.UNION | __TypeKind.INTERFACE | __TypeKind.OBJECT => zunit
       case _                                                           =>
         val targetTypeName = targetType.name.getOrElse("")
         failValidation(
@@ -804,7 +792,7 @@ object Validator {
 
   private[caliban] def validateEnum(t: __Type): EReader[Any, ValidationError, Unit] =
     t.allEnumValues match {
-      case _ :: _ => ZPure.unit
+      case _ :: _ => zunit
       case Nil    =>
         failValidation(
           s"Enum ${t.name.getOrElse("")} doesn't contain any values",
@@ -825,7 +813,7 @@ object Validator {
             types.filterNot(isObjectType).map(_.name.getOrElse("")).filterNot(_.isEmpty).mkString("", ", ", "."),
           s"The member types of a Union type must all be Object base types."
         )
-      case _                                          => ZPure.unit
+      case _                                          => zunit
     }
 
   private[caliban] def validateInputObject(t: __Type): EReader[Any, ValidationError, Unit] = {
@@ -842,7 +830,7 @@ object Validator {
     }
 
     def validateFields(fields: List[__InputValue]): EReader[Any, ValidationError, Unit] =
-      ZPure.foreachDiscard(fields)(validateInputValue(_, inputObjectContext)) *>
+      validateAll(fields)(validateInputValue(_, inputObjectContext)) *>
         noDuplicateInputValueName(fields, inputObjectContext)
 
     t.allInputFields match {
@@ -924,11 +912,11 @@ object Validator {
           isNonNullableSubtype(supertypeFieldType, objectFieldType)
         }
 
-        ZPure.foreachDiscard(objectFields) { objField =>
+        validateAll(objectFields) { objField =>
           lazy val fieldContext = s"Field '${objField.name}'"
 
           supertypeFields.find(_.name == objField.name) match {
-            case None             => ZPure.unit
+            case None             => zunit
             case Some(superField) =>
               val superArgs = superField.allArgs.map(arg => (arg.name, arg)).toMap
               val extraArgs = objField.allArgs.filter { arg =>
@@ -963,7 +951,7 @@ object Validator {
                     s"$fieldContext with extra non-nullable arg(s) '$argNames' in $objectContext is invalid",
                     "Any additional field arguments must not be of a non-nullable type."
                   )
-                case _                                 => ZPure.unit
+                case _                                 => zunit
               }
           }
         }
@@ -1005,18 +993,18 @@ object Validator {
           s"${errorType.name.getOrElse("")} of $errorContext is of kind ${errorType.kind}, must be an InputType",
           """The input field must accept a type where IsInputType(type) returns true, https://spec.graphql.org/June2018/#IsInputType()"""
         )
-      case Right(_)        => ZPure.unit
+      case Right(_)        => zunit
     }
   }
 
   private[caliban] def validateFields(fields: List[__Field], context: => String): EReader[Any, ValidationError, Unit] =
     noDuplicateFieldName(fields, context) <*
-      ZPure.foreachDiscard(fields) { field =>
+      validateAll(fields) { field =>
         lazy val fieldContext = s"Field '${field.name}' of $context"
         for {
           _ <- checkName(field.name, fieldContext)
           _ <- onlyOutputType(field._type, fieldContext)
-          _ <- ZPure.foreachDiscard(field.allArgs)(validateInputValue(_, fieldContext))
+          _ <- validateAll(field.allArgs)(validateInputValue(_, fieldContext))
         } yield ()
       }
 
@@ -1044,7 +1032,7 @@ object Validator {
           s"${errorType.name.getOrElse("")} of $errorContext is of kind ${errorType.kind}, must be an OutputType",
           """The input field must accept a type where IsOutputType(type) returns true, https://spec.graphql.org/June2018/#IsInputType()"""
         )
-      case Right(_)        => ZPure.unit
+      case Right(_)        => zunit
     }
   }
 
@@ -1057,7 +1045,7 @@ object Validator {
     listOfNamed
       .groupBy(nameExtractor(_))
       .collectFirst { case (_, f :: _ :: _) => f }
-      .fold[EReader[Any, ValidationError, Unit]](ZPure.unit)(duplicate =>
+      .fold[EReader[Any, ValidationError, Unit]](zunit)(duplicate =>
         failValidation(messageBuilder(duplicate), explanatoryText)
       )
 
@@ -1110,7 +1098,7 @@ object Validator {
           "The mutation root operation is not an object type.",
           "The mutation root operation type is optional; if it is not provided, the service does not support mutations. If it is provided, it must be an Object type."
         )
-      case _                                                           => ZPure.unit
+      case _                                                           => zunit
     }
 
   private[caliban] def validateRootSubscription[R](schema: RootSchemaBuilder[R]): EReader[Any, ValidationError, Unit] =
@@ -1120,13 +1108,13 @@ object Validator {
           "The mutation root subscription is not an object type.",
           "The mutation root subscription type is optional; if it is not provided, the service does not support subscriptions. If it is provided, it must be an Object type."
         )
-      case _                                                                   => ZPure.unit
+      case _                                                                   => zunit
     }
 
   private[caliban] def validateClashingTypes(types: List[__Type]): EReader[Any, ValidationError, Unit] = {
     val check = types.groupBy(_.name).collectFirst { case (Some(name), v) if v.size > 1 => (name, v) }
     check match {
-      case None                 => ZPure.unit
+      case None                 => zunit
       case Some((name, values)) =>
         failValidation(
           s"Type '$name' is defined multiple times (${values
@@ -1145,7 +1133,7 @@ object Validator {
       errorContext: => String
     ): EReader[Any, ValidationError, Unit] = {
       val argumentErrorContextBuilder = (name: String) => s"Argument '$name' of $errorContext"
-      ZPure.foreachDiscard(args.keys)(argName => checkName(argName, argumentErrorContextBuilder(argName)))
+      validateAll(args.keys)(argName => checkName(argName, argumentErrorContextBuilder(argName)))
     }
 
     def validateDirective(directive: Directive, errorContext: => String) = {
@@ -1159,14 +1147,14 @@ object Validator {
       directives: Option[List[Directive]],
       errorContext: => String
     ): EReader[Any, ValidationError, Unit] =
-      ZPure.foreachDiscard(directives.getOrElse(List.empty))(validateDirective(_, errorContext))
+      validateAll(directives.getOrElse(List.empty))(validateDirective(_, errorContext))
 
     def validateInputValueDirectives(
       inputValues: List[__InputValue],
       errorContext: => String
     ): EReader[Any, ValidationError, Unit] = {
       val inputValueErrorContextBuilder = (name: String) => s"InputValue '$name' of $errorContext"
-      ZPure.foreachDiscard(inputValues)(iv => validateDirectives(iv.directives, inputValueErrorContextBuilder(iv.name)))
+      validateAll(inputValues)(iv => validateDirectives(iv.directives, inputValueErrorContextBuilder(iv.name)))
     }
 
     def validateFieldDirectives(
@@ -1178,13 +1166,20 @@ object Validator {
         validateInputValueDirectives(field.allArgs, fieldErrorContext)
     }
 
-    ZPure.foreachDiscard(types) { t =>
+    validateAll(types) { t =>
       lazy val typeErrorContext = s"Type '${t.name.getOrElse("")}'"
       for {
         _ <- validateDirectives(t.directives, typeErrorContext)
         _ <- validateInputValueDirectives(t.allInputFields, typeErrorContext)
-        _ <- ZPure.foreachDiscard(t.allFields)(validateFieldDirectives(_, typeErrorContext))
+        _ <- validateAll(t.allFields)(validateFieldDirectives(_, typeErrorContext))
       } yield ()
     }
   }
+
+  // Pure's implementation doesn't check if the Iterable is empty, and this is causing some performance degradation
+  private def validateAll[R, A, B](
+    in: Iterable[A]
+  )(f: A => EReader[R, ValidationError, B]): EReader[R, ValidationError, Unit] =
+    if (in.isEmpty) zunit
+    else ZPure.foreachDiscard(in)(f)
 }

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -9,7 +9,6 @@ import caliban.parsing.Parser
 import caliban.{ InputValue, Value }
 import zio.prelude.EReader
 import zio.prelude.fx.ZPure
-import zio.prelude._
 
 object ValueValidator {
   def validateDefaultValue(field: __InputValue, errorContext: => String): EReader[Any, ValidationError, Unit] =
@@ -68,7 +67,7 @@ object ValueValidator {
           case LIST     =>
             argValue match {
               case ListValue(values) =>
-                values.forEach_(v =>
+                ZPure.foreachDiscard(values)(v =>
                   validateType(inputType.ofType.getOrElse(inputType), v, context, s"List item in $errorContext")
                 )
               case NullValue         =>
@@ -81,14 +80,14 @@ object ValueValidator {
           case INPUT_OBJECT =>
             argValue match {
               case ObjectValue(fields) =>
-                inputType.allInputFields.forEach_ { f =>
+                ZPure.foreachDiscard(inputType.allInputFields) { f =>
                   fields.collectFirst { case (name, fieldValue) if name == f.name => fieldValue } match {
-                    case Some(value) =>
+                    case Some(value)                    =>
                       validateType(f._type, value, context, s"Field ${f.name} in $errorContext")
-                    case None        =>
-                      ZPure.when(f.defaultValue.isEmpty) {
-                        validateType(f._type, NullValue, context, s"Field ${f.name} in $errorContext")
-                      }
+                    case None if f.defaultValue.isEmpty =>
+                      validateType(f._type, NullValue, context, s"Field ${f.name} in $errorContext")
+                    case _                              =>
+                      ZPure.unit
                   }
                 }
               case NullValue           =>

--- a/core/src/main/scala/caliban/validation/package.scala
+++ b/core/src/main/scala/caliban/validation/package.scala
@@ -12,7 +12,9 @@ package object validation {
     parentType: __Type,
     selection: Field,
     fieldDef: __Field
-  )
+  ) {
+    final override lazy val hashCode: Int = super.hashCode()
+  }
 
   type FieldMap = Map[String, Set[SelectedField]]
 


### PR DESCRIPTION
Last stretch of optimizations before 2.5.0. Recently we focused very heavily on optimizing the Executor so I thought it'd be good to take a look at validation as well.

For the most of it, validation is fairly quick with the exception when fragments / recursive fields are involved, so I spent most of the time optimizing for them.

Main optimizations:
1. Avoiding usage of `ZPure.when(condition)(effect)` when `effect` is a method that relies on recursion (either direct or indirect).
2. "Caching" of the `hashCode` for `Selection` and `SelectionSet`. We use these objects in Sets and as keys in Maps, and due to their recursive nature calculating their hash code is fairly expensive

Other minor optimizations:
1. Change logic in Utils.cross so that we don't return the same tuple in mirror representation
2. Short-circuit `ZPure.foreachDiscard` for empty collections
3. (Executor) Avoid using `.partitionMap` when support for Defer is not enabled

Some of these optimizations require binary incompatible changes. Some of the methods are public, but I doubt that are used by any end-users.

series 2/x:
```
[info] Benchmark                             Mode  Cnt     Score    Error  Units
[info] GraphQLBenchmarks.fragmentsCaliban   thrpt    5   256.513 ±  8.843  ops/s
[info] GraphQLBenchmarks.introspectCaliban  thrpt    5  9000.317 ± 45.534  ops/s
```

PR:
```
[info] Benchmark                             Mode  Cnt      Score     Error  Units
[info] GraphQLBenchmarks.fragmentsCaliban   thrpt    5    482.216 ±   7.531  ops/s
[info] GraphQLBenchmarks.introspectCaliban  thrpt    5  12161.453 ± 139.028  ops/s
```