### PR TITLE
Ensure fields are unique after merge

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -10,6 +10,7 @@ import caliban.parsing.adt.{ Directive, LocationInfo, Selection, VariableDefinit
 import caliban.schema.{ RootType, Types }
 import caliban.{ InputValue, Value }
 
+import scala.collection.compat._
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -47,7 +47,10 @@ case class Field(
 
   def combine(other: Field): Field =
     self.copy(
-      fields = self.fields ::: other.fields,
+      fields =
+        if (self.fields.isEmpty) other.fields
+        else if (other.fields.isEmpty) self.fields
+        else (self.fields ++ other.fields).distinctBy(f => (f.aliasedName, f._condition)),
       targets = (self.targets, other.targets) match {
         case (Some(t1), Some(t2)) => if (t1 == t2) self.targets else Some(t1 ++ t2)
         case (Some(_), None)      => self.targets

--- a/core/src/test/scala/caliban/execution/FieldSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldSpec.scala
@@ -154,7 +154,7 @@ object FieldSpec extends ZIOSpecDefault {
                 FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"))),
                 FieldTree.Leaf("id", "String!"),
                 FieldTree.Leaf("count", "Int!"),
-                FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!")))
+                FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"), FieldTree.Leaf("num", "Int!")))
               )
             )
           )

--- a/core/src/test/scala/caliban/execution/FieldSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldSpec.scala
@@ -154,7 +154,7 @@ object FieldSpec extends ZIOSpecDefault {
                 FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"))),
                 FieldTree.Leaf("id", "String!"),
                 FieldTree.Leaf("count", "Int!"),
-                FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!"), FieldTree.Leaf("num", "Int!")))
+                FieldTree.Node("inner", "Inner!", List(FieldTree.Leaf("num", "Int!")))
               )
             )
           )

--- a/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
@@ -265,7 +265,8 @@ object SchemaDerivationIssuesSpec extends ZIOSpecDefault {
         i       <- schema.interpreter
         data1   <- i.execute(queryFragments).map(_.data.toString)
         data2   <- i.execute(queryInlined).map(_.data.toString)
-        expected = """{"widget":{"__typename":"WidgetA","name":"a","children":{"total":1,"nodes":[{"name":"a"}]}}}"""
+        expected =
+          """{"widget":{"__typename":"WidgetB","name":"a","children":{"total":1,"nodes":[{"name":"a","foo":"FOO"}]}}}"""
       } yield assertTrue(data1 == expected, data2 == expected)
     }
   )
@@ -610,7 +611,7 @@ object i2076 {
 
   val schema = {
     val queries = Queries(
-      Some(Widget.A("a", _ => ZIO.succeed(Widget.A.Connection(1, Chunk(Widget.A.Child("a", "FOO"))))))
+      Some(Widget.B("a", _ => ZIO.succeed(Widget.B.Connection(1, Chunk(Widget.B.Child("a", "FOO"))))))
     )
     graphQL(RootResolver(queries))
   }

--- a/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
@@ -1,11 +1,10 @@
 package caliban.schema
 
-import caliban.schema.Annotations.{ GQLDescription, GQLInterface, GQLName, GQLUnion }
-import zio.Chunk
-import zio.test.ZIOSpecDefault
-import zio.test._
-import caliban.{ graphQL, RootResolver }
 import caliban.Macros._
+import caliban.schema.Annotations.{ GQLDescription, GQLInterface, GQLName, GQLUnion }
+import caliban.{ graphQL, RootResolver }
+import zio.test.{ ZIOSpecDefault, _ }
+import zio.{ Chunk, ZIO }
 
 object SchemaDerivationIssuesSpec extends ZIOSpecDefault {
   def spec = suite("SchemaDerivationIssuesSpec")(
@@ -211,6 +210,63 @@ object SchemaDerivationIssuesSpec extends ZIOSpecDefault {
         res <- i.execute(gqldoc("{ e1 { b } e2 { b } e3 { b } }"))
         data = res.data.toString
       } yield assertTrue(data == """{"e1":{"b":"b"},"e2":{"b":"b"},"e3":{"b":"b"}}""")
+    },
+    test("i2076") {
+      import i2076._
+      val queryFragments =
+        gqldoc("""
+            query {
+              widget {
+                __typename
+                ...Widgets
+              }
+            }
+
+            fragment Widgets on Widget {
+              ... on WidgetA {
+                name
+                children {
+                  total
+                  nodes { name }
+                }
+              }
+              ... on WidgetB {
+                name
+                children {
+                  total
+                  nodes { name foo }
+                }
+              }
+            }
+            """)
+
+      val queryInlined = gqldoc("""
+          query {
+            widget {
+              __typename
+              ... on WidgetA {
+                name
+                children {
+                  total
+                  nodes { name }
+                }
+              }
+              ... on WidgetB {
+                name
+                children {
+                  total
+                  nodes { name foo }
+                }
+              }
+            }
+          }
+          """)
+      for {
+        i       <- schema.interpreter
+        data1   <- i.execute(queryFragments).map(_.data.toString)
+        data2   <- i.execute(queryInlined).map(_.data.toString)
+        expected = """{"widget":{"__typename":"WidgetA","name":"a","children":{"total":1,"nodes":[{"name":"a"}]}}}"""
+      } yield assertTrue(data1 == expected, data2 == expected)
     }
   )
 }
