### PR TITLE
codegen: Generate `@lazy` fields with abstract effect

### DIFF
--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -676,6 +676,54 @@ object SchemaWriterSpec extends ZIOSpecDefault {
         |}""".stripMargin
     ),
     (
+      "recognize @lazy intention and generate side-effecting field with abstracted effect type",
+      gen(
+        """
+        |directive @lazy on FIELD_DEFINITION
+        |
+        |type Foo {
+        |  bar: String!
+        |  baz: String! @lazy
+        |}""",
+        effect = "F",
+        isEffectTypeAbstract = true
+      ),
+      """object Types {
+        |
+        |  final case class Foo[F[_]](bar: String, baz: F[String])
+        |
+        |}"""
+    ),
+    (
+      "generate nested @lazy fields with abstracted effect type",
+      gen(
+        """
+        |directive @lazy on FIELD_DEFINITION
+        |
+        |type Foo {
+        |  bar: Bar!
+        |}
+        |
+        |type Bar {
+        |  baz: Baz! @lazy
+        |}
+        |
+        |type Baz {
+        |  x: String!
+        |  y: String! @lazy
+        |}""",
+        effect = "F",
+        isEffectTypeAbstract = true
+      ),
+      """object Types {
+        |
+        |  final case class Foo[F[_]](bar: Bar[F])
+        |  final case class Bar[F[_]](baz: F[Baz[F]])
+        |  final case class Baz[F[_]](x: String, y: F[String])
+        |
+        |}"""
+    ),
+    (
       "type appears in type union and implements interface",
       gen(
         """


### PR DESCRIPTION
Hello!

We use a heavily customized version of the Caliban code generator at $Work and would like to contribute back some of our changes. Caliban recently added support for the `@lazy` directive, the point of this PR is to improve its support for code with abstract effect (`F[_]`). Codegen currently generates code that won't compile due to a missing abstract type parameter in case classes:

```scala
type Foo {
  bar: String!
  baz: String! @lazy
}

object Types {
  final case class Foo(bar: String, baz: F[String])
}
```

This PR adds a couple tests and changes for object and nested lazy fields generation.