### PR TITLE
Create sbt submodules per scala version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.18 core/test http4s/test akkaHttp/test pekkoHttp/test zioHttp/test quickAdapter/test catsInterop/test tools/test codegenSbt/test clientJVM/test monixInterop/compile tapirInterop/test federation/test reporting/test tracing/test
+      - run: sbt ++2.12.18 rootJVM212/Test/compile rootJVM212/test
       - save_cache:
           key: sbtcache
           paths:
@@ -68,7 +68,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.12 core/test http4s/test akkaHttp/test pekkoHttp/test play/test zioHttp/test quickAdapter/test examples/compile catsInterop/test benchmarks/compile monixInterop/compile tapirInterop/test clientJVM/test tools/test federation/test reporting/test tracing/test
+      - run: sbt ++2.13.12 rootJVM213/Test/compile rootJVM213/test examples/compile benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -83,7 +83,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.12 core/test http4s/test akkaHttp/test pekkoHttp/test play/test zioHttp/test quickAdapter/test examples/compile catsInterop/test benchmarks/compile monixInterop/compile tapirInterop/test clientJVM/test tools/test federation/test reporting/test tracing/test
+      - run: sbt ++2.13.12 rootJVM213/Test/compile rootJVM213/test examples/compile benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -98,7 +98,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.3.1 core/test catsInterop/test benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile zioHttp/test quickAdapter/test tapirInterop/test pekkoHttp/test http4s/test play/test federation/test tools/test reporting/test tracing/test
+      - run: sbt ++3.3.1 rootJVM3/Test/compile rootJVM3/test benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -113,7 +113,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.3.1 core/test catsInterop/test benchmarks/compile monixInterop/compile clientJVM/test clientJS/compile zioHttp/test quickAdapter/test tapirInterop/test pekkoHttp/test http4s/test play/test federation/test tools/test reporting/test tracing/test
+      - run: sbt ++3.3.1 rootJVM3/Test/compile rootJVM3/test benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.18 rootJVM212/Test/compile rootJVM212/test
+      - run: sbt ++2.12.18 rootJVM212/compile rootJVM212/test
       - save_cache:
           key: sbtcache
           paths:
@@ -68,7 +68,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.12 rootJVM213/Test/compile rootJVM213/test examples/compile benchmarks/compile
+      - run: sbt ++2.13.12 rootJVM213/compile rootJVM213/test examples/compile benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -83,7 +83,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.12 rootJVM213/Test/compile rootJVM213/test examples/compile benchmarks/compile
+      - run: sbt ++2.13.12 rootJVM213/compile rootJVM213/test examples/compile benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -98,7 +98,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.3.1 rootJVM3/Test/compile rootJVM3/test benchmarks/compile
+      - run: sbt ++3.3.1 rootJVM3/compile rootJVM3/test benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -113,7 +113,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.3.1 rootJVM3/Test/compile rootJVM3/test benchmarks/compile
+      - run: sbt ++3.3.1 rootJVM3/compile rootJVM3/test benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.12.18 rootJVM212/compile rootJVM212/test
+      - run: sbt ++2.12.18 rootJVM212/test
       - save_cache:
           key: sbtcache
           paths:
@@ -68,7 +68,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.12 rootJVM213/compile rootJVM213/test examples/compile benchmarks/compile
+      - run: sbt ++2.13.12 rootJVM213/test examples/compile benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -83,7 +83,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++2.13.12 rootJVM213/compile rootJVM213/test examples/compile benchmarks/compile
+      - run: sbt ++2.13.12 rootJVM213/test examples/compile benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -98,7 +98,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.3.1 rootJVM3/compile rootJVM3/test benchmarks/compile
+      - run: sbt ++3.3.1 rootJVM3/test benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:
@@ -113,7 +113,7 @@ jobs:
       - checkout
       - restore_cache:
           key: sbtcache
-      - run: sbt ++3.3.1 rootJVM3/compile rootJVM3/test benchmarks/compile
+      - run: sbt ++3.3.1 rootJVM3/test benchmarks/compile
       - save_cache:
           key: sbtcache
           paths:

