### PR TITLE
add-extensions-in-ServerError-print

### DIFF
--- a/client/src/main/scala/caliban/client/CalibanClientError.scala
+++ b/client/src/main/scala/caliban/client/CalibanClientError.scala
@@ -36,7 +36,7 @@ object CalibanClientError {
      * @param includeExtensions whether to include the extensions in the error message
      * @return the error message
      */
-    override def render(includeExtensions: Boolean = false) =
+    override def render(includeExtensions: Boolean = false): String =
       s"Server Error: ${errors.map(_.render(includeExtensions)).mkString("\n")}"
 
   }

--- a/client/src/main/scala/caliban/client/CalibanClientError.scala
+++ b/client/src/main/scala/caliban/client/CalibanClientError.scala
@@ -5,6 +5,7 @@ package caliban.client
  */
 sealed trait CalibanClientError extends Throwable with Product with Serializable {
   override def getMessage: String = toString
+  def getFullMessage: String   = toString
 }
 
 object CalibanClientError {
@@ -28,20 +29,9 @@ object CalibanClientError {
    */
   case class ServerError(errors: List[GraphQLResponseError]) extends CalibanClientError {
 
-    override def toString: String =
-      s"Server Error: ${errors
-        .map(e =>
-          s"${e.message} ${e.locations
-            .getOrElse(Nil)
-            .map(loc => s"at line ${loc.line} and column ${loc.column}")
-            .mkString(" ")}${e.path.fold("")(p =>
-            s" at path ${p.map {
-              case Left(value)  => s"/$value"
-              case Right(value) => s"[$value]"
-            }.mkString("")}${e.extensions.fold("")(ext => s" Extensions: $ext")}"
-          )}"
-        )
-        .mkString("\n")}"
-  }
+    override def toString: String = s"Server Error: ${errors.map(_.print).mkString("\n")}"
 
+    override def getFullMessage = s"Server Error: ${errors.map(_.fullPrint).mkString("\n")}"
+
+  }
 }

--- a/client/src/main/scala/caliban/client/CalibanClientError.scala
+++ b/client/src/main/scala/caliban/client/CalibanClientError.scala
@@ -38,7 +38,7 @@ object CalibanClientError {
             s" at path ${p.map {
               case Left(value)  => s"/$value"
               case Right(value) => s"[$value]"
-            }.mkString("")}"
+            }.mkString("")}${e.extensions.fold("")(ext => s" Extensions: $ext")}"
           )}"
         )
         .mkString("\n")}"

