### PR TITLE
Define an `innerThrowable` for `ExecutionError`s raised within provided `ArgBuilder`s

### DIFF
--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -217,5 +217,8 @@ case object InvalidInputArgument extends NoStackTrace {
   override def getMessage: String = "invalid input argument"
 
   private[caliban] def apply(expected: String, actual: String): ExecutionError =
-    ExecutionError(s"Can't an instance of '$expected' from '$actual''", innerThrowable = Some(InvalidInputArgument))
+    ExecutionError(
+      s"Can't build an instance of '$expected' from '$actual'",
+      innerThrowable = Some(InvalidInputArgument)
+    )
 }

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -12,7 +12,6 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.Temporal
 import java.util.UUID
 import scala.annotation.implicitNotFound
-import scala.collection.immutable.BitSet
 import scala.util.Try
 import scala.util.control.{ NoStackTrace, NonFatal }
 
@@ -93,45 +92,45 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
   implicit lazy val unit: ArgBuilder[Unit]             = _ => Right(())
   implicit lazy val int: ArgBuilder[Int]               = {
     case value: IntValue => Right(value.toInt)
-    case other           => Left(InvalidInputArgument("Int", other.toString))
+    case other           => Left(InvalidInputArgument("Int", other))
   }
   implicit lazy val long: ArgBuilder[Long]             = {
     case value: IntValue    => Right(value.toLong)
     case StringValue(value) =>
       Try(value.toLong).fold(_ => Left(InvalidInputArgument("Long", value)), Right(_))
-    case other              => Left(InvalidInputArgument("Long", other.toString))
+    case other              => Left(InvalidInputArgument("Long", other))
   }
   implicit lazy val bigInt: ArgBuilder[BigInt]         = {
     case value: IntValue => Right(value.toBigInt)
-    case other           => Left(InvalidInputArgument("BigInt", other.toString))
+    case other           => Left(InvalidInputArgument("BigInt", other))
   }
   implicit lazy val float: ArgBuilder[Float]           = {
     case value: IntValue   => Right(value.toLong.toFloat)
     case value: FloatValue => Right(value.toFloat)
-    case other             => Left(InvalidInputArgument("Float", other.toString))
+    case other             => Left(InvalidInputArgument("Float", other))
   }
   implicit lazy val double: ArgBuilder[Double]         = {
     case value: IntValue   => Right(value.toLong.toDouble)
     case value: FloatValue => Right(value.toDouble)
-    case other             => Left(InvalidInputArgument("Double", other.toString))
+    case other             => Left(InvalidInputArgument("Double", other))
   }
   implicit lazy val bigDecimal: ArgBuilder[BigDecimal] = {
     case value: IntValue   => Right(BigDecimal(value.toBigInt))
     case value: FloatValue => Right(value.toBigDecimal)
-    case other             => Left(InvalidInputArgument("BigDecimal", other.toString))
+    case other             => Left(InvalidInputArgument("BigDecimal", other))
   }
   implicit lazy val string: ArgBuilder[String]         = {
     case StringValue(value) => Right(value)
-    case other              => Left(InvalidInputArgument("String", other.toString))
+    case other              => Left(InvalidInputArgument("String", other))
   }
   implicit lazy val uuid: ArgBuilder[UUID]             = {
     case StringValue(value) =>
       Try(UUID.fromString(value)).fold(_ => Left(InvalidInputArgument("UUID", value)), Right(_))
-    case other              => Left(InvalidInputArgument("UUID", other.toString))
+    case other              => Left(InvalidInputArgument("UUID", other))
   }
   implicit lazy val boolean: ArgBuilder[Boolean]       = {
     case BooleanValue(value) => Right(value)
-    case other               => Left(InvalidInputArgument("Boolean", other.toString))
+    case other               => Left(InvalidInputArgument("Boolean", other))
   }
 
   private abstract class TemporalDecoder[A](name: String) extends ArgBuilder[A] {
@@ -147,7 +146,7 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
             else Left(InvalidInputArgument(name, s"$value ($message)"))
         }
       case _                  =>
-        Left(InvalidInputArgument(name, input.toString))
+        Left(InvalidInputArgument(name, input))
     }
   }
 
@@ -172,7 +171,7 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
 
   lazy val instantEpoch: ArgBuilder[Instant] = {
     case i: IntValue => Right(Instant.ofEpochMilli(i.toLong))
-    case value       => Left(InvalidInputArgument("Instant", value.toString))
+    case value       => Left(InvalidInputArgument("Instant", value))
   }
 
   implicit lazy val instant: ArgBuilder[Instant]               = TemporalDecoder("Instant")(Instant.parse)