--- a/build.sbt
+++ b/build.sbt
@@ -76,12 +76,8 @@ addCommandAlias(
   "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck"
 )
 
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(ScalaJSPlugin)
-  .settings(publish / skip := true)
-  .settings(crossScalaVersions := Nil)
-  .aggregate(
+lazy val allProjects: Seq[ProjectReference] =
+  List(
     macros,
     core,
     http4s,
@@ -103,6 +99,51 @@ lazy val root = project
     reporting,
     tracing
   )
+
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(publish / skip := true)
+  .settings(crossScalaVersions := Nil)
+  .aggregate(allProjects *)
+
+lazy val rootJVM212 = project
+  .in(file("target/rootJVM212"))
+  .settings(
+    crossScalaVersions := Nil,
+    publish / skip     := true,
+    ideSkipProject     := true
+  )
+  .settings(crossScalaVersions := Nil)
+  .aggregate({
+    val excluded: Set[ProjectReference] = Set(clientJS, clientNative, clientLaminext, play)
+    allProjects.filterNot(excluded.contains)
+  } *)
+
+lazy val rootJVM213 = project
+  .in(file("target/rootJVM213"))
+  .settings(
+    crossScalaVersions := Nil,
+    publish / skip     := true,
+    ideSkipProject     := true
+  )
+  .settings(crossScalaVersions := Nil)
+  .aggregate({
+    val excluded: Set[ProjectReference] = Set(clientJS, clientNative, clientLaminext, codegenSbt)
+    allProjects.filterNot(excluded.contains)
+  } *)
+
+lazy val rootJVM3 = project
+  .in(file("target/rootJVM3"))
+  .settings(
+    crossScalaVersions := Nil,
+    publish / skip     := true,
+    ideSkipProject     := true
+  )
+  .aggregate({
+    val excluded: Set[ProjectReference] = Set(clientJS, clientNative, clientLaminext, codegenSbt, akkaHttp)
+    allProjects.filterNot(excluded.contains)
+  } *)
 
 lazy val macros = project
   .in(file("macros"))

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 inThisBuild(
   List(
-    scalaVersion             := scala213, // Change to control IntelliJ's highlighting
+    scalaVersion             := scala213,
     crossScalaVersions       := allScala,
     organization             := "com.github.ghostdogpr",
     homepage                 := Some(url("https://github.com/ghostdogpr/caliban")),
@@ -60,7 +60,7 @@ inThisBuild(
       )
     ),
     versionScheme            := Some("pvp"),
-    ConsoleHelper.welcomeMessage,
+    ConsoleHelper.welcomeMessage(scala212, scala213, scala3),
     // See https://github.com/playframework/playframework/issues/11461#issuecomment-1276028512
     // Can be removed when the entire Scala ecosystem has migrated to Scala 2.12.17+, sbt 1.8.x, and moved away from scala-xml v1 in general.
     libraryDependencySchemes ++= Seq(
@@ -114,7 +114,6 @@ lazy val rootJVM212 = project
     publish / skip     := true,
     ideSkipProject     := true
   )
-  .settings(crossScalaVersions := Nil)
   .aggregate({
     val excluded: Set[ProjectReference] = Set(clientJS, clientNative, clientLaminext, play)
     allProjects.filterNot(excluded.contains)
@@ -127,7 +126,6 @@ lazy val rootJVM213 = project
     publish / skip     := true,
     ideSkipProject     := true
   )
-  .settings(crossScalaVersions := Nil)
   .aggregate({
     val excluded: Set[ProjectReference] = Set(clientJS, clientNative, clientLaminext, codegenSbt)
     allProjects.filterNot(excluded.contains)

--- a/project/ConsoleHelper.scala
+++ b/project/ConsoleHelper.scala
@@ -9,6 +9,7 @@ object ConsoleHelper {
 
   def welcomeMessage(scala212Version: String, scala213Version: String, scala3Version: String) =
     onLoadMessage := {
+      val scalaVersions = s"++$scala212Version; ++$scala213Version; ++$scala3Version"
       raw"""|${header(s"""   ____      _ _ _                 """)}
             |${header(s"""  / ___|__ _| (_) |__   __ _ _ __  """)}
             |${header(s""" | |   / _` | | | '_ \\ / _` | '_ \\ """)}
@@ -24,11 +25,6 @@ object ConsoleHelper {
             |${item("examples/runMain example.quick.ExampleApp")} - Start the example server
             |${item("benchmarks/jmh:run")} - Run the benchmarks
             |${item("+publishLocal")} - Publish caliban locally
-            |
-            |Changing scala versions:
-            |${item(s"++$scala212Version")}
-            |${item(s"++$scala213Version")}
-            |${item(s"++$scala3Version")}""".stripMargin
+            |${item(scalaVersions)} - Changing scala versions""".stripMargin
     }
-
 }

--- a/project/ConsoleHelper.scala
+++ b/project/ConsoleHelper.scala
@@ -1,4 +1,4 @@
-import sbt.Keys._
+import sbt.Keys.*
 
 object ConsoleHelper {
   def prompt: String               = s"${Console.CYAN}>${Console.RESET} "
@@ -7,8 +7,13 @@ object ConsoleHelper {
   def item(text: String): String =
     s"${Console.RED}> ${Console.CYAN}$text${Console.RESET}"
 
-  def welcomeMessage =
-    onLoadMessage :=
+  def addCurrent(version: String, current: String) =
+    if (version == current)
+      s"${Console.YELLOW}(current)${Console.RESET}"
+    else ""
+
+  def welcomeMessage(scala212Version: String, scala213Version: String, scala3Version: String) =
+    onLoadMessage := {
       raw"""|${header(s"""   ____      _ _ _                 """)}
             |${header(s"""  / ___|__ _| (_) |__   __ _ _ __  """)}
             |${header(s""" | |   / _` | | | '_ \\ / _` | '_ \\ """)}
@@ -17,12 +22,18 @@ object ConsoleHelper {
             |
             |Useful sbt tasks:
             |${item("~compile")} - Compile all modules with file-watch enabled
-            |${item("test")} - Run the unit test suite
+            |${item("+test")} - Run the unit test suite for all modules and Scala versions
+            |${item(s"++$scala3Version; rootJVM3/test")} - Run tests for all JVM modules in Scala 3
             |${item("fmt")} - Run scalafmt on the entire project
             |${item("scripted")} - Run the scripted test suite
-            |${item("examples/runMain example.http4s.ExampleApp")} - Start the example server (http4s based)
-            |${item("examples/runMain example.akkahttp.ExampleApp")} - Start the example server (akka-http based)
+            |${item("examples/runMain example.quick.ExampleApp")} - Start the example server
             |${item("benchmarks/jmh:run")} - Run the benchmarks
-            |${item("+publishLocal")} - Publish caliban locally""".stripMargin
+            |${item("+publishLocal")} - Publish caliban locally
+            |
+            |Changing scala versions:
+            |${item(s"++$scala212Version")}
+            |${item(s"++$scala213Version")}
+            |${item(s"++$scala3Version")}""".stripMargin
+    }
 
 }

--- a/project/ConsoleHelper.scala
+++ b/project/ConsoleHelper.scala
@@ -7,11 +7,6 @@ object ConsoleHelper {
   def item(text: String): String =
     s"${Console.RED}> ${Console.CYAN}$text${Console.RESET}"
 
-  def addCurrent(version: String, current: String) =
-    if (version == current)
-      s"${Console.YELLOW}(current)${Console.RESET}"
-    else ""
-
   def welcomeMessage(scala212Version: String, scala213Version: String, scala3Version: String) =
     onLoadMessage := {
       raw"""|${header(s"""   ____      _ _ _                 """)}


### PR DESCRIPTION
This allows us to run the compile / test all modules for a given Scala version which makes dev experience a bit better. e.g., to run all the test suites for Scala 3, all we need to run is `sbt ++3.3.1 rootJVM3/test`.

In addition to improving dev experience, it also makes CI run faster as SBT can parallelise the compiling of SBT modules & test execution