### PR TITLE
Add Mixed query execution mode

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -58,6 +58,9 @@ object Executor {
         case QueryExecution.Batched             => ZQuery.foreachBatched(in)(as)
         case QueryExecution.Parallel            => ZQuery.foreachPar(in)(as)
         case QueryExecution.Sequential          => ZQuery.foreach(in)(as)
+        case QueryExecution.Mixed               =>
+          if (isTopLevelField) ZQuery.foreachPar(in)(as)
+          else ZQuery.foreachBatched(in)(as)
       }
     }
 

--- a/core/src/main/scala/caliban/execution/QueryExecution.scala
+++ b/core/src/main/scala/caliban/execution/QueryExecution.scala
@@ -19,7 +19,13 @@ object QueryExecution {
 
   /**
    * Run effectful fields sequentially but batch effects wrapped with `ZQuery.fromRequest`.
-   * This mode is recommended when most of your effects are relying on ZQuery as it avoids forking unnecessary fibers.
+   * This mode is recommended when most of your effects are backed by ZQuery DataSources as it avoids forking unnecessary fibers.
    */
   case object Batched extends QueryExecution
+
+  /**
+   * Run effectful top-level fields in [[Parallel]] mode and nested fields in [[Batched]] mode.
+   * This mode is recommended when most of your effects are backed by ZQuery DataSources but want to guarantee that top-level fields are always executed in parallel.
+   */
+  case object Mixed extends QueryExecution
 }


### PR DESCRIPTION
Not sure how common this is, but in some of our schemas we don't need use DataSources for some of the top-level query fields as they're not reused elsewhere in the schema, and therefor we don't need to make use of caching / batching. The downside is that unless we wrap them in DataSources, they won't be executed in parallel if the client requests multiple top-level fields.

With this change, we provide a `QueryExecution.Mixed` mode, where top-level fields are guaranteed to be executed in parallel (regardless if backed by a DataSource), and nested fields are executed in batched mode