### PR TITLE
Add annotations for forcing object fields as nullable / non-nullable

### DIFF
--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -148,12 +148,17 @@ private object DerivationUtils {
     getDescription(annotations),
     fields.map { (name, fieldAnnotations, schema) =>
       val deprecatedReason = getDeprecatedReason(fieldAnnotations)
+      val isOptional       = {
+        val hasNullableAnn = fieldAnnotations.contains(GQLNullable())
+        val hasNonNullAnn  = fieldAnnotations.contains(GQLNonNullable())
+        !hasNonNullAnn && (hasNullableAnn || schema.optional)
+      }
       Types.makeField(
         name,
         getDescription(fieldAnnotations),
         schema.arguments,
         () =>
-          if (schema.optional) schema.toType_(isInput, isSubscription)
+          if (isOptional) schema.toType_(isInput, isSubscription)
           else schema.toType_(isInput, isSubscription).nonNull,
         deprecatedReason.isDefined,
         deprecatedReason,

--- a/core/src/main/scala/caliban/schema/Annotations.scala
+++ b/core/src/main/scala/caliban/schema/Annotations.scala
@@ -65,4 +65,15 @@ object Annotations extends AnnotationsVersionSpecific {
    * Annotation to specify the default value of an input field
    */
   case class GQLDefault(value: String) extends StaticAnnotation
+
+  /**
+   * Annotation that can be applied to force a field to be derived as nullable
+   */
+  case class GQLNullable() extends StaticAnnotation
+
+  /**
+   * Annotation that can be applied to force a field to be derived as non-nullable
+   */
+  case class GQLNonNullable() extends StaticAnnotation
+
 }


### PR DESCRIPTION
This change is primarily useful for users that use cats-effect or Futures in their schemas, as they'll be able to force fallible effectual fields to be derived as non-nullable / nullable