### PR TITLE
Avoid redundant fragment validations

### DIFF
--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -446,8 +446,9 @@ object Validator {
 
   private def containsFragments(selectionSet: List[Selection]): Boolean =
     selectionSet.exists {
-      case f: Selection.Field => containsFragments(f.selectionSet)
-      case _                  => true
+      case f: Selection.Field          => containsFragments(f.selectionSet)
+      case _: Selection.InlineFragment => true
+      case _: Selection.FragmentSpread => true
     }
 
   private def validateSelectionSet(


### PR DESCRIPTION
The `FragmentValidator.findConflictsWithinSelectionSet` is by far our most expensive validation, accounting for ~5-10% of the execution time for queries returning a small number of fields even if they don't contain any fragments.

We can avoid it by checking whether the query contains any fragments / inline fragments, and skip it if it doesn't contain any. This should have negligible performance impact for queries containing fragments, and an extremely minor impact for queries that have inlined fragments but not fragment spreads