### PR TITLE
Run `codegenScriptedScala3` with Scala 2.12 as the base version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.18 codegenScriptedScala3
+      - run: sbt 'set ThisBuild / scalaVersion := "2.12.18"; codegenScriptedScala3'
       - save_cache:
           key: sbtcache
           paths:


### PR DESCRIPTION
Since we've changed the base version to Scala 2.13, the `codegenScriptedScala3` script has been taking an abnormally long time to run (some cases ~10 mins). I had a look at the logs, and it seems that it's been publishing all Scala versions during the `+publish` command whereas it's supposed to only publish for Scala 2.12 and Scala 3.

With this change, the script runs much faster as it doesn't publish the modules for Scala 2.13