### PR TITLE
codegen: Generate the GQLDeprecated annotation

### DIFF
--- a/codegen-sbt/src/sbt-test/codegen/test-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/build.sbt
@@ -5,6 +5,7 @@ lazy val root = project
   .enablePlugins(CalibanPlugin)
   .settings(
     libraryDependencies ++= Seq(
+      "com.github.ghostdogpr" %% "caliban"        % Version.pluginVersion,
       "com.github.ghostdogpr" %% "caliban-client" % Version.pluginVersion
     ),
     Compile / caliban / calibanSettings ++= Seq(
@@ -17,6 +18,12 @@ lazy val root = project
           .scalarMapping("Json" -> "String")
           .effect("scala.util.Try")
           .addDerives(false)
+      ),
+      calibanSetting(file("src/main/graphql/schema.graphql"))(
+        _.genType(Codegen.GenType.Schema)
+          .scalarMapping("Json" -> "String")
+          .effect("F")
+          .abstractEffectType(true)
       ),
       calibanSetting(file("src/main/graphql/genview/schema.graphql"))(
         _.clientName("Client").packageName("genview").genView(true)

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/schema.graphql
@@ -1,3 +1,5 @@
+directive @lazy on FIELD_DEFINITION
+
 # Schema
 schema {
     query: Q
@@ -22,6 +24,9 @@ type Q {
     # test for scala.Option / Option conflicts
     defaultOptionForProductId(id: String!): Option
     availableOptionsForProductId(id: String!): [Option!]
+
+    # nested @lazy fields
+    cant: Canterbury!
 }
 
 # Input object
@@ -55,6 +60,15 @@ type Character {
     oldNicknames: [String!]! @deprecated
     # Deprecated field + comment newline
     oldName2: String! @deprecated(reason: "foo\nbar")
+    # Deprecated field + comment with double quotes and newlines
+    """a deprecated field"""
+    oldName3: String!
+      @deprecated(reason: """
+        This field is deprecated for the following reasons:
+        1. "Outdated data model": The field relies on an outdated data model.
+        2. "Performance issues": Queries using this field have performance issues.
+        Please use `name` instead.
+      """)
 }
 
 # Enum
@@ -93,4 +107,17 @@ type Product {
     configuredOption: Option
     availableOptions: [Option!]!
     specialOrderOption: [Option]
+}
+
+type Canterbury {
+  officer: Officer!
+}
+
+type Officer {
+  dossier: Dossier! @lazy
+}
+
+type Dossier {
+  homeWorld: String!
+  faction: String! @lazy
 }


### PR DESCRIPTION
When using the schema-first approach, it is useful to add annotations from the schema to the generated Caliban code, they will be used for introspection. It's helpful to see deprecated fields and types in tools like Graphiql.

The changes also include a small improvement following up on my previous PR #2064: root fields should also be generated with the parameterized effect type in the case of nested lazy fields.