### PR TITLE
Propagate type condition from nested fragments to parent

### DIFF
--- a/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
@@ -227,7 +227,7 @@ object SchemaDerivationIssuesSpec extends ZIOSpecDefault {
                 name
                 children {
                   total
-                  nodes { name }
+                  nodes { name bar }
                 }
               }
               ... on WidgetB {
@@ -248,7 +248,7 @@ object SchemaDerivationIssuesSpec extends ZIOSpecDefault {
                 name
                 children {
                   total
-                  nodes { name }
+                  nodes { name bar }
                 }
               }
               ... on WidgetB {
@@ -574,7 +574,7 @@ object i2076 {
       }
 
       @GQLName("WidgetAChild")
-      case class Child(name: String, foo: String)
+      case class Child(name: String, foo: String, bar: String)
       object Child      {
         implicit val schema: Schema[Any, Child] = Schema.gen
       }


### PR DESCRIPTION
Fix for sub-issue for #2076.

In short, when we have nested fragments with type conditions, we propagate the subtype selection to the top-level fragment.

@guymers, would you by any chance be able to publish this branch locally and test it against your schema to make sure I didn't accidentally cause something else to start failing. It shouldn't, but there might be some edge-case that we didn't account for