### PR TITLE
[Scala 3] Field derivation from case class methods

### DIFF
--- a/core/src/main/scala-2/caliban/schema/AnnotationsVersionSpecific.scala
+++ b/core/src/main/scala-2/caliban/schema/AnnotationsVersionSpecific.scala
@@ -1,0 +1,3 @@
+package caliban.schema
+
+trait AnnotationsVersionSpecific

--- a/core/src/main/scala-3/caliban/schema/AnnotationsVersionSpecific.scala
+++ b/core/src/main/scala-3/caliban/schema/AnnotationsVersionSpecific.scala
@@ -1,0 +1,15 @@
+package caliban.schema
+
+import scala.annotation.StaticAnnotation
+
+trait AnnotationsVersionSpecific {
+
+  /**
+   * Annotation that can be used on a case class method to mark it as a GraphQL field.
+   * The method must not take any arguments.
+   *
+   * NOTE: This annotation is not safe for use with GraalVM native-image
+   */
+  case class GQLField() extends StaticAnnotation
+
+}

--- a/core/src/main/scala-3/caliban/schema/AnnotationsVersionSpecific.scala
+++ b/core/src/main/scala-3/caliban/schema/AnnotationsVersionSpecific.scala
@@ -6,9 +6,9 @@ trait AnnotationsVersionSpecific {
 
   /**
    * Annotation that can be used on a case class method to mark it as a GraphQL field.
-   * The method must not take any arguments.
+   * The method must be public, a `def` (does not work on `val`s / `lazy val`s) and must not take any arguments.
    *
-   * NOTE: This annotation is not safe for use with GraalVM native-image
+   * NOTE: This annotation is not safe for use with ahead-of-time compilation (e.g., generating a GraalVM native-image executable)
    */
   case class GQLField() extends StaticAnnotation
 

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -117,12 +117,12 @@ private object DerivationUtils {
 
   def mkInputObject[R](
     annotations: List[Any],
-    fields: List[(String, List[Any], Schema[R, Any], Int)],
+    fields: List[(String, List[Any], Schema[R, Any])],
     info: TypeInfo
   )(isInput: Boolean, isSubscription: Boolean): __Type = makeInputObject(
     Some(getInputName(annotations).getOrElse(customizeInputTypeName(getName(annotations, info)))),
     getDescription(annotations),
-    fields.map { (name, fieldAnnotations, schema, _) =>
+    fields.map { (name, fieldAnnotations, schema) =>
       __InputValue(
         name,
         getDescription(fieldAnnotations),
@@ -141,12 +141,12 @@ private object DerivationUtils {
 
   def mkObject[R](
     annotations: List[Any],
-    fields: List[(String, List[Any], Schema[R, Any], Int)],
+    fields: List[(String, List[Any], Schema[R, Any])],
     info: TypeInfo
   )(isInput: Boolean, isSubscription: Boolean): __Type = makeObject(
     Some(getName(annotations, info)),
     getDescription(annotations),
-    fields.map { (name, fieldAnnotations, schema, _) =>
+    fields.map { (name, fieldAnnotations, schema) =>
       val deprecatedReason = getDeprecatedReason(fieldAnnotations)
       Types.makeField(
         name,

--- a/core/src/main/scala-3/caliban/schema/ObjectSchema.scala
+++ b/core/src/main/scala-3/caliban/schema/ObjectSchema.scala
@@ -5,32 +5,49 @@ import caliban.schema.DerivationUtils.*
 import magnolia1.TypeInfo
 
 import scala.annotation.threadUnsafe
+import scala.reflect.ClassTag
 
 final private class ObjectSchema[R, A](
-  _fields: => List[(String, Schema[R, Any], Int)],
+  _constructorFields: => List[(String, Schema[R, Any], Int)],
+  _methodFields: => List[(String, Schema[R, ?])],
   info: TypeInfo,
   anns: List[Any],
   paramAnnotations: Map[String, List[Any]]
-) extends Schema[R, A] {
+)(using ct: ClassTag[A])
+    extends Schema[R, A] {
 
   @threadUnsafe
-  private lazy val fields = _fields.map { (label, schema, index) =>
+  private lazy val constructorFields = _constructorFields.map { (label, schema, index) =>
     val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
     (getName(fieldAnnotations, label), fieldAnnotations, schema, index)
   }
 
   @threadUnsafe
+  private lazy val methodFields = _methodFields.map { (label, schema) =>
+    val fieldAnnotations = paramAnnotations.getOrElse(label, Nil)
+    (getName(fieldAnnotations, label), fieldAnnotations, schema.asInstanceOf[Schema[R, Any]])
+  }
+
+  @threadUnsafe
   private lazy val resolver = {
-    def fs = fields.map { (name, _, schema, i) =>
+    val clazz           = ct.runtimeClass
+    def fromConstructor = constructorFields.map { (name, _, schema, i) =>
       name -> { (v: A) => schema.resolve(v.asInstanceOf[Product].productElement(i)) }
     }
-    ObjectFieldResolver(getName(anns, info), fs)
+    def fromMethods     = methodFields.map { (name, _, schema) =>
+      name -> {
+        val method = clazz.getMethod(name)
+        (v: A) => schema.resolve(method.invoke(v))
+      }
+    }
+    ObjectFieldResolver(getName(anns, info), fromMethods ::: fromConstructor)
   }
 
   def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
-    val _ = resolver // Init the lazy val
-    if (isInput) mkInputObject[R](anns, fields, info)(isInput, isSubscription)
-    else mkObject[R](anns, fields, info)(isInput, isSubscription)
+    val _              = resolver // Init the lazy val
+    val combinedFields = constructorFields.map(t => (t._1, t._2, t._3)) ::: methodFields
+    if (isInput) mkInputObject[R](anns, combinedFields, info)(isInput, isSubscription)
+    else mkObject[R](anns, combinedFields, info)(isInput, isSubscription)
   }
 
   def resolve(value: A): Step[R] = resolver.resolve(value)

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -109,7 +109,7 @@ trait CommonSchemaDerivation {
               Macros.fieldsFromMethods[R, A],
               MagnoliaMacro.typeInfo[A],
               MagnoliaMacro.anns[A],
-              MagnoliaMacro.paramAnns[A].toMap // FIXME: Get annotations from methods
+              MagnoliaMacro.paramAnns[A].toMap
             )(using summonInline[ClassTag[A]])
         }
 

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -7,6 +7,7 @@ import magnolia1.Macro as MagnoliaMacro
 
 import scala.compiletime.*
 import scala.deriving.Mirror
+import scala.reflect.ClassTag
 import scala.util.NotGiven
 
 object PrintDerived {
@@ -105,10 +106,11 @@ trait CommonSchemaDerivation {
           case _                                          =>
             new ObjectSchema[R, A](
               recurseProduct[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
+              Macros.fieldsFromMethods[R, A],
               MagnoliaMacro.typeInfo[A],
               MagnoliaMacro.anns[A],
-              MagnoliaMacro.paramAnns[A].toMap
-            )
+              MagnoliaMacro.paramAnns[A].toMap // FIXME: Get annotations from methods
+            )(using summonInline[ClassTag[A]])
         }
 
     }

--- a/core/src/main/scala-3/caliban/schema/macros/Macros.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/Macros.scala
@@ -68,8 +68,13 @@ object Macros {
       }
     }
 
+    def checkMethodNoArgs(methodSym: Symbol): Unit =
+      if (methodSym.signature.paramSigs.size > 0)
+        report.errorAndAbort(s"Method '${methodSym.name}' annotated with @GQLField must be parameterless")
+
     Expr.ofList {
-      targetSym.methodMembers.filter(_.getAnnotation(annSymbol).isDefined).map { method =>
+      targetSym.declaredMethods.filter(_.getAnnotation(annSymbol).isDefined).map { method =>
+        checkMethodNoArgs(method)
         '{
           (
             ${ Expr(method.name) },

--- a/core/src/main/scala-3/caliban/schema/macros/Macros.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/Macros.scala
@@ -1,6 +1,7 @@
 package caliban.schema.macros
 
-import caliban.schema.Annotations.GQLExcluded
+import caliban.schema.Annotations.{ GQLExcluded, GQLField }
+import caliban.schema.Schema
 
 import scala.quoted.*
 
@@ -12,21 +13,25 @@ object Macros {
   inline def implicitExists[T]: Boolean     = ${ implicitExistsImpl[T] }
   inline def hasAnnotation[T, Ann]: Boolean = ${ hasAnnotationImpl[T, Ann] }
 
+  inline def fieldsFromMethods[R, T]: List[(String, Schema[R, ?])] = ${ fieldsFromMethodsImpl[R, T] }
+
   /**
    * Tests whether type argument [[FieldT]] in [[Parent]] is annotated with [[GQLExcluded]]
    */
   private def isFieldExcludedImpl[Parent: Type, FieldT: Type](using qctx: Quotes): Expr[Boolean] = {
     import qctx.reflect.*
     val fieldName = Type.valueOfConstant[FieldT]
+    val annSymbol = TypeRepr.of[GQLExcluded].typeSymbol
     Expr(TypeRepr.of[Parent].typeSymbol.primaryConstructor.paramSymss.flatten.exists { v =>
       fieldName.map(_ == v.name).getOrElse(false)
-      && v.annotations.exists(_.tpe =:= TypeRepr.of[GQLExcluded])
+      && v.getAnnotation(annSymbol).isDefined
     })
   }
 
   private def hasAnnotationImpl[T: Type, Ann: Type](using qctx: Quotes): Expr[Boolean] = {
     import qctx.reflect.*
-    Expr(TypeRepr.of[T].typeSymbol.annotations.exists(_.tpe =:= TypeRepr.of[Ann]))
+    val annSymbol = TypeRepr.of[Ann].typeSymbol
+    Expr(TypeRepr.of[T].typeSymbol.getAnnotation(annSymbol).isDefined)
   }
 
   private def implicitExistsImpl[T: Type](using q: Quotes): Expr[Boolean] = {
@@ -40,6 +45,35 @@ object Macros {
   private def isEnumFieldImpl[P: Type, T: Type](using q: Quotes): Expr[Boolean] = {
     import q.reflect.*
     Expr(TypeRepr.of[P].typeSymbol.flags.is(Flags.Enum) && TypeRepr.of[T].typeSymbol.flags.is(Flags.Enum))
+  }
+
+  private def fieldsFromMethodsImpl[R: Type, T: Type](using
+    q: Quotes
+  ): Expr[List[(String, Schema[R, ?])]] = {
+    import q.reflect.*
+
+    def summonSchema(fieldType: TypeRef) =
+      (fieldType.asType match {
+        case '[f] => Expr.summon[Schema[R, f]]
+      }).getOrElse {
+        report.errorAndAbort(s"Cannot find an instance of Schema for $fieldType")
+      }
+
+    val targetType = TypeRepr.of[T]
+    val targetSym  = TypeTree.of[T].symbol
+    val annSymbol  = TypeRepr.of[GQLField].typeSymbol
+
+    Expr.ofList {
+      targetSym.methodMembers.filter(_.getAnnotation(annSymbol).isDefined).map { method =>
+        val methodTypeRef = targetType.memberType(method).typeSymbol.typeRef
+        '{
+          (
+            ${ Expr(method.name) },
+            ${ summonSchema(methodTypeRef) }
+          )
+        }
+      }
+    }
   }
 
 }

--- a/core/src/main/scala/caliban/schema/Annotations.scala
+++ b/core/src/main/scala/caliban/schema/Annotations.scala
@@ -4,7 +4,7 @@ import caliban.parsing.adt.Directive
 
 import scala.annotation.StaticAnnotation
 
-object Annotations {
+object Annotations extends AnnotationsVersionSpecific {
 
   /**
    * Annotation used to indicate a type or a field is deprecated.
@@ -65,7 +65,4 @@ object Annotations {
    * Annotation to specify the default value of an input field
    */
   case class GQLDefault(value: String) extends StaticAnnotation
-
-  // FIXME: Add in a version-specific trait
-  case class GQLField() extends StaticAnnotation
 }

--- a/core/src/main/scala/caliban/schema/Annotations.scala
+++ b/core/src/main/scala/caliban/schema/Annotations.scala
@@ -65,4 +65,7 @@ object Annotations {
    * Annotation to specify the default value of an input field
    */
   case class GQLDefault(value: String) extends StaticAnnotation
+
+  // FIXME: Add in a version-specific trait
+  case class GQLField() extends StaticAnnotation
 }


### PR DESCRIPTION
Currently, derivation of graphql fields works only with case class arguments. With this PR, we add a new annotation (available for Scala 3 only) which allows us to annotate a method to include in field derivation. This is useful in cases that a field can be resolved from the values of other fields, e.g.,

```scala
case class Stock(apples: Int, oranges: Int) {
  @GQLField def total: Int = apples + oranges
}
```

The methods can also be annotated with any other annotation that is normally used to annotate case class fields:

```scala
case class Stock(apples: Int, oranges: Int) {
  @GQLField
  @GQLDescription("The total number of fruits in stock")
  def total: Int = apples + oranges
}
```

Derivation via this case class methods relies partially on Java runtime reflection. This is mostly because the macros required for compiler-based derivation are extremely complex and very hard to maintain. This means that this annotation should NOT be used when Ahead-of-time compilation is required (e.g., GraalVM native-image).

Regarding Scala 2: We could potentially add this method to Scala 2 as well, but we'd have to port the Scala 3 macro to Scala 2 to make this work. Also I'm not too sure whether it's even possible given that we use magnolia for the derivation

PS: I'm not sure regarding the naming of the annotation. Another option is to use `@GQLInclude` (as opposite of `GQLExclude`) - @ghostdogpr any thoughts on the naming?)