--- a/client/src/main/scala/caliban/client/CalibanClientError.scala
+++ b/client/src/main/scala/caliban/client/CalibanClientError.scala
@@ -5,7 +5,7 @@ package caliban.client
  */
 sealed trait CalibanClientError extends Throwable with Product with Serializable {
   override def getMessage: String = toString
-  def getFullMessage: String   = toString
+  def getFullMessage: String      = toString
 }
 
 object CalibanClientError {

--- a/client/src/main/scala/caliban/client/CalibanClientError.scala
+++ b/client/src/main/scala/caliban/client/CalibanClientError.scala
@@ -4,8 +4,8 @@ package caliban.client
  * The base type for all Caliban Client errors.
  */
 sealed trait CalibanClientError extends Throwable with Product with Serializable {
-  override def getMessage: String = toString
-  def getFullMessage: String      = toString
+  override def getMessage: String                        = toString
+  def render(includeExtensions: Boolean = false): String = toString
 }
 
 object CalibanClientError {
@@ -29,9 +29,15 @@ object CalibanClientError {
    */
   case class ServerError(errors: List[GraphQLResponseError]) extends CalibanClientError {
 
-    override def toString: String = s"Server Error: ${errors.map(_.print).mkString("\n")}"
+    override def toString: String = render(false)
 
-    override def getFullMessage = s"Server Error: ${errors.map(_.fullPrint).mkString("\n")}"
+    /**
+     * Renders the error as a string
+     * @param includeExtensions whether to include the extensions in the error message
+     * @return the error message
+     */
+    override def render(includeExtensions: Boolean = false) =
+      s"Server Error: ${errors.map(_.render(includeExtensions)).mkString("\n")}"
 
   }
 }

--- a/client/src/main/scala/caliban/client/GraphQLResponseError.scala
+++ b/client/src/main/scala/caliban/client/GraphQLResponseError.scala
@@ -18,15 +18,19 @@ case class GraphQLResponseError(
   path: Option[List[Either[String, Int]]],
   extensions: Option[__Value]
 ) {
-  def print: String =
+
+  /**
+   * Renders the error as a string
+   * @param includeExtensions whether to include the extensions in the error message
+   * @return the error message
+   */
+  def render(includeExtensions: Boolean): String =
     s"${message} ${locations.getOrElse(Nil).map(loc => s"at line ${loc.line} and column ${loc.column}").mkString(" ")}${path.fold("")(p =>
       s" at path ${p.map {
         case Left(value)  => s"/$value"
         case Right(value) => s"[$value]"
       }.mkString("")}"
-    )}"
-
-  def fullPrint: String = print + extensions.fold("")(ext => s" Extensions: $ext")
+    )}${if (includeExtensions) extensions.fold("")(ext => s" Extensions: $ext") else ""}"
 }
 
 object GraphQLResponseError {

--- a/client/src/main/scala/caliban/client/GraphQLResponseError.scala
+++ b/client/src/main/scala/caliban/client/GraphQLResponseError.scala
@@ -17,7 +17,17 @@ case class GraphQLResponseError(
   locations: Option[List[Location]],
   path: Option[List[Either[String, Int]]],
   extensions: Option[__Value]
-)
+) {
+  def print: String =
+    s"${message} ${locations.getOrElse(Nil).map(loc => s"at line ${loc.line} and column ${loc.column}").mkString(" ")}${path.fold("")(p =>
+      s" at path ${p.map {
+        case Left(value)  => s"/$value"
+        case Right(value) => s"[$value]"
+      }.mkString("")}"
+    )}"
+
+  def fullPrint: String = print + extensions.fold("")(ext => s" Extensions: $ext")
+}
 
 object GraphQLResponseError {
 

--- a/client/src/test/scala/caliban/client/CalibanClientErrorSpec.scala
+++ b/client/src/test/scala/caliban/client/CalibanClientErrorSpec.scala
@@ -4,6 +4,8 @@ import caliban.client.CalibanClientError.{ CommunicationError, DecodingError, Se
 import caliban.client.GraphQLResponseError.Location
 import zio.test._
 
+import caliban.client.__Value.__ObjectValue
+
 object CalibanClientErrorSpec extends ZIOSpecDefault {
   override def spec = {
     val msg = "SOME_MSG"
@@ -35,7 +37,9 @@ object CalibanClientErrorSpec extends ZIOSpecDefault {
               message = "Error1",
               locations = Option(List(Location(line = 1, column = 1))),
               path = Option(List(Left("somewhere"), Right(1))),
-              extensions = Option.empty
+              extensions = Option(
+                __ObjectValue(List("key1" -> __Value.__StringValue("value1"), "key2" -> __Value.__NumberValue(2)))
+              )
             ),
             GraphQLResponseError(
               message = "Error2",
@@ -46,7 +50,7 @@ object CalibanClientErrorSpec extends ZIOSpecDefault {
           )
           val error                 = ServerError(graphQLResponseErrors)
           assertTrue(
-            error.getMessage == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1]\nError2 at line 1 and column 1 at path /somewhere"
+            error.getMessage == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1] Extensions: {key1:\"value1\",key2:2}\nError2 at line 1 and column 1 at path /somewhere"
           )
         }
       )

--- a/client/src/test/scala/caliban/client/CalibanClientErrorSpec.scala
+++ b/client/src/test/scala/caliban/client/CalibanClientErrorSpec.scala
@@ -15,24 +15,28 @@ object CalibanClientErrorSpec extends ZIOSpecDefault {
         test("getMessage - no innerThrowable") {
           val error = CommunicationError(msg = msg)
           assertTrue(error.getMessage == "Communication Error: SOME_MSG")
-          assertTrue(error.getFullMessage == "Communication Error: SOME_MSG")
+          assertTrue(error.render(true) == "Communication Error: SOME_MSG")
+          assertTrue(error.render(false) == "Communication Error: SOME_MSG")
         },
         test("getMessage - innerThrowable") {
           val error = CommunicationError(msg = msg, innerThrowable = Option(CommunicationError("INNER")))
           assertTrue(error.getMessage == "Communication Error: SOME_MSG Communication Error: INNER")
-          assertTrue(error.getFullMessage == "Communication Error: SOME_MSG Communication Error: INNER")
+          assertTrue(error.render(true) == "Communication Error: SOME_MSG Communication Error: INNER")
+          assertTrue(error.render(false) == "Communication Error: SOME_MSG Communication Error: INNER")
         }
       ),
       suite("DecodingError")(
         test("getMessage - no innerThrowable") {
           val error = DecodingError(msg = msg)
           assertTrue(error.getMessage == "Decoding Error: SOME_MSG")
-          assertTrue(error.getFullMessage == "Decoding Error: SOME_MSG")
+          assertTrue(error.render(true) == "Decoding Error: SOME_MSG")
+          assertTrue(error.render(false) == "Decoding Error: SOME_MSG")
         },
         test("getMessage - innerThrowable") {
           val error = DecodingError(msg = msg, innerThrowable = Option(DecodingError("INNER")))
           assertTrue(error.getMessage == "Decoding Error: SOME_MSG Decoding Error: INNER")
-          assertTrue(error.getFullMessage == "Decoding Error: SOME_MSG Decoding Error: INNER")
+          assertTrue(error.render(true) == "Decoding Error: SOME_MSG Decoding Error: INNER")
+          assertTrue(error.render(false) == "Decoding Error: SOME_MSG Decoding Error: INNER")
         }
       ),
       suite("ServerError")(
@@ -57,8 +61,14 @@ object CalibanClientErrorSpec extends ZIOSpecDefault {
           assertTrue(
             error.getMessage == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1]\nError2 at line 1 and column 1 at path /somewhere"
           )
+
+          assertTrue(
+            error.render(
+              false
+            ) == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1]\nError2 at line 1 and column 1 at path /somewhere"
+          )
         },
-        test("getFullMessage") {
+        test("render") {
           val graphQLResponseErrors = List(
             GraphQLResponseError(
               message = "Error1",
@@ -77,7 +87,9 @@ object CalibanClientErrorSpec extends ZIOSpecDefault {
           )
           val error                 = ServerError(graphQLResponseErrors)
           assertTrue(
-            error.getFullMessage == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1] Extensions: {key1:\"value1\",key2:2}\nError2 at line 1 and column 1 at path /somewhere"
+            error.render(
+              true
+            ) == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1] Extensions: {key1:\"value1\",key2:2}\nError2 at line 1 and column 1 at path /somewhere"
           )
         }
       )

--- a/client/src/test/scala/caliban/client/CalibanClientErrorSpec.scala
+++ b/client/src/test/scala/caliban/client/CalibanClientErrorSpec.scala
@@ -4,6 +4,7 @@ import caliban.client.CalibanClientError.{ CommunicationError, DecodingError, Se
 import caliban.client.GraphQLResponseError.Location
 import zio.test._
 
+import caliban.client.CalibanClientErrorSpec.test
 import caliban.client.__Value.__ObjectValue
 
 object CalibanClientErrorSpec extends ZIOSpecDefault {
@@ -14,20 +15,24 @@ object CalibanClientErrorSpec extends ZIOSpecDefault {
         test("getMessage - no innerThrowable") {
           val error = CommunicationError(msg = msg)
           assertTrue(error.getMessage == "Communication Error: SOME_MSG")
+          assertTrue(error.getFullMessage == "Communication Error: SOME_MSG")
         },
         test("getMessage - innerThrowable") {
           val error = CommunicationError(msg = msg, innerThrowable = Option(CommunicationError("INNER")))
           assertTrue(error.getMessage == "Communication Error: SOME_MSG Communication Error: INNER")
+          assertTrue(error.getFullMessage == "Communication Error: SOME_MSG Communication Error: INNER")
         }
       ),
       suite("DecodingError")(
         test("getMessage - no innerThrowable") {
           val error = DecodingError(msg = msg)
           assertTrue(error.getMessage == "Decoding Error: SOME_MSG")
+          assertTrue(error.getFullMessage == "Decoding Error: SOME_MSG")
         },
         test("getMessage - innerThrowable") {
           val error = DecodingError(msg = msg, innerThrowable = Option(DecodingError("INNER")))
           assertTrue(error.getMessage == "Decoding Error: SOME_MSG Decoding Error: INNER")
+          assertTrue(error.getFullMessage == "Decoding Error: SOME_MSG Decoding Error: INNER")
         }
       ),
       suite("ServerError")(
@@ -50,7 +55,29 @@ object CalibanClientErrorSpec extends ZIOSpecDefault {
           )
           val error                 = ServerError(graphQLResponseErrors)
           assertTrue(
-            error.getMessage == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1] Extensions: {key1:\"value1\",key2:2}\nError2 at line 1 and column 1 at path /somewhere"
+            error.getMessage == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1]\nError2 at line 1 and column 1 at path /somewhere"
+          )
+        },
+        test("getFullMessage") {
+          val graphQLResponseErrors = List(
+            GraphQLResponseError(
+              message = "Error1",
+              locations = Option(List(Location(line = 1, column = 1))),
+              path = Option(List(Left("somewhere"), Right(1))),
+              extensions = Option(
+                __ObjectValue(List("key1" -> __Value.__StringValue("value1"), "key2" -> __Value.__NumberValue(2)))
+              )
+            ),
+            GraphQLResponseError(
+              message = "Error2",
+              locations = Option(List(Location(line = 1, column = 1))),
+              path = Option(List(Left("somewhere"))),
+              extensions = Option.empty
+            )
+          )
+          val error                 = ServerError(graphQLResponseErrors)
+          assertTrue(
+            error.getFullMessage == "Server Error: Error1 at line 1 and column 1 at path /somewhere[1] Extensions: {key1:\"value1\",key2:2}\nError2 at line 1 and column 1 at path /somewhere"
           )
         }
       )


### PR DESCRIPTION
I think it is useful to have it included. 
In a case I am working it has info useful to the caller. 
eg 
```
"extensions": {
                "code": "BAD_REQUEST_ERROR",
                "information": [
                    "owner.id - Expected string, received null"
                ],
                "timestamp": "2024-02-01T09:02:37.910Z"
            }
```            