### PR TITLE
Make Document serialization friendly-ier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,8 @@ lazy val core = project
         "io.circe"                              %% "circe-parser"          % circeVersion    % Test,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % jsoniterVersion % Optional,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterVersion % Provided,
-        "org.playframework"                     %% "play-json"             % playJsonVersion % Optional
+        "org.playframework"                     %% "play-json"             % playJsonVersion % Optional,
+        "org.apache.commons"                     % "commons-lang3"         % "3.14.0"        % Test
       )
   )
   .dependsOn(macros)

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -12,10 +12,10 @@ import zio.stream.Stream
 import scala.util.control.NonFatal
 import scala.util.hashing.MurmurHash3
 
-sealed trait InputValue { self =>
+sealed trait InputValue extends Serializable { self =>
   def toInputString: String = ValueRenderer.inputValueRenderer.renderCompact(self)
 }
-object InputValue       {
+object InputValue {
   case class ListValue(values: List[InputValue])          extends InputValue {
     override def toString: String      = values.mkString("[", ",", "]")
     override def toInputString: String = ValueRenderer.inputListValueRenderer.render(this)
@@ -46,7 +46,7 @@ object InputValue       {
     caliban.interop.play.json.ValuePlayJson.inputValueReads.asInstanceOf[F[InputValue]]
 }
 
-sealed trait ResponseValue { self =>
+sealed trait ResponseValue extends Serializable { self =>
 
   /**
    * Performs a deep merge of two response values. This currently means that the list values will be concatenated, and
@@ -74,8 +74,8 @@ object ResponseValue {
     override def toString: String =
       ValueRenderer.responseObjectValueRenderer.renderCompact(this)
 
-    override lazy val hashCode: Int          = MurmurHash3.unorderedHash(fields)
-    override def equals(other: Any): Boolean =
+    @transient override lazy val hashCode: Int = MurmurHash3.unorderedHash(fields)
+    override def equals(other: Any): Boolean   =
       other match {
         case o: ObjectValue => o.hashCode == hashCode
         case _              => false

--- a/core/src/main/scala/caliban/parsing/SourceMapper.scala
+++ b/core/src/main/scala/caliban/parsing/SourceMapper.scala
@@ -6,7 +6,7 @@ import fastparse.internal.Util
 /**
  * Maps an index to the "friendly" version of an index based on the underlying source.
  */
-trait SourceMapper {
+trait SourceMapper extends Serializable {
 
   def getLocation(index: Int): LocationInfo
 

--- a/core/src/main/scala/caliban/parsing/adt/Definition.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Definition.scala
@@ -8,7 +8,7 @@ import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.{
 }
 import caliban.parsing.adt.Type.NamedType
 
-sealed trait Definition
+sealed trait Definition extends Serializable
 
 object Definition {
   sealed trait ExecutableDefinition extends Definition
@@ -48,7 +48,7 @@ object Definition {
       locations: Set[DirectiveLocation]
     ) extends TypeSystemDefinition
 
-    sealed trait DirectiveLocation
+    sealed trait DirectiveLocation extends Serializable
     object DirectiveLocation {
       sealed trait ExecutableDirectiveLocation extends DirectiveLocation
       object ExecutableDirectiveLocation {

--- a/core/src/main/scala/caliban/parsing/adt/Document.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Document.scala
@@ -8,46 +8,38 @@ import caliban.parsing.adt.Definition.TypeSystemDefinition.{ DirectiveDefinition
 import caliban.parsing.adt.OperationType.{ Mutation, Query, Subscription }
 
 case class Document(definitions: List[Definition], sourceMapper: SourceMapper) {
-  lazy val isIntrospection: Boolean                                    = Introspector.isIntrospection(this)
-  lazy val directiveDefinitions: List[DirectiveDefinition]             = definitions.collect { case dd: DirectiveDefinition =>
-    dd
-  }
-  lazy val typeDefinitions: List[TypeDefinition]                       = definitions.collect { case td: TypeDefinition =>
-    td
-  }
-  lazy val objectTypeDefinitions: List[ObjectTypeDefinition]           = definitions.collect { case td: ObjectTypeDefinition =>
-    td
-  }
-  lazy val inputObjectTypeDefinitions: List[InputObjectTypeDefinition] = definitions.collect {
-    case td: InputObjectTypeDefinition => td
-  }
-  lazy val interfaceTypeDefinitions: List[InterfaceTypeDefinition]     = definitions.collect {
-    case td: InterfaceTypeDefinition => td
-  }
-  lazy val enumTypeDefinitions: List[EnumTypeDefinition]               = definitions.collect { case td: EnumTypeDefinition =>
-    td
-  }
-  lazy val scalarTypeDefinitions: List[ScalarTypeDefinition]           = definitions.collect { case td: ScalarTypeDefinition =>
-    td
-  }
-  lazy val unionTypeDefinitions: List[UnionTypeDefinition]             = definitions.collect { case td: UnionTypeDefinition =>
-    td
-  }
-  lazy val fragmentDefinitions: List[FragmentDefinition]               = definitions.collect { case fd: FragmentDefinition =>
-    fd
-  }
-  lazy val schemaDefinition: Option[SchemaDefinition]                  = definitions.collectFirst { case sd: SchemaDefinition =>
-    sd
-  }
-  lazy val operationDefinitions: List[OperationDefinition]             = definitions.collect { case od: OperationDefinition =>
-    od
-  }
-  lazy val queryDefinitions: List[OperationDefinition]                 =
-    definitions.collect { case od: OperationDefinition => od }.filter(q => q.operationType == Query)
-  lazy val mutationDefinitions: List[OperationDefinition]              =
-    definitions.collect { case od: OperationDefinition => od }.filter(q => q.operationType == Mutation)
-  lazy val subscriptionDefinitions: List[OperationDefinition]          =
-    definitions.collect { case od: OperationDefinition => od }.filter(q => q.operationType == Subscription)
+
+  lazy val isIntrospection: Boolean = Introspector.isIntrospection(this)
+
+  @transient lazy val directiveDefinitions: List[DirectiveDefinition]             =
+    definitions.collect { case dd: DirectiveDefinition => dd }
+  @transient lazy val typeDefinitions: List[TypeDefinition]                       =
+    definitions.collect { case td: TypeDefinition => td }
+  @transient lazy val objectTypeDefinitions: List[ObjectTypeDefinition]           =
+    definitions.collect { case td: ObjectTypeDefinition => td }
+  @transient lazy val inputObjectTypeDefinitions: List[InputObjectTypeDefinition] =
+    definitions.collect { case td: InputObjectTypeDefinition => td }
+  @transient lazy val interfaceTypeDefinitions: List[InterfaceTypeDefinition]     =
+    definitions.collect { case td: InterfaceTypeDefinition => td }
+  @transient lazy val enumTypeDefinitions: List[EnumTypeDefinition]               =
+    definitions.collect { case td: EnumTypeDefinition => td }
+  @transient lazy val scalarTypeDefinitions: List[ScalarTypeDefinition]           =
+    definitions.collect { case td: ScalarTypeDefinition => td }
+  @transient lazy val unionTypeDefinitions: List[UnionTypeDefinition]             =
+    definitions.collect { case td: UnionTypeDefinition => td }
+  @transient lazy val fragmentDefinitions: List[FragmentDefinition]               =
+    definitions.collect { case fd: FragmentDefinition => fd }
+  @transient lazy val schemaDefinition: Option[SchemaDefinition]                  =
+    definitions.collectFirst { case sd: SchemaDefinition => sd }
+  @transient lazy val operationDefinitions: List[OperationDefinition]             =
+    definitions.collect { case od: OperationDefinition => od }
+  @transient lazy val queryDefinitions: List[OperationDefinition]                 =
+    definitions.collect { case od: OperationDefinition if od.operationType == Query => od }
+  @transient lazy val mutationDefinitions: List[OperationDefinition]              =
+    definitions.collect { case od: OperationDefinition if od.operationType == Mutation => od }
+  @transient lazy val subscriptionDefinitions: List[OperationDefinition]          =
+    definitions.collect { case od: OperationDefinition if od.operationType == Subscription => od }
+
   def objectTypeDefinition(name: String): Option[ObjectTypeDefinition] =
     objectTypeDefinitions.find(t => t.name == name)
 }

--- a/core/src/main/scala/caliban/parsing/adt/OperationType.scala
+++ b/core/src/main/scala/caliban/parsing/adt/OperationType.scala
@@ -1,6 +1,6 @@
 package caliban.parsing.adt
 
-sealed trait OperationType
+sealed trait OperationType extends Serializable
 
 object OperationType {
   case object Query        extends OperationType

--- a/core/src/main/scala/caliban/parsing/adt/Selection.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Selection.scala
@@ -3,8 +3,8 @@ package caliban.parsing.adt
 import caliban.InputValue
 import caliban.parsing.adt.Type.NamedType
 
-sealed trait Selection {
-  final override lazy val hashCode: Int = super.hashCode()
+sealed trait Selection extends Serializable {
+  @transient final override lazy val hashCode: Int = super.hashCode()
 }
 
 object Selection {

--- a/core/src/main/scala/caliban/parsing/adt/Type.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Type.scala
@@ -2,9 +2,9 @@ package caliban.parsing.adt
 
 import scala.annotation.tailrec
 
-sealed trait Type { self =>
+sealed trait Type extends Serializable { self =>
   val nonNull: Boolean
-  lazy val nullable: Boolean = !nonNull
+  def nullable: Boolean = !nonNull
 
   override def toString: String = self match {
     case Type.NamedType(name, nonNull)  => if (nonNull) s"$name!" else name

--- a/core/src/main/scala/caliban/parsing/adt/Type.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Type.scala
@@ -4,7 +4,7 @@ import scala.annotation.tailrec
 
 sealed trait Type extends Serializable { self =>
   val nonNull: Boolean
-  def nullable: Boolean = !nonNull
+  lazy val nullable: Boolean = !nonNull
 
   override def toString: String = self match {
     case Type.NamedType(name, nonNull)  => if (nonNull) s"$name!" else name

--- a/core/src/test/scala/caliban/parsing/DocumentSpec.scala
+++ b/core/src/test/scala/caliban/parsing/DocumentSpec.scala
@@ -1,0 +1,17 @@
+package caliban.parsing
+
+import caliban.TestUtils
+import org.apache.commons.lang3.SerializationUtils
+import zio._
+import zio.test._
+
+object DocumentSpec extends ZIOSpecDefault {
+  def spec = suite("DocumentSpec")(
+    test("is serializable") {
+      for {
+        doc1 <- Parser.parseQuery(TestUtils.introspectionQuery)
+        doc2 <- ZIO.attempt(SerializationUtils.roundtrip(doc1))
+      } yield assertTrue(doc1 == doc2)
+    }
+  )
+}


### PR DESCRIPTION
Main motivation behind this is that in Apollo Persisted Queries, we cache the document so that parsing / validation can be skipped for queries matching the provided hash. In case that we cache in local memory what we currently have works fine, but it's not very friendly for caching in remote caches like Redis. This PR changes 2 things to make a `Document` a bit more serialization-friendly:

1. Extend all possible traits contained within the definitions with `Serializable`. While this is not strictly required, it prevents us from accidentally extending those sealed traits with non-case classes / objects
2. Annotate lazy vals with `@transient` so that they're not serialized, improving serde performance and reducing storage costs