### PR TITLE
Parser & Validator optimizations

### DIFF
--- a/core/src/main/scala/caliban/Configurator.scala
+++ b/core/src/main/scala/caliban/Configurator.scala
@@ -26,7 +26,7 @@ object Configurator {
     Unsafe.unsafe(implicit u => FiberRef.unsafe.make(ExecutionConfiguration()))
 
   private[caliban] def configuration: UIO[ExecutionConfiguration] =
-    configRef.get
+    configRef.get(Trace.empty)
 
   private[caliban] def setWith[R, E, A](cfg: ExecutionConfiguration)(f: ZIO[R, E, A])(implicit
     trace: Trace

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -244,7 +244,7 @@ object Executor {
 
         def collectMixed() = {
           val queries                       = new VectorBuilder[(String, ReducedStep[R], FieldInfo)]
-          val nil                           = Nil
+          val nil                           = Nil // Bring into stack memory to avoid fetching from heap on each iteration
           var names: List[String]           = nil
           var resolved: List[ResponseValue] = nil
           var remaining                     = steps

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -109,8 +109,9 @@ object Executor {
       def reduceListStep(steps: List[Step[R]]) = {
         var i         = 0
         val lb        = ListBuffer.empty[ReducedStep[R]]
+        val nil       = Nil
         var remaining = steps
-        while (remaining ne Nil) {
+        while (remaining ne nil) {
           lb addOne reduceStep(remaining.head, currentField, arguments, PathValue.Index(i) :: path)
           i += 1
           remaining = remaining.tail
@@ -207,9 +208,10 @@ object Executor {
         def collectAllQueries() = {
           def combineQueryResults(results: List[ResponseValue]) = {
             val builder = ListBuffer.empty[(String, ResponseValue)]
+            val nil     = Nil
             var resps   = results
             var names   = steps
-            while (resps ne Nil) {
+            while (resps ne nil) {
               val (name, _, _) = names.head
               builder addOne ((name, resps.head))
               resps = resps.tail
@@ -224,11 +226,12 @@ object Executor {
         }
 
         def combineResults(names: List[String], resolved: List[ResponseValue])(fromQueries: Vector[ResponseValue]) = {
-          var results: List[(String, ResponseValue)] = Nil
+          val nil                                    = Nil
+          var results: List[(String, ResponseValue)] = nil
           var i                                      = fromQueries.length
           var remainingResponses                     = resolved
           var remainingNames                         = names
-          while (remainingResponses ne Nil) {
+          while (remainingResponses ne nil) {
             val name = remainingNames.head
             var resp = remainingResponses.head
             if (resp eq null) {
@@ -369,8 +372,9 @@ object Executor {
 
     def mergeFields(fields: List[Field]) = {
       val map       = new java.util.LinkedHashMap[String, Field](calculateMapCapacity(fields.size))
+      val nil       = Nil
       var remaining = fields
-      while (remaining ne Nil) {
+      while (remaining ne nil) {
         val h = remaining.head
         if (matchesTypename(h)) {
           map.compute(
@@ -408,9 +412,10 @@ object Executor {
     wrapPureValues: Boolean
   ): ReducedStep[R] = {
     var hasPures   = false
+    val nil        = Nil
     var hasQueries = wrapPureValues
     var remaining  = items
-    while ((remaining ne Nil) && !(hasPures && hasQueries)) {
+    while ((remaining ne nil) && !(hasPures && hasQueries)) {
       if (remaining.head._2.isPure) hasPures = true
       else hasQueries = true
       remaining = remaining.tail

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -209,12 +209,12 @@ object Executor {
             // Only way we could have ended with pure fields here is if we wrap pure values, so we check that first as it's cheaper
             objectFieldQuery(step, info, wrapPureValues && step.isPure)
           }.map { ls =>
-            val builder = List.newBuilder[(String, ResponseValue)]
+            val builder = ListBuffer.empty[(String, ResponseValue)]
             var resps   = ls
             var names   = steps
             while (resps ne Nil) {
               val (name, _, _) = names.head
-              builder += ((name, resps.head))
+              builder addOne ((name, resps.head))
               resps = resps.tail
               names = names.tail
             }

--- a/core/src/main/scala/caliban/parsing/Parser.scala
+++ b/core/src/main/scala/caliban/parsing/Parser.scala
@@ -15,8 +15,18 @@ object Parser {
 
   /**
    * Parses the given string into a [[caliban.parsing.adt.Document]] object or fails with a [[caliban.CalibanError.ParsingError]].
+   *
+   * @see [[parseQueryEither]] for a version that returns an `Either` instead of an `IO`.
    */
   def parseQuery(query: String)(implicit trace: Trace): IO[ParsingError, Document] = ZIO.fromEither {
+    parseQueryEither(query)
+  }
+
+  /**
+   * Parses the given string into a [[caliban.parsing.adt.Document]] object or returns a [[caliban.CalibanError.ParsingError]]
+   * if the string is not a valid GraphQL document.
+   */
+  def parseQueryEither(query: String): Either[ParsingError, Document] = {
     val sm = SourceMapper(query)
     try parse(query, document(_)) match {
       case Parsed.Success(value, _) => Right(Document(value.definitions, sm))
@@ -24,7 +34,6 @@ object Parser {
     } catch {
       case NonFatal(ex) => Left(ParsingError(s"Internal parsing error", innerThrowable = Some(ex)))
     }
-
   }
 
   def parseInputValue(rawValue: String): Either[ParsingError, InputValue] = {

--- a/core/src/main/scala/caliban/parsing/parsers/NumberParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/NumberParsers.scala
@@ -4,20 +4,20 @@ import caliban.Value._
 import fastparse._
 
 private[caliban] trait NumberParsers extends StringParsers {
-  def negativeSign(implicit ev: P[Any]): P[Unit] = P("-")
-  def nonZeroDigit(implicit ev: P[Any]): P[Unit] = P(CharIn("1-9"))
-  def digit(implicit ev: P[Any]): P[Unit]        = P("0" | nonZeroDigit)
-  def integerPart(implicit ev: P[Any]): P[Unit]  = P(
-    (negativeSign.? ~~ "0") | (negativeSign.? ~~ nonZeroDigit ~~ digit.repX)
-  )
+  def negativeSign(implicit ev: P[Any]): P[Unit] = StringIn("-")
+  def nonZeroDigit(implicit ev: P[Any]): P[Unit] = CharIn("1-9")
+  def digit(implicit ev: P[Any]): P[Unit]        = CharIn("0-9")
+  def integerPart(implicit ev: P[Any]): P[Unit]  =
+    negativeSign.? ~~ ("0" | (nonZeroDigit ~~ digit.repX))
+
   def intValue(implicit ev: P[Any]): P[IntValue] = integerPart.!.map(IntValue.fromStringUnsafe)
 
-  def sign(implicit ev: P[Any]): P[Unit]              = P("-" | "+")
-  def exponentIndicator(implicit ev: P[Any]): P[Unit] = P(CharIn("eE"))
-  def exponentPart(implicit ev: P[Any]): P[Unit]      = P(exponentIndicator ~~ sign.? ~~ digit.repX(1))
-  def fractionalPart(implicit ev: P[Any]): P[Unit]    = P("." ~~ digit.repX(1))
+  def sign(implicit ev: P[Any]): P[Unit]              = StringIn("-", "+")
+  def exponentIndicator(implicit ev: P[Any]): P[Unit] = CharIn("eE")
+  def exponentPart(implicit ev: P[Any]): P[Unit]      = exponentIndicator ~~ sign.? ~~ digit.repX(1)
+  def fractionalPart(implicit ev: P[Any]): P[Unit]    = "." ~~ digit.repX(1)
   def floatValue(implicit ev: P[Any]): P[FloatValue]  =
-    P(
-      (integerPart ~~ fractionalPart) | (integerPart ~~ exponentPart) | (integerPart ~~ fractionalPart ~~ exponentPart)
+    (
+      integerPart ~~ (fractionalPart | exponentPart | (fractionalPart ~~ exponentPart))
     ).!.map(FloatValue(_))
 }

--- a/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
@@ -18,46 +18,48 @@ import scala.annotation.nowarn
 @nowarn("msg=NoWhitespace") // False positive warning in Scala 2.x
 object Parsers extends SelectionParsers {
   def argumentDefinition(implicit ev: P[Any]): P[InputValueDefinition]        =
-    P(stringValue.? ~ name ~ ":" ~ type_ ~ defaultValue.? ~ directives.?).map {
+    (stringValue.? ~ name ~ ":" ~ type_ ~ defaultValue.? ~ directives.?).map {
       case (description, name, type_, defaultValue, directives) =>
         InputValueDefinition(description.map(_.value), name, type_, defaultValue, directives.getOrElse(Nil))
     }
   def argumentDefinitions(implicit ev: P[Any]): P[List[InputValueDefinition]] =
-    P("(" ~/ argumentDefinition.rep ~ ")").map(_.toList)
+    ("(" ~/ argumentDefinition.rep ~ ")").map(_.toList)
 
   def fieldDefinition(implicit ev: P[Any]): P[FieldDefinition] =
-    P(stringValue.? ~ name ~ argumentDefinitions.? ~ ":" ~ type_ ~ directives.?).map {
+    (stringValue.? ~ name ~ argumentDefinitions.? ~ ":" ~ type_ ~ directives.?).map {
       case (description, name, args, type_, directives) =>
         FieldDefinition(description.map(_.value), name, args.getOrElse(Nil), type_, directives.getOrElse(Nil))
     }
 
   def variableDefinitions(implicit ev: P[Any]): P[List[VariableDefinition]] =
-    P("(" ~/ variableDefinition.rep ~ ")").map(_.toList)
+    ("(" ~/ variableDefinition.rep ~ ")").map(_.toList)
 
   def variableDefinition(implicit ev: P[Any]): P[VariableDefinition] =
-    P(variableValue ~ ":" ~/ type_ ~ defaultValue.? ~ directives).map { case (v, t, default, dirs) =>
+    (variableValue ~ ":" ~/ type_ ~ defaultValue.? ~ directives).map { case (v, t, default, dirs) =>
       VariableDefinition(v.name, t, default, dirs)
     }
-  def defaultValue(implicit ev: P[Any]): P[InputValue]               = P("=" ~/ value)
+  def defaultValue(implicit ev: P[Any]): P[InputValue]               = "=" ~/ value
 
   def operationType(implicit ev: P[Any]): P[OperationType] =
-    P("query").map(_ => OperationType.Query) | P("mutation").map(_ => OperationType.Mutation) | P("subscription").map(
-      _ => OperationType.Subscription
-    )
+    StringIn("query", "mutation", "subscription").!.map {
+      case "query"        => OperationType.Query
+      case "mutation"     => OperationType.Mutation
+      case "subscription" => OperationType.Subscription
+    }
 
   def operationDefinition(implicit ev: P[Any]): P[OperationDefinition] =
-    P(operationType ~/ name.? ~ variableDefinitions.? ~ directives ~ selectionSet).map {
+    (operationType ~/ name.? ~ variableDefinitions.? ~ directives ~ selectionSet).map {
       case (operationType, name, variableDefinitions, directives, selection) =>
         OperationDefinition(operationType, name, variableDefinitions.getOrElse(Nil), directives, selection)
-    } | P(selectionSet).map(selection => OperationDefinition(OperationType.Query, None, Nil, Nil, selection))
+    } | selectionSet.map(selection => OperationDefinition(OperationType.Query, None, Nil, Nil, selection))
 
   def fragmentDefinition(implicit ev: P[Any]): P[FragmentDefinition] =
-    P("fragment" ~/ fragmentName ~ typeCondition ~ directives ~ selectionSet).map {
+    ("fragment" ~/ fragmentName ~ typeCondition ~ directives ~ selectionSet).map {
       case (name, typeCondition, dirs, sel) => FragmentDefinition(name, typeCondition, dirs, sel)
     }
 
   def objectTypeDefinition(implicit ev: P[Any]): P[ObjectTypeDefinition] =
-    P(stringValue.? ~ "type" ~/ name ~ implements.? ~ directives.? ~ "{" ~ fieldDefinition.rep ~ "}").map {
+    (stringValue.? ~ "type" ~/ name ~ implements.? ~ directives.? ~ "{" ~ fieldDefinition.rep ~ "}").map {
       case (description, name, implements, directives, fields) =>
         ObjectTypeDefinition(
           description.map(_.value),
@@ -69,12 +71,12 @@ object Parsers extends SelectionParsers {
     }
 
   def implements(implicit ev: P[Any]): P[List[NamedType]] =
-    P("implements" ~ ("&".? ~ namedType) ~ ("&" ~ namedType).rep).map { case (head, tail) =>
+    ("implements" ~ ("&".? ~ namedType) ~ ("&" ~ namedType).rep).map { case (head, tail) =>
       head :: tail.toList
     }
 
   def interfaceTypeDefinition(implicit ev: P[Any]): P[InterfaceTypeDefinition] =
-    P(stringValue.? ~ "interface" ~/ name ~ implements.? ~ directives.? ~ "{" ~ fieldDefinition.rep ~ "}").map {
+    (stringValue.? ~ "interface" ~/ name ~ implements.? ~ directives.? ~ "{" ~ fieldDefinition.rep ~ "}").map {
       case (description, name, implements, directives, fields) =>
         InterfaceTypeDefinition(
           description.map(_.value),
@@ -86,7 +88,7 @@ object Parsers extends SelectionParsers {
     }
 
   def inputObjectTypeDefinition(implicit ev: P[Any]): P[InputObjectTypeDefinition] =
-    P(stringValue.? ~ "input" ~/ name ~ directives.? ~ ("{" ~ argumentDefinition.rep ~ "}").?).map {
+    (stringValue.? ~ "input" ~/ name ~ directives.? ~ ("{" ~ argumentDefinition.rep ~ "}").?).map {
       case (description, name, directives, fields) =>
         InputObjectTypeDefinition(
           description.map(_.value),
@@ -97,14 +99,14 @@ object Parsers extends SelectionParsers {
     }
 
   def enumValueDefinition(implicit ev: P[Any]): P[EnumValueDefinition] =
-    P(stringValue.? ~ name ~ directives.?).map { case (description, enumValue, directives) =>
+    (stringValue.? ~ name ~ directives.?).map { case (description, enumValue, directives) =>
       EnumValueDefinition(description.map(_.value), enumValue, directives.getOrElse(Nil))
     }
 
   def enumName(implicit ev: P[Any]): P[String] = name.filter(s => s != "true" && s != "false" && s != "null")
 
   def enumTypeDefinition(implicit ev: P[Any]): P[EnumTypeDefinition] =
-    P(stringValue.? ~ "enum" ~/ enumName ~ directives.? ~ ("{" ~ enumValueDefinition.rep ~ "}").?).map {
+    (stringValue.? ~ "enum" ~/ enumName ~ directives.? ~ ("{" ~ enumValueDefinition.rep ~ "}").?).map {
       case (description, name, directives, enumValuesDefinition) =>
         EnumTypeDefinition(
           description.map(_.value),
@@ -115,22 +117,21 @@ object Parsers extends SelectionParsers {
     }
 
   def unionTypeDefinition(implicit ev: P[Any]): P[UnionTypeDefinition] =
-    P(stringValue.? ~ "union" ~/ name ~ directives.? ~ "=" ~ ("|".? ~ namedType) ~ ("|" ~ namedType).rep).map {
+    (stringValue.? ~ "union" ~/ name ~ directives.? ~ "=" ~ ("|".? ~ namedType) ~ ("|" ~ namedType).rep).map {
       case (description, name, directives, m, ms) =>
         UnionTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil), (m :: ms.toList).map(_.name))
     }
 
   def scalarTypeDefinition(implicit ev: P[Any]): P[ScalarTypeDefinition] =
-    P(stringValue.? ~ "scalar" ~/ name ~ directives.?).map { case (description, name, directives) =>
+    (stringValue.? ~ "scalar" ~/ name ~ directives.?).map { case (description, name, directives) =>
       ScalarTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil))
     }
 
-  def rootOperationTypeDefinition(implicit ev: P[Any]): P[(OperationType, NamedType)] = P(
+  def rootOperationTypeDefinition(implicit ev: P[Any]): P[(OperationType, NamedType)] =
     operationType ~ ":" ~ namedType
-  )
 
   def schemaDefinition(implicit ev: P[Any]): P[SchemaDefinition] =
-    P(stringValue.? ~ "schema" ~/ directives.? ~ "{" ~ rootOperationTypeDefinition.rep ~ "}").map {
+    (stringValue.? ~ "schema" ~/ directives.? ~ "{" ~ rootOperationTypeDefinition.rep ~ "}").map {
       case (description, directives, ops) =>
         val opsMap = ops.toMap
         SchemaDefinition(
@@ -143,7 +144,7 @@ object Parsers extends SelectionParsers {
     }
 
   def schemaExtensionWithOptionalDirectivesAndOperations(implicit ev: P[Any]): P[SchemaExtension] =
-    P(directives.? ~ "{" ~ rootOperationTypeDefinition.rep ~ "}").map { case (directives, ops) =>
+    (directives.? ~ "{" ~ rootOperationTypeDefinition.rep ~ "}").map { case (directives, ops) =>
       val opsMap = ops.toMap
       SchemaExtension(
         directives.getOrElse(Nil),
@@ -154,20 +155,20 @@ object Parsers extends SelectionParsers {
     }
 
   def schemaExtensionWithDirectives(implicit ev: P[Any]): P[SchemaExtension] =
-    P(directives).map(SchemaExtension(_, None, None, None))
+    directives.map(SchemaExtension(_, None, None, None))
 
   def schemaExtension(implicit ev: P[Any]): P[SchemaExtension] =
-    P("extend schema" ~/ (NoCut(schemaExtensionWithOptionalDirectivesAndOperations) | schemaExtensionWithDirectives))
+    "extend schema" ~/ (NoCut(schemaExtensionWithOptionalDirectivesAndOperations) | schemaExtensionWithDirectives)
 
   def scalarTypeExtension(implicit ev: P[Any]): P[ScalarTypeExtension] =
-    P("extend scalar" ~/ name ~ directives).map { case (name, directives) =>
+    ("extend scalar" ~/ name ~ directives).map { case (name, directives) =>
       ScalarTypeExtension(name, directives)
     }
 
   def objectTypeExtensionWithOptionalInterfacesOptionalDirectivesAndFields(implicit
     ev: P[Any]
   ): P[ObjectTypeExtension] =
-    P(name ~ implements.? ~ directives.? ~ "{" ~ fieldDefinition.rep ~ "}").map {
+    (name ~ implements.? ~ directives.? ~ "{" ~ fieldDefinition.rep ~ "}").map {
       case (name, implements, directives, fields) =>
         ObjectTypeExtension(
           name,
@@ -178,18 +179,17 @@ object Parsers extends SelectionParsers {
     }
 
   def objectTypeExtensionWithOptionalInterfacesAndDirectives(implicit ev: P[Any]): P[ObjectTypeExtension] =
-    P(name ~ implements.? ~ directives ~ !("{" ~ fieldDefinition.rep ~ "}")).map {
-      case (name, implements, directives) =>
-        ObjectTypeExtension(
-          name,
-          implements.getOrElse(Nil),
-          directives,
-          Nil
-        )
+    (name ~ implements.? ~ directives ~ !("{" ~ fieldDefinition.rep ~ "}")).map { case (name, implements, directives) =>
+      ObjectTypeExtension(
+        name,
+        implements.getOrElse(Nil),
+        directives,
+        Nil
+      )
     }
 
   def objectTypeExtensionWithInterfaces(implicit ev: P[Any]): P[ObjectTypeExtension] =
-    P(name ~ implements).map { case (name, implements) =>
+    (name ~ implements).map { case (name, implements) =>
       ObjectTypeExtension(
         name,
         implements,
@@ -199,82 +199,74 @@ object Parsers extends SelectionParsers {
     }
 
   def objectTypeExtension(implicit ev: P[Any]): P[ObjectTypeExtension] =
-    P(
-      "extend type" ~/ (
-        NoCut(objectTypeExtensionWithOptionalInterfacesOptionalDirectivesAndFields) |
-          NoCut(objectTypeExtensionWithOptionalInterfacesAndDirectives) |
-          objectTypeExtensionWithInterfaces
-      )
+    "extend type" ~/ (
+      NoCut(objectTypeExtensionWithOptionalInterfacesOptionalDirectivesAndFields) |
+        NoCut(objectTypeExtensionWithOptionalInterfacesAndDirectives) |
+        objectTypeExtensionWithInterfaces
     )
 
   def interfaceTypeExtensionWithOptionalDirectivesAndFields(implicit ev: P[Any]): P[InterfaceTypeExtension] =
-    P(name ~ directives.? ~ "{" ~ fieldDefinition.rep ~ "}").map { case (name, directives, fields) =>
+    (name ~ directives.? ~ "{" ~ fieldDefinition.rep ~ "}").map { case (name, directives, fields) =>
       InterfaceTypeExtension(name, directives.getOrElse(Nil), fields.toList)
     }
 
   def interfaceTypeExtensionWithDirectives(implicit ev: P[Any]): P[InterfaceTypeExtension] =
-    P(name ~ directives).map { case (name, directives) =>
+    (name ~ directives).map { case (name, directives) =>
       InterfaceTypeExtension(name, directives, Nil)
     }
 
   def interfaceTypeExtension(implicit ev: P[Any]): P[InterfaceTypeExtension] =
-    P(
-      "extend interface" ~/ (
-        NoCut(interfaceTypeExtensionWithOptionalDirectivesAndFields) |
-          interfaceTypeExtensionWithDirectives
-      )
+    "extend interface" ~/ (
+      NoCut(interfaceTypeExtensionWithOptionalDirectivesAndFields) |
+        interfaceTypeExtensionWithDirectives
     )
 
   def unionTypeExtensionWithOptionalDirectivesAndUnionMembers(implicit ev: P[Any]): P[UnionTypeExtension] =
-    P(name ~ directives.? ~ "=" ~ ("|".? ~ namedType) ~ ("|" ~ namedType).rep).map { case (name, directives, m, ms) =>
+    (name ~ directives.? ~ "=" ~ ("|".? ~ namedType) ~ ("|" ~ namedType).rep).map { case (name, directives, m, ms) =>
       UnionTypeExtension(name, directives.getOrElse(Nil), (m :: ms.toList).map(_.name))
     }
 
   def unionTypeExtensionWithDirectives(implicit ev: P[Any]): P[UnionTypeExtension] =
-    P(name ~ directives).map { case (name, directives) =>
+    (name ~ directives).map { case (name, directives) =>
       UnionTypeExtension(name, directives, Nil)
     }
 
   def unionTypeExtension(implicit ev: P[Any]): P[UnionTypeExtension] =
-    P(
-      "extend union" ~/
-        (NoCut(unionTypeExtensionWithOptionalDirectivesAndUnionMembers) | unionTypeExtensionWithDirectives)
-    )
+    "extend union" ~/
+      (NoCut(unionTypeExtensionWithOptionalDirectivesAndUnionMembers) | unionTypeExtensionWithDirectives)
 
   def enumTypeExtensionWithOptionalDirectivesAndValues(implicit ev: P[Any]): P[EnumTypeExtension] =
-    P(enumName ~ directives.? ~ "{" ~ enumValueDefinition.rep ~ "}").map {
+    (enumName ~ directives.? ~ "{" ~ enumValueDefinition.rep ~ "}").map {
       case (name, directives, enumValuesDefinition) =>
         EnumTypeExtension(name, directives.getOrElse(Nil), enumValuesDefinition.toList)
     }
 
   def enumTypeExtensionWithDirectives(implicit ev: P[Any]): P[EnumTypeExtension] =
-    P(enumName ~ directives).map { case (name, directives) =>
+    (enumName ~ directives).map { case (name, directives) =>
       EnumTypeExtension(name, directives, Nil)
     }
 
   def enumTypeExtension(implicit ev: P[Any]): P[EnumTypeExtension] =
-    P("extend enum" ~/ (NoCut(enumTypeExtensionWithOptionalDirectivesAndValues) | enumTypeExtensionWithDirectives))
+    ("extend enum" ~/ (NoCut(enumTypeExtensionWithOptionalDirectivesAndValues) | enumTypeExtensionWithDirectives))
 
   def inputObjectTypeExtensionWithOptionalDirectivesAndFields(implicit ev: P[Any]): P[InputObjectTypeExtension] =
-    P(name ~ directives.? ~ "{" ~ argumentDefinition.rep ~ "}").map { case (name, directives, fields) =>
+    (name ~ directives.? ~ "{" ~ argumentDefinition.rep ~ "}").map { case (name, directives, fields) =>
       InputObjectTypeExtension(name, directives.getOrElse(Nil), fields.toList)
     }
 
   def inputObjectTypeExtensionWithDirectives(implicit ev: P[Any]): P[InputObjectTypeExtension] =
-    P(name ~ directives).map { case (name, directives) =>
+    (name ~ directives).map { case (name, directives) =>
       InputObjectTypeExtension(name, directives, Nil)
     }
 
   def inputObjectTypeExtension(implicit ev: P[Any]): P[InputObjectTypeExtension] =
-    P(
-      "extend input" ~/ (
-        NoCut(inputObjectTypeExtensionWithOptionalDirectivesAndFields) |
-          inputObjectTypeExtensionWithDirectives
-      )
+    "extend input" ~/ (
+      NoCut(inputObjectTypeExtensionWithOptionalDirectivesAndFields) |
+        inputObjectTypeExtensionWithDirectives
     )
 
   def directiveLocation(implicit ev: P[Any]): P[DirectiveLocation] =
-    P(
+    (
       StringIn(
         "QUERY",
         "MUTATION",
@@ -318,7 +310,7 @@ object Parsers extends SelectionParsers {
     }
 
   def directiveDefinition(implicit ev: P[Any]): P[DirectiveDefinition] =
-    P(
+    (
       stringValue.? ~ "directive @" ~/ name ~ argumentDefinitions.? ~ "repeatable".!.? ~ "on" ~ ("|".? ~ directiveLocation) ~ ("|" ~ directiveLocation).rep
     ).map { case (description, name, args, repeatable, firstLoc, otherLoc) =>
       DirectiveDefinition(
@@ -342,7 +334,7 @@ object Parsers extends SelectionParsers {
     typeDefinition | schemaDefinition | directiveDefinition
 
   def executableDefinition(implicit ev: P[Any]): P[ExecutableDefinition] =
-    P(operationDefinition | fragmentDefinition)
+    operationDefinition | fragmentDefinition
 
   def typeExtension(implicit ev: P[Any]): P[TypeExtension] =
     objectTypeExtension |
@@ -355,8 +347,9 @@ object Parsers extends SelectionParsers {
   def typeSystemExtension(implicit ev: P[Any]): P[TypeSystemExtension] =
     schemaExtension | typeExtension
 
-  def definition(implicit ev: P[Any]): P[Definition] = executableDefinition | typeSystemDefinition | typeSystemExtension
+  def definition(implicit ev: P[Any]): P[Definition] =
+    executableDefinition | typeSystemDefinition | typeSystemExtension
 
   def document(implicit ev: P[Any]): P[ParsedDocument] =
-    P(Start ~ definition.rep ~ End).map(seq => ParsedDocument(seq.toList))
+    ((Start ~ executableDefinition.rep ~ End) | (Start ~ definition.rep ~ End)).map(seq => ParsedDocument(seq.toList))
 }

--- a/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
@@ -12,37 +12,37 @@ import scala.annotation.nowarn
 private[caliban] trait SelectionParsers extends ValueParsers {
 
   @deprecated("Kept for bincompat only, scheduled to be removed")
-  def alias(implicit ev: P[Any]): P[String] = P(name ~ ":")
-  def aliasOrName(implicit ev: P[Any]): P[String] = P(":" ~ name)
+  def alias(implicit ev: P[Any]): P[String] = name ~ ":"
+  def aliasOrName(implicit ev: P[Any]): P[String] = ":" ~/ name
 
-  def argument(implicit ev: P[Any]): P[(String, InputValue)]     = P(name ~ ":" ~ value)
-  def arguments(implicit ev: P[Any]): P[Map[String, InputValue]] = P("(" ~/ argument.rep ~ ")").map(_.toMap)
+  def argument(implicit ev: P[Any]): P[(String, InputValue)]     = name ~ ":" ~ value
+  def arguments(implicit ev: P[Any]): P[Map[String, InputValue]] = ("(" ~/ argument.rep ~ ")").map(_.toMap)
 
-  def directive(implicit ev: P[Any]): P[Directive]        = P(Index ~ "@" ~ name ~ arguments.?).map {
+  def directive(implicit ev: P[Any]): P[Directive]        = ("@" ~~/ Index ~~ name ~ arguments.?).map {
     case (index, name, arguments) =>
-      Directive(name, arguments.getOrElse(Map()), index)
+      Directive(name, arguments.getOrElse(Map()), index - 1)
   }
-  def directives(implicit ev: P[Any]): P[List[Directive]] = P(directive.rep).map(_.toList)
+  def directives(implicit ev: P[Any]): P[List[Directive]] = directive.rep.map(_.toList)
 
-  def selection(implicit ev: P[Any]): P[Selection]          = P(field | fragmentSpread | inlineFragment)
-  def selectionSet(implicit ev: P[Any]): P[List[Selection]] = P("{" ~/ selection.rep ~ "}").map(_.toList)
+  def selection(implicit ev: P[Any]): P[Selection]          = !"}" ~~ (field | fragmentSpread | inlineFragment)
+  def selectionSet(implicit ev: P[Any]): P[List[Selection]] = ("{" ~/ selection.rep ~ "}").map(_.toList)
 
-  def namedType(implicit ev: P[Any]): P[NamedType] = P(name.filter(_ != "null")).map(NamedType(_, nonNull = false))
-  def listType(implicit ev: P[Any]): P[ListType]   = P("[" ~ type_ ~ "]").map(t => ListType(t, nonNull = false))
+  def namedType(implicit ev: P[Any]): P[NamedType] = name.filter(_ != "null").map(NamedType(_, nonNull = false))
+  def listType(implicit ev: P[Any]): P[ListType]   = ("[" ~ type_ ~ "]").map(t => ListType(t, nonNull = false))
 
   @deprecated("Kept for bincompat only, scheduled to be removed")
-  def nonNullType(implicit ev: P[Any]): P[Type] = P((namedType | listType) ~ "!").map {
+  def nonNullType(implicit ev: P[Any]): P[Type] = ((namedType | listType) ~ "!").map {
     case t: NamedType => t.copy(nonNull = true)
     case t: ListType  => t.copy(nonNull = true)
   }
 
-  def type_(implicit ev: P[Any]): P[Type] = P((namedType | listType) ~ "!".!.?).map {
+  def type_(implicit ev: P[Any]): P[Type] = ((namedType | listType) ~ "!".!.?).map {
     case (t: NamedType, nn) => if (nn.isDefined) t.copy(nonNull = true) else t
     case (t: ListType, nn)  => if (nn.isDefined) t.copy(nonNull = true) else t
   }
 
   def field(implicit ev: P[Any]): P[Field] =
-    P(Index ~ name ~ aliasOrName.? ~ arguments.? ~ directives.? ~ selectionSet.?).map {
+    (Index ~ name ~ aliasOrName.? ~ arguments.? ~ directives.? ~ selectionSet.?).map {
       case (index, alias, Some(name), args, dirs, sels) =>
         Field(Some(alias), name, args.getOrElse(Map()), dirs.getOrElse(Nil), sels.getOrElse(Nil), index)
       case (index, name, _, args, dirs, sels)           =>
@@ -50,17 +50,17 @@ private[caliban] trait SelectionParsers extends ValueParsers {
 
     }
 
-  def fragmentName(implicit ev: P[Any]): P[String] = P(name).filter(_ != "on")
+  def fragmentName(implicit ev: P[Any]): P[String] = name.filter(_ != "on")
 
-  def fragmentSpread(implicit ev: P[Any]): P[FragmentSpread] = P("..." ~ fragmentName ~ directives).map {
+  def fragmentSpread(implicit ev: P[Any]): P[FragmentSpread] = ("..." ~ fragmentName ~ directives).map {
     case (name, dirs) =>
       FragmentSpread(name, dirs)
   }
 
-  def typeCondition(implicit ev: P[Any]): P[NamedType] = P("on" ~/ namedType)
+  def typeCondition(implicit ev: P[Any]): P[NamedType] = "on" ~/ namedType
 
   def inlineFragment(implicit ev: P[Any]): P[InlineFragment] =
-    P("..." ~ typeCondition.? ~ directives ~ selectionSet).map { case (typeCondition, dirs, sel) =>
+    ("..." ~ typeCondition.? ~ directives ~ selectionSet).map { case (typeCondition, dirs, sel) =>
       InlineFragment(typeCondition, dirs, sel)
     }
 }

--- a/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
@@ -55,16 +55,16 @@ private[caliban] trait StringParsers {
       } else ctx.freshSuccessUnit(index)
   }
 
-  def sourceCharacter(implicit ev: P[Any]): P[Unit]                      = P(CharIn("\u0009\u000A\u000D\u0020-\uFFFF"))
-  def sourceCharacterWithoutLineTerminator(implicit ev: P[Any]): P[Unit] = P(CharIn("\u0009\u0020-\uFFFF"))
-  def name(implicit ev: P[Any]): P[String]                               = P(CharIn("_A-Za-z") ~~ CharIn("_0-9A-Za-z").repX).!
-  def nameOnly(implicit ev: P[Any]): P[String]                           = P(Start ~ name ~ End)
+  def sourceCharacter(implicit ev: P[Any]): P[Unit]                      = CharIn("\u0009\u000A\u000D\u0020-\uFFFF")
+  def sourceCharacterWithoutLineTerminator(implicit ev: P[Any]): P[Unit] = CharIn("\u0009\u0020-\uFFFF")
+  def name(implicit ev: P[Any]): P[String]                               = (CharIn("_A-Za-z") ~~ CharIn("_0-9A-Za-z").repX).!
+  def nameOnly(implicit ev: P[Any]): P[String]                           = Start ~ name ~ End
 
-  def hexDigit(implicit ev: P[Any]): P[Unit]         = P(CharIn("0-9a-fA-F"))
+  def hexDigit(implicit ev: P[Any]): P[Unit]         = CharIn("0-9a-fA-F")
   def escapedUnicode(implicit ev: P[Any]): P[String] =
-    P(hexDigit ~~ hexDigit ~~ hexDigit ~~ hexDigit).!.map(Integer.parseInt(_, 16).toChar.toString)
+    (hexDigit ~~ hexDigit ~~ hexDigit ~~ hexDigit).!.map(Integer.parseInt(_, 16).toChar.toString)
 
-  def escapedCharacter(implicit ev: P[Any]): P[String] = P(CharIn("\"\\\\/bfnrt").!).map {
+  def escapedCharacter(implicit ev: P[Any]): P[String] = CharIn("\"\\\\/bfnrt").!.map {
     case "b"   => "\b"
     case "n"   => "\n"
     case "f"   => "\f"
@@ -74,16 +74,14 @@ private[caliban] trait StringParsers {
   }
 
   def stringCharacter(implicit ev: P[Any]): P[String] =
-    P(
-      sourceCharacterWithoutLineTerminator.!.filter(c =>
-        c != "\"" && c != "\\"
-      ) | "\\u" ~~ escapedUnicode | "\\" ~~ escapedCharacter
-    )
+    sourceCharacterWithoutLineTerminator.!.filter(c =>
+      c != "\"" && c != "\\"
+    ) | "\\u" ~~ escapedUnicode | "\\" ~~ escapedCharacter
 
-  def blockStringCharacter(implicit ev: P[Any]): P[String] = P("\\\"\"\"".!.map(_ => "\"\"\"") | sourceCharacter.!)
+  def blockStringCharacter(implicit ev: P[Any]): P[String] = "\\\"\"\"".!.map(_ => "\"\"\"") | sourceCharacter.!
 
   def stringValue(implicit ev: P[Any]): P[StringValue] =
-    P(
+    (
       ("\"\"\"" ~~ ((!"\"\"\"") ~~ blockStringCharacter).repX.map(s => blockStringValue(s.mkString)) ~~ "\"\"\"") |
         ("\"" ~~ stringCharacter.repX.map(_.mkString) ~~ "\"")
     ).map(v => StringValue(v))

--- a/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
@@ -10,20 +10,19 @@ import scala.annotation.nowarn
 @nowarn("msg=NoWhitespace") // False positive warning in Scala 2.x
 private[caliban] trait ValueParsers extends NumberParsers {
   def booleanValue(implicit ev: P[Any]): P[BooleanValue] =
-    P("true").map(_ => BooleanValue(true)) | P("false").map(_ => BooleanValue(false))
+    StringIn("true", "false").!.map(v => BooleanValue(v.toBoolean))
 
-  def nullValue(implicit ev: P[Any]): P[InputValue] = P("null").map(_ => NullValue)
-  def enumValue(implicit ev: P[Any]): P[InputValue] = P(name).map(EnumValue.apply)
-  def listValue(implicit ev: P[Any]): P[ListValue]  = P("[" ~/ value.rep ~ "]").map(values => ListValue(values.toList))
+  def nullValue(implicit ev: P[Any]): P[InputValue] = LiteralStr("null").map(_ => NullValue)
+  def enumValue(implicit ev: P[Any]): P[InputValue] = name.map(EnumValue.apply)
+  def listValue(implicit ev: P[Any]): P[ListValue]  = ("[" ~/ value.rep ~ "]").map(values => ListValue(values.toList))
 
-  def objectField(implicit ev: P[Any]): P[(String, InputValue)] = P(name ~ ":" ~/ value)
+  def objectField(implicit ev: P[Any]): P[(String, InputValue)] = name ~ ":" ~/ value
   def objectValue(implicit ev: P[Any]): P[ObjectValue]          =
-    P("{" ~ objectField.rep ~ "}").map(values => ObjectValue(values.toMap))
+    ("{" ~/ objectField.rep ~ "}").map(values => ObjectValue(values.toMap))
 
-  def variableValue(implicit ev: P[Any]): P[VariableValue] = P("$" ~/ name).map(VariableValue.apply)
+  def variableValue(implicit ev: P[Any]): P[VariableValue] = ("$" ~/ name).map(VariableValue.apply)
 
   def value(implicit ev: P[Any]): P[InputValue] =
-    P(
-      floatValue | intValue | booleanValue | stringValue | nullValue | enumValue | listValue | objectValue | variableValue
-    )
+    floatValue | intValue | booleanValue | stringValue | nullValue | enumValue | listValue | objectValue | variableValue
+
 }

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -25,6 +25,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.{ IO, Trace, ZIO }
 
 import scala.annotation.tailrec
+import scala.collection.compat._
 import scala.collection.mutable
 
 object Validator {

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -49,7 +49,9 @@ object Validator {
    * Verifies that the given document is valid for this type. Fails with a [[caliban.CalibanError.ValidationError]] otherwise.
    */
   def validate(document: Document, rootType: RootType)(implicit trace: Trace): IO[ValidationError, Unit] =
-    Configurator.configuration.map(_.validations).flatMap(check(document, rootType, Map.empty, _).unit.toZIO)
+    Configurator.configuration
+      .map(_.validations)
+      .flatMap(v => ZIO.fromEither(check(document, rootType, Map.empty, v).map(_ => ())))
 
   /**
    * Verifies that the given schema is valid. Fails with a [[caliban.CalibanError.ValidationError]] otherwise.
@@ -85,6 +87,9 @@ object Validator {
   def failValidation(msg: String, explanatoryText: String): EReader[Any, ValidationError, Nothing] =
     ZPure.fail(ValidationError(msg, explanatoryText))
 
+  private def failValidationEither(msg: String, explanatoryText: String): Either[ValidationError, Nothing] =
+    Left(ValidationError(msg, explanatoryText))
+
   /**
    * Prepare the request for execution.
    * Fails with a [[caliban.CalibanError.ValidationError]] otherwise.
@@ -97,9 +102,9 @@ object Validator {
     variables: Map[String, InputValue],
     skipValidation: Boolean,
     validations: List[QueryValidation]
-  ): IO[ValidationError, ExecutionRequest] = {
-    val fragments: EReader[Any, ValidationError, Map[String, FragmentDefinition]] = if (skipValidation) {
-      ZPure.succeed[Unit, Map[String, FragmentDefinition]](
+  ): IO[ValidationError, ExecutionRequest] = ZIO.fromEither {
+    val fragments: Either[ValidationError, Map[String, FragmentDefinition]] = if (skipValidation) {
+      Right(
         collectDefinitions(document)._2
           .foldLeft(List.empty[(String, FragmentDefinition)]) { case (l, f) => (f.name, f) :: l }
           .toMap
@@ -119,20 +124,15 @@ object Validator {
       }
 
       operation match {
-        case Left(error) => failValidation(error, "")
+        case Left(error) => Left(ValidationError(error, ""))
         case Right(op)   =>
           (op.operationType match {
-            case Query        => ZPure.succeed[Unit, Operation[R]](rootSchema.query)
+            case Query        =>
+              Right(rootSchema.query)
             case Mutation     =>
-              rootSchema.mutation match {
-                case Some(m) => ZPure.succeed[Unit, Operation[R]](m)
-                case None    => failValidation("Mutations are not supported on this schema", "")
-              }
+              rootSchema.mutation.toRight(ValidationError("Mutations are not supported on this schema", ""))
             case Subscription =>
-              rootSchema.subscription match {
-                case Some(m) => ZPure.succeed[Unit, Operation[R]](m)
-                case None    => failValidation("Subscriptions are not supported on this schema", "")
-              }
+              rootSchema.subscription.toRight(ValidationError("Subscriptions are not supported on this schema", ""))
           }).map(operation =>
             ExecutionRequest(
               F(
@@ -151,19 +151,19 @@ object Validator {
           )
       }
     }
-  }.toZIO
+  }(Trace.empty)
 
   private def check(
     document: Document,
     rootType: RootType,
     variables: Map[String, InputValue],
     validations: List[QueryValidation]
-  ): EReader[Any, ValidationError, Map[String, FragmentDefinition]] = {
+  ): Either[ValidationError, Map[String, FragmentDefinition]] = {
     val (operations, fragments, _, _) = collectDefinitions(document)
     validateFragments(fragments).flatMap { fragmentMap =>
       val selectionSets = collectSelectionSets(operations.flatMap(_.selectionSet) ++ fragments.flatMap(_.selectionSet))
       val context       = Context(document, rootType, operations, fragmentMap, selectionSets, variables)
-      validateAll(validations)(identity).provideService(context) as fragmentMap
+      ZPure.collectAll(validations).provideService(context).runEither.map(_ => fragmentMap)
     }
   }
 
@@ -194,23 +194,26 @@ object Validator {
       selectionSet: List[Selection]
     ): mutable.Builder[InputValue, List[InputValue]] = {
       // ugly mutable code but it's worth it for the speed ;)
-      def add(list: Iterable[InputValue]) = if (list.nonEmpty) builder ++= list
+      def add(args: Map[String, InputValue]): Unit = {
+        if (args.nonEmpty) builder ++= args.values
+        ()
+      }
 
       selectionSet.foreach {
         case FragmentSpread(name, directives)                    =>
-          directives.foreach(d => add(d.arguments.values))
+          directives.foreach(d => add(d.arguments))
           context.fragments
             .get(name)
             .foreach { f =>
-              f.directives.foreach(d => add(d.arguments.values))
+              f.directives.foreach(d => add(d.arguments))
               collectValues(builder, f.selectionSet)
             }
         case Field(_, _, arguments, directives, selectionSet, _) =>
-          add(arguments.values)
-          directives.foreach(d => add(d.arguments.values))
+          add(arguments)
+          directives.foreach(d => add(d.arguments))
           collectValues(builder, selectionSet)
         case InlineFragment(_, directives, selectionSet)         =>
-          directives.foreach(d => add(d.arguments.values))
+          directives.foreach(d => add(d.arguments))
           collectValues(builder, selectionSet)
       }
       builder
@@ -397,21 +400,24 @@ object Validator {
 
   lazy val validateFragmentSpreads: QueryValidation =
     ZPure.serviceWithPure { context =>
-      val spreads     = collectFragmentSpreads(context.selectionSets)
-      val spreadNames = spreads.map(_.name).toSet
-      validateAll(context.fragments.values)(f =>
-        if (!spreadNames.contains(f.name))
-          failValidation(
-            s"Fragment '${f.name}' is not used in any spread.",
-            "Defined fragments must be used within a document."
-          )
-        else if (detectCycles(context, f))
-          failValidation(
-            s"Fragment '${f.name}' forms a cycle.",
-            "The graph of fragment spreads must not form any cycles including spreading itself. Otherwise an operation could infinitely spread or infinitely execute on cycles in the underlying data."
-          )
-        else zunit
-      )
+      if (context.fragments.isEmpty) zunit
+      else {
+        val spreads     = collectFragmentSpreads(context.selectionSets)
+        val spreadNames = mutable.Set.from(spreads.map(_.name))
+        validateAll(context.fragments.values) { f =>
+          if (!spreadNames.contains(f.name))
+            failValidation(
+              s"Fragment '${f.name}' is not used in any spread.",
+              "Defined fragments must be used within a document."
+            )
+          else if (detectCycles(context, f))
+            failValidation(
+              s"Fragment '${f.name}' forms a cycle.",
+              "The graph of fragment spreads must not form any cycles including spreading itself. Otherwise an operation could infinitely spread or infinitely execute on cycles in the underlying data."
+            )
+          else zunit
+        }
+      }
     }
 
   private def detectCycles(context: Context, fragment: FragmentDefinition, visited: Set[String] = Set()): Boolean = {
@@ -457,8 +463,9 @@ object Validator {
     currentType: __Type
   ): EReader[Any, ValidationError, Unit] = {
     val v1 = validateFields(context, selectionSet, currentType)
-    def v2 = FragmentValidator.findConflictsWithinSelectionSet(context, context.rootType.queryType, selectionSet)
-    if (context.fragments.nonEmpty || containsFragments(selectionSet)) v1 *> v2 else v1
+    if (context.fragments.nonEmpty || containsFragments(selectionSet))
+      v1 *> FragmentValidator.findConflictsWithinSelectionSet(context, context.rootType.queryType, selectionSet)
+    else v1
   }
 
   private def validateFields(
@@ -737,20 +744,20 @@ object Validator {
 
   private def validateFragments(
     fragments: List[FragmentDefinition]
-  ): EReader[Any, ValidationError, Map[String, FragmentDefinition]] = {
+  ): Either[ValidationError, Map[String, FragmentDefinition]] = {
     var fragmentMap = Map.empty[String, FragmentDefinition]
     val iter        = fragments.iterator
     while (iter.hasNext) {
       val fragment = iter.next()
       if (fragmentMap.contains(fragment.name)) {
-        return failValidation(
+        return failValidationEither(
           s"Fragment '${fragment.name}' is defined more than once.",
           "Fragment definitions are referenced in fragment spreads by name. To avoid ambiguity, each fragment’s name must be unique within a document."
         )
       }
       fragmentMap = fragmentMap.updated(fragment.name, fragment)
     }
-    ZPure.succeed(fragmentMap)
+    Right(fragmentMap)
   }
 
   lazy val validateSubscriptionOperation: QueryValidation = ZPure.serviceWithPure { context =>
@@ -883,7 +890,7 @@ object Validator {
   }
 
   def validateObject(obj: __Type): EReader[Any, ValidationError, Unit] = {
-    val objectContext = s"Object '${obj.name.getOrElse("")}'"
+    lazy val objectContext = s"Object '${obj.name.getOrElse("")}'"
 
     def validateInterfaceFields(obj: __Type) = {
       def fieldNames(t: __Type) = t.allFieldsMap.keySet

--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -151,6 +151,9 @@ object Wrapper {
     loop(process, wrappers)(info)
   }
 
+  private val emptyWrappers =
+    ZIO.succeed((Nil, Nil, Nil, Nil, Nil, Nil))(Trace.empty)
+
   private[caliban] def decompose[R](wrappers: List[Wrapper[R]])(implicit trace: Trace): UIO[
     (
       List[OverallWrapper[R]],
@@ -161,7 +164,7 @@ object Wrapper {
       List[IntrospectionWrapper[R]]
     )
   ] =
-    if (wrappers.isEmpty) ZIO.succeed((Nil, Nil, Nil, Nil, Nil, Nil))
+    if (wrappers.isEmpty) emptyWrappers
     else
       ZIO.suspendSucceed {
         val o = ListBuffer.empty[OverallWrapper[R]]

--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -160,31 +160,34 @@ object Wrapper {
       List[FieldWrapper[R]],
       List[IntrospectionWrapper[R]]
     )
-  ] = ZIO.suspendSucceed {
-    val o = ListBuffer.empty[OverallWrapper[R]]
-    val p = ListBuffer.empty[ParsingWrapper[R]]
-    val v = ListBuffer.empty[ValidationWrapper[R]]
-    val e = ListBuffer.empty[ExecutionWrapper[R]]
-    val f = ListBuffer.empty[FieldWrapper[R]]
-    val i = ListBuffer.empty[IntrospectionWrapper[R]]
+  ] =
+    if (wrappers.isEmpty) ZIO.succeed((Nil, Nil, Nil, Nil, Nil, Nil))
+    else
+      ZIO.suspendSucceed {
+        val o = ListBuffer.empty[OverallWrapper[R]]
+        val p = ListBuffer.empty[ParsingWrapper[R]]
+        val v = ListBuffer.empty[ValidationWrapper[R]]
+        val e = ListBuffer.empty[ExecutionWrapper[R]]
+        val f = ListBuffer.empty[FieldWrapper[R]]
+        val i = ListBuffer.empty[IntrospectionWrapper[R]]
 
-    def loop(wrapper: Wrapper[R]): UIO[Unit] = wrapper match {
-      case wrapper: OverallWrapper[R]       => ZIO.succeed(o append wrapper)
-      case wrapper: ParsingWrapper[R]       => ZIO.succeed(p append wrapper)
-      case wrapper: ValidationWrapper[R]    => ZIO.succeed(v append wrapper)
-      case wrapper: ExecutionWrapper[R]     => ZIO.succeed(e append wrapper)
-      case wrapper: FieldWrapper[R]         => ZIO.succeed(f append wrapper)
-      case wrapper: IntrospectionWrapper[R] => ZIO.succeed(i append wrapper)
-      case CombinedWrapper(wrappers)        => ZIO.foreachDiscard(wrappers)(loop)
-      case EffectfulWrapper(wrapper)        => wrapper.flatMap(loop)
-      case Wrapper.Empty                    => ZIO.unit
-    }
+        def loop(wrapper: Wrapper[R]): UIO[Unit] = wrapper match {
+          case wrapper: OverallWrapper[R]       => ZIO.succeed(o append wrapper)
+          case wrapper: ParsingWrapper[R]       => ZIO.succeed(p append wrapper)
+          case wrapper: ValidationWrapper[R]    => ZIO.succeed(v append wrapper)
+          case wrapper: ExecutionWrapper[R]     => ZIO.succeed(e append wrapper)
+          case wrapper: FieldWrapper[R]         => ZIO.succeed(f append wrapper)
+          case wrapper: IntrospectionWrapper[R] => ZIO.succeed(i append wrapper)
+          case CombinedWrapper(wrappers)        => ZIO.foreachDiscard(wrappers)(loop)
+          case EffectfulWrapper(wrapper)        => wrapper.flatMap(loop)
+          case Wrapper.Empty                    => ZIO.unit
+        }
 
-    def finalize[W <: Wrapper[R]](buffer: ListBuffer[W]): List[W] = buffer.sortBy(_.priority).result()
+        def finalize[W <: Wrapper[R]](buffer: ListBuffer[W]): List[W] = buffer.sortBy(_.priority).result()
 
-    ZIO
-      .foreachDiscard(wrappers)(loop)
-      .as((finalize(o), finalize(p), finalize(v), finalize(e), finalize(f), finalize(i)))
-  }
+        ZIO
+          .foreachDiscard(wrappers)(loop)
+          .as((finalize(o), finalize(p), finalize(v), finalize(e), finalize(f), finalize(i)))
+      }
 
 }


### PR DESCRIPTION
Parser (~15% improvement based on our benchmark):

1. Avoid usage of named parser (i.e., `P( ... )`). Based on our benchmarks, they seem to perform a bit better. I think this is ok given that we don't do really use the parser name?
2. Introduce shortcuts cases where `.rep` is used. e.g., if we're parsing a selection set, we use the `!"}"` at the start of the parser to signal it that we reached the end of the selection set
3. Use `StringIn("caseA", "caseB")` in favour of `"caseA" | "caseB"`

Validator:

1. Change the `Validator.check` method to return an Either instead of a ZPure. It seems that past this method we don't need anything that is ZPure specific, and reducing the number of flatmaps improves performance particularly for very simple / small queries

General:
1. Added the `Validator.prepareEither` and `Parser.parseQueryEither` methods as a UX improvement for debugging / benchmarking