### PR TITLE
Resolve empty union objects within Sum schema derivation & cleanups

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -1,11 +1,9 @@
 package caliban.schema
 
-import caliban.ResponseValue.ObjectValue
 import caliban.Value._
 import caliban.introspection.adt._
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations._
-import caliban.schema.Step.{ MetadataFunctionStep, PureStep => _ }
 import caliban.schema.Types._
 import magnolia1._
 

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -164,7 +164,6 @@ trait CommonSchemaDerivation[R] {
           Some(getDirectives(ctx.annotations))
         )
       else if (!isInterface) {
-        val _ = emptyUnionObjectIdxs
         containsEmptyUnionObjects = emptyUnionObjectIdxs.exists(identity)
         makeUnion(
           Some(getName(ctx)),

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -162,7 +162,7 @@ trait CommonSchemaDerivation[R] {
           Some(getDirectives(ctx.annotations))
         )
       else if (!isInterface) {
-        containsEmptyUnionObjects = emptyUnionObjectIdxs.exists(identity)
+        containsEmptyUnionObjects = emptyUnionObjectIdxs.contains(true)
         makeUnion(
           Some(getName(ctx)),
           getDescription(ctx),

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -18,28 +18,6 @@ private object DerivationUtils {
     if (name.endsWith("Input")) name
     else s"${name}Input"
 
-  // see https://github.com/graphql/graphql-spec/issues/568
-  def fixEmptyUnionObject(t: __Type): __Type =
-    t.fields(__DeprecatedArgs(Some(true))) match {
-      case Some(Nil) =>
-        t.copy(
-          fields = (_: __DeprecatedArgs) =>
-            Some(
-              List(
-                __Field(
-                  "_",
-                  Some(
-                    "Fake field because GraphQL does not support empty objects. Do not query, use __typename instead."
-                  ),
-                  _ => Nil,
-                  () => makeScalar("Boolean")
-                )
-              )
-            )
-        )
-      case _         => t
-    }
-
   def getName(annotations: Seq[Any], info: TypeInfo): String =
     annotations.collectFirst { case GQLName(name) => name }.getOrElse {
       info.typeParams match {

--- a/core/src/main/scala-3/caliban/schema/SumSchema.scala
+++ b/core/src/main/scala-3/caliban/schema/SumSchema.scala
@@ -35,7 +35,7 @@ final private class SumSchema[R, A](
 
     if (!isInterface && !isUnion && subTypes.nonEmpty && isEnum) mkEnum(annotations, info, subTypes)
     else if (!isInterface) {
-      containsEmptyUnionObjects = emptyUnionObjectIdxs.exists(identity)
+      containsEmptyUnionObjects = emptyUnionObjectIdxs.contains(true)
       makeUnion(
         Some(getName(annotations, info)),
         getDescription(annotations),

--- a/core/src/main/scala-3/caliban/schema/SumSchema.scala
+++ b/core/src/main/scala-3/caliban/schema/SumSchema.scala
@@ -16,33 +16,44 @@ final private class SumSchema[R, A](
     extends Schema[R, A] {
 
   @threadUnsafe
-  private lazy val (subTypes, schemas) = {
+  private lazy val (subTypes, schemas, emptyUnionObjectIdxs) = {
     val (m, s) = _members
-    (m.sortBy(_._1), s.toVector)
+    (
+      m.sortBy(_._1),
+      s.toVector,
+      s.map(s0 => SchemaUtils.isEmptyUnionObject(s0.toType_())).toArray[Boolean]
+    )
   }
 
-  @threadUnsafe
-  private lazy val isEnum = subTypes.forall((_, t, _) => t.allFields.isEmpty && t.allInputFields.isEmpty)
-
-  private val isInterface = annotations.exists(_.isInstanceOf[GQLInterface])
-  private val isUnion     = annotations.contains(GQLUnion())
+  private var containsEmptyUnionObjects = false
 
   def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
-    val _ = schemas
+    val _                         = schemas
+    val isInterface               = annotations.exists(_.isInstanceOf[GQLInterface])
+    val isUnion                   = annotations.contains(GQLUnion())
+    @threadUnsafe lazy val isEnum = subTypes.forall((_, t, _) => t.allFields.isEmpty && t.allInputFields.isEmpty)
+
     if (!isInterface && !isUnion && subTypes.nonEmpty && isEnum) mkEnum(annotations, info, subTypes)
-    else if (!isInterface)
+    else if (!isInterface) {
+      containsEmptyUnionObjects = emptyUnionObjectIdxs.exists(identity)
       makeUnion(
         Some(getName(annotations, info)),
         getDescription(annotations),
-        subTypes.map(_._2).distinctBy(_.name).map(fixEmptyUnionObject),
+        subTypes.map(_._2).distinctBy(_.name).map(SchemaUtils.fixEmptyUnionObject),
         Some(info.full),
         Some(getDirectives(annotations))
       )
-    else {
+    } else {
       val impl = subTypes.map(_._2.copy(interfaces = () => Some(List(toType(isInput, isSubscription)))))
       mkInterface(annotations, info, impl)
     }
   }
 
-  def resolve(value: A): Step[R] = schemas(ordinal(value)).resolve(value)
+  def resolve(value: A): Step[R] = {
+    val idx  = ordinal(value)
+    val step = schemas(idx).resolve(value)
+    if (containsEmptyUnionObjects && emptyUnionObjectIdxs(idx))
+      SchemaUtils.resolveEmptyUnionStep(step)
+    else step
+  }
 }

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -51,15 +51,15 @@ case class Field(
       val _             = set.add(fields.head.aliasedName)
 
       var remaining = fields.tail
-      while (remaining ne Nil) {
-        val f      = remaining.head
-        val result = set.add(f.aliasedName) && f._condition == headCondition
-        if (!result) return false
+      var result    = true
+      while ((remaining ne Nil) && result) {
+        val f = remaining.head
+        result = set.add(f.aliasedName) && f._condition == headCondition
         remaining = remaining.tail
       }
-      true
+      result
     }
-    if (fields.isEmpty) true else inner
+    fields.isEmpty || fields.tail.isEmpty || inner
   }
 
   def combine(other: Field): Field =

--- a/core/src/main/scala/caliban/introspection/adt/__DeprecatedArgs.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__DeprecatedArgs.scala
@@ -1,3 +1,7 @@
 package caliban.introspection.adt
 
 case class __DeprecatedArgs(includeDeprecated: Option[Boolean] = None)
+
+object __DeprecatedArgs {
+  val include: __DeprecatedArgs = __DeprecatedArgs(Some(true))
+}

--- a/core/src/main/scala/caliban/introspection/adt/__DeprecatedArgs.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__DeprecatedArgs.scala
@@ -1,7 +1,13 @@
 package caliban.introspection.adt
 
+import scala.runtime.AbstractFunction1
+
 case class __DeprecatedArgs(includeDeprecated: Option[Boolean] = None)
 
-object __DeprecatedArgs {
+// NOTE: This object extends AbstractFunction1 to maintain binary compatibility for Scala 2.13.
+// TODO: Remove inheritance in the next major version
+object __DeprecatedArgs extends AbstractFunction1[Option[Boolean], __DeprecatedArgs] {
   val include: __DeprecatedArgs = __DeprecatedArgs(Some(true))
+
+  def apply(v: Option[Boolean] = None): __DeprecatedArgs = new __DeprecatedArgs(v)
 }

--- a/core/src/main/scala/caliban/introspection/adt/__Directive.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Directive.scala
@@ -19,5 +19,5 @@ case class __Directive(
     )
 
   lazy val allArgs: List[__InputValue] =
-    args(__DeprecatedArgs(Some(true)))
+    args(__DeprecatedArgs.include)
 }

--- a/core/src/main/scala/caliban/introspection/adt/__Field.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Field.scala
@@ -32,7 +32,7 @@ case class __Field(
     InputValueDefinition(description, name, _type.toType(), None, directives.getOrElse(Nil))
 
   lazy val allArgs: List[__InputValue] =
-    args(__DeprecatedArgs(Some(true)))
+    args(__DeprecatedArgs.include)
 
   private[caliban] lazy val _type: __Type = `type`()
 }

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -102,7 +102,7 @@ case class __Type(
             description,
             name.getOrElse(""),
             directives.getOrElse(Nil),
-            enumValues(__DeprecatedArgs(Some(true))).getOrElse(Nil).map(_.toEnumValueDefinition)
+            enumValues(__DeprecatedArgs.include).getOrElse(Nil).map(_.toEnumValueDefinition)
           )
         )
       case __TypeKind.INPUT_OBJECT =>
@@ -127,13 +127,13 @@ case class __Type(
   lazy val nonNull: __Type = __Type(__TypeKind.NON_NULL, ofType = Some(self))
 
   lazy val allFields: List[__Field] =
-    fields(__DeprecatedArgs(Some(true))).getOrElse(Nil)
+    fields(__DeprecatedArgs.include).getOrElse(Nil)
 
   lazy val allInputFields: List[__InputValue] =
-    inputFields(__DeprecatedArgs(Some(true))).getOrElse(Nil)
+    inputFields(__DeprecatedArgs.include).getOrElse(Nil)
 
   lazy val allEnumValues: List[__EnumValue] =
-    enumValues(__DeprecatedArgs(Some(true))).getOrElse(Nil)
+    enumValues(__DeprecatedArgs.include).getOrElse(Nil)
 
   private[caliban] lazy val allFieldsMap: collection.Map[String, __Field] = {
     val map = collection.mutable.HashMap.empty[String, __Field]

--- a/core/src/main/scala/caliban/schema/SchemaUtils.scala
+++ b/core/src/main/scala/caliban/schema/SchemaUtils.scala
@@ -1,0 +1,44 @@
+package caliban.schema
+
+import caliban.ResponseValue.ObjectValue
+import caliban.Value.{ EnumValue, NullValue, StringValue }
+import caliban.introspection.adt.{ __DeprecatedArgs, __Field, __Type }
+import caliban.schema.Step.{ MetadataFunctionStep, PureStep }
+
+private[schema] object SchemaUtils {
+  private val fakeField =
+    Some(
+      List(
+        __Field(
+          "_",
+          Some(
+            "Fake field because GraphQL does not support empty objects. Do not query, use __typename instead."
+          ),
+          _ => Nil,
+          () => Types.makeScalar("Boolean")
+        )
+      )
+    )
+
+  def isEmptyUnionObject(t: __Type): Boolean =
+    t.fields(__DeprecatedArgs.include).contains(Nil)
+
+  // see https://github.com/graphql/graphql-spec/issues/568
+  def fixEmptyUnionObject(t: __Type): __Type =
+    if (isEmptyUnionObject(t)) t.copy(fields = (_: __DeprecatedArgs) => fakeField)
+    else t
+
+  def resolveEmptyUnionStep[R](step: Step[R]): Step[R] = step match {
+    case s @ PureStep(EnumValue(v)) =>
+      MetadataFunctionStep { field =>
+        field.fields.view
+          .filter(_._condition.forall(_.contains(v)))
+          .collectFirst {
+            case f if f.name == "__typename" => ObjectValue(List(f.aliasedName -> StringValue(v)))
+            case f if f.name == "_"          => NullValue
+          }
+          .fold(s)(PureStep(_))
+      }
+    case _                          => step
+  }
+}

--- a/core/src/main/scala/caliban/schema/SchemaUtils.scala
+++ b/core/src/main/scala/caliban/schema/SchemaUtils.scala
@@ -3,7 +3,7 @@ package caliban.schema
 import caliban.ResponseValue.ObjectValue
 import caliban.Value.{ EnumValue, NullValue, StringValue }
 import caliban.introspection.adt.{ __DeprecatedArgs, __Field, __Type }
-import caliban.schema.Step.{ MetadataFunctionStep, PureStep }
+import caliban.schema.Step.MetadataFunctionStep
 
 private[schema] object SchemaUtils {
   private val fakeField =
@@ -30,7 +30,7 @@ private[schema] object SchemaUtils {
 
   def resolveEmptyUnionStep[R](step: Step[R]): Step[R] = step match {
     case s @ PureStep(EnumValue(v)) =>
-      MetadataFunctionStep { field =>
+      MetadataFunctionStep[R] { field =>
         field.fields.view
           .filter(_._condition.forall(_.contains(v)))
           .collectFirst {

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -1,8 +1,7 @@
 package caliban.schema
 
 import caliban.CalibanError.ExecutionError
-import caliban.ResponseValue.ObjectValue
-import caliban.Value.{ EnumValue, NullValue, StringValue }
+import caliban.Value.NullValue
 import caliban.execution.{ Field, FieldInfo }
 import caliban.{ InputValue, PathValue, ResponseValue }
 import zio.query.ZQuery

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -1,7 +1,8 @@
 package caliban.schema
 
 import caliban.CalibanError.ExecutionError
-import caliban.Value.NullValue
+import caliban.ResponseValue.ObjectValue
+import caliban.Value.{ EnumValue, NullValue, StringValue }
 import caliban.execution.{ Field, FieldInfo }
 import caliban.{ InputValue, PathValue, ResponseValue }
 import zio.query.ZQuery

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -121,7 +121,7 @@ object ValueValidator {
 
   def validateEnum(value: String, inputType: __Type, errorContext: => String): EReader[Any, ValidationError, Unit] = {
     val possible = inputType
-      .enumValues(__DeprecatedArgs(Some(true)))
+      .enumValues(__DeprecatedArgs.include)
       .getOrElse(List.empty)
       .map(_.name)
     val exists   = possible.contains(value)

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -692,7 +692,7 @@ object ExecutionSpec extends ZIOSpecDefault {
           assertTrue(response.data.toString == """{"test":{"union":{"__typename":"UnionChild","field":"f"}}}""")
         }
       },
-      test("rename on a union child and parent") {
+      test("rename on a union child and parent (typename)") {
         sealed trait Union
         object Union {
           case class Child(field: String) extends Union


### PR DESCRIPTION
The main optimization in this PR is that we avoid matching on `PureStep(EnumValue(v))` for all steps by delegating this responsibility to the derived Sum schema.

Other cleanups & minor optimizations that I came across while working on this PR:
1. Moved handling of empty union objects into a common Scala 2 & 3 object to avoid code duplication
2. Added the `__DeprecatedArgs.include` since we've been using `__DeprecatedArgs(Some(true))` quite a lot
3. Moved StreamStep reduction into separate method so that the pattern matching doesn't contain any reduction logic
4. Improved performance of `Field#allFieldsUniqueNameAndCondition` by avoiding creation of the HashSet when there's only 1 queried field in the object

With these changes, we see ~10% improvement in execution of simple queries (where only the top-level field is effectful) and ~5% for cases that fields contain ZQueries