### PR TITLE
Implement `path` via `PathValue` instead of Either[String, Int] for paths

### DIFF
--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -14,7 +14,6 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
 
 import java.nio.charset.StandardCharsets.UTF_8
-import scala.util.Try
 import scala.util.control.NonFatal
 
 final private class QuickRequestHandler[-R, E](interpreter: GraphQLInterpreter[R, E]) {
@@ -103,11 +102,7 @@ final private class QuickRequestHandler[-R, E](interpreter: GraphQLInterpreter[R
         .flatMap(v => ZIO.attempt(readFromArray[A](v.toArray)))
         .orElseFail(Response.badRequest)
 
-    def parsePath(path: String): List[Either[String, Int]] =
-      path.split('.').toList.map { segment =>
-        try Right(segment.toInt)
-        catch { case _: NumberFormatException => Left(segment) }
-      }
+    def parsePath(path: String): List[PathValue] = path.split('.').toList.map(PathValue.parse)
 
     for {
       partsMap   <- request.body.asMultipartForm.mapBoth(_ => Response.internalServerError, _.map)

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -1,7 +1,7 @@
 package caliban
 
 import caliban.ResponseValue.{ ListValue, ObjectValue }
-import caliban.Value.{ IntValue, StringValue }
+import caliban.Value.StringValue
 import caliban.interop.circe.{ IsCirceDecoder, IsCirceEncoder }
 import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.play.{ IsPlayJsonReads, IsPlayJsonWrites }
@@ -68,7 +68,7 @@ object CalibanError {
    */
   case class ExecutionError(
     msg: String,
-    path: List[Either[String, Int]] = Nil,
+    path: List[PathValue] = Nil,
     locationInfo: Option[LocationInfo] = None,
     innerThrowable: Option[Throwable] = None,
     extensions: Option[ObjectValue] = None
@@ -80,15 +80,7 @@ object CalibanError {
         List(
           "message"    -> Some(StringValue(msg)),
           "locations"  -> locationInfo.map(li => ListValue(List(li.toResponseValue))),
-          "path"       -> Some(path).collect {
-            case p if p.nonEmpty =>
-              ListValue(
-                p.map {
-                  case Left(value)  => StringValue(value)
-                  case Right(value) => IntValue(value)
-                }
-              )
-          },
+          "path"       -> Some(path).collect { case p if p.nonEmpty => ListValue(p) },
           "extensions" -> extensions
         ).collect { case (name, Some(v)) => name -> v }
       )

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -1,14 +1,15 @@
 package caliban
 
-import scala.util.Try
+import caliban.Value.StringValue
 import caliban.interop.circe._
-import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.play.{ IsPlayJsonReads, IsPlayJsonWrites }
+import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 import caliban.rendering.ValueRenderer
 import zio.stream.Stream
 
+import scala.util.control.NonFatal
 import scala.util.hashing.MurmurHash3
 
 sealed trait InputValue { self =>
@@ -104,26 +105,26 @@ object ResponseValue {
 
 sealed trait Value extends InputValue with ResponseValue
 object Value {
-  case object NullValue                   extends Value {
+  case object NullValue                   extends Value                {
     override def toString: String = "null"
   }
-  sealed trait IntValue                   extends Value {
+  sealed trait IntValue                   extends Value                {
     def toInt: Int
     def toLong: Long
     def toBigInt: BigInt
   }
-  sealed trait FloatValue                 extends Value {
+  sealed trait FloatValue                 extends Value                {
     def toFloat: Float
     def toDouble: Double
     def toBigDecimal: BigDecimal
   }
-  case class StringValue(value: String)   extends Value {
+  case class StringValue(value: String)   extends Value with PathValue {
     override def toString: String = s""""${value.replace("\"", "\\\"").replace("\n", "\\n")}""""
   }
-  case class BooleanValue(value: Boolean) extends Value {
+  case class BooleanValue(value: Boolean) extends Value                {
     override def toString: String = if (value) "true" else "false"
   }
-  case class EnumValue(value: String)     extends Value {
+  case class EnumValue(value: String)     extends Value                {
     override def toString: String      = s""""${value.replace("\"", "\\\"")}""""
     override def toInputString: String = ValueRenderer.enumInputValueRenderer.render(this)
   }
@@ -132,24 +133,35 @@ object Value {
     def apply(v: Int): IntValue    = IntNumber(v)
     def apply(v: Long): IntValue   = LongNumber(v)
     def apply(v: BigInt): IntValue = BigIntNumber(v)
-    def apply(s: String): IntValue =
-      Try(IntNumber(s.toInt)) orElse
-        Try(LongNumber(s.toLong)) getOrElse
-        BigIntNumber(BigInt(s))
 
-    final case class IntNumber(value: Int)       extends IntValue {
+    @deprecated("Use `fromStringUnsafe` instead", "2.5.0")
+    def apply(s: String): IntValue = fromStringUnsafe(s)
+
+    @throws[NumberFormatException]("if the string is not a valid representation of an integer")
+    def fromStringUnsafe(s: String): IntValue =
+      try {
+        val mod  = if (s.charAt(0) == '-') 1 else 0
+        val size = s.length - mod
+        if (size < 10) IntNumber(s.toInt)
+        else if (size < 19) LongNumber(s.toLong)
+        else BigIntNumber(BigInt(s))
+      } catch {
+        case NonFatal(_) => BigIntNumber(BigInt(s)) // Should never happen, but we leave it as a fallback
+      }
+
+    final case class IntNumber(value: Int)       extends IntValue with PathValue {
       override def toInt: Int       = value
       override def toLong: Long     = value.toLong
       override def toBigInt: BigInt = BigInt(value)
       override def toString: String = value.toString
     }
-    final case class LongNumber(value: Long)     extends IntValue {
+    final case class LongNumber(value: Long)     extends IntValue                {
       override def toInt: Int       = value.toInt
       override def toLong: Long     = value
       override def toBigInt: BigInt = BigInt(value)
       override def toString: String = value.toString
     }
-    final case class BigIntNumber(value: BigInt) extends IntValue {
+    final case class BigIntNumber(value: BigInt) extends IntValue                {
       override def toInt: Int       = value.toInt
       override def toLong: Long     = value.toLong
       override def toBigInt: BigInt = value
@@ -181,5 +193,51 @@ object Value {
       override def toBigDecimal: BigDecimal = value
       override def toString: String         = value.toString
     }
+  }
+}
+
+sealed trait PathValue extends Value {
+  def isKey: Boolean = this match {
+    case StringValue(_) => true
+    case _              => false
+  }
+}
+
+object PathValue {
+  def fromEither(either: Either[String, Int]): PathValue = either.fold(Key.apply, Index.apply)
+
+  object Key   {
+    def apply(value: String): PathValue           = Value.StringValue(value)
+    def unapply(value: PathValue): Option[String] = value match {
+      case Value.StringValue(s) => Some(s)
+      case _                    => None
+    }
+  }
+  object Index {
+    def apply(value: Int): PathValue           = Value.IntValue.IntNumber(value)
+    def unapply(value: PathValue): Option[Int] = value match {
+      case Value.IntValue.IntNumber(i) => Some(i)
+      case _                           => None
+    }
+  }
+
+  /**
+   * This function parses a string and returns a PathValue.
+   * If the string contains only digits, it returns a `PathValue.Index`.
+   * Otherwise, it returns a `PathValue.Key`.
+   *
+   * @param value the string to parse
+   * @return a PathValue which is either an `Index` if the string is numeric, or a `Key` otherwise
+   */
+  def parse(value: String): PathValue = {
+    var i    = 0
+    val size = value.length
+    while (i < size) {
+      val c = value.charAt(i)
+      if (c >= '0' && c <= '9') i += 1
+      else return PathValue.Key(value)
+    }
+    try PathValue.Index(value.toInt)
+    catch { case NonFatal(_) => PathValue.Key(value) } // Should never happen, just a fallback
   }
 }

--- a/core/src/main/scala/caliban/execution/Deferred.scala
+++ b/core/src/main/scala/caliban/execution/Deferred.scala
@@ -1,9 +1,10 @@
 package caliban.execution
 
+import caliban.PathValue
 import caliban.schema.ReducedStep
 
 case class Deferred[-R](
-  path: List[Either[String, Int]],
+  path: List[PathValue],
   step: ReducedStep[R],
   label: Option[String]
 )

--- a/core/src/main/scala/caliban/execution/FieldInfo.scala
+++ b/core/src/main/scala/caliban/execution/FieldInfo.scala
@@ -1,12 +1,13 @@
 package caliban.execution
 
+import caliban.PathValue
 import caliban.introspection.adt.__Type
 import caliban.parsing.adt.Directive
 
 case class FieldInfo(
   name: String,
   details: Field,
-  path: List[Either[String, Int]],
+  path: List[PathValue],
   directives: List[Directive] = Nil,
   parent: Option[__Type]
 )

--- a/core/src/main/scala/caliban/interop/circe/circe.scala
+++ b/core/src/main/scala/caliban/interop/circe/circe.scala
@@ -120,10 +120,10 @@ object json {
       } yield LocationInfo(column, line)
     )
 
-    private implicit val pathEitherDecoder: Decoder[Either[String, Int]] = Decoder.instance { cursor =>
+    private implicit val pathEitherDecoder: Decoder[PathValue] = Decoder.instance { cursor =>
       (cursor.as[String].toOption, cursor.as[Int].toOption) match {
-        case (Some(s), _) => Right(Left(s))
-        case (_, Some(n)) => Right(Right(n))
+        case (Some(s), _) => Right(PathValue.Key(s))
+        case (_, Some(n)) => Right(PathValue.Index(n))
         case _            => Left(DecodingFailure("failed to decode as string or int", cursor.history))
       }
     }
@@ -133,7 +133,7 @@ object json {
     implicit val errorValueDecoder: Decoder[CalibanError] = Decoder.instance(cursor =>
       for {
         message    <- cursor.downField("message").as[String]
-        path       <- cursor.downField("path").as[Option[List[Either[String, Int]]]]
+        path       <- cursor.downField("path").as[Option[List[PathValue]]]
         locations  <- cursor.downField("locations").downArray.as[Option[LocationInfo]]
         extensions <- cursor.downField("extensions").as[Option[ResponseValue.ObjectValue]]
       } yield CalibanError.ExecutionError(

--- a/core/src/main/scala/caliban/interop/play/play.scala
+++ b/core/src/main/scala/caliban/interop/play/play.scala
@@ -161,8 +161,8 @@ object json {
             .value
             .toList
             .map {
-              case JsString(s)  => Left(s)
-              case JsNumber(bd) => Right(bd.toInt)
+              case JsString(s)  => PathValue.Key(s)
+              case JsNumber(bd) => PathValue.Index(bd.toInt)
               case _            => throw new Exception("invalid json")
             },
           locationInfo = e.locations.flatMap(_.headOption),

--- a/core/src/main/scala/caliban/interop/zio/zio.scala
+++ b/core/src/main/scala/caliban/interop/zio/zio.scala
@@ -1,7 +1,7 @@
 package caliban.interop.zio
 
+import caliban.Value._
 import caliban._
-import caliban.Value.{ BooleanValue, EnumValue, FloatValue, IntValue, NullValue, StringValue }
 import caliban.parsing.adt.LocationInfo
 import zio.Chunk
 import zio.json.{ JsonDecoder, JsonEncoder }
@@ -377,11 +377,12 @@ private[caliban] object ErrorZioJson {
     message: String,
     extensions: Option[ResponseValue.ObjectValue],
     locations: Option[List[LocationInfo]],
-    path: Option[List[Either[String, Int]]]
+    path: Option[List[PathValue]]
   )
   private object ErrorDTO {
     implicit val locationInfoDecoder: JsonDecoder[LocationInfo]                     = DeriveJsonDecoder.gen[LocationInfo]
-    implicit val pathDecoder: JsonDecoder[Either[String, Int]]                      = JsonDecoder[String].orElseEither(JsonDecoder[Int])
+    implicit val pathDecoder: JsonDecoder[PathValue]                                =
+      JsonDecoder[String].map(PathValue.Key(_)) orElse JsonDecoder[Int].map(PathValue.Index(_))
     implicit val responseObjectValueDecoder: JsonDecoder[ResponseValue.ObjectValue] = ValueZIOJson.Obj.responseDecoder
     implicit val decoder: JsonDecoder[ErrorDTO]                                     = DeriveJsonDecoder.gen[ErrorDTO]
   }

--- a/core/src/main/scala/caliban/parsing/parsers/NumberParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/NumberParsers.scala
@@ -10,7 +10,7 @@ private[caliban] trait NumberParsers extends StringParsers {
   def integerPart(implicit ev: P[Any]): P[Unit]  = P(
     (negativeSign.? ~~ "0") | (negativeSign.? ~~ nonZeroDigit ~~ digit.repX)
   )
-  def intValue(implicit ev: P[Any]): P[IntValue] = integerPart.!.map(IntValue(_))
+  def intValue(implicit ev: P[Any]): P[IntValue] = integerPart.!.map(IntValue.fromStringUnsafe)
 
   def sign(implicit ev: P[Any]): P[Unit]              = P("-" | "+")
   def exponentIndicator(implicit ev: P[Any]): P[Unit] = P(CharIn("eE"))

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -3,7 +3,7 @@ package caliban.schema
 import caliban.CalibanError.ExecutionError
 import caliban.Value.NullValue
 import caliban.execution.{ Field, FieldInfo }
-import caliban.{ InputValue, ResponseValue }
+import caliban.{ InputValue, PathValue, ResponseValue }
 import zio.query.ZQuery
 import zio.stream.ZStream
 
@@ -93,7 +93,7 @@ object ReducedStep {
   case class DeferStep[-R](
     obj: ReducedStep[R],
     deferred: List[(ReducedStep[R], Option[String])],
-    path: List[Either[String, Int]]
+    path: List[PathValue]
   ) extends ReducedStep[R]
 
   // PureStep is both a Step and a ReducedStep so it is defined outside this object

--- a/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
@@ -7,7 +7,7 @@ import caliban.execution.FieldInfo
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations.GQLDirective
 import caliban.wrappers.Wrapper.{ EffectfulWrapper, FieldWrapper, OverallWrapper }
-import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, ResponseValue }
+import caliban._
 import zio._
 import zio.query.ZQuery
 
@@ -67,7 +67,7 @@ object ApolloCaching {
 
   case class CacheHint(
     fieldName: String = "",
-    path: List[Either[String, Int]] = Nil,
+    path: List[PathValue] = Nil,
     maxAge: Duration,
     scope: CacheScope
   ) {
@@ -75,7 +75,7 @@ object ApolloCaching {
     def toResponseValue: ResponseValue =
       ObjectValue(
         List(
-          "path"   -> ListValue((Left(fieldName) :: path).reverse.map(_.fold(StringValue.apply, IntValue(_)))),
+          "path"   -> ListValue((PathValue.Key(fieldName) :: path).reverse),
           "maxAge" -> IntValue(maxAge.toMillis / 1000),
           "scope"  -> StringValue(scope match {
             case CacheScope.Private => "PRIVATE"

--- a/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloTracing.scala
@@ -9,7 +9,7 @@ import caliban.execution.{ ExecutionRequest, FieldInfo }
 import caliban.parsing.adt.Document
 import caliban.rendering.DocumentRenderer
 import caliban.wrappers.Wrapper.{ EffectfulWrapper, FieldWrapper, OverallWrapper, ParsingWrapper, ValidationWrapper }
-import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, ResponseValue }
+import caliban.{ CalibanError, GraphQLRequest, GraphQLResponse, PathValue, ResponseValue }
 import zio._
 import zio.query.ZQuery
 
@@ -69,7 +69,7 @@ object ApolloTracing {
   }
 
   case class Resolver(
-    path: List[Either[String, Int]] = Nil,
+    path: List[PathValue] = Nil,
     parentType: String = "",
     fieldName: String = "",
     returnType: String = "",
@@ -79,10 +79,7 @@ object ApolloTracing {
     def toResponseValue: ResponseValue =
       ObjectValue(
         List(
-          "path"        -> ListValue((Left(fieldName) :: path).reverse.map {
-            case Left(s)  => StringValue(s)
-            case Right(i) => IntValue(i)
-          }),
+          "path"        -> ListValue((PathValue.Key(fieldName) :: path).reverse),
           "parentType"  -> StringValue(parentType),
           "fieldName"   -> StringValue(fieldName),
           "returnType"  -> StringValue(returnType),

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -468,7 +468,7 @@ object ExecutionSpec extends ZIOSpecDefault {
             response.errors == List(
               ExecutionError(
                 "Effect failure",
-                List(Left("a"), Left("b"), Left("c")),
+                List(StringValue("a"), StringValue("b"), StringValue("c")),
                 Some(LocationInfo(21, 5)),
                 Some(e)
               )
@@ -784,7 +784,7 @@ object ExecutionSpec extends ZIOSpecDefault {
             assertTrue(result.data.toString == """{"user1":{"name":"user","friends":["friend"]},"user2":null}""") &&
               assertTrue(
                 result.errors.collectFirst { case e: ExecutionError => e }.map(_.path).get ==
-                  List(Left("user2"), Left("friends"))
+                  List(StringValue("user2"), StringValue("friends"))
               )
           )
       },

--- a/core/src/test/scala/caliban/interop/circe/GraphQLResponseCirceSpec.scala
+++ b/core/src/test/scala/caliban/interop/circe/GraphQLResponseCirceSpec.scala
@@ -4,7 +4,7 @@ import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.Value.{ IntValue, StringValue }
 import caliban.parsing.adt.LocationInfo
-import caliban.{ CalibanError, GraphQLResponse }
+import caliban.{ CalibanError, GraphQLResponse, PathValue }
 import io.circe._
 import io.circe.parser.decode
 import io.circe.syntax._
@@ -89,7 +89,7 @@ object GraphQLResponseCirceSpec extends ZIOSpecDefault {
               errors = List(
                 ExecutionError(
                   "boom",
-                  path = List(Left("step"), Right(0)),
+                  path = List(PathValue.Key("step"), PathValue.Index(0)),
                   locationInfo = Some(LocationInfo(1, 2)),
                   extensions = Some(
                     ObjectValue(

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
@@ -4,7 +4,7 @@ import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.Value.{ IntValue, StringValue }
 import caliban.parsing.adt.LocationInfo
-import caliban.{ CalibanError, GraphQLResponse, TestUtils }
+import caliban.{ CalibanError, GraphQLResponse, PathValue, TestUtils }
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import zio.test.Assertion.equalTo
 import zio.test.{ assert, assertTrue, ZIOSpecDefault }
@@ -72,11 +72,11 @@ object GraphQLResponseJsoniterSpec extends ZIOSpecDefault {
         assert(readFromString[GraphQLResponse[CalibanError]](req))(
           equalTo(
             GraphQLResponse(
-              data = ObjectValue(List("value" -> IntValue("42"))),
+              data = ObjectValue(List("value" -> IntValue(42))),
               errors = List(
                 ExecutionError(
                   "boom",
-                  path = List(Left("step"), Right(0)),
+                  path = List(PathValue.Key("step"), PathValue.Index(0)),
                   locationInfo = Some(LocationInfo(1, 2)),
                   extensions = Some(
                     ObjectValue(

--- a/core/src/test/scala/caliban/interop/play/GraphQLResponsePlaySpec.scala
+++ b/core/src/test/scala/caliban/interop/play/GraphQLResponsePlaySpec.scala
@@ -2,8 +2,8 @@ package caliban.interop.play
 
 import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue.{ ListValue, ObjectValue }
-import caliban.{ CalibanError, GraphQLResponse, Value }
-import caliban.Value.StringValue
+import caliban.{ CalibanError, GraphQLResponse, PathValue, Value }
+import caliban.Value.{ IntValue, StringValue }
 import caliban.parsing.adt.LocationInfo
 import play.api.libs.json._
 import zio.test.Assertion._
@@ -87,11 +87,11 @@ object GraphQLResponsePlaySpec extends ZIOSpecDefault {
           isRight(
             equalTo(
               GraphQLResponse(
-                data = ObjectValue(List("value" -> Value.IntValue("42"))),
+                data = ObjectValue(List("value" -> Value.IntValue(42))),
                 errors = List(
                   ExecutionError(
                     "boom",
-                    path = List(Left("step"), Right(0)),
+                    path = List(PathValue.Key("step"), PathValue.Index(0)),
                     locationInfo = Some(LocationInfo(1, 2)),
                     extensions = Some(
                       ObjectValue(

--- a/core/src/test/scala/caliban/interop/zio/GraphQLResponseZIOSpec.scala
+++ b/core/src/test/scala/caliban/interop/zio/GraphQLResponseZIOSpec.scala
@@ -4,7 +4,7 @@ import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.Value.{ IntValue, StringValue }
 import caliban.parsing.adt.LocationInfo
-import caliban.{ CalibanError, GraphQLResponse }
+import caliban.{ CalibanError, GraphQLResponse, PathValue }
 import zio.json._
 import zio.test.Assertion.{ equalTo, isRight }
 import zio.test.{ assert, assertTrue, ZIOSpecDefault }
@@ -73,11 +73,11 @@ object GraphQLResponseZIOSpec extends ZIOSpecDefault {
           isRight(
             equalTo(
               GraphQLResponse(
-                data = ObjectValue(List("value" -> IntValue("42"))),
+                data = ObjectValue(List("value" -> IntValue(42))),
                 errors = List(
                   ExecutionError(
                     "boom",
-                    path = List(Left("step"), Right(0)),
+                    path = List(PathValue.Key("step"), PathValue.Index(0)),
                     locationInfo = Some(LocationInfo(1, 2)),
                     extensions = Some(
                       ObjectValue(

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/HttpUploadInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/HttpUploadInterpreter.scala
@@ -1,5 +1,6 @@
 package caliban.interop.tapir
 
+import caliban.Value.{ IntValue, StringValue }
 import caliban._
 import caliban.interop.tapir.TapirAdapter._
 import caliban.uploads.{ FileMeta, GraphQLUploadRequest, Uploads }
@@ -23,8 +24,7 @@ sealed trait HttpUploadInterpreter[-R, E] { self =>
     serverRequest: ServerRequest
   )(implicit streamConstructor: StreamConstructor[BS]): ZIO[R, TapirResponse, CalibanResponse[BS]]
 
-  private def parsePath(path: String): List[Either[String, Int]] =
-    path.split('.').map(c => Try(c.toInt).toEither.left.map(_ => c)).toList
+  private def parsePath(path: String): List[PathValue] = path.split('.').map(PathValue.parse).toList
 
   def serverEndpoint[R1 <: R, S](streams: Streams[S])(implicit
     streamConstructor: StreamConstructor[streams.BinaryStream],


### PR DESCRIPTION
This is more of an experiment just to see what we think.

So, what's wrong with `Either[String, Int]`? There are 2 things that are kind of wrong with it:

1. From a UX / dev perspective, It can be unclear on what it means unless you understand the structure of a graphql path
2. From a performance perspective, it causes unnecessary object allocations and boxing of Ints in the Executor.

With this PR, we substitute the `Either[String, Int]` with `PathValue`, a sealed trait that is extended by `StringValue` and `IntValue.IntNumber`. In a world where we've all migrated to Scala 3, this could have easily been a `type PathValue = StringValue | IntValue.IntNumber` but unfortunately we have to make the code compatible with Scala 2 🥲.

I also made a few changes to some of the methods used to parse paths / IntValues from String to avoid wrapping them in `Try` (which causes boxing) and avoid throwing exceptions as a control flow mechanism