@@ -209,16 +208,16 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
 
   implicit lazy val upload: ArgBuilder[Upload] = {
     case StringValue(v) => Right(Upload(v))
-    case other          => Left(InvalidInputArgument("Upload", other.toString))
+    case other          => Left(InvalidInputArgument("Upload", other))
   }
 }
 
 case object InvalidInputArgument extends NoStackTrace {
   override def getMessage: String = "invalid input argument"
 
-  private[caliban] def apply(expected: String, actual: String): ExecutionError =
+  private[caliban] def apply(argType: String, argValue: Any): ExecutionError =
     ExecutionError(
-      s"Can't build an instance of '$expected' from '$actual'",
+      s"Can't build an instance of '$argType' from '$argValue'",
       innerThrowable = Some(InvalidInputArgument)
     )
 }

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -12,6 +12,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.Temporal
 import java.util.UUID
 import scala.annotation.implicitNotFound
+import scala.collection.immutable.BitSet
 import scala.util.Try
 import scala.util.control.{ NoStackTrace, NonFatal }
 
@@ -89,50 +90,48 @@ object ArgBuilder extends ArgBuilderInstances {
 }
 
 trait ArgBuilderInstances extends ArgBuilderDerivation {
-  private def error(msg: String): ExecutionError = ExecutionError(msg, innerThrowable = Some(InvalidInputArgument))
-
   implicit lazy val unit: ArgBuilder[Unit]             = _ => Right(())
   implicit lazy val int: ArgBuilder[Int]               = {
     case value: IntValue => Right(value.toInt)
-    case other           => Left(error(s"Can't build an Int from input $other"))
+    case other           => Left(MkInvalidInputArgument("Int", other.toString))
   }
   implicit lazy val long: ArgBuilder[Long]             = {
     case value: IntValue    => Right(value.toLong)
     case StringValue(value) =>
-      Try(value.toLong).fold(_ => Left(error(s"Can't build a Long from input $value")), Right(_))
-    case other              => Left(error(s"Can't build a Long from input $other"))
+      Try(value.toLong).fold(_ => Left(MkInvalidInputArgument("Long", value)), Right(_))
+    case other              => Left(MkInvalidInputArgument("Long", other.toString))
   }
   implicit lazy val bigInt: ArgBuilder[BigInt]         = {
     case value: IntValue => Right(value.toBigInt)
-    case other           => Left(error(s"Can't build a BigInt from input $other"))
+    case other           => Left(MkInvalidInputArgument("BigInt", other.toString))
   }
   implicit lazy val float: ArgBuilder[Float]           = {
     case value: IntValue   => Right(value.toLong.toFloat)
     case value: FloatValue => Right(value.toFloat)
-    case other             => Left(error(s"Can't build a Float from input $other"))
+    case other             => Left(MkInvalidInputArgument("Float", other.toString))
   }
   implicit lazy val double: ArgBuilder[Double]         = {
     case value: IntValue   => Right(value.toLong.toDouble)
     case value: FloatValue => Right(value.toDouble)
-    case other             => Left(error(s"Can't build a Double from input $other"))
+    case other             => Left(MkInvalidInputArgument("Double", other.toString))
   }
   implicit lazy val bigDecimal: ArgBuilder[BigDecimal] = {
     case value: IntValue   => Right(BigDecimal(value.toBigInt))
     case value: FloatValue => Right(value.toBigDecimal)
-    case other             => Left(error(s"Can't build a BigDecimal from input $other"))
+    case other             => Left(MkInvalidInputArgument("BigDecimal", other.toString))
   }
   implicit lazy val string: ArgBuilder[String]         = {
     case StringValue(value) => Right(value)
-    case other              => Left(error(s"Can't build a String from input $other"))
+    case other              => Left(MkInvalidInputArgument("String", other.toString))
   }
   implicit lazy val uuid: ArgBuilder[UUID]             = {
     case StringValue(value) =>
-      Try(UUID.fromString(value)).fold(_ => Left(error(s"Can't parse $value into a UUID")), Right(_))
-    case other              => Left(error(s"Can't build a UUID from input $other"))
+      Try(UUID.fromString(value)).fold(_ => Left(MkInvalidInputArgument("UUID", value)), Right(_))
+    case other              => Left(MkInvalidInputArgument("UUID", other.toString))
   }
   implicit lazy val boolean: ArgBuilder[Boolean]       = {
     case BooleanValue(value) => Right(value)
-    case other               => Left(error(s"Can't build a Boolean from input $other"))
+    case other               => Left(MkInvalidInputArgument("Boolean", other.toString))
   }
 
   private abstract class TemporalDecoder[A](name: String) extends ArgBuilder[A] {
@@ -144,11 +143,11 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
         catch {
           case NonFatal(e) =>
             val message = e.getMessage
-            if (message.eq(null)) Left(error(s"Can't build a $name from $value"))
-            else Left(error(s"Can't build a $name from $value ($message)"))
+            if (message.eq(null)) Left(MkInvalidInputArgument(name, value))
+            else Left(MkInvalidInputArgument(name, s"$value ($message)"))
         }
       case _                  =>
-        Left(error(s"Can't build a $name from $input"))
+        Left(MkInvalidInputArgument(name, input.toString))
     }
   }
 
