### PR TITLE
Derives fails for @lazy directive when Env != Any

### DIFF
--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/src/main/graphql/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/src/main/graphql/schema.graphql
@@ -1,3 +1,4 @@
+directive @lazy on FIELD_DEFINITION
 directive @newtype(name : String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
 scalar FID
@@ -25,7 +26,13 @@ type Foo {
     allIDsOpt: [ID]! @newtype(name: "InnerOptId")
     mapbeAllIDs: [ID!] @newtype(name: "MaybeInnerId")
     mapbeAllIDsOpt: [ID] @newtype(name: "MaybeInnerIdOpt")
+    getLazyFoo : FooLazy @lazy
 }
+
+type FooLazy {
+    id : ID!
+}
+
 
 input FooInput {
     id : ID! @newtype(name: "CustomId")

--- a/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/test
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile-newtype/test
@@ -4,3 +4,4 @@ $ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/Generate
 $ exec sh verify.sh Foo target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/GeneratedAPI.scala
 $ exec sh verify.sh FooInput target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/GeneratedAPI.scala
 $ exec sh verify.sh CustomId target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/GeneratedAPI.scala
+$ exec sh verify.sh FooLazy target/scala-2.12/src_managed/main/caliban-codegen-sbt/graphql/GeneratedAPI.scala


### PR DESCRIPTION
When using @lazy directive and derives. 
Generated objects might have fields with effect types and hence then there will be problem when Env != Any.

This merge request corrects this issue. 

What do you think? @ghostdogpr @kyri-petrou 
