### PR TITLE
Add `Step.FailureStep` and helper methods for converting errors into steps

### DIFF
--- a/core/src/main/scala/caliban/interop/circe/circe.scala
+++ b/core/src/main/scala/caliban/interop/circe/circe.scala
@@ -1,15 +1,12 @@
 package caliban.interop.circe
 
-import caliban.Value.{ BooleanValue, EnumValue, FloatValue, IntValue, NullValue, StringValue }
+import caliban.Value._
+import caliban._
 import caliban.introspection.adt.__Type
 import caliban.parsing.adt.LocationInfo
-import caliban.schema.Step.QueryStep
 import caliban.schema.Types.makeScalar
-import caliban.schema.{ ArgBuilder, PureStep, Schema, Step }
-import caliban._
+import caliban.schema.{ ArgBuilder, Schema, Step }
 import io.circe._
-import zio.ZIO
-import zio.query.ZQuery
 
 /**
  * This class is an implementation of the pattern described in https://blog.7mind.io/no-more-orphans.html
@@ -32,8 +29,7 @@ private[caliban] object IsCirceDecoder {
 object json {
   implicit val jsonSchema: Schema[Any, Json]    = new Schema[Any, Json] {
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = makeScalar("Json")
-    override def resolve(value: Json): Step[Any]                           =
-      QueryStep(ZQuery.fromZIO(ZIO.fromEither(Decoder[ResponseValue].decodeJson(value))).map(PureStep.apply))
+    override def resolve(value: Json): Step[Any]                           = Step.fromEither(Decoder[ResponseValue].decodeJson(value))
   }
   implicit val jsonArgBuilder: ArgBuilder[Json] = (input: InputValue) => Right(Encoder[InputValue].apply(input))
 

--- a/core/src/main/scala/caliban/interop/play/play.scala
+++ b/core/src/main/scala/caliban/interop/play/play.scala
@@ -1,16 +1,13 @@
 package caliban.interop.play
 
-import caliban.Value.{ BooleanValue, EnumValue, FloatValue, IntValue, NullValue, StringValue }
+import caliban.Value._
+import caliban._
 import caliban.introspection.adt.__Type
 import caliban.parsing.adt.LocationInfo
-import caliban.schema.Step.QueryStep
 import caliban.schema.Types.makeScalar
-import caliban.schema.{ ArgBuilder, PureStep, Schema, Step }
-import caliban._
-import play.api.libs.json.{ JsPath, JsValue, Json, JsonValidationError, Reads, Writes }
+import caliban.schema.{ ArgBuilder, Schema, Step }
 import play.api.libs.functional.syntax._
-import zio.ZIO
-import zio.query.ZQuery
+import play.api.libs.json._
 
 import scala.util.Try
 
@@ -42,8 +39,7 @@ object json {
         .map(parsingException)
 
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = makeScalar("Json")
-    override def resolve(value: JsValue): Step[Any]                        =
-      QueryStep(ZQuery.fromZIO(ZIO.fromEither(parse(value))).map(PureStep.apply))
+    override def resolve(value: JsValue): Step[Any]                        = Step.fromEither(parse(value))
   }
   implicit val jsonArgBuilder: ArgBuilder[JsValue] = (input: InputValue) => Right(Json.toJson(input))
 
@@ -178,7 +174,6 @@ object json {
 
   private[caliban] object GraphQLResponsePlayJson {
     import play.api.libs.json._
-    import play.api.libs.json.Json.toJson
 
     val graphQLResponseWrites: Writes[GraphQLResponse[Any]] =
       Writes(r => ValuePlayJson.responseValueWrites.writes(r.toResponseValue))

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -220,7 +220,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     override def resolve(value: A): Step[Any] = {
       val asString = repr(value)
       if (validEnumValues.contains(asString)) PureStep(EnumValue(asString))
-      else QueryStep(ZQuery.fail(ExecutionError(s"Invalid enum value '$asString'")))
+      else Step.fail(s"Invalid enum value '$asString'")
     }
   }
 
@@ -475,7 +475,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
               Right(_)
             )
           )
-            .fold(error => QueryStep(ZQuery.fail(error)), value => ev2.resolve(f(value)))
+            .fold(error => Step.fail(error), value => ev2.resolve(f(value)))
 
         }
       private def handleInput[T](onWrapped: => T)(onUnwrapped: => T): T =

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -127,8 +127,8 @@ package object tapir {
                     .fromZIO(ZIO.fromEither(argBuilder.build(InputValue.ObjectValue(replacedArgs))))
                     .flatMap(input => serverEndpoint.logic(queryMonadError)(())(input))
                     .map {
-                      case Left(error: Throwable) => QueryStep(ZQuery.fail(error))
-                      case Left(otherError)       => QueryStep(ZQuery.fail(new Throwable(otherError.toString)))
+                      case Left(error: Throwable) => Step.fail(error)
+                      case Left(otherError)       => Step.fail(otherError.toString)
                       case Right(output)          => outputSchema.resolve(output)
                     }
                 )


### PR DESCRIPTION
This PR adds helper methods (mostly for use internally) to convert errors and `Either[Throwable, ResponseValue]` into a query step.

Note that we could potentially create a concrete `FailureStep` but that might be too much of an overkill