@@ -173,7 +172,7 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
 
   lazy val instantEpoch: ArgBuilder[Instant] = {
     case i: IntValue => Right(Instant.ofEpochMilli(i.toLong))
-    case value       => Left(error(s"Can't build an Instant from $value"))
+    case value       => Left(MkInvalidInputArgument("Instant", value.toString))
   }
 
   implicit lazy val instant: ArgBuilder[Instant]               = TemporalDecoder("Instant")(Instant.parse)
@@ -210,10 +209,19 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
 
   implicit lazy val upload: ArgBuilder[Upload] = {
     case StringValue(v) => Right(Upload(v))
-    case other          => Left(error(s"Can't build an Upload from $other"))
+    case other          => Left(MkInvalidInputArgument("Upload", other.toString))
   }
 }
 
 case object InvalidInputArgument extends NoStackTrace {
   override def getMessage: String = "invalid input argument"
+}
+
+private object MkInvalidInputArgument {
+  private val vowels = BitSet(List('a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U').map(_.toInt): _*)
+
+  def apply(expected: String, actual: String): ExecutionError = {
+    val prefix = if (expected.nonEmpty && vowels.contains(expected.codePointAt(0))) "an" else "a"
+    ExecutionError(s"Can't build $prefix $expected from $actual", innerThrowable = Some(InvalidInputArgument))
+  }
 }

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -13,7 +13,7 @@ import java.time.temporal.Temporal
 import java.util.UUID
 import scala.annotation.implicitNotFound
 import scala.util.Try
