### PR TITLE
Improve tracing propagation

### DIFF
--- a/adapters/akka-http/src/test/scala/caliban/AkkaHttpAdapterSpec.scala
+++ b/adapters/akka-http/src/test/scala/caliban/AkkaHttpAdapterSpec.scala
@@ -34,16 +34,20 @@ object AkkaHttpAdapterSpec extends ZIOSpecDefault {
       mat          = Materializer(system)
       interpreter <- TestApi.api.interpreter
       adapter      = AkkaHttpAdapter.default(ec)
-      route        = path("api" / "graphql") {
-                       adapter
-                         .makeHttpService(
-                           HttpInterpreter(interpreter).intercept(FakeAuthorizationInterceptor.bearer[TestService & Uploads])
-                         )(runtime, mat)
-                     } ~ path("upload" / "graphql") {
-                       adapter.makeHttpUploadService(HttpUploadInterpreter(interpreter))(runtime, mat, implicitly, implicitly)
-                     } ~ path("ws" / "graphql") {
-                       adapter.makeWebSocketService(WebSocketInterpreter(interpreter))(runtime, mat)
-                     }
+      route        = {
+        implicit val rt0: Runtime[TestService with Uploads] = runtime
+        implicit val mat0: Materializer                     = mat
+        path("api" / "graphql") {
+          adapter
+            .makeHttpService(
+              HttpInterpreter(interpreter).intercept(FakeAuthorizationInterceptor.bearer[TestService & Uploads])
+            )
+        } ~ path("upload" / "graphql") {
+          adapter.makeHttpUploadService(HttpUploadInterpreter(interpreter))
+        } ~ path("ws" / "graphql") {
+          adapter.makeWebSocketService(WebSocketInterpreter(interpreter))
+        }
+      }
       _           <- ZIO.fromFuture { _ =>
                        implicit val s: ActorSystem = system
                        Http().newServerAt("localhost", 8086).bind(route)

--- a/adapters/pekko-http/src/test/scala/caliban/PekkoHttpAdapterSpec.scala
+++ b/adapters/pekko-http/src/test/scala/caliban/PekkoHttpAdapterSpec.scala
@@ -34,20 +34,16 @@ object PekkoHttpAdapterSpec extends ZIOSpecDefault {
       mat          = Materializer(system)
       interpreter <- TestApi.api.interpreter
       adapter      = PekkoHttpAdapter.default(ec)
-      route        = {
-        implicit val rt0: Runtime[TestService with Uploads] = runtime
-        implicit val mat0: Materializer                     = mat
-        path("api" / "graphql") {
-          adapter
-            .makeHttpService(
-              HttpInterpreter(interpreter).intercept(FakeAuthorizationInterceptor.bearer[TestService & Uploads])
-            )
-        } ~ path("upload" / "graphql") {
-          adapter.makeHttpUploadService(HttpUploadInterpreter(interpreter))
-        } ~ path("ws" / "graphql") {
-          adapter.makeWebSocketService(WebSocketInterpreter(interpreter))
-        }
-      }
+      route        = path("api" / "graphql") {
+                       adapter
+                         .makeHttpService(
+                           HttpInterpreter(interpreter).intercept(FakeAuthorizationInterceptor.bearer[TestService & Uploads])
+                         )(runtime, mat)
+                     } ~ path("upload" / "graphql") {
+                       adapter.makeHttpUploadService(HttpUploadInterpreter(interpreter))(runtime, mat, implicitly, implicitly)
+                     } ~ path("ws" / "graphql") {
+                       adapter.makeWebSocketService(WebSocketInterpreter(interpreter))(runtime, mat)
+                     }
       _           <- ZIO.fromFuture { _ =>
                        implicit val s: ActorSystem = system
                        Http().newServerAt("localhost", 8085).bind(route)

--- a/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
+++ b/adapters/play/src/test/scala/caliban/PlayAdapterSpec.scala
@@ -34,25 +34,21 @@ object PlayAdapterSpec extends ZIOSpecDefault {
       mat          = Materializer(system)
       runtime     <- ZIO.runtime[TestService with Uploads]
       interpreter <- TestApi.api.interpreter
-      router       = {
-        implicit val rt0: Runtime[TestService with Uploads] = runtime
-        implicit val mat0: Materializer                     = mat
-        Router.from {
-          case req @ (GET(p"/api/graphql") | POST(p"/api/graphql")) =>
-            PlayAdapter
-              .makeHttpService(
-                HttpInterpreter(interpreter)
-                  .intercept(FakeAuthorizationInterceptor.bearer[TestService & Uploads])
-              )
-              .apply(req)
-          case req @ POST(p"/upload/graphql")                       =>
-            PlayAdapter
-              .makeHttpUploadService(HttpUploadInterpreter(interpreter))
-              .apply(req)
-          case req @ GET(p"/ws/graphql")                            =>
-            PlayAdapter.makeWebSocketService(WebSocketInterpreter(interpreter)).apply(req)
-        }
-      }
+      router       = Router.from {
+                       case req @ (GET(p"/api/graphql") | POST(p"/api/graphql")) =>
+                         PlayAdapter
+                           .makeHttpService(
+                             HttpInterpreter(interpreter)
+                               .intercept(FakeAuthorizationInterceptor.bearer[TestService & Uploads])
+                           )(runtime, mat)
+                           .apply(req)
+                       case req @ POST(p"/upload/graphql")                       =>
+                         PlayAdapter
+                           .makeHttpUploadService(HttpUploadInterpreter(interpreter))(runtime, mat, implicitly, implicitly)
+                           .apply(req)
+                       case req @ GET(p"/ws/graphql")                            =>
+                         PlayAdapter.makeWebSocketService(WebSocketInterpreter(interpreter))(runtime, mat).apply(req)
+                     }
       _           <- ZIO
                        .attempt(
                          PekkoHttpServer.fromRouterWithComponents(

--- a/adapters/quick/src/main/scala/caliban/GraphiQLHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/GraphiQLHandler.scala
@@ -1,6 +1,7 @@
 package caliban
 
 import zio.http._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object GraphiQLHandler {
 

--- a/adapters/quick/src/main/scala/caliban/QuickHandlers.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickHandlers.scala
@@ -1,6 +1,8 @@
 package caliban
 
+import zio.Trace
 import zio.http.{ HandlerAspect, RequestHandler }
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 final case class QuickHandlers[-R](
   api: RequestHandler[R, Nothing],
@@ -10,7 +12,7 @@ final case class QuickHandlers[-R](
   /**
    * Applies a ZIO HTTP `HandlerAspect` to both the api and upload handlers
    */
-  def @@[R1 <: R](aspect: HandlerAspect[R1, Unit]): QuickHandlers[R1] =
+  def @@[R1 <: R](aspect: HandlerAspect[R1, Unit])(implicit trace: Trace): QuickHandlers[R1] =
     QuickHandlers(
       api = (api @@ aspect).merge,
       upload = (upload @@ aspect).merge

--- a/adapters/quick/src/main/scala/caliban/quick/package.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/package.scala
@@ -3,10 +3,11 @@ package caliban
 import caliban.Configurator.ExecutionConfiguration
 import zio._
 import zio.http._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 package object quick {
 
-  implicit class GraphqlServerOps[R](val gql: GraphQL[R]) extends AnyVal {
+  implicit class GraphqlServerOps[R](private val gql: GraphQL[R]) extends AnyVal {
 
     /**
      * Serves the GraphQL API on the specified port using the default zio-http configuration.
@@ -99,10 +100,10 @@ package object quick {
       ZIOApp.fromZIO(run.asInstanceOf[RIO[Any, Nothing]]).main(Array.empty)
     }
 
-    def provideLayer(layer: ZLayer[Any, Any, R]): UnsafeApi[Any] =
+    def provideLayer(layer: ZLayer[Any, Any, R])(implicit trace: Trace): UnsafeApi[Any] =
       new UnsafeApi(interpreter.provideLayer(layer))
 
-    def provideSomeLayer[R0](layer: ZLayer[R0, Any, R])(implicit tag: Tag[R]): UnsafeApi[R0] =
+    def provideSomeLayer[R0](layer: ZLayer[R0, Any, R])(implicit tag: Tag[R], trace: Trace): UnsafeApi[R0] =
       new UnsafeApi(interpreter.provideSomeLayer(layer))
 
     def configure(cfg: ExecutionConfiguration): UnsafeApi[R] =

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -5,7 +5,9 @@ import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
 import sttp.capabilities.zio.ZioStreams
 import sttp.model.HeaderNames
 import sttp.tapir.server.ziohttp.{ ZioHttpInterpreter, ZioHttpServerOptions }
+import zio.Trace
 import zio.http._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object ZHttpAdapter {
 
@@ -16,14 +18,16 @@ object ZHttpAdapter {
   }
 
   def makeHttpService[R, E](interpreter: HttpInterpreter[R, E])(implicit
-    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
+    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R],
+    trace: Trace
   ): RequestHandler[R, Nothing] =
     ZioHttpInterpreter(serverOptions)
       .toHttp(interpreter.serverEndpoints[R, ZioStreams](ZioStreams))
       .toHandler
 
   def makeWebSocketService[R, E](interpreter: WebSocketInterpreter[R, E])(implicit
-    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
+    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R],
+    trace: Trace
   ): RequestHandler[R, Nothing] =
     ZioHttpInterpreter(patchWsServerOptions(serverOptions))
       .toHttp(interpreter.serverEndpoint[R])

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -5,7 +5,6 @@ import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
 import sttp.capabilities.zio.ZioStreams
 import sttp.model.HeaderNames
 import sttp.tapir.server.ziohttp.{ ZioHttpInterpreter, ZioHttpServerOptions }
-import zio.Trace
 import zio.http._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -18,16 +17,14 @@ object ZHttpAdapter {
   }
 
   def makeHttpService[R, E](interpreter: HttpInterpreter[R, E])(implicit
-    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R],
-    trace: Trace
+    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
   ): RequestHandler[R, Nothing] =
     ZioHttpInterpreter(serverOptions)
       .toHttp(interpreter.serverEndpoints[R, ZioStreams](ZioStreams))
       .toHandler
 
   def makeWebSocketService[R, E](interpreter: WebSocketInterpreter[R, E])(implicit
-    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R],
-    trace: Trace
+    serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]
   ): RequestHandler[R, Nothing] =
     ZioHttpInterpreter(patchWsServerOptions(serverOptions))
       .toHttp(interpreter.serverEndpoint[R])

--- a/build.sbt
+++ b/build.sbt
@@ -707,7 +707,7 @@ lazy val commonSettings = Def.settings(
   })
 )
 
-lazy val enforceMimaCompatibility = true // Enable / disable failing CI on binary incompatibilities
+lazy val enforceMimaCompatibility = false // Enable / disable failing CI on binary incompatibilities
 
 lazy val enableMimaSettingsJVM =
   Def.settings(

--- a/core/src/main/scala/caliban/Configurator.scala
+++ b/core/src/main/scala/caliban/Configurator.scala
@@ -3,6 +3,7 @@ package caliban
 import caliban.execution.QueryExecution
 import caliban.validation.Validator.{ AllValidations, QueryValidation }
 import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object Configurator {
 
@@ -37,33 +38,33 @@ object Configurator {
    * Skip validation of the query.
    * @param skip if true, the query will not be validated (in that case, the `validations` field is ignored).
    */
-  def setSkipValidation(skip: Boolean): URIO[Scope, Unit] =
+  def setSkipValidation(skip: Boolean)(implicit trace: Trace): URIO[Scope, Unit] =
     configRef.locallyScopedWith(_.copy(skipValidation = skip))
 
   /**
    * Set the validations to run on the query during the validation phase.
    * @param validations the validations to run on the query during the validation phase.
    */
-  def setValidations(validations: List[QueryValidation]): URIO[Scope, Unit] =
+  def setValidations(validations: List[QueryValidation])(implicit trace: Trace): URIO[Scope, Unit] =
     configRef.locallyScopedWith(_.copy(validations = validations))
 
   /**
    * Enable or disable introspection queries.
    * @param enable if true, introspection queries are allowed.
    */
-  def setEnableIntrospection(enable: Boolean): URIO[Scope, Unit] =
+  def setEnableIntrospection(enable: Boolean)(implicit trace: Trace): URIO[Scope, Unit] =
     configRef.locallyScopedWith(_.copy(enableIntrospection = enable))
 
   /**
    * Set the execution strategy to use (sequential, parallel, batched).
    * @param queryExecution the execution strategy to use.
    */
-  def setQueryExecution(queryExecution: QueryExecution): URIO[Scope, Unit] =
+  def setQueryExecution(queryExecution: QueryExecution)(implicit trace: Trace): URIO[Scope, Unit] =
     configRef.locallyScopedWith(_.copy(queryExecution = queryExecution))
 
   /**
    * Enable or disable mutations for GET requests. See [[ExecutionConfiguration]] for more details
    */
-  def setAllowMutationsOverGetRequests(allow: Boolean): URIO[Scope, Unit] =
+  def setAllowMutationsOverGetRequests(allow: Boolean)(implicit trace: Trace): URIO[Scope, Unit] =
     configRef.locallyScopedWith(_.copy(allowMutationsOverGetRequests = allow))
 }

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -85,7 +85,8 @@ trait GraphQL[-R] { self =>
           )
 
         private val introWrappers                               = wrappers.collect { case w: IntrospectionWrapper[R] => w }
-        private lazy val introspectionRootSchema: RootSchema[R] = Introspector.introspect(rootType, introWrappers)
+        private lazy val introspectionRootSchema: RootSchema[R] =
+          Introspector.introspect(rootType, introWrappers)(Trace.empty)
 
         override def check(query: String)(implicit trace: Trace): IO[CalibanError, Unit] =
           for {
@@ -181,7 +182,9 @@ trait GraphQL[-R] { self =>
    * @param aspect A wrapper type that will be applied to this GraphQL
    * @return A new GraphQL API
    */
-  final def @@[LowerR <: UpperR, UpperR <: R](aspect: GraphQLAspect[LowerR, UpperR]): GraphQL[UpperR] =
+  final def @@[LowerR <: UpperR, UpperR <: R](aspect: GraphQLAspect[LowerR, UpperR])(implicit
+    trace: Trace
+  ): GraphQL[UpperR] =
     aspect(self)
 
   /**

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -182,9 +182,7 @@ trait GraphQL[-R] { self =>
    * @param aspect A wrapper type that will be applied to this GraphQL
    * @return A new GraphQL API
    */
-  final def @@[LowerR <: UpperR, UpperR <: R](aspect: GraphQLAspect[LowerR, UpperR])(implicit
-    trace: Trace
-  ): GraphQL[UpperR] =
+  final def @@[LowerR <: UpperR, UpperR <: R](aspect: GraphQLAspect[LowerR, UpperR]): GraphQL[UpperR] =
     aspect(self)
 
   /**

--- a/core/src/main/scala/caliban/GraphQLAspect.scala
+++ b/core/src/main/scala/caliban/GraphQLAspect.scala
@@ -2,6 +2,8 @@ package caliban
 
 import caliban.introspection.adt.{ __Directive, __Type }
 import caliban.parsing.adt.Directive
+import zio.Trace
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * A `GraphQLAspect` is wrapping type similar to a polymorphic function, which is capable

--- a/core/src/main/scala/caliban/GraphQLInterpreter.scala
+++ b/core/src/main/scala/caliban/GraphQLInterpreter.scala
@@ -2,6 +2,7 @@ package caliban
 
 import caliban.Value.NullValue
 import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * A `GraphQLInterpreter[-R, +E]` represents a GraphQL interpreter whose execution requires
@@ -48,14 +49,14 @@ trait GraphQLInterpreter[-R, +E] { self =>
    * @param f a function from the current error type `E` to another type `E2`
    * @return a new GraphQL interpreter with error type `E2`
    */
-  final def mapError[E2](f: E => E2): GraphQLInterpreter[R, E2] =
+  final def mapError[E2](f: E => E2)(implicit trace: Trace): GraphQLInterpreter[R, E2] =
     wrapExecutionWith(_.map(res => GraphQLResponse(res.data, res.errors.map(f), res.extensions)))
 
   /**
    * Provides the interpreter with its required environment, which eliminates
    * its dependency on `R`.
    */
-  final def provideEnvironment(r: => ZEnvironment[R]): GraphQLInterpreter[Any, E] =
+  final def provideEnvironment(r: => ZEnvironment[R])(implicit trace: Trace): GraphQLInterpreter[Any, E] =
     wrapExecutionWith(_.provideEnvironment(r))
 
   /**
@@ -63,7 +64,7 @@ trait GraphQLInterpreter[-R, +E] { self =>
    */
   final def provideLayer[E1 >: E, R0](
     layer: => ZLayer[R0, E1, R]
-  ): GraphQLInterpreter[R0, E1] =
+  )(implicit trace: Trace): GraphQLInterpreter[R0, E1] =
     wrapExecutionWith(_.provideLayer(layer).fold(e => GraphQLResponse(NullValue, List(e)), identity))
 
   /**
@@ -94,7 +95,7 @@ object GraphQLInterpreter {
   final class ProvideSomeLayer[R0, -R, +E](private val self: GraphQLInterpreter[R, E]) extends AnyVal {
     def apply[E1 >: E, R1](
       layer: => ZLayer[R0, E1, R1]
-    )(implicit ev1: R0 with R1 <:< R, tagged: Tag[R1]): GraphQLInterpreter[R0, E1] =
+    )(implicit ev1: R0 with R1 <:< R, tagged: Tag[R1], trace: Trace): GraphQLInterpreter[R0, E1] =
       self.asInstanceOf[GraphQLInterpreter[R0 with R1, E]].provideLayer(ZLayer.environment[R0] ++ layer)
   }
 }

--- a/core/src/main/scala/caliban/HttpRequestMethod.scala
+++ b/core/src/main/scala/caliban/HttpRequestMethod.scala
@@ -1,7 +1,8 @@
 package caliban
 
 import caliban.CalibanError.ValidationError
-import zio.{ FiberRef, Scope, UIO, URIO, Unsafe, ZIO }
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.{ FiberRef, Trace, UIO, Unsafe, ZIO }
 
 private[caliban] sealed trait HttpRequestMethod
 
@@ -13,9 +14,9 @@ private[caliban] object HttpRequestMethod {
 
   private val fiberRef: FiberRef[HttpRequestMethod] = Unsafe.unsafe(implicit u => FiberRef.unsafe.make(POST))
 
-  val get: UIO[HttpRequestMethod] = fiberRef.get
+  val get: UIO[HttpRequestMethod] = fiberRef.get(Trace.empty)
 
-  def setWith[R, E, B](method: HttpRequestMethod)(zio: ZIO[R, E, B]): ZIO[R, E, B] =
+  def setWith[R, E, B](method: HttpRequestMethod)(zio: ZIO[R, E, B])(implicit trace: Trace): ZIO[R, E, B] =
     method match {
       case POST => zio
       case GET  => fiberRef.locally(method)(zio)

--- a/core/src/main/scala/caliban/HttpUtils.scala
+++ b/core/src/main/scala/caliban/HttpUtils.scala
@@ -1,8 +1,9 @@
 package caliban
 
 import caliban.wrappers.Caching
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.{ ZChannel, ZPipeline }
-import zio.{ Cause, Chunk }
+import zio.{ Cause, Chunk, Trace }
 
 private[caliban] object HttpUtils {
 
@@ -19,7 +20,9 @@ private[caliban] object HttpUtils {
 
     val DeferHeaderParams: Map[String, String] = Map("boundary" -> BoundaryHeader, "deferSpec" -> DeferSpec)
 
-    def createPipeline[E](resp: GraphQLResponse[E]): ZPipeline[Any, Throwable, ResponseValue, ResponseValue] =
+    def createPipeline[E](
+      resp: GraphQLResponse[E]
+    )(implicit trace: Trace): ZPipeline[Any, Throwable, ResponseValue, ResponseValue] =
       ZPipeline.fromChannel {
         lazy val reader: ZChannel[Any, Throwable, Chunk[ResponseValue], Any, Throwable, Chunk[ResponseValue], Any] =
           ZChannel.readWithCause(

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -8,6 +8,7 @@ import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 import caliban.rendering.ValueRenderer
 import zio.stream.Stream
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.util.control.NonFatal
 import scala.util.hashing.MurmurHash3

--- a/core/src/main/scala/caliban/introspection/Introspector.scala
+++ b/core/src/main/scala/caliban/introspection/Introspector.scala
@@ -8,8 +8,9 @@ import caliban.parsing.adt.Selection.Field
 import caliban.schema.Step.QueryStep
 import caliban.schema._
 import caliban.wrappers.Wrapper.IntrospectionWrapper
-import zio.ZIO
+import zio.{ Trace, ZIO }
 import zio.query.ZQuery
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.annotation.tailrec
 
@@ -53,7 +54,7 @@ object Introspector extends IntrospectionDerivation {
   def introspect[R](
     rootType: RootType,
     introWrappers: List[IntrospectionWrapper[R]] = Nil
-  ): RootSchema[R] = {
+  )(implicit trace: Trace): RootSchema[R] = {
 
     @tailrec
     def wrap(

--- a/core/src/main/scala/caliban/package.scala
+++ b/core/src/main/scala/caliban/package.scala
@@ -7,6 +7,7 @@ import caliban.rendering.DocumentRenderer
 import caliban.schema.Types.collectTypes
 import caliban.schema._
 import caliban.wrappers.Wrapper
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 package object caliban {
 

--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -11,6 +11,7 @@ import caliban.{ GraphQLRequest, InputValue, Value }
 import zio._
 import zio.prelude.EReader
 import zio.prelude.fx.ZPure
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object VariablesCoercer {
   private val primitiveTypes: List[__Type] = List(

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -5,7 +5,8 @@ import caliban.InputValue
 import caliban.Value._
 import caliban.parsing.Parser
 import caliban.uploads.Upload
-import zio.Chunk
+import zio.{ Chunk, Trace }
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.time._
 import java.time.format.DateTimeFormatter
@@ -207,7 +208,7 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
   implicit def chunk[A](implicit ev: ArgBuilder[A]): ArgBuilder[Chunk[A]]   = list[A].map(Chunk.fromIterable)
 
   implicit lazy val upload: ArgBuilder[Upload] = {
-    case StringValue(v) => Right(Upload(v))
+    case StringValue(v) => Right(Upload(v)(Trace.empty))
     case other          => Left(InvalidInputArgument("Upload", other))
   }
 }

--- a/core/src/main/scala/caliban/schema/SubscriptionSchema.scala
+++ b/core/src/main/scala/caliban/schema/SubscriptionSchema.scala
@@ -1,5 +1,6 @@
 package caliban.schema
 
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
 
 /**

--- a/core/src/main/scala/caliban/uploads/Upload.scala
+++ b/core/src/main/scala/caliban/uploads/Upload.scala
@@ -2,12 +2,14 @@ package caliban.uploads
 
 import caliban.Value.{ IntValue, NullValue, StringValue }
 import caliban.{ GraphQLRequest, InputValue, PathValue }
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZSink
-import zio.{ Chunk, RIO, UIO, URIO }
+import zio.{ Chunk, RIO, Trace, UIO, URIO }
 
 import scala.annotation.tailrec
 
-final case class Upload(name: String) {
+final case class Upload(name: String)(implicit val trace: Trace) {
+
   val allBytes: RIO[Uploads, Chunk[Byte]] =
     Uploads.stream(name).run(ZSink.foldLeftChunks(Chunk[Byte]())(_ ++ (_: Chunk[Byte])))
 

--- a/core/src/main/scala/caliban/uploads/Uploads.scala
+++ b/core/src/main/scala/caliban/uploads/Uploads.scala
@@ -1,7 +1,8 @@
 package caliban.uploads
 
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
-import zio.{ Chunk, UIO, ULayer, URIO, ZIO, ZLayer }
+import zio.{ Chunk, Trace, UIO, ULayer, URIO, ZIO, ZLayer }
 
 trait Uploads {
   def stream(name: String): ZStream[Any, Throwable, Byte]
@@ -9,19 +10,21 @@ trait Uploads {
 }
 
 object Uploads {
-  val empty: ULayer[Uploads] =
+  val empty: ULayer[Uploads] = {
+    implicit val trace: Trace = Trace.empty
     ZLayer.succeed(new Uploads {
       def stream(name: String): ZStream[Any, Throwable, Byte] = ZStream.empty
       def file(name: String): UIO[Option[FileMeta]]           = ZIO.none
     })
+  }
 
-  def stream(name: String): ZStream[Uploads, Throwable, Byte] =
+  def stream(name: String)(implicit trace: Trace): ZStream[Uploads, Throwable, Byte] =
     ZStream.serviceWithStream(_.stream(name))
 
-  def fileMeta(name: String): URIO[Uploads, Option[FileMeta]] =
+  def fileMeta(name: String)(implicit trace: Trace): URIO[Uploads, Option[FileMeta]] =
     ZIO.serviceWithZIO(_.file(name))
 
-  def handler(fileHandle: String => UIO[Option[FileMeta]]): UIO[Uploads] =
+  def handler(fileHandle: String => UIO[Option[FileMeta]])(implicit trace: Trace): UIO[Uploads] =
     ZIO
       .succeed(new Uploads {
         def stream(name: String): ZStream[Any, Throwable, Byte] =

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -3,7 +3,8 @@ package caliban.validation
 import caliban.introspection.adt._
 import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
 import caliban.parsing.adt._
-import Utils._
+import caliban.validation.Utils._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object FieldMap {
   val empty: FieldMap = Map.empty

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -7,6 +7,7 @@ import caliban.validation.Utils._
 import zio.Chunk
 import zio.prelude._
 import zio.prelude.fx.ZPure
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3

--- a/core/src/main/scala/caliban/validation/Utils.scala
+++ b/core/src/main/scala/caliban/validation/Utils.scala
@@ -4,6 +4,7 @@ import caliban.introspection.adt._
 import caliban.introspection.adt.__TypeKind._
 import caliban.parsing.adt.Type.NamedType
 import zio.Chunk
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.compat._
 

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -9,6 +9,7 @@ import caliban.parsing.Parser
 import caliban.{ InputValue, Value }
 import zio.prelude.EReader
 import zio.prelude.fx.ZPure
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object ValueValidator {
   def validateDefaultValue(field: __InputValue, errorContext: => String): EReader[Any, ValidationError, Unit] =

--- a/core/src/main/scala/caliban/validation/package.scala
+++ b/core/src/main/scala/caliban/validation/package.scala
@@ -1,11 +1,12 @@
 package caliban
 
-import caliban.parsing.adt.Definition.ExecutableDefinition.{ FragmentDefinition, OperationDefinition }
 import caliban.introspection.adt.{ __Field, __Type }
 import caliban.parsing.SourceMapper
-import caliban.parsing.adt.{ Document, Selection, VariableDefinition }
+import caliban.parsing.adt.Definition.ExecutableDefinition.{ FragmentDefinition, OperationDefinition }
 import caliban.parsing.adt.Selection.Field
+import caliban.parsing.adt.{ Document, Selection, VariableDefinition }
 import caliban.schema.{ RootType, Types }
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 package object validation {
   case class SelectedField(

--- a/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloCaching.scala
@@ -3,13 +3,14 @@ package caliban.wrappers
 import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.Value.{ EnumValue, IntValue, StringValue }
+import caliban._
 import caliban.execution.FieldInfo
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations.GQLDirective
 import caliban.wrappers.Wrapper.{ EffectfulWrapper, FieldWrapper, OverallWrapper }
-import caliban._
 import zio._
 import zio.query.ZQuery
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.TimeUnit
 
@@ -46,10 +47,12 @@ object ApolloCaching {
 
   }
 
-  val apolloCaching: EffectfulWrapper[Any] =
+  val apolloCaching: EffectfulWrapper[Any] = {
+    implicit val trace: Trace = Trace.empty
     EffectfulWrapper(
       Ref.make(Caching()).map(ref => apolloCachingOverall(ref) |+| apolloCachingField(ref))
     )
+  }
 
   sealed trait CacheScope
 

--- a/core/src/main/scala/caliban/wrappers/CostEstimation.scala
+++ b/core/src/main/scala/caliban/wrappers/CostEstimation.scala
@@ -295,7 +295,7 @@ object CostEstimation {
         go(head.fields ++ tail, f(head) :: result)
     }
 
-    ZIO.mergeAll(go(List(field), Nil))(0.0)(_ + _)(Trace.empty)
+    ZIO.mergeAllPar(go(List(field), Nil))(0.0)(_ + _)(Trace.empty)
   }
 
 }

--- a/core/src/main/scala/caliban/wrappers/DeferSupport.scala
+++ b/core/src/main/scala/caliban/wrappers/DeferSupport.scala
@@ -4,6 +4,8 @@ import caliban.execution.Feature
 import caliban.introspection.adt.{ __Directive, __DirectiveLocation, __InputValue }
 import caliban.schema.Types
 import caliban.{ GraphQL, GraphQLAspect }
+import zio.Trace
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object DeferSupport {
   private[caliban] val deferDirective = __Directive(

--- a/core/src/main/scala/caliban/wrappers/FieldMetrics.scala
+++ b/core/src/main/scala/caliban/wrappers/FieldMetrics.scala
@@ -26,13 +26,12 @@ object FieldMetrics {
     buckets: Histogram.Boundaries,
     extraLabels: Set[MetricLabel]
   ) {
+    private implicit val trace: Trace = Trace.empty
 
-    def recordFailures(fieldNames: List[String])(implicit trace: Trace): UIO[Unit] =
+    def recordFailures(fieldNames: List[String]): UIO[Unit] =
       ZIO.foreachDiscard(fieldNames)(fn => failed.tagged("field", fn).increment)
 
-    def recordSuccesses(nodeOffsets: Map[Vector[PathValue], Long], timings: List[Timing])(implicit
-      trace: Trace
-    ): UIO[Unit] =
+    def recordSuccesses(nodeOffsets: Map[Vector[PathValue], Long], timings: List[Timing]): UIO[Unit] =
       ZIO.foreachDiscard(timings) { timing =>
         val d = timing.duration - nodeOffsets.getOrElse(timing.path :+ StringValue(timing.name), 0L)
         succeeded.tagged(Set(MetricLabel("field", timing.fullName))).increment *>

--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -39,7 +39,7 @@ sealed trait Wrapper[-R] extends GraphQLAspect[Nothing, R] { self =>
     that.withWrapper(self)
 
   // Disables tracing only for wrappers in the caliban package
-  final private[caliban] def trace: Trace = Trace.empty
+  private[caliban] implicit val trace: Trace = Trace.empty
 }
 
 object Wrapper {
@@ -151,8 +151,10 @@ object Wrapper {
     loop(process, wrappers)(info)
   }
 
-  private val emptyWrappers =
-    ZIO.succeed((Nil, Nil, Nil, Nil, Nil, Nil))(Trace.empty)
+  private val emptyWrappers = {
+    val w = (Nil, Nil, Nil, Nil, Nil, Nil)
+    ZIO.succeed(w)(Trace.empty)
+  }
 
   private[caliban] def decompose[R](wrappers: List[Wrapper[R]])(implicit trace: Trace): UIO[
     (

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -96,7 +96,7 @@ object ExampleApi {
       timeout(3 seconds) @@           // wrapper that fails slow queries
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
-      apolloTracing() @@                // wrapper for https://github.com/apollographql/apollo-tracing
+      apolloTracing() @@              // wrapper for https://github.com/apollographql/apollo-tracing
       DeferSupport.defer              // wrapper that enables @defer directive support
   }
 

--- a/examples/src/main/scala/example/ExampleService.scala
+++ b/examples/src/main/scala/example/ExampleService.scala
@@ -23,7 +23,7 @@ object ExampleService {
       } yield new ExampleService {
 
         def getCharacters(origin: Option[Origin]): UIO[List[Character]] =
-          characters.get.map(_.filter(c => origin.forall(c.origin == _))) <* foo
+          characters.get.map(_.filter(c => origin.forall(c.origin == _)))
 
         def findCharacter(name: String): UIO[Option[Character]] = characters.get.map(_.find(c => c.name == name))
 
@@ -38,7 +38,6 @@ object ExampleService {
         def deletedEvents: ZStream[Any, Nothing, String] =
           ZStream.scoped(subscribers.subscribe).flatMap(ZStream.fromQueue(_))
 
-        private def foo = ZIO.stackTrace.debug
       }
     }
 }

--- a/examples/src/main/scala/example/ExampleService.scala
+++ b/examples/src/main/scala/example/ExampleService.scala
@@ -23,7 +23,7 @@ object ExampleService {
       } yield new ExampleService {
 
         def getCharacters(origin: Option[Origin]): UIO[List[Character]] =
-          characters.get.map(_.filter(c => origin.forall(c.origin == _)))
+          characters.get.map(_.filter(c => origin.forall(c.origin == _))) <* foo
 
         def findCharacter(name: String): UIO[Option[Character]] = characters.get.map(_.find(c => c.name == name))
 
@@ -37,6 +37,8 @@ object ExampleService {
 
         def deletedEvents: ZStream[Any, Nothing, String] =
           ZStream.scoped(subscribers.subscribe).flatMap(ZStream.fromQueue(_))
+
+        private def foo = ZIO.stackTrace.debug
       }
     }
 }

--- a/federation/src/main/scala/caliban/federation/FederationSupport.scala
+++ b/federation/src/main/scala/caliban/federation/FederationSupport.scala
@@ -5,7 +5,9 @@ import caliban.introspection.adt._
 import caliban.parsing.adt.Directive
 import caliban.schema.Step.QueryStep
 import caliban.schema._
+import zio.Trace
 import zio.query.ZQuery
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 abstract class FederationSupport(
   supportedDirectives: List[__Directive],
@@ -96,7 +98,7 @@ abstract class FederationSupport(
       RootResolver(
         Query(
           _entities = args => args.representations.map(rep => _Entity(rep.__typename, rep.fields)),
-          _service = ZQuery.succeed(_Service(withSDL.render))
+          _service = ZQuery.succeed(_Service(withSDL.render))(Trace.empty)
         )
       ),
       supportedDirectives

--- a/interop/tapir/src/main/scala-2/caliban/interop/tapir/DisableAutoTraceVersionSpecific.scala
+++ b/interop/tapir/src/main/scala-2/caliban/interop/tapir/DisableAutoTraceVersionSpecific.scala
@@ -1,0 +1,8 @@
+package caliban.interop.tapir
+
+import zio.stacktracer.{ DisableAutoTrace, TracingImplicits }
+
+// See https://github.com/zio/zio-http/issues/2700
+private object DisableAutoTraceVersionSpecific {
+  implicit val disableAutoTrace: DisableAutoTrace = TracingImplicits.disableAutoTrace
+}

--- a/interop/tapir/src/main/scala-3/caliban/interop/tapir/DisableAutoTraceVersionSpecific.scala
+++ b/interop/tapir/src/main/scala-3/caliban/interop/tapir/DisableAutoTraceVersionSpecific.scala
@@ -1,0 +1,4 @@
+package caliban.interop.tapir
+
+// See https://github.com/zio/zio-http/issues/2700
+private object DisableAutoTraceVersionSpecific {}

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
@@ -23,10 +23,11 @@ sealed trait HttpInterpreter[-R, E] { self =>
   def serverEndpoints[R1 <: R, S](stream: Streams[S])(implicit
     streamConstructor: StreamConstructor[stream.BinaryStream]
   ): List[CalibanEndpoint[R1, stream.BinaryStream, S]] = {
+    implicit val trace: Trace = Trace.empty
+
     def logic(
       request: (GraphQLRequest, ServerRequest)
     ): RIO[R1, Either[TapirResponse, CalibanResponse[stream.BinaryStream]]] = {
-      implicit val trace: Trace           = Trace.empty
       val (graphQLRequest, serverRequest) = request
       executeRequest(graphQLRequest, serverRequest).either
     }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
@@ -1,6 +1,7 @@
 package caliban.interop.tapir
 
 import caliban._
+import caliban.interop.tapir.DisableAutoTraceVersionSpecific._
 import caliban.interop.tapir.TapirAdapter._
 import sttp.capabilities.Streams
 import sttp.model.{ headers => _, _ }
@@ -8,7 +9,6 @@ import sttp.tapir.Codec.JsonCodec
 import sttp.tapir._
 import sttp.tapir.model.ServerRequest
 import zio._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 sealed trait HttpInterpreter[-R, E] { self =>
   protected def endpoints[S](streams: Streams[S]): List[

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/HttpUploadInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/HttpUploadInterpreter.scala
@@ -1,6 +1,7 @@
 package caliban.interop.tapir
 
 import caliban._
+import caliban.interop.tapir.DisableAutoTraceVersionSpecific._
 import caliban.interop.tapir.TapirAdapter._
 import caliban.uploads.{ FileMeta, GraphQLUploadRequest, Uploads }
 import sttp.capabilities.Streams
@@ -9,7 +10,6 @@ import sttp.tapir.Codec.JsonCodec
 import sttp.tapir._
 import sttp.tapir.model.ServerRequest
 import zio._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.nio.charset.StandardCharsets
 

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/StreamConstructor.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/StreamConstructor.scala
@@ -1,6 +1,6 @@
 package caliban.interop.tapir
 
-import sttp.capabilities.Streams
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
 
 trait StreamConstructor[BS] {

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
@@ -17,8 +17,10 @@ trait WebSocketHooks[-R, +E] { self =>
   def onPing: Option[Option[InputValue] => ZIO[R, E, Option[ResponseValue]]] = None
   def onAck: Option[ZIO[R, E, ResponseValue]]                                = None
 
-  def ++[R2 <: R, E2 >: E](other: WebSocketHooks[R2, E2])(implicit trace: Trace): WebSocketHooks[R2, E2] =
+  def ++[R2 <: R, E2 >: E](other: WebSocketHooks[R2, E2]): WebSocketHooks[R2, E2] =
     new WebSocketHooks[R2, E2] {
+      private implicit val trace: Trace = Trace.empty
+
       override def beforeInit: Option[InputValue => ZIO[R2, E2, Any]] = (self.beforeInit, other.beforeInit) match {
         case (None, Some(f))      => Some(f)
         case (Some(f), None)      => Some(f)

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
@@ -1,7 +1,8 @@
 package caliban.interop.tapir
 
 import caliban.{ GraphQLWSOutput, InputValue, ResponseValue }
-import zio.ZIO
+import zio.{ Trace, ZIO }
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
 
 trait StreamTransformer[-R, +E] {
@@ -16,7 +17,7 @@ trait WebSocketHooks[-R, +E] { self =>
   def onPing: Option[Option[InputValue] => ZIO[R, E, Option[ResponseValue]]] = None
   def onAck: Option[ZIO[R, E, ResponseValue]]                                = None
 
-  def ++[R2 <: R, E2 >: E](other: WebSocketHooks[R2, E2]): WebSocketHooks[R2, E2] =
+  def ++[R2 <: R, E2 >: E](other: WebSocketHooks[R2, E2])(implicit trace: Trace): WebSocketHooks[R2, E2] =
     new WebSocketHooks[R2, E2] {
       override def beforeInit: Option[InputValue => ZIO[R2, E2, Any]] = (self.beforeInit, other.beforeInit) match {
         case (None, Some(f))      => Some(f)

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
@@ -1,6 +1,7 @@
 package caliban.interop.tapir
 
 import caliban._
+import caliban.interop.tapir.DisableAutoTraceVersionSpecific._
 import caliban.interop.tapir.TapirAdapter._
 import caliban.interop.tapir.ws.Protocol
 import sttp.capabilities.zio.ZioStreams
@@ -11,7 +12,6 @@ import sttp.tapir.model.{ ServerRequest, UnsupportedWebSocketFrameException }
 import sttp.tapir.server.ServerEndpoint
 import sttp.ws.WebSocketFrame
 import zio._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 sealed trait WebSocketInterpreter[-R, E] { self =>
   protected val endpoint: PublicEndpoint[(ServerRequest, String), TapirResponse, (String, CalibanPipe), ZioWebSockets]

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
@@ -21,9 +21,9 @@ sealed trait WebSocketInterpreter[-R, E] { self =>
     protocol: String
   )(implicit trace: Trace): URIO[R, Either[TapirResponse, (String, CalibanPipe)]]
 
-  def serverEndpoint[R1 <: R](implicit trace: Trace): ServerEndpoint[ZioWebSockets, RIO[R1, *]] =
+  def serverEndpoint[R1 <: R]: ServerEndpoint[ZioWebSockets, RIO[R1, *]] =
     endpoint.serverLogic[RIO[R1, *]] { case (serverRequest, protocol) =>
-      makeProtocol(serverRequest, protocol)
+      makeProtocol(serverRequest, protocol)(Trace.empty)
     }
 
   def intercept[R1](interceptor: Interceptor[R1, R])(implicit trace: Trace): WebSocketInterpreter[R1, E] =

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
@@ -17,7 +17,7 @@ sealed trait Protocol {
     interpreter: GraphQLInterpreter[R, E],
     keepAliveTime: Option[Duration],
     webSocketHooks: WebSocketHooks[R, E]
-  ): URIO[R, CalibanPipe]
+  )(implicit trace: Trace): URIO[R, CalibanPipe]
 
 }
 
@@ -64,8 +64,7 @@ object Protocol {
       interpreter: GraphQLInterpreter[R, E],
       keepAliveTime: Option[Duration],
       webSocketHooks: WebSocketHooks[R, E]
-    ): URIO[R, CalibanPipe] = {
-      implicit val trace: Trace = Trace.empty
+    )(implicit trace: Trace): URIO[R, CalibanPipe] =
       for {
         env           <- ZIO.environment[R]
         subscriptions <- SubscriptionManager.make
@@ -157,7 +156,6 @@ object Protocol {
                            ) *> ZStream.fromQueueWithShutdown(output)
                          }
       } yield pipe
-    }
 
     private def connectionError(id: Option[String]): GraphQLWSOutput           = GraphQLWSOutput(Ops.Error, id, None)
     private def connectionAck(payload: Option[ResponseValue]): GraphQLWSOutput =
@@ -217,8 +215,7 @@ object Protocol {
       interpreter: GraphQLInterpreter[R, E],
       keepAliveTime: Option[Duration],
       webSocketHooks: WebSocketHooks[R, E]
-    ): URIO[R, CalibanPipe] = {
-      implicit val trace: Trace = Trace.empty
+    )(implicit trace: Trace): URIO[R, CalibanPipe] =
       for {
         env           <- ZIO.environment[R]
         ack           <- Ref.make(false)
@@ -288,7 +285,6 @@ object Protocol {
                              )(_.interrupt) *> ZStream.fromQueueWithShutdown(output)
                          }
       } yield pipe
-    }
 
     private def keepAlive(keepAlive: Option[Duration])(implicit trace: Trace): UStream[GraphQLWSOutput] =
       keepAlive match {

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/ws/Protocol.scala
@@ -340,9 +340,9 @@ object Protocol {
     }
   }
 
-  private[ws] class SubscriptionManager private (private val tracked: TMap[String, Promise[Any, Unit]])(implicit
-    trace: Trace
-  ) {
+  private[ws] class SubscriptionManager private (private val tracked: TMap[String, Promise[Any, Unit]]) {
+    private implicit val trace: Trace = Trace.empty
+
     def track(id: String): UStream[Promise[Any, Unit]] =
       ZStream.fromZIO(Promise.make[Any, Unit].tap(tracked.put(id, _).commit))
 
@@ -359,7 +359,7 @@ object Protocol {
   }
 
   private object SubscriptionManager {
-    def make(implicit trace: Trace) = TMap.make[String, Promise[Any, Unit]]().map(new SubscriptionManager(_)).commit
+    val make = TMap.make[String, Promise[Any, Unit]]().map(new SubscriptionManager(_)).commit(Trace.empty)
   }
 
 }

--- a/tracing/src/main/scala/caliban/tracing/FieldTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/FieldTracer.scala
@@ -1,11 +1,12 @@
 package caliban.tracing
 
-import caliban.{ CalibanError, ResponseValue }
 import caliban.execution.FieldInfo
 import caliban.wrappers.Wrapper.FieldWrapper
+import caliban.{ CalibanError, ResponseValue }
 import io.opentelemetry.api.trace.StatusCode
 import zio._
 import zio.query.ZQuery
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.telemetry.opentelemetry.tracing.{ StatusMapper, Tracing }
 
 object FieldTracer {

--- a/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
@@ -11,6 +11,7 @@ import caliban.wrappers.Wrapper.ExecutionWrapper
 import caliban.{ CalibanError, GraphQLResponse, InputValue, Value }
 import io.opentelemetry.api.trace.SpanKind
 import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.telemetry.opentelemetry.tracing.Tracing
 
 object SchemaTracer {
@@ -68,7 +69,7 @@ object SchemaTracer {
         case x                   => x
       }
       (k, v1)
-    }.toMap
+    }
 
   private def maskField(f: Field): Field =
     f.copy(


### PR DESCRIPTION
⚠️ Binary incompatible changes ⚠️

With this PR, we disable auto-tracing across all of Caliban's codebase and propagate traces via the implicit requirement, or disable them wherever it doesn't make sense to propagate them via `Trace.empty`.

This is largely driven by an issue recently reported by @frekw, where the stack traces were incorrectly showing that an error was thrown within Caliban's code, since we were not propagating / disabling traces properly.

For example, running the Quick adapter example app, and adding `<* ZIO.stackTrace.debug` [here](https://github.com/ghostdogpr/caliban/blob/a64f85d789761e058c2c065ea1d009de7796fedf/examples/src/main/scala/example/ExampleService.scala#L26):

series/2.x:
```
Stack trace for thread "zio-fiber-43":
	at example.ExampleService.make.$anon.getCharacters(ExampleService.scala:26)
	at example.ExampleApi.makeApi(ExampleApi.scala:87)
	at caliban.QuickAdapter.handlers(QuickAdapter.scala:13)
	at caliban.wrappers.ApolloTracing.apolloTracingField.$anon.wrap(ApolloTracing.scala:210)
	at caliban.QuickAdapter.handlers(QuickAdapter.scala:13)
	at caliban.wrappers.ApolloTracing.apolloTracingOverall.$anon.wrap(ApolloTracing.scala:139)
	at caliban.wrappers.Wrappers.printErrors.$anon.wrap(Wrappers.scala:28)
	at caliban.wrappers.Wrappers.onSlowQueries.$anon.wrap(Wrappers.scala:70)
	at caliban.wrappers.Wrappers.timeout.$anon.wrap(Wrappers.scala:86)
```

PR:
```
Stack trace for thread "zio-fiber-43":
	at example.ExampleService.make.$anon.getCharacters(ExampleService.scala:26)
	at example.ExampleApi.makeApi(ExampleApi.scala:87)
```

Note that while these changes are no binary compatible, they should be mostly source compatible for most users