### PR TITLE
Optimize field parsing

### DIFF
--- a/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
@@ -10,7 +10,7 @@ import scala.annotation.nowarn
 
 @nowarn("msg=NoWhitespace") // False positive warning in Scala 2.x
 private[caliban] trait SelectionParsers extends ValueParsers {
-  def alias(implicit ev: P[Any]): P[String] = P(name ~ ":")
+  def aliasOrName(implicit ev: P[Any]): P[String] = P(":" ~ name)
 
   def argument(implicit ev: P[Any]): P[(String, InputValue)]     = P(name ~ ":" ~ value)
   def arguments(implicit ev: P[Any]): P[Map[String, InputValue]] = P("(" ~/ argument.rep ~ ")").map(_.toMap)
@@ -27,23 +27,18 @@ private[caliban] trait SelectionParsers extends ValueParsers {
   def namedType(implicit ev: P[Any]): P[NamedType] = P(name.filter(_ != "null")).map(NamedType(_, nonNull = false))
   def listType(implicit ev: P[Any]): P[ListType]   = P("[" ~ type_ ~ "]").map(t => ListType(t, nonNull = false))
 
-  def nonNullType(implicit ev: P[Any]): P[Type] = P((namedType | listType) ~ "!").map {
-    case t: NamedType => t.copy(nonNull = true)
-    case t: ListType  => t.copy(nonNull = true)
+  def type_(implicit ev: P[Any]): P[Type] = P((namedType | listType) ~ "!".!.?).map {
+    case (t: NamedType, nn) => if (nn.isDefined) t.copy(nonNull = true) else t
+    case (t: ListType, nn)  => if (nn.isDefined) t.copy(nonNull = true) else t
   }
-  def type_(implicit ev: P[Any]): P[Type]       = P(nonNullType | namedType | listType)
 
   def field(implicit ev: P[Any]): P[Field] =
-    P(Index ~ alias.? ~ name ~ arguments.? ~ directives.? ~ selectionSet.?).map {
-      case (index, alias, name, args, dirs, sels) =>
-        Field(
-          alias,
-          name,
-          args.getOrElse(Map()),
-          dirs.getOrElse(Nil),
-          sels.getOrElse(Nil),
-          index
-        )
+    P(Index ~ name ~ aliasOrName.? ~ arguments.? ~ directives.? ~ selectionSet.?).map {
+      case (index, alias, Some(name), args, dirs, sels) =>
+        Field(Some(alias), name, args.getOrElse(Map()), dirs.getOrElse(Nil), sels.getOrElse(Nil), index)
+      case (index, name, _, args, dirs, sels)           =>
+        Field(None, name, args.getOrElse(Map()), dirs.getOrElse(Nil), sels.getOrElse(Nil), index)
+
     }
 
   def fragmentName(implicit ev: P[Any]): P[String] = P(name).filter(_ != "on")

--- a/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
@@ -10,6 +10,9 @@ import scala.annotation.nowarn
 
 @nowarn("msg=NoWhitespace") // False positive warning in Scala 2.x
 private[caliban] trait SelectionParsers extends ValueParsers {
+
+  @deprecated("Kept for bincompat only, scheduled to be removed")
+  def alias(implicit ev: P[Any]): P[String] = P(name ~ ":")
   def aliasOrName(implicit ev: P[Any]): P[String] = P(":" ~ name)
 
   def argument(implicit ev: P[Any]): P[(String, InputValue)]     = P(name ~ ":" ~ value)
@@ -26,6 +29,12 @@ private[caliban] trait SelectionParsers extends ValueParsers {
 
   def namedType(implicit ev: P[Any]): P[NamedType] = P(name.filter(_ != "null")).map(NamedType(_, nonNull = false))
   def listType(implicit ev: P[Any]): P[ListType]   = P("[" ~ type_ ~ "]").map(t => ListType(t, nonNull = false))
+
+  @deprecated("Kept for bincompat only, scheduled to be removed")
+  def nonNullType(implicit ev: P[Any]): P[Type] = P((namedType | listType) ~ "!").map {
+    case t: NamedType => t.copy(nonNull = true)
+    case t: ListType  => t.copy(nonNull = true)
+  }
 
   def type_(implicit ev: P[Any]): P[Type] = P((namedType | listType) ~ "!".!.?).map {
     case (t: NamedType, nn) => if (nn.isDefined) t.copy(nonNull = true) else t


### PR DESCRIPTION
Improves performance ~15-20% of the parser. The main optimization comes from avoiding parsing the field name twice in cases that it's not aliased (which is almost always)