-import scala.util.control.NonFatal
+import scala.util.control.{ NoStackTrace, NonFatal }
 
 /**
  * Typeclass that defines how to build an argument of type `T` from an input [[caliban.InputValue]].
@@ -43,7 +43,11 @@ trait ArgBuilder[T] { self =>
   def buildMissing(default: Option[String]): Either[ExecutionError, T] =
     default
       .map(
-        Parser.parseInputValue(_).flatMap(build).left.map(e => ExecutionError(e.getMessage()))
+        Parser
+          .parseInputValue(_)
+          .flatMap(build)
+          .left
+          .map(e => ExecutionError(e.getMessage(), innerThrowable = Some(InvalidInputArgument)))
       )
       .getOrElse(build(NullValue))
 
@@ -85,49 +89,50 @@ object ArgBuilder extends ArgBuilderInstances {
 }
 
 trait ArgBuilderInstances extends ArgBuilderDerivation {
+  private def error(msg: String): ExecutionError = ExecutionError(msg, innerThrowable = Some(InvalidInputArgument))
+
   implicit lazy val unit: ArgBuilder[Unit]             = _ => Right(())
   implicit lazy val int: ArgBuilder[Int]               = {
     case value: IntValue => Right(value.toInt)
-    case other           => Left(ExecutionError(s"Can't build an Int from input $other"))
+    case other           => Left(error(s"Can't build an Int from input $other"))
   }
   implicit lazy val long: ArgBuilder[Long]             = {
     case value: IntValue    => Right(value.toLong)
     case StringValue(value) =>
-      Try(value.toLong).fold(_ => Left(ExecutionError(s"Can't build a Long from input $value")), Right(_))
-    case other              => Left(ExecutionError(s"Can't build a Long from input $other"))
+      Try(value.toLong).fold(_ => Left(error(s"Can't build a Long from input $value")), Right(_))
+    case other              => Left(error(s"Can't build a Long from input $other"))
   }
   implicit lazy val bigInt: ArgBuilder[BigInt]         = {
     case value: IntValue => Right(value.toBigInt)
-    case other           => Left(ExecutionError(s"Can't build a BigInt from input $other"))
+    case other           => Left(error(s"Can't build a BigInt from input $other"))
   }
   implicit lazy val float: ArgBuilder[Float]           = {
     case value: IntValue   => Right(value.toLong.toFloat)
     case value: FloatValue => Right(value.toFloat)
-    case other             => Left(ExecutionError(s"Can't build a Float from input $other"))
+    case other             => Left(error(s"Can't build a Float from input $other"))
   }
   implicit lazy val double: ArgBuilder[Double]         = {
     case value: IntValue   => Right(value.toLong.toDouble)
     case value: FloatValue => Right(value.toDouble)
-    case other             => Left(ExecutionError(s"Can't build a Double from input $other"))
+    case other             => Left(error(s"Can't build a Double from input $other"))
   }
   implicit lazy val bigDecimal: ArgBuilder[BigDecimal] = {
     case value: IntValue   => Right(BigDecimal(value.toBigInt))
     case value: FloatValue => Right(value.toBigDecimal)
-    case other             => Left(ExecutionError(s"Can't build a BigDecimal from input $other"))
+    case other             => Left(error(s"Can't build a BigDecimal from input $other"))
   }
   implicit lazy val string: ArgBuilder[String]         = {
     case StringValue(value) => Right(value)
-    case other              => Left(ExecutionError(s"Can't build a String from input $other"))
+    case other              => Left(error(s"Can't build a String from input $other"))
   }
   implicit lazy val uuid: ArgBuilder[UUID]             = {
     case StringValue(value) =>
-      Try(UUID.fromString(value))
-        .fold(ex => Left(ExecutionError(s"Can't parse $value into a UUID", innerThrowable = Some(ex))), Right(_))
-    case other              => Left(ExecutionError(s"Can't build a UUID from input $other"))
+      Try(UUID.fromString(value)).fold(_ => Left(error(s"Can't parse $value into a UUID")), Right(_))
+    case other              => Left(error(s"Can't build a UUID from input $other"))
   }
   implicit lazy val boolean: ArgBuilder[Boolean]       = {
     case BooleanValue(value) => Right(value)
-    case other               => Left(ExecutionError(s"Can't build a Boolean from input $other"))
+    case other               => Left(error(s"Can't build a Boolean from input $other"))
   }
 
   private abstract class TemporalDecoder[A](name: String) extends ArgBuilder[A] {
@@ -139,11 +144,11 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
         catch {
           case NonFatal(e) =>
             val message = e.getMessage
-            if (message.eq(null)) Left(ExecutionError(s"Can't build a $name from $value", innerThrowable = Some(e)))
-            else Left(ExecutionError(s"Can't build a $name from $value ($message)", innerThrowable = Some(e)))
+            if (message.eq(null)) Left(error(s"Can't build a $name from $value"))
+            else Left(error(s"Can't build a $name from $value ($message)"))
         }
       case _                  =>
-        Left(ExecutionError(s"Can't build a $name from $input"))
+        Left(error(s"Can't build a $name from $input"))
     }
   }
 
@@ -168,7 +173,7 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
 
   lazy val instantEpoch: ArgBuilder[Instant] = {
     case i: IntValue => Right(Instant.ofEpochMilli(i.toLong))
-    case value       => Left(ExecutionError(s"Can't build an Instant from $value"))
+    case value       => Left(error(s"Can't build an Instant from $value"))
   }
 
   implicit lazy val instant: ArgBuilder[Instant]               = TemporalDecoder("Instant")(Instant.parse)
@@ -205,6 +210,10 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
 
   implicit lazy val upload: ArgBuilder[Upload] = {
     case StringValue(v) => Right(Upload(v))
-    case other          => Left(ExecutionError(s"Can't build an Upload from $other"))
+    case other          => Left(error(s"Can't build an Upload from $other"))
   }
+}
+
+case object InvalidInputArgument extends NoStackTrace {
+  override def getMessage: String = "invalid input argument"
 }


### PR DESCRIPTION
As discussed on Discord: https://discord.com/channels/629491597070827530/633200096393166868/1204421751942152193

One downside is that for some ArgBuilders (UUID, temporal) we were already defining inner throwables. I don't think that's very necessary (given that for temporal ABs we add the message to the ExecutionError message. WDUT?