@@ -488,5 +544,74 @@ object NestedInterfaceIssue {
       NestedInterface.FooC("c", "b")
     )
     caliban.graphQL(RootResolver(queries))
+  }
+}
+
+object i2076 {
+  sealed trait Widget
+  object Widget  {
+    implicit val schema: Schema[Any, Widget] = Schema.gen
+
+    case class Args(limit: Option[Int])
+    object Args {
+      implicit val schema: Schema[Any, Args]    = Schema.gen
+      implicit val argBuilder: ArgBuilder[Args] = ArgBuilder.gen
+    }
+
+    @GQLName("WidgetA")
+    case class A(
+      name: String,
+      children: Args => ZIO[Any, Throwable, A.Connection]
+    ) extends Widget
+    object A    {
+      implicit val schema: Schema[Any, A] = Schema.gen
+
+      @GQLName("WidgetAConnection")
+      case class Connection(total: Int, nodes: Chunk[Child])
+      object Connection {
+        implicit val schema: Schema[Any, Connection] = Schema.gen
+      }
+
+      @GQLName("WidgetAChild")
+      case class Child(name: String, foo: String)
+      object Child      {
+        implicit val schema: Schema[Any, Child] = Schema.gen
+      }
+    }
+
+    @GQLName("WidgetB")
+    case class B(
+      name: String,
+      children: Args => ZIO[Any, Throwable, B.Connection]
+    ) extends Widget
+    object B    {
+      implicit val schema: Schema[Any, B] = Schema.gen
+
+      @GQLName("WidgetBConnection")
+      case class Connection(total: Int, nodes: Chunk[Child])
+      object Connection {
+        implicit val schema: Schema[Any, Connection] = Schema.gen
+      }
+
+      @GQLName("WidgetBChild")
+      case class Child(name: String, foo: String)
+      object Child      {
+        implicit val schema: Schema[Any, Child] = Schema.gen
+      }
+    }
+  }
+
+  case class Queries(
+    widget: Option[Widget]
+  )
+  object Queries {
+    implicit val schema: Schema[Any, Queries] = Schema.gen
+  }
+
+  val schema = {
+    val queries = Queries(
+      Some(Widget.A("a", _ => ZIO.succeed(Widget.A.Connection(1, Chunk(Widget.A.Child("a", "FOO"))))))
+    )
+    graphQL(RootResolver(queries))
   }
 }


### PR DESCRIPTION
Fixes #2076.

Some of the optimizations we did for 2.5.0 required us to rely more heavily on the deduplication happening during the construction of Field. Unfortunately, we missed an edge case where fields with the same name and condition still made it through in the list of fields. ~~To solve this, we need to ensure that fields being merged as part of `combine` are unique~~

EDIT: To solve this, we check for name & condition uniqueness within the Executor. To avoid the additional overhead, we "cache" the uniqueness flag as a lazy val on `Field`.