### PR TITLE
Typesafe directive - for wrapping case classes on fields (incl. input types) and arguments

### DIFF
--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/build.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/build.sbt
@@ -1,0 +1,28 @@
+import _root_.caliban.tools.Codegen
+
+lazy val base = project
+  .in(file("modules/base"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.ghostdogpr" %% "caliban" % Version.pluginVersion
+    )
+  )
+
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(CalibanPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.ghostdogpr" %% "caliban" % Version.pluginVersion
+    ),
+    Compile / caliban / calibanSettings ++= Seq(
+      calibanSetting(file("src/main/graphql/schema.graphql"))(
+        _.genType(Codegen.GenType.Schema)
+          .clientName("GeneratedAPI")
+          .packageName("graphql")
+          .effect("MyZQuery")
+          .scalarMapping("ID" -> "String")
+      )
+    )
+  )
+  .dependsOn(base)

--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/modules/base/src/main/scala/graphql/package.scala
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/modules/base/src/main/scala/graphql/package.scala
@@ -1,0 +1,7 @@
+import zio.query.ZQuery
+
+package object graphql {
+  type Env         = Any
+  type FID         = Int
+  type MyZQuery[A] = ZQuery[Env, Throwable, A]
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/project/Version.scala
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/project/Version.scala
@@ -1,0 +1,7 @@
+object Version {
+  def pluginVersion: String =
+    sys.props.get("plugin.version") match {
+      case Some(x) => x
+      case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                                   |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+    }}

--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/project/plugins.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/src/main/graphql/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/src/main/graphql/schema.graphql
@@ -1,0 +1,34 @@
+directive @newtype(name : String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+scalar FID
+
+type Query {
+    getFoo(
+        id: ID! @newtype(name: "CustomId"),
+        maybeId : ID @newtype(name: "ACustomIdOpt")
+        maybeAllIDsOpt: [ID] @newtype(name: "AMaybeInnerIdOpt")
+    ): Foo
+}
+
+type Mutation {
+    updateFoo(foo: FooInput!): Foo
+}
+
+type Foo {
+    id : ID! @newtype(name: "CustomId")
+    strId : String! @newtype(name: "CustomStrId")
+    intId : Int! @newtype(name: "CustomIntId")
+    fid : FID! @newtype(name: "CustomFId")
+    maybeId : ID @newtype(name: "CustomIdOpt")
+    IDs : [ID!]!
+    allIDs : [ID!]! @newtype(name: "InnerId")
+    allIDsOpt: [ID]! @newtype(name: "InnerOptId")
+    mapbeAllIDs: [ID!] @newtype(name: "MaybeInnerId")
+    mapbeAllIDsOpt: [ID] @newtype(name: "MaybeInnerIdOpt")
+}
+
+input FooInput {
+    id : ID! @newtype(name: "CustomId")
+    allIDs : [ID!]! @newtype(name: "IInnerId")
+    maybeAllIDsOpt: [ID] @newtype(name: "IMaybeInnerIdOpt")
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/test
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/test
@@ -1,0 +1,6 @@
+> compile
+
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/GeneratedAPI.scala
+$ exec sh verify.sh Foo target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/GeneratedAPI.scala
+$ exec sh verify.sh FooInput target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/GeneratedAPI.scala
+$ exec sh verify.sh CustomId target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/GeneratedAPI.scala

--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/verify.sh
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if grep -q "$1" "$2"; then
+  echo "$1 exists in $2"
+  exit 0
+else
+  echo "$1 is missing in $2"
+  exit 1
+fi

--- a/core/src/main/scala/caliban/parsing/adt/Directive.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Directive.scala
@@ -6,21 +6,20 @@ case class Directive(name: String, arguments: Map[String, InputValue] = Map.empt
 
 object Directives {
 
-  val LazyDirective      = "lazy"
-  val TypesafeDirective  = "typesafe"
-  val DeprecatedDiretive = "deprecated"
+  val LazyDirective       = "lazy"
+  val NewtypeDirective    = "newtype"
+  val DeprecatedDirective = "deprecated"
 
   def isDeprecated(directives: List[Directive]): Boolean =
-    directives.exists(_.name == DeprecatedDiretive)
+    directives.exists(_.name == DeprecatedDirective)
 
   def deprecationReason(directives: List[Directive]): Option[String] =
-    findDirective(directives, DeprecatedDiretive, "reason")
+    findDirective(directives, DeprecatedDirective, "reason")
 
-  def isTypesafe(directives: List[Directive]): Boolean          =
-    directives.exists(_.name == TypesafeDirective)
-  def typesafeName(directives: List[Directive]): Option[String] =
-    Directives
-      .findDirective(directives, TypesafeDirective, "name")
+  def isNewType(directives: List[Directive]): Boolean          =
+    directives.exists(_.name == NewtypeDirective)
+  def newTypeName(directives: List[Directive]): Option[String] =
+    findDirective(directives, NewtypeDirective, "name")
 
   private def findDirective(directives: List[Directive], name: String, argument: String): Option[String] =
     directives.collectFirst {

--- a/core/src/main/scala/caliban/parsing/adt/Directive.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Directive.scala
@@ -5,17 +5,32 @@ import caliban.{ InputValue, Value }
 case class Directive(name: String, arguments: Map[String, InputValue] = Map.empty, index: Int = 0)
 
 object Directives {
+
+  val LazyDirective      = "lazy"
+  val TypesafeDirective  = "typesafe"
+  val DeprecatedDiretive = "deprecated"
+
   def isDeprecated(directives: List[Directive]): Boolean =
-    directives.exists(_.name == "deprecated")
+    directives.exists(_.name == DeprecatedDiretive)
 
   def deprecationReason(directives: List[Directive]): Option[String] =
+    findDirective(directives, DeprecatedDiretive, "reason")
+
+  def isTypesafe(directives: List[Directive]): Boolean          =
+    directives.exists(_.name == TypesafeDirective)
+  def typesafeName(directives: List[Directive]): Option[String] =
+    Directives
+      .findDirective(directives, TypesafeDirective, "name")
+
+  private def findDirective(directives: List[Directive], name: String, argument: String): Option[String] =
     directives.collectFirst {
-      case f if f.name == "deprecated" =>
+      case f if f.name == name =>
         f.arguments
-          .get("reason")
+          .get(argument)
           .flatMap(_ match {
             case Value.StringValue(value) => Some(value)
             case _                        => None
           })
     }.flatten
+
 }

--- a/core/src/main/scala/caliban/parsing/adt/Directive.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Directive.scala
@@ -6,9 +6,9 @@ case class Directive(name: String, arguments: Map[String, InputValue] = Map.empt
 
 object Directives {
 
-  val LazyDirective       = "lazy"
-  val NewtypeDirective    = "newtype"
-  val DeprecatedDirective = "deprecated"
+  final val LazyDirective       = "lazy"
+  final val NewtypeDirective    = "newtype"
+  final val DeprecatedDirective = "deprecated"
 
   def isDeprecated(directives: List[Directive]): Boolean =
     directives.exists(_.name == DeprecatedDirective)

--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -220,8 +220,8 @@ object SchemaWriter {
 
       s"""case class $fnName(value : $newtype) extends AnyVal
          |object $fnName {
-         |    implicit val schema: Schema[Any, $fnName] = summon[Schema[Any, $newtype]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[$fnName] = summon[ArgBuilder[$newtype]].map($fnName(_))
+         |    implicit val schema: Schema[Any, $fnName] = implicitly[Schema[Any, $newtype]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[$fnName] = implicitly[ArgBuilder[$newtype]].map($fnName(_))
          |}""".stripMargin
     }
 

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -1,6 +1,7 @@
 package caliban.tools
 
 import caliban.parsing.Parser
+import caliban.parsing.adt.Directives.NewtypeDirective
 import zio.Task
 import zio.test._
 
@@ -785,18 +786,18 @@ object SchemaWriterSpec extends ZIOSpecDefault {
         |}""".stripMargin
     ),
     (
-      "generate typesafe ids with @typesafe directive fields of types, input types and arguments",
+      "generate typesafe ids with @newtype directive, for fields on types, input types and arguments",
       gen(
-        """
-          |directive @typesafe(name : String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+        s"""
+          |directive @$NewtypeDirective(name : String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
           |
           |scalar FID
           |
           |type Query {
           | getFoo(
-          |   id: ID! @typesafe(name: "CustomId"),
-          |   maybeId : ID @typesafe(name: "ACustomIdOpt")
-          |   mapbeAllIDsOpt: [ID] @typesafe(name: "AMaybeInnerIdOpt")
+          |   id: ID! @$NewtypeDirective(name: "CustomId"),
+          |   maybeId : ID @$NewtypeDirective(name: "ACustomIdOpt")
+          |   mapbeAllIDsOpt: [ID] @$NewtypeDirective(name: "AMaybeInnerIdOpt")
           | ): Foo
           |}
           |
@@ -805,151 +806,151 @@ object SchemaWriterSpec extends ZIOSpecDefault {
           |}
           |
           |type Foo {
-          |  id : ID! @typesafe(name: "CustomId")
-          |  strId : String! @typesafe(name: "CustomStrId")
-          |  intId : Int! @typesafe(name: "CustomIntId")
-          |  fid : FID! @typesafe(name: "CustomFId")
-          |  maybeId : ID @typesafe(name: "CustomIdOpt")
+          |  id : ID! @$NewtypeDirective(name: "CustomId")
+          |  strId : String! @$NewtypeDirective(name: "CustomStrId")
+          |  intId : Int! @$NewtypeDirective(name: "CustomIntId")
+          |  fid : FID! @$NewtypeDirective(name: "CustomFId")
+          |  maybeId : ID @$NewtypeDirective(name: "CustomIdOpt")
           |  IDs : [ID!]!
-          |  allIDs : [ID!]! @typesafe(name: "InnerId")
-          |  allIDsOpt: [ID]! @typesafe(name: "InnerOptId")
-          |  mapbeAllIDs: [ID!] @typesafe(name: "MaybeInnerId")
-          |  mapbeAllIDsOpt: [ID] @typesafe(name: "MaybeInnerIdOpt")
+          |  allIDs : [ID!]! @$NewtypeDirective(name: "InnerId")
+          |  allIDsOpt: [ID]! @$NewtypeDirective(name: "InnerOptId")
+          |  mapbeAllIDs: [ID!] @$NewtypeDirective(name: "MaybeInnerId")
+          |  mapbeAllIDsOpt: [ID] @$NewtypeDirective(name: "MaybeInnerIdOpt")
           |}
           |
           |input FooInput {
-          |  id : ID! @typesafe(name: "CustomId")
-          |  allIDs : [ID!]! @typesafe(name: "IInnerId")
-          |  mapbeAllIDsOpt: [ID] @typesafe(name: "IMaybeInnerIdOpt")
+          |  id : ID! @$NewtypeDirective(name: "CustomId")
+          |  allIDs : [ID!]! @$NewtypeDirective(name: "IInnerId")
+          |  mapbeAllIDsOpt: [ID] @$NewtypeDirective(name: "IMaybeInnerIdOpt")
           |}
           |
           |""",
         scalarMappings = Map("ID" -> "String")
       ),
-      """|import Types._
-         |
-         |import caliban.schema.Annotations._
-         |
-         |import caliban.Value._
-         |import caliban.parsing.adt.Directive
-         |import caliban.schema.{ ArgBuilder, Schema }
-         |
-         |object Types {
-         |  final case class QueryGetFooArgs(
-         |    id: CustomId,
-         |    maybeId: scala.Option[ACustomIdOpt],
-         |    mapbeAllIDsOpt: scala.Option[List[scala.Option[AMaybeInnerIdOpt]]]
-         |  )
-         |  final case class MutationUpdateFooArgs(foo: FooInput)
-         |  case class ACustomIdOpt(value: String) extends AnyVal
-         |  object ACustomIdOpt     {
-         |    implicit val schema: Schema[Any, ACustomIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[ACustomIdOpt] = summon[ArgBuilder[String]].map(ACustomIdOpt(_))
-         |  }
-         |  case class AMaybeInnerIdOpt(value: String) extends AnyVal
-         |  object AMaybeInnerIdOpt {
-         |    implicit val schema: Schema[Any, AMaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[AMaybeInnerIdOpt] = summon[ArgBuilder[String]].map(AMaybeInnerIdOpt(_))
-         |  }
-         |  case class CustomFId(value: FID) extends AnyVal
-         |  object CustomFId        {
-         |    implicit val schema: Schema[Any, CustomFId]    = summon[Schema[Any, FID]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[CustomFId] = summon[ArgBuilder[FID]].map(CustomFId(_))
-         |  }
-         |  case class CustomId(value: String) extends AnyVal
-         |  object CustomId         {
-         |    implicit val schema: Schema[Any, CustomId]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[CustomId] = summon[ArgBuilder[String]].map(CustomId(_))
-         |  }
-         |  case class CustomIdOpt(value: String) extends AnyVal
-         |  object CustomIdOpt      {
-         |    implicit val schema: Schema[Any, CustomIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[CustomIdOpt] = summon[ArgBuilder[String]].map(CustomIdOpt(_))
-         |  }
-         |  case class CustomIntId(value: Int) extends AnyVal
-         |  object CustomIntId      {
-         |    implicit val schema: Schema[Any, CustomIntId]    = summon[Schema[Any, Int]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[CustomIntId] = summon[ArgBuilder[Int]].map(CustomIntId(_))
-         |  }
-         |  case class CustomStrId(value: String) extends AnyVal
-         |  object CustomStrId      {
-         |    implicit val schema: Schema[Any, CustomStrId]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[CustomStrId] = summon[ArgBuilder[String]].map(CustomStrId(_))
-         |  }
-         |  case class IInnerId(value: String) extends AnyVal
-         |  object IInnerId         {
-         |    implicit val schema: Schema[Any, IInnerId]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[IInnerId] = summon[ArgBuilder[String]].map(IInnerId(_))
-         |  }
-         |  case class IMaybeInnerIdOpt(value: String) extends AnyVal
-         |  object IMaybeInnerIdOpt {
-         |    implicit val schema: Schema[Any, IMaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[IMaybeInnerIdOpt] = summon[ArgBuilder[String]].map(IMaybeInnerIdOpt(_))
-         |  }
-         |  case class InnerId(value: String) extends AnyVal
-         |  object InnerId          {
-         |    implicit val schema: Schema[Any, InnerId]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[InnerId] = summon[ArgBuilder[String]].map(InnerId(_))
-         |  }
-         |  case class InnerOptId(value: String) extends AnyVal
-         |  object InnerOptId       {
-         |    implicit val schema: Schema[Any, InnerOptId]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[InnerOptId] = summon[ArgBuilder[String]].map(InnerOptId(_))
-         |  }
-         |  case class MaybeInnerId(value: String) extends AnyVal
-         |  object MaybeInnerId     {
-         |    implicit val schema: Schema[Any, MaybeInnerId]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[MaybeInnerId] = summon[ArgBuilder[String]].map(MaybeInnerId(_))
-         |  }
-         |  case class MaybeInnerIdOpt(value: String) extends AnyVal
-         |  object MaybeInnerIdOpt  {
-         |    implicit val schema: Schema[Any, MaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-         |    implicit val argBuilder: ArgBuilder[MaybeInnerIdOpt] = summon[ArgBuilder[String]].map(MaybeInnerIdOpt(_))
-         |  }
-         |  final case class Foo(
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomId"))))
-         |    id: CustomId,
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomStrId"))))
-         |    strId: CustomStrId,
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomIntId"))))
-         |    intId: CustomIntId,
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomFId"))))
-         |    fid: CustomFId,
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomIdOpt"))))
-         |    maybeId: scala.Option[CustomIdOpt],
-         |    IDs: List[String],
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("InnerId"))))
-         |    allIDs: List[InnerId],
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("InnerOptId"))))
-         |    allIDsOpt: List[scala.Option[InnerOptId]],
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("MaybeInnerId"))))
-         |    mapbeAllIDs: scala.Option[List[MaybeInnerId]],
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("MaybeInnerIdOpt"))))
-         |    mapbeAllIDsOpt: scala.Option[List[scala.Option[MaybeInnerIdOpt]]]
-         |  )
-         |  final case class FooInput(
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomId"))))
-         |    id: CustomId,
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("IInnerId"))))
-         |    allIDs: List[IInnerId],
-         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("IMaybeInnerIdOpt"))))
-         |    mapbeAllIDsOpt: scala.Option[List[scala.Option[IMaybeInnerIdOpt]]]
-         |  )
-         |
-         |}
-         |
-         |object Operations {
-         |
-         |  final case class Query(
-         |    getFoo: QueryGetFooArgs => zio.UIO[scala.Option[Foo]]
-         |  )
-         |
-         |  final case class Mutation(
-         |    updateFoo: MutationUpdateFooArgs => zio.UIO[scala.Option[Foo]]
-         |  )
-         |
-         |}
-         |""".stripMargin
+      s"""|import Types._
+          |
+          |import caliban.schema.Annotations._
+          |
+          |import caliban.Value._
+          |import caliban.parsing.adt.Directive
+          |import caliban.schema.{ ArgBuilder, Schema }
+          |
+          |object Types {
+          |  final case class QueryGetFooArgs(
+          |    id: CustomId,
+          |    maybeId: scala.Option[ACustomIdOpt],
+          |    mapbeAllIDsOpt: scala.Option[List[scala.Option[AMaybeInnerIdOpt]]]
+          |  )
+          |  final case class MutationUpdateFooArgs(foo: FooInput)
+          |  case class ACustomIdOpt(value: String) extends AnyVal
+          |  object ACustomIdOpt     {
+          |    implicit val schema: Schema[Any, ACustomIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[ACustomIdOpt] = summon[ArgBuilder[String]].map(ACustomIdOpt(_))
+          |  }
+          |  case class AMaybeInnerIdOpt(value: String) extends AnyVal
+          |  object AMaybeInnerIdOpt {
+          |    implicit val schema: Schema[Any, AMaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[AMaybeInnerIdOpt] = summon[ArgBuilder[String]].map(AMaybeInnerIdOpt(_))
+          |  }
+          |  case class CustomFId(value: FID) extends AnyVal
+          |  object CustomFId        {
+          |    implicit val schema: Schema[Any, CustomFId]    = summon[Schema[Any, FID]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomFId] = summon[ArgBuilder[FID]].map(CustomFId(_))
+          |  }
+          |  case class CustomId(value: String) extends AnyVal
+          |  object CustomId         {
+          |    implicit val schema: Schema[Any, CustomId]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomId] = summon[ArgBuilder[String]].map(CustomId(_))
+          |  }
+          |  case class CustomIdOpt(value: String) extends AnyVal
+          |  object CustomIdOpt      {
+          |    implicit val schema: Schema[Any, CustomIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomIdOpt] = summon[ArgBuilder[String]].map(CustomIdOpt(_))
+          |  }
+          |  case class CustomIntId(value: Int) extends AnyVal
+          |  object CustomIntId      {
+          |    implicit val schema: Schema[Any, CustomIntId]    = summon[Schema[Any, Int]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomIntId] = summon[ArgBuilder[Int]].map(CustomIntId(_))
+          |  }
+          |  case class CustomStrId(value: String) extends AnyVal
+          |  object CustomStrId      {
+          |    implicit val schema: Schema[Any, CustomStrId]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomStrId] = summon[ArgBuilder[String]].map(CustomStrId(_))
+          |  }
+          |  case class IInnerId(value: String) extends AnyVal
+          |  object IInnerId         {
+          |    implicit val schema: Schema[Any, IInnerId]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[IInnerId] = summon[ArgBuilder[String]].map(IInnerId(_))
+          |  }
+          |  case class IMaybeInnerIdOpt(value: String) extends AnyVal
+          |  object IMaybeInnerIdOpt {
+          |    implicit val schema: Schema[Any, IMaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[IMaybeInnerIdOpt] = summon[ArgBuilder[String]].map(IMaybeInnerIdOpt(_))
+          |  }
+          |  case class InnerId(value: String) extends AnyVal
+          |  object InnerId          {
+          |    implicit val schema: Schema[Any, InnerId]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[InnerId] = summon[ArgBuilder[String]].map(InnerId(_))
+          |  }
+          |  case class InnerOptId(value: String) extends AnyVal
+          |  object InnerOptId       {
+          |    implicit val schema: Schema[Any, InnerOptId]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[InnerOptId] = summon[ArgBuilder[String]].map(InnerOptId(_))
+          |  }
+          |  case class MaybeInnerId(value: String) extends AnyVal
+          |  object MaybeInnerId     {
+          |    implicit val schema: Schema[Any, MaybeInnerId]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[MaybeInnerId] = summon[ArgBuilder[String]].map(MaybeInnerId(_))
+          |  }
+          |  case class MaybeInnerIdOpt(value: String) extends AnyVal
+          |  object MaybeInnerIdOpt  {
+          |    implicit val schema: Schema[Any, MaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[MaybeInnerIdOpt] = summon[ArgBuilder[String]].map(MaybeInnerIdOpt(_))
+          |  }
+          |  final case class Foo(
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("CustomId"))))
+          |    id: CustomId,
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("CustomStrId"))))
+          |    strId: CustomStrId,
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("CustomIntId"))))
+          |    intId: CustomIntId,
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("CustomFId"))))
+          |    fid: CustomFId,
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("CustomIdOpt"))))
+          |    maybeId: scala.Option[CustomIdOpt],
+          |    IDs: List[String],
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("InnerId"))))
+          |    allIDs: List[InnerId],
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("InnerOptId"))))
+          |    allIDsOpt: List[scala.Option[InnerOptId]],
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("MaybeInnerId"))))
+          |    mapbeAllIDs: scala.Option[List[MaybeInnerId]],
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("MaybeInnerIdOpt"))))
+          |    mapbeAllIDsOpt: scala.Option[List[scala.Option[MaybeInnerIdOpt]]]
+          |  )
+          |  final case class FooInput(
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("CustomId"))))
+          |    id: CustomId,
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("IInnerId"))))
+          |    allIDs: List[IInnerId],
+          |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("IMaybeInnerIdOpt"))))
+          |    mapbeAllIDsOpt: scala.Option[List[scala.Option[IMaybeInnerIdOpt]]]
+          |  )
+          |
+          |}
+          |
+          |object Operations {
+          |
+          |  final case class Query(
+          |    getFoo: QueryGetFooArgs => zio.UIO[scala.Option[Foo]]
+          |  )
+          |
+          |  final case class Mutation(
+          |    updateFoo: MutationUpdateFooArgs => zio.UIO[scala.Option[Foo]]
+          |  )
+          |
+          |}
+          |""".stripMargin
     )
   )
 

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -844,68 +844,68 @@ object SchemaWriterSpec extends ZIOSpecDefault {
           |  final case class MutationUpdateFooArgs(foo: FooInput)
           |  case class ACustomIdOpt(value: String) extends AnyVal
           |  object ACustomIdOpt     {
-          |    implicit val schema: Schema[Any, ACustomIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[ACustomIdOpt] = summon[ArgBuilder[String]].map(ACustomIdOpt(_))
+          |    implicit val schema: Schema[Any, ACustomIdOpt]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[ACustomIdOpt] = implicitly[ArgBuilder[String]].map(ACustomIdOpt(_))
           |  }
           |  case class AMaybeInnerIdOpt(value: String) extends AnyVal
           |  object AMaybeInnerIdOpt {
-          |    implicit val schema: Schema[Any, AMaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[AMaybeInnerIdOpt] = summon[ArgBuilder[String]].map(AMaybeInnerIdOpt(_))
+          |    implicit val schema: Schema[Any, AMaybeInnerIdOpt]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[AMaybeInnerIdOpt] = implicitly[ArgBuilder[String]].map(AMaybeInnerIdOpt(_))
           |  }
           |  case class CustomFId(value: FID) extends AnyVal
           |  object CustomFId        {
-          |    implicit val schema: Schema[Any, CustomFId]    = summon[Schema[Any, FID]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[CustomFId] = summon[ArgBuilder[FID]].map(CustomFId(_))
+          |    implicit val schema: Schema[Any, CustomFId]    = implicitly[Schema[Any, FID]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomFId] = implicitly[ArgBuilder[FID]].map(CustomFId(_))
           |  }
           |  case class CustomId(value: String) extends AnyVal
           |  object CustomId         {
-          |    implicit val schema: Schema[Any, CustomId]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[CustomId] = summon[ArgBuilder[String]].map(CustomId(_))
+          |    implicit val schema: Schema[Any, CustomId]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomId] = implicitly[ArgBuilder[String]].map(CustomId(_))
           |  }
           |  case class CustomIdOpt(value: String) extends AnyVal
           |  object CustomIdOpt      {
-          |    implicit val schema: Schema[Any, CustomIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[CustomIdOpt] = summon[ArgBuilder[String]].map(CustomIdOpt(_))
+          |    implicit val schema: Schema[Any, CustomIdOpt]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomIdOpt] = implicitly[ArgBuilder[String]].map(CustomIdOpt(_))
           |  }
           |  case class CustomIntId(value: Int) extends AnyVal
           |  object CustomIntId      {
-          |    implicit val schema: Schema[Any, CustomIntId]    = summon[Schema[Any, Int]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[CustomIntId] = summon[ArgBuilder[Int]].map(CustomIntId(_))
+          |    implicit val schema: Schema[Any, CustomIntId]    = implicitly[Schema[Any, Int]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomIntId] = implicitly[ArgBuilder[Int]].map(CustomIntId(_))
           |  }
           |  case class CustomStrId(value: String) extends AnyVal
           |  object CustomStrId      {
-          |    implicit val schema: Schema[Any, CustomStrId]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[CustomStrId] = summon[ArgBuilder[String]].map(CustomStrId(_))
+          |    implicit val schema: Schema[Any, CustomStrId]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[CustomStrId] = implicitly[ArgBuilder[String]].map(CustomStrId(_))
           |  }
           |  case class IInnerId(value: String) extends AnyVal
           |  object IInnerId         {
-          |    implicit val schema: Schema[Any, IInnerId]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[IInnerId] = summon[ArgBuilder[String]].map(IInnerId(_))
+          |    implicit val schema: Schema[Any, IInnerId]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[IInnerId] = implicitly[ArgBuilder[String]].map(IInnerId(_))
           |  }
           |  case class IMaybeInnerIdOpt(value: String) extends AnyVal
           |  object IMaybeInnerIdOpt {
-          |    implicit val schema: Schema[Any, IMaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[IMaybeInnerIdOpt] = summon[ArgBuilder[String]].map(IMaybeInnerIdOpt(_))
+          |    implicit val schema: Schema[Any, IMaybeInnerIdOpt]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[IMaybeInnerIdOpt] = implicitly[ArgBuilder[String]].map(IMaybeInnerIdOpt(_))
           |  }
           |  case class InnerId(value: String) extends AnyVal
           |  object InnerId          {
-          |    implicit val schema: Schema[Any, InnerId]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[InnerId] = summon[ArgBuilder[String]].map(InnerId(_))
+          |    implicit val schema: Schema[Any, InnerId]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[InnerId] = implicitly[ArgBuilder[String]].map(InnerId(_))
           |  }
           |  case class InnerOptId(value: String) extends AnyVal
           |  object InnerOptId       {
-          |    implicit val schema: Schema[Any, InnerOptId]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[InnerOptId] = summon[ArgBuilder[String]].map(InnerOptId(_))
+          |    implicit val schema: Schema[Any, InnerOptId]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[InnerOptId] = implicitly[ArgBuilder[String]].map(InnerOptId(_))
           |  }
           |  case class MaybeInnerId(value: String) extends AnyVal
           |  object MaybeInnerId     {
-          |    implicit val schema: Schema[Any, MaybeInnerId]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[MaybeInnerId] = summon[ArgBuilder[String]].map(MaybeInnerId(_))
+          |    implicit val schema: Schema[Any, MaybeInnerId]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[MaybeInnerId] = implicitly[ArgBuilder[String]].map(MaybeInnerId(_))
           |  }
           |  case class MaybeInnerIdOpt(value: String) extends AnyVal
           |  object MaybeInnerIdOpt  {
-          |    implicit val schema: Schema[Any, MaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
-          |    implicit val argBuilder: ArgBuilder[MaybeInnerIdOpt] = summon[ArgBuilder[String]].map(MaybeInnerIdOpt(_))
+          |    implicit val schema: Schema[Any, MaybeInnerIdOpt]    = implicitly[Schema[Any, String]].contramap(_.value)
+          |    implicit val argBuilder: ArgBuilder[MaybeInnerIdOpt] = implicitly[ArgBuilder[String]].map(MaybeInnerIdOpt(_))
           |  }
           |  final case class Foo(
           |    @GQLDirective(Directive("$NewtypeDirective", Map("name" -> StringValue("CustomId"))))

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -783,6 +783,173 @@ object SchemaWriterSpec extends ZIOSpecDefault {
         |  ) derives caliban.schema.Schema.SemiAuto
         |
         |}""".stripMargin
+    ),
+    (
+      "generate typesafe ids with @typesafe directive fields of types, input types and arguments",
+      gen(
+        """
+          |directive @typesafe(name : String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+          |
+          |scalar FID
+          |
+          |type Query {
+          | getFoo(
+          |   id: ID! @typesafe(name: "CustomId"),
+          |   maybeId : ID @typesafe(name: "ACustomIdOpt")
+          |   mapbeAllIDsOpt: [ID] @typesafe(name: "AMaybeInnerIdOpt")
+          | ): Foo
+          |}
+          |
+          |type Mutation {
+          | updateFoo(foo: FooInput!): Foo
+          |}
+          |
+          |type Foo {
+          |  id : ID! @typesafe(name: "CustomId")
+          |  strId : String! @typesafe(name: "CustomStrId")
+          |  intId : Int! @typesafe(name: "CustomIntId")
+          |  fid : FID! @typesafe(name: "CustomFId")
+          |  maybeId : ID @typesafe(name: "CustomIdOpt")
+          |  IDs : [ID!]!
+          |  allIDs : [ID!]! @typesafe(name: "InnerId")
+          |  allIDsOpt: [ID]! @typesafe(name: "InnerOptId")
+          |  mapbeAllIDs: [ID!] @typesafe(name: "MaybeInnerId")
+          |  mapbeAllIDsOpt: [ID] @typesafe(name: "MaybeInnerIdOpt")
+          |}
+          |
+          |input FooInput {
+          |  id : ID! @typesafe(name: "CustomId")
+          |  allIDs : [ID!]! @typesafe(name: "IInnerId")
+          |  mapbeAllIDsOpt: [ID] @typesafe(name: "IMaybeInnerIdOpt")
+          |}
+          |
+          |""",
+        scalarMappings = Map("ID" -> "String")
+      ),
+      """|import Types._
+         |
+         |import caliban.schema.Annotations._
+         |
+         |import caliban.Value._
+         |import caliban.parsing.adt.Directive
+         |import caliban.schema.{ ArgBuilder, Schema }
+         |
+         |object Types {
+         |  final case class QueryGetFooArgs(
+         |    id: CustomId,
+         |    maybeId: scala.Option[ACustomIdOpt],
+         |    mapbeAllIDsOpt: scala.Option[List[scala.Option[AMaybeInnerIdOpt]]]
+         |  )
+         |  final case class MutationUpdateFooArgs(foo: FooInput)
+         |  case class ACustomIdOpt(value: String) extends AnyVal
+         |  object ACustomIdOpt     {
+         |    implicit val schema: Schema[Any, ACustomIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[ACustomIdOpt] = summon[ArgBuilder[String]].map(ACustomIdOpt(_))
+         |  }
+         |  case class AMaybeInnerIdOpt(value: String) extends AnyVal
+         |  object AMaybeInnerIdOpt {
+         |    implicit val schema: Schema[Any, AMaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[AMaybeInnerIdOpt] = summon[ArgBuilder[String]].map(AMaybeInnerIdOpt(_))
+         |  }
+         |  case class CustomFId(value: FID) extends AnyVal
+         |  object CustomFId        {
+         |    implicit val schema: Schema[Any, CustomFId]    = summon[Schema[Any, FID]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[CustomFId] = summon[ArgBuilder[FID]].map(CustomFId(_))
+         |  }
+         |  case class CustomId(value: String) extends AnyVal
+         |  object CustomId         {
+         |    implicit val schema: Schema[Any, CustomId]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[CustomId] = summon[ArgBuilder[String]].map(CustomId(_))
+         |  }
+         |  case class CustomIdOpt(value: String) extends AnyVal
+         |  object CustomIdOpt      {
+         |    implicit val schema: Schema[Any, CustomIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[CustomIdOpt] = summon[ArgBuilder[String]].map(CustomIdOpt(_))
+         |  }
+         |  case class CustomIntId(value: Int) extends AnyVal
+         |  object CustomIntId      {
+         |    implicit val schema: Schema[Any, CustomIntId]    = summon[Schema[Any, Int]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[CustomIntId] = summon[ArgBuilder[Int]].map(CustomIntId(_))
+         |  }
+         |  case class CustomStrId(value: String) extends AnyVal
+         |  object CustomStrId      {
+         |    implicit val schema: Schema[Any, CustomStrId]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[CustomStrId] = summon[ArgBuilder[String]].map(CustomStrId(_))
+         |  }
+         |  case class IInnerId(value: String) extends AnyVal
+         |  object IInnerId         {
+         |    implicit val schema: Schema[Any, IInnerId]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[IInnerId] = summon[ArgBuilder[String]].map(IInnerId(_))
+         |  }
+         |  case class IMaybeInnerIdOpt(value: String) extends AnyVal
+         |  object IMaybeInnerIdOpt {
+         |    implicit val schema: Schema[Any, IMaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[IMaybeInnerIdOpt] = summon[ArgBuilder[String]].map(IMaybeInnerIdOpt(_))
+         |  }
+         |  case class InnerId(value: String) extends AnyVal
+         |  object InnerId          {
+         |    implicit val schema: Schema[Any, InnerId]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[InnerId] = summon[ArgBuilder[String]].map(InnerId(_))
+         |  }
+         |  case class InnerOptId(value: String) extends AnyVal
+         |  object InnerOptId       {
+         |    implicit val schema: Schema[Any, InnerOptId]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[InnerOptId] = summon[ArgBuilder[String]].map(InnerOptId(_))
+         |  }
+         |  case class MaybeInnerId(value: String) extends AnyVal
+         |  object MaybeInnerId     {
+         |    implicit val schema: Schema[Any, MaybeInnerId]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[MaybeInnerId] = summon[ArgBuilder[String]].map(MaybeInnerId(_))
+         |  }
+         |  case class MaybeInnerIdOpt(value: String) extends AnyVal
+         |  object MaybeInnerIdOpt  {
+         |    implicit val schema: Schema[Any, MaybeInnerIdOpt]    = summon[Schema[Any, String]].contramap(_.value)
+         |    implicit val argBuilder: ArgBuilder[MaybeInnerIdOpt] = summon[ArgBuilder[String]].map(MaybeInnerIdOpt(_))
+         |  }
+         |  final case class Foo(
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomId"))))
+         |    id: CustomId,
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomStrId"))))
+         |    strId: CustomStrId,
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomIntId"))))
+         |    intId: CustomIntId,
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomFId"))))
+         |    fid: CustomFId,
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomIdOpt"))))
+         |    maybeId: scala.Option[CustomIdOpt],
+         |    IDs: List[String],
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("InnerId"))))
+         |    allIDs: List[InnerId],
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("InnerOptId"))))
+         |    allIDsOpt: List[scala.Option[InnerOptId]],
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("MaybeInnerId"))))
+         |    mapbeAllIDs: scala.Option[List[MaybeInnerId]],
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("MaybeInnerIdOpt"))))
+         |    mapbeAllIDsOpt: scala.Option[List[scala.Option[MaybeInnerIdOpt]]]
+         |  )
+         |  final case class FooInput(
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("CustomId"))))
+         |    id: CustomId,
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("IInnerId"))))
+         |    allIDs: List[IInnerId],
+         |    @GQLDirective(Directive("typesafe", Map("name" -> StringValue("IMaybeInnerIdOpt"))))
+         |    mapbeAllIDsOpt: scala.Option[List[scala.Option[IMaybeInnerIdOpt]]]
+         |  )
+         |
+         |}
+         |
+         |object Operations {
+         |
+         |  final case class Query(
+         |    getFoo: QueryGetFooArgs => zio.UIO[scala.Option[Foo]]
+         |  )
+         |
+         |  final case class Mutation(
+         |    updateFoo: MutationUpdateFooArgs => zio.UIO[scala.Option[Foo]]
+         |  )
+         |
+         |}
+         |""".stripMargin
     )
   )
 


### PR DESCRIPTION
By using @typesafe directive, the code generator will wrap your typesafe fields in case classes without
imposing further changes to GraphQl schema. Hence allowing type safety on important identifiers and fields.
Tested with Option and List as well.

Schema example:
```
directive @typesafe(name : String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION

type Query {
  getUser(id: ID! @typesafe(name: "UserId")): User
}

type User {
  id: ID! @typesafe(name: "UserId")
  ...
}
```
with ID as scalar mapping to Int you would get something like this:
```
case class UserId(value: Int) extends AnyVal
object UserId {
  implicit val schema: Schema[Any, UserId] = summon[Schema[Any, Int]].contramap(_.value)
  implicit val argBuilder: ArgBuilder[UserId] = summon[ArgBuilder[Int]].map(UserId(_))
}

final case class QueryGetUserArgs(id: UserId)

final case class User(
  @GQLDirective(Directive("typesafe", Map("name" -> StringValue("UserId"))))
  id: UserId,
  ...
}
```

See SchemaWriterSpec.scala for more extensive type mapping.