### PR TITLE
WebSocket support for `caliban-quick`

### DIFF
--- a/adapters/quick/src/main/scala/caliban/GraphiQLHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/GraphiQLHandler.scala
@@ -13,7 +13,11 @@ object GraphiQLHandler {
    * @see [[https://github.com/graphql/graphiql/tree/main/examples/graphiql-cdn]]
    */
   def handler(apiPath: String, graphiqlPath: String): RequestHandler[Any, Nothing] =
-    Handler.fromBody(Body.fromString(html(apiPath, graphiqlPath)))
+    Response(
+      Status.Ok,
+      Headers(Header.ContentType(MediaType.text.html).untyped),
+      Body.fromString(html(apiPath, graphiqlPath))
+    ).toHandler
 
   def html(apiPath: String, uiPath: String): String =
     s"""

--- a/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
@@ -43,8 +43,8 @@ final class QuickAdapter[-R] private (requestHandler: QuickRequestHandler[R]) {
     val uploadRoute   = uploadPath.toList.map { uPath =>
       RoutePattern(Method.POST, uPath) -> handlers.upload
     }
-    val wsRoute       = webSocketPath.toList.map { uPath =>
-      RoutePattern(Method.ANY, uPath) -> handlers.webSocket
+    val wsRoute       = webSocketPath.toList.map { wsPath =>
+      RoutePattern(Method.ANY, wsPath) -> handlers.webSocket
     }
     Routes.fromIterable(apiRoutes ::: graphiqlRoute ::: uploadRoute ::: wsRoute).toHttpApp
   }
@@ -76,8 +76,8 @@ final class QuickAdapter[-R] private (requestHandler: QuickRequestHandler[R]) {
   def configure[R1](configurator: QuickAdapter.Configurator[R1])(implicit trace: Trace): QuickAdapter[R & R1] =
     new QuickAdapter(requestHandler.configure[R1](configurator))
 
-  def configureWebSockets[R1](config: quick.WebSocketConfig[R1]): QuickAdapter[R & R1] =
-    new QuickAdapter(requestHandler.configureWebSockets(config))
+  def configureWebSocket[R1](config: quick.WebSocketConfig[R1]): QuickAdapter[R & R1] =
+    new QuickAdapter(requestHandler.configureWebSocket(config))
 
 }
 

--- a/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
@@ -76,8 +76,8 @@ final class QuickAdapter[-R] private (requestHandler: QuickRequestHandler[R]) {
   def configure[R1](configurator: QuickAdapter.Configurator[R1])(implicit trace: Trace): QuickAdapter[R & R1] =
     new QuickAdapter(requestHandler.configure[R1](configurator))
 
-  def configure[R1](config: quick.WebSocketConfig[R1]): QuickAdapter[R & R1] =
-    new QuickAdapter(requestHandler.configure(config))
+  def configureWebSockets[R1](config: quick.WebSocketConfig[R1]): QuickAdapter[R & R1] =
+    new QuickAdapter(requestHandler.configureWebSockets(config))
 
 }
 

--- a/adapters/quick/src/main/scala/caliban/QuickHandlers.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickHandlers.scala
@@ -4,7 +4,8 @@ import zio.http.{ HandlerAspect, RequestHandler }
 
 final case class QuickHandlers[-R](
   api: RequestHandler[R, Nothing],
-  upload: RequestHandler[R, Nothing]
+  upload: RequestHandler[R, Nothing],
+  webSocket: RequestHandler[R, Nothing]
 ) {
 
   /**
@@ -13,7 +14,8 @@ final case class QuickHandlers[-R](
   def @@[R1 <: R](aspect: HandlerAspect[R1, Unit]): QuickHandlers[R1] =
     QuickHandlers(
       api = (api @@ aspect).merge,
-      upload = (upload @@ aspect).merge
+      upload = (upload @@ aspect).merge,
+      webSocket = (webSocket @@ aspect).merge
     )
 
 }

--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -6,9 +6,11 @@ import caliban.ResponseValue.StreamValue
 import caliban.interop.jsoniter.ValueJsoniter
 import caliban.uploads.{ FileMeta, GraphQLUploadRequest, Uploads }
 import caliban.wrappers.Caching
+import caliban.ws.Protocol
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import zio._
+import zio.http.ChannelEvent.UserEvent.HandshakeComplete
 import zio.http.Header.ContentType
 import zio.http._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
@@ -17,20 +19,28 @@ import zio.stream.{ UStream, ZStream }
 import java.nio.charset.StandardCharsets.UTF_8
 import scala.util.control.NonFatal
 
-final private class QuickRequestHandler[-R](interpreter: GraphQLInterpreter[R, Any]) {
+final private class QuickRequestHandler[R](
+  interpreter: GraphQLInterpreter[R, Any],
+  wsConfig: quick.WebSocketConfig[R]
+) {
   import QuickRequestHandler._
 
   def configure(config: ExecutionConfiguration)(implicit trace: Trace): QuickRequestHandler[R] =
     new QuickRequestHandler[R](
-      interpreter.wrapExecutionWith[R, Any](Configurator.setWith(config)(_))
+      interpreter.wrapExecutionWith[R, Any](Configurator.setWith(config)(_)),
+      wsConfig
     )
 
   def configure[R1](configurator: QuickAdapter.Configurator[R1])(implicit
     trace: Trace
   ): QuickRequestHandler[R & R1] =
     new QuickRequestHandler[R & R1](
-      interpreter.wrapExecutionWith[R & R1, Any](exec => ZIO.scoped[R1 & R](configurator *> exec))
+      interpreter.wrapExecutionWith[R & R1, Any](exec => ZIO.scoped[R1 & R](configurator *> exec)),
+      wsConfig
     )
+
+  def configure[R1](config: quick.WebSocketConfig[R1]): QuickRequestHandler[R & R1] =
+    new QuickRequestHandler[R & R1](interpreter, config)
 
   def handleHttpRequest(request: Request)(implicit trace: Trace): URIO[R, Response] =
     transformHttpRequest(request)
@@ -44,6 +54,15 @@ final private class QuickRequestHandler[-R](interpreter: GraphQLInterpreter[R, A
         .map(transformResponse(request, _))
         .provideSomeLayer[R](fileHandle)
     }.merge
+
+  def handleWebSocketRequest(request: Request)(implicit trace: Trace): URIO[R, Response] = {
+    val protocol  = request.headers.get(Header.SecWebSocketProtocol) match {
+      case Some(value) => Protocol.fromName(value.renderedValue)
+      case None        => Protocol.Legacy
+    }
+    val socketApp = makeSocketApp(protocol)
+    Response.fromSocketApp(socketApp.withConfig(WebSocketConfig.default.subProtocol(Some(protocol.name))))
+  }
 
   private def transformHttpRequest(httpReq: Request)(implicit trace: Trace): IO[Response, GraphQLRequest] = {
 
@@ -214,6 +233,30 @@ final private class QuickRequestHandler[-R](interpreter: GraphQLInterpreter[R, A
     req.headers
       .get(GraphQLRequest.`apollo-federation-include-trace`)
       .exists(_.equalsIgnoreCase(GraphQLRequest.ftv1))
+
+  private def makeSocketApp(protocol: Protocol)(implicit trace: Trace): WebSocketApp[R] =
+    Handler.webSocket[R] { ch =>
+      for {
+        queue <- Queue.unbounded[GraphQLWSInput]
+        pipe  <- protocol.make(interpreter, wsConfig.keepAliveTime, wsConfig.hooks)
+        in     = ZStream.fromQueueWithShutdown(queue)
+        out    = pipe(in).map {
+                   case Right(output) => WebSocketFrame.Text(writeToString(output))
+                   case Left(close)   => WebSocketFrame.Close(close.code, Some(close.reason))
+                 }
+        _     <- ZIO.scoped(ch.receiveAll {
+                   case ChannelEvent.UserEventTriggered(HandshakeComplete) =>
+                     out
+                       .runForeach(frame => ch.send(ChannelEvent.Read(frame)))
+                       .race(ch.awaitShutdown)
+                       .forkScoped
+                   case ChannelEvent.Read(WebSocketFrame.Text(text))       =>
+                     ZIO.attempt(readFromString[GraphQLWSInput](text)).flatMap(queue.offer(_))
+                   case _                                                  =>
+                     ZIO.unit
+                 })
+      } yield ()
+    }
 }
 
 object QuickRequestHandler {

--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -39,7 +39,7 @@ final private class QuickRequestHandler[R](
       wsConfig
     )
 
-  def configure[R1](config: quick.WebSocketConfig[R1]): QuickRequestHandler[R & R1] =
+  def configureWebSockets[R1](config: quick.WebSocketConfig[R1]): QuickRequestHandler[R & R1] =
     new QuickRequestHandler[R & R1](interpreter, config)
 
   def handleHttpRequest(request: Request)(implicit trace: Trace): URIO[R, Response] =

--- a/adapters/quick/src/main/scala/caliban/quick/WebSocketConfig.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/WebSocketConfig.scala
@@ -2,18 +2,23 @@ package caliban.quick
 
 import caliban.ws.WebSocketHooks
 import zio._
+import zio.http.{ WebSocketConfig => ZWebSocketConfig }
 
 case class WebSocketConfig[-R](
   keepAliveTime: Option[Duration],
-  hooks: WebSocketHooks[R, Any]
+  hooks: WebSocketHooks[R, Any],
+  zHttpConfig: ZWebSocketConfig
 ) {
   def withHooks[R1](newHooks: WebSocketHooks[R1, Any]): WebSocketConfig[R & R1] =
     copy(hooks = hooks ++ newHooks)
 
   def withKeepAliveTime(time: Duration): WebSocketConfig[R] =
     copy(keepAliveTime = Some(time))
+
+  def withZHttpConfig(newConfig: ZWebSocketConfig): WebSocketConfig[R] =
+    copy(zHttpConfig = newConfig)
 }
 
 object WebSocketConfig {
-  val default: WebSocketConfig[Any] = WebSocketConfig(None, WebSocketHooks.empty)
+  def default: WebSocketConfig[Any] = WebSocketConfig(None, WebSocketHooks.empty, ZWebSocketConfig.default)
 }

--- a/adapters/quick/src/main/scala/caliban/quick/WebSocketConfig.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/WebSocketConfig.scala
@@ -1,0 +1,19 @@
+package caliban.quick
+
+import caliban.ws.WebSocketHooks
+import zio._
+
+case class WebSocketConfig[-R](
+  keepAliveTime: Option[Duration],
+  hooks: WebSocketHooks[R, Any]
+) {
+  def withHooks[R1](newHooks: WebSocketHooks[R1, Any]): WebSocketConfig[R & R1] =
+    copy(hooks = hooks ++ newHooks)
+
+  def withKeepAliveTime(time: Duration): WebSocketConfig[R] =
+    copy(keepAliveTime = Some(time))
+}
+
+object WebSocketConfig {
+  val default: WebSocketConfig[Any] = WebSocketConfig(None, WebSocketHooks.empty)
+}

--- a/adapters/quick/src/main/scala/caliban/quick/package.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/package.scala
@@ -16,16 +16,26 @@ package object quick {
      * @param apiPath The route to serve the API on, e.g., `/api/graphql`
      * @param graphiqlPath Optionally define a route to serve the GraphiQL UI on, e.g., `/graphiql`
      * @param uploadPath Optionally define a route to serve file uploads on, e.g., `/api/upload`
+     * @param webSocketPath The path where websocket requests will be set. If None, websocket-based subscriptions will be disabled.
      */
     def runServer(
       port: Int,
       apiPath: String,
       graphiqlPath: Option[String] = None,
-      uploadPath: Option[String] = None
+      uploadPath: Option[String] = None,
+      webSocketPath: Option[String] = None
     )(implicit
       trace: Trace
     ): RIO[R, Nothing] =
-      gql.interpreter.flatMap(QuickAdapter(_).runServer(port, apiPath, graphiqlPath, uploadPath))
+      gql.interpreter.flatMap(
+        QuickAdapter(_).runServer(
+          port,
+          apiPath = apiPath,
+          graphiqlPath = graphiqlPath,
+          uploadPath = uploadPath,
+          webSocketPath = webSocketPath
+        )
+      )
 
     /**
      * Creates zio-http `HttpApp` from the GraphQL API
@@ -37,9 +47,17 @@ package object quick {
     def toApp(
       apiPath: String,
       graphiqlPath: Option[String] = None,
-      uploadPath: Option[String] = None
+      uploadPath: Option[String] = None,
+      webSocketPath: Option[String] = None
     )(implicit trace: Trace): IO[CalibanError.ValidationError, HttpApp[R]] =
-      gql.interpreter.map(QuickAdapter(_).toApp(apiPath, graphiqlPath, uploadPath))
+      gql.interpreter.map(
+        QuickAdapter(_).toApp(
+          apiPath = apiPath,
+          graphiqlPath = graphiqlPath,
+          uploadPath = uploadPath,
+          webSocketPath = webSocketPath
+        )
+      )
 
     /**
      * Creates a zio-http handler for the GraphQL API

--- a/adapters/quick/src/test/scala/caliban/QuickAdapterSpec.scala
+++ b/adapters/quick/src/test/scala/caliban/QuickAdapterSpec.scala
@@ -24,7 +24,9 @@ object QuickAdapterSpec extends ZIOSpecDefault {
 
   private val apiLayer = envLayer >>> ZLayer.fromZIO {
     for {
-      app     <- TestApi.api.toApp("/api/graphql", uploadPath = Some("/upload/graphql")).map(_ @@ auth)
+      app     <- TestApi.api
+                   .toApp("/api/graphql", uploadPath = Some("/upload/graphql"), webSocketPath = Some("/ws/graphql"))
+                   .map(_ @@ auth)
       _       <- Server.serve(app).forkScoped
       _       <- Live.live(Clock.sleep(3 seconds))
       service <- ZIO.service[TestService]
@@ -35,7 +37,7 @@ object QuickAdapterSpec extends ZIOSpecDefault {
     val suite = TapirAdapterSpec.makeSuite(
       "QuickAdapterSpec",
       uri"http://localhost:8090/api/graphql",
-      wsUri = None,
+      wsUri = Some(uri"ws://localhost:8090/ws/graphql"),
       uploadUri = Some(uri"http://localhost:8090/upload/graphql")
     )
     suite.provideShared(

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -8,7 +8,7 @@ import sttp.tapir.server.ziohttp.{ ZioHttpInterpreter, ZioHttpServerOptions }
 import zio.http._
 
 @deprecated(
-  "The `caliban-zio-http` package is deprecated and scheduled to be removed in a future release. To use Caliban with zio-http, use the `caliban-quick` instead",
+  "The `caliban-zio-http` package is deprecated and scheduled to be removed in a future release. To use Caliban with zio-http, use the `caliban-quick` module instead",
   "2.6.0"
 )
 object ZHttpAdapter {

--- a/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
+++ b/adapters/zio-http/src/main/scala/caliban/ZHttpAdapter.scala
@@ -1,12 +1,16 @@
 package caliban
 
-import caliban.interop.tapir.ws.Protocol
 import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
+import caliban.ws.Protocol
 import sttp.capabilities.zio.ZioStreams
 import sttp.model.HeaderNames
 import sttp.tapir.server.ziohttp.{ ZioHttpInterpreter, ZioHttpServerOptions }
 import zio.http._
 
+@deprecated(
+  "The `caliban-zio-http` package is deprecated and scheduled to be removed in a future release. To use Caliban with zio-http, use the `caliban-quick` instead",
+  "2.6.0"
+)
 object ZHttpAdapter {
 
   @deprecated("Defining subprotocols in the server config is no longer required")

--- a/adapters/zio-http/src/test/scala/caliban/ZHttpAdapterSpec.scala
+++ b/adapters/zio-http/src/test/scala/caliban/ZHttpAdapterSpec.scala
@@ -15,8 +15,10 @@ import zio._
 import zio.http._
 import zio.test.{ Live, ZIOSpecDefault }
 
+import scala.annotation.nowarn
 import scala.language.postfixOps
 
+@nowarn
 object ZHttpAdapterSpec extends ZIOSpecDefault {
   import sttp.tapir.json.zio._
 

--- a/build.sbt
+++ b/build.sbt
@@ -707,7 +707,7 @@ lazy val commonSettings = Def.settings(
   })
 )
 
-lazy val enforceMimaCompatibility = true // Enable / disable failing CI on binary incompatibilities
+lazy val enforceMimaCompatibility = false // Enable / disable failing CI on binary incompatibilities
 
 lazy val enableMimaSettingsJVM =
   Def.settings(

--- a/core/src/main/scala/caliban/ws/Protocol.scala
+++ b/core/src/main/scala/caliban/ws/Protocol.scala
@@ -1,10 +1,8 @@
-package caliban.interop.tapir.ws
+package caliban.ws
 
 import caliban.ResponseValue.{ ObjectValue, StreamValue }
 import caliban.Value.StringValue
 import caliban._
-import caliban.interop.tapir.TapirAdapter.CalibanPipe
-import caliban.interop.tapir.WebSocketHooks
 import zio.stm.TMap
 import zio.stream.{ UStream, ZStream }
 import zio.{ Duration, Promise, Queue, Random, Ref, Schedule, UIO, URIO, ZIO }
@@ -39,9 +37,9 @@ object Protocol {
       final val ConnectionAck  = "connection_ack"
     }
 
-    val name = "graphql-transport-ws"
+    final val name = "graphql-transport-ws"
 
-    val handler = new ResponseHandler {
+    private val handler: ResponseHandler = new ResponseHandler {
       override def toResponse[E](id: String, r: GraphQLResponse[E]): GraphQLWSOutput =
         GraphQLWSOutput(Ops.Next, Some(id), Some(r.toResponseValue))
 
@@ -190,9 +188,9 @@ object Protocol {
       final val Data                = "data"
     }
 
-    val name = "graphql-ws"
+    final val name = "graphql-ws"
 
-    val handler: ResponseHandler = new ResponseHandler {
+    private val handler: ResponseHandler = new ResponseHandler {
       override def toResponse[E](id: String, r: GraphQLResponse[E]): GraphQLWSOutput =
         GraphQLWSOutput(Ops.Data, Some(id), Some(r.toResponseValue))
 

--- a/core/src/main/scala/caliban/ws/Protocol.scala
+++ b/core/src/main/scala/caliban/ws/Protocol.scala
@@ -20,10 +20,9 @@ sealed trait Protocol {
 
 object Protocol {
 
-  def fromName(name: String): Protocol = name match {
-    case GraphQLWS.name => GraphQLWS
-    case _              => Legacy
-  }
+  def fromName(name: String): Protocol =
+    if (name.equalsIgnoreCase(GraphQLWS.name)) GraphQLWS
+    else Legacy
 
   object GraphQLWS extends Protocol {
     object Ops {
@@ -296,7 +295,7 @@ object Protocol {
       GraphQLWSOutput(Ops.ConnectionAck, None, payload)
   }
 
-  private[ws] trait ResponseHandler {
+  private trait ResponseHandler {
     self =>
     def toResponse[E](id: String, fieldName: String, r: ResponseValue, errors: List[E]): GraphQLWSOutput =
       toResponse(id, GraphQLResponse(ObjectValue(List(fieldName -> r)), errors))
@@ -337,7 +336,7 @@ object Protocol {
     }
   }
 
-  private[ws] class SubscriptionManager private (private val tracked: TMap[String, Promise[Any, Unit]]) {
+  private class SubscriptionManager private (private val tracked: TMap[String, Promise[Any, Unit]]) {
     def track(id: String): UStream[Promise[Any, Unit]] =
       ZStream.fromZIO(Promise.make[Any, Unit].tap(tracked.put(id, _).commit))
 

--- a/core/src/main/scala/caliban/ws/WebSocketHooks.scala
+++ b/core/src/main/scala/caliban/ws/WebSocketHooks.scala
@@ -1,0 +1,125 @@
+package caliban.ws
+
+import caliban.{ GraphQLWSOutput, InputValue, ResponseValue }
+import zio.ZIO
+import zio.stream.ZStream
+
+trait StreamTransformer[-R, +E] {
+  def transform[R1 <: R, E1 >: E](stream: ZStream[R1, E1, GraphQLWSOutput]): ZStream[R1, E1, GraphQLWSOutput]
+}
+
+trait WebSocketHooks[-R, +E] { self =>
+  def beforeInit: Option[InputValue => ZIO[R, E, Any]]                       = None
+  def afterInit: Option[ZIO[R, E, Any]]                                      = None
+  def onMessage: Option[StreamTransformer[R, E]]                             = None
+  def onPong: Option[InputValue => ZIO[R, E, Any]]                           = None
+  def onPing: Option[Option[InputValue] => ZIO[R, E, Option[ResponseValue]]] = None
+  def onAck: Option[ZIO[R, E, ResponseValue]]                                = None
+
+  def ++[R2 <: R, E2 >: E](other: WebSocketHooks[R2, E2]): WebSocketHooks[R2, E2] =
+    new WebSocketHooks[R2, E2] {
+      override def beforeInit: Option[InputValue => ZIO[R2, E2, Any]] = (self.beforeInit, other.beforeInit) match {
+        case (None, Some(f))      => Some(f)
+        case (Some(f), None)      => Some(f)
+        case (Some(f1), Some(f2)) => Some((x: InputValue) => f1(x) *> f2(x))
+        case _                    => None
+      }
+
+      override def afterInit: Option[ZIO[R2, E2, Any]] = (self.afterInit, other.afterInit) match {
+        case (None, Some(f))      => Some(f)
+        case (Some(f), None)      => Some(f)
+        case (Some(f1), Some(f2)) => Some(f1 &> f2)
+        case _                    => None
+      }
+
+      override def onMessage: Option[StreamTransformer[R2, E2]] =
+        (self.onMessage, other.onMessage) match {
+          case (None, Some(f))      => Some(f)
+          case (Some(f), None)      => Some(f)
+          case (Some(f1), Some(f2)) =>
+            Some(new StreamTransformer[R2, E2] {
+              def transform[R1 <: R2, E1 >: E2](s: ZStream[R1, E1, GraphQLWSOutput]): ZStream[R1, E1, GraphQLWSOutput] =
+                f2.transform(f1.transform(s))
+            })
+          case _                    => None
+        }
+
+      override def onPong: Option[InputValue => ZIO[R2, E2, Any]] = (self.onPong, other.onPong) match {
+        case (None, Some(f))      => Some(f)
+        case (Some(f), None)      => Some(f)
+        case (Some(f1), Some(f2)) => Some((x: InputValue) => f1(x) &> f2(x))
+        case _                    => None
+      }
+
+      override def onPing: Option[Option[InputValue] => ZIO[R2, E2, Option[ResponseValue]]] =
+        (self.onPing, other.onPing) match {
+          case (None, Some(f))      => Some(f)
+          case (Some(f), None)      => Some(f)
+          case (Some(f1), Some(f2)) =>
+            Some { (x: Option[InputValue]) =>
+              f1(x).zipWithPar(f2(x)) {
+                case (a @ Some(_), None) => a
+                case (None, b @ Some(_)) => b
+                case (Some(a), Some(b))  => Some(a.deepMerge(b))
+                case _                   => None
+              }
+            }
+          case _                    => None
+        }
+
+      override def onAck: Option[ZIO[R2, E2, ResponseValue]] = (self.onAck, other.onAck) match {
+        case (None, Some(f))      => Some(f)
+        case (Some(f), None)      => Some(f)
+        case (Some(f1), Some(f2)) => Some((f1 zipWithPar f2)(_ deepMerge _))
+        case _                    => None
+      }
+    }
+}
+
+object WebSocketHooks {
+  def empty[R, E]: WebSocketHooks[R, E] = new WebSocketHooks[R, E] {}
+
+  /**
+   * Specifies a callback that will be run before an incoming subscription
+   * request is accepted. Useful for e.g authorizing the incoming subscription
+   * before accepting it.
+   */
+  def init[R, E](f: InputValue => ZIO[R, E, Any]): WebSocketHooks[R, E] =
+    new WebSocketHooks[R, E] {
+      override def beforeInit: Option[InputValue => ZIO[R, E, Any]] = Some(f)
+    }
+
+  /**
+   * Specifies a callback that will be run after an incoming subscription
+   * request has been accepted. Useful for e.g terminating a subscription
+   * after some time, such as authorization expiring.
+   */
+  def afterInit[R, E](f: ZIO[R, E, Any]): WebSocketHooks[R, E] =
+    new WebSocketHooks[R, E] {
+      override def afterInit: Option[ZIO[R, E, Any]] = Some(f)
+    }
+
+  /**
+   * Specifies a callback that will be run on the resulting `ZStream`
+   * for every active subscription. Useful to e.g modify the environment
+   * to inject session information into the `ZStream` handling the
+   * subscription.
+   */
+  def message[R, E](f: StreamTransformer[R, E]): WebSocketHooks[R, E] =
+    new WebSocketHooks[R, E] {
+      override def onMessage: Option[StreamTransformer[R, E]] = Some(f)
+    }
+
+  /**
+   * Specifies a callback that will be run when ever a pong message is received.
+   */
+  def pong[R, E](f: InputValue => ZIO[R, E, Any]): WebSocketHooks[R, E] =
+    new WebSocketHooks[R, E] {
+      override def onPong: Option[InputValue => ZIO[R, E, Any]] = Some(f)
+    }
+
+  def ack[R, E](f: ZIO[R, E, ResponseValue]): WebSocketHooks[R, E] =
+    new WebSocketHooks[R, E] {
+      override def onAck: Option[ZIO[R, E, ResponseValue]] = Some(f)
+    }
+}

--- a/core/src/main/scala/caliban/ws/package.scala
+++ b/core/src/main/scala/caliban/ws/package.scala
@@ -1,0 +1,8 @@
+package caliban
+
+import zio.stream.Stream
+
+package object ws {
+  type Pipe[A, B]  = Stream[Throwable, A] => Stream[Throwable, B]
+  type CalibanPipe = Pipe[GraphQLWSInput, Either[GraphQLWSClose, GraphQLWSOutput]]
+}

--- a/examples/src/main/scala/example/quick/ExampleApp.scala
+++ b/examples/src/main/scala/example/quick/ExampleApp.scala
@@ -1,10 +1,10 @@
 package example.quick
 
 import caliban._
+import caliban.quick._
 import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
 import zio._
-import caliban.quick._
 
 object ExampleApp extends ZIOAppDefault {
 
@@ -20,7 +20,8 @@ object ExampleApp extends ZIOAppDefault {
         _.runServer(
           port = 8090,
           apiPath = "/api/graphql",
-          graphiqlPath = Some("/graphiql")
+          graphiqlPath = Some("/graphiql"),
+          webSocketPath = Some("/ws/graphql")
         )
       }
       .provide(

--- a/examples/src/main/scala/example/stitching/ExampleApp.scala
+++ b/examples/src/main/scala/example/stitching/ExampleApp.scala
@@ -102,7 +102,7 @@ object ExampleApp extends ZIOAppDefault {
   def run =
     StitchingExample.api.flatMap {
       _.runServer(
-        port = 8090,
+        port = 8080,
         apiPath = "/api/graphql",
         graphiqlPath = Some("/graphiql"),
         webSocketPath = Some("/ws/graphql")

--- a/examples/src/main/scala/example/stitching/ExampleApp.scala
+++ b/examples/src/main/scala/example/stitching/ExampleApp.scala
@@ -13,6 +13,8 @@ import sttp.client3.SttpBackend
 import sttp.client3.httpclient.zio._
 import zio._
 
+import scala.annotation.nowarn
+
 object StitchingExample extends GenericSchema[Any] {
   val GITHUB_API = "https://api.github.com/graphql"
 
@@ -102,6 +104,7 @@ import zio.stream._
 import zio.http._
 import caliban.ZHttpAdapter
 
+@nowarn
 object ExampleApp extends ZIOAppDefault {
   import sttp.tapir.json.circe._
 

--- a/examples/src/main/scala/example/stitching/ExampleApp.scala
+++ b/examples/src/main/scala/example/stitching/ExampleApp.scala
@@ -1,19 +1,17 @@
 package example.stitching
 
 import caliban._
-import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
-import caliban.schema._
-import caliban.schema.Schema.auto._
+import caliban.quick._
 import caliban.schema.ArgBuilder.auto._
-import caliban.tools.{ Options, RemoteSchema, SchemaLoader }
+import caliban.schema.Schema.auto._
+import caliban.schema._
 import caliban.tools.stitching.{ HttpRequest, RemoteResolver, RemoteSchemaResolver, ResolveRequest }
+import caliban.tools.{ Options, RemoteSchema, SchemaLoader }
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.SttpBackend
 import sttp.client3.httpclient.zio._
 import zio._
-
-import scala.annotation.nowarn
 
 object StitchingExample extends GenericSchema[Any] {
   val GITHUB_API = "https://api.github.com/graphql"
@@ -100,36 +98,17 @@ object Configuration {
   private def read(key: String): Task[String] = ZIO.attempt(sys.env(key))
 }
 
-import zio.stream._
-import zio.http._
-import caliban.ZHttpAdapter
-
-@nowarn
 object ExampleApp extends ZIOAppDefault {
-  import sttp.tapir.json.circe._
-
-  private val graphiql = Handler.fromResource("graphiql.html").sandbox
-
   def run =
-    (for {
-      api         <- StitchingExample.api
-      interpreter <- api.interpreter
-      _           <-
-        Server
-          .serve(
-            Routes(
-              Method.ANY / "api" / "graphql" ->
-                ZHttpAdapter.makeHttpService(HttpInterpreter(interpreter)),
-              Method.ANY / "ws" / "graphql"  ->
-                ZHttpAdapter.makeWebSocketService(WebSocketInterpreter(interpreter)),
-              Method.ANY / "graphiql"        ->
-                graphiql
-            ).toHttpApp
-          )
-    } yield ())
-      .provide(
-        HttpClientZioBackend.layer(),
-        Configuration.fromEnvironment,
-        Server.default
+    StitchingExample.api.flatMap {
+      _.runServer(
+        port = 8090,
+        apiPath = "/api/graphql",
+        graphiqlPath = Some("/graphiql"),
+        webSocketPath = Some("/ws/graphql")
       )
+    }.provide(
+      HttpClientZioBackend.layer(),
+      Configuration.fromEnvironment
+    )
 }

--- a/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/AuthExampleApp.scala
@@ -2,14 +2,17 @@ package example.ziohttp
 
 import caliban.Value.StringValue
 import caliban._
-import caliban.interop.tapir.{ HttpInterpreter, WebSocketHooks, WebSocketInterpreter }
+import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
 import caliban.schema.GenericSchema
+import caliban.ws.WebSocketHooks
 import example.ExampleData._
 import example.{ ExampleApi, ExampleService }
 import sttp.tapir.json.circe._
 import zio._
 import zio.http._
 import zio.stream._
+
+import scala.annotation.nowarn
 
 case object Unauthorized extends RuntimeException("Unauthorized")
 
@@ -20,6 +23,7 @@ trait Auth {
   def setUser(name: Option[String]): UIO[Unit]
 }
 
+@nowarn
 object Auth {
 
   val http: ULayer[Auth] = ZLayer.scoped {
@@ -81,6 +85,7 @@ object Authed extends GenericSchema[Auth] {
   val api = graphQL(RootResolver(Queries(), None, Subscriptions()))
 }
 
+@nowarn
 object AuthExampleApp extends ZIOAppDefault {
   private val graphiql = Handler.fromResource("graphiql.html").sandbox
 

--- a/examples/src/main/scala/example/ziohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/ziohttp/ExampleApp.scala
@@ -7,6 +7,9 @@ import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
 import zio._
 import zio.http._
 
+import scala.annotation.nowarn
+
+@nowarn
 object ExampleApp extends ZIOAppDefault {
   import sttp.tapir.json.circe._
 

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketHooks.scala
@@ -5,7 +5,7 @@ import zio.ZIO
 import zio.stream.{ ZPipeline, ZStream }
 
 @deprecated(
-  "No longer used. WebSocketHooks.onMessage now uses a ZPipeline instead. To convert your existing logic into a ZPipeline, use `ZPipeline.fromFunction`",
+  "WebSocketHooks.onMessage now uses a ZPipeline instead. To convert your existing logic into a ZPipeline, use `ZPipeline.fromFunction`",
   "2.6.0"
 )
 trait StreamTransformer[-R, +E] {
@@ -41,6 +41,18 @@ object WebSocketHooks {
 
   /**
    * Specifies a callback that will be run on the resulting `ZStream`
+   * for every active subscription. Useful to e.g modify the environment
+   * to inject session information into the `ZStream` handling the
+   * subscription.
+   */
+  def message[R, E](f: StreamTransformer[R, E]): WebSocketHooks[R, E] =
+    new WebSocketHooks[R, E] {
+      override def onMessage: Option[ZPipeline[R, E, GraphQLWSOutput, GraphQLWSOutput]] =
+        Some(ZPipeline.fromFunction(f.transform))
+    }
+
+  /**
+   * Specifies a ZPipeline that will be applied on the resulting `ZStream`
    * for every active subscription. Useful to e.g modify the environment
    * to inject session information into the `ZStream` handling the
    * subscription.

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
@@ -2,7 +2,7 @@ package caliban.interop.tapir
 
 import caliban._
 import caliban.interop.tapir.TapirAdapter._
-import caliban.ws.{ Protocol, WebSocketHooks }
+import caliban.ws.Protocol
 import sttp.capabilities.zio.ZioStreams
 import sttp.model.{ headers => _ }
 import sttp.tapir.Codec.JsonCodec
@@ -36,7 +36,7 @@ object WebSocketInterpreter {
   private case class Base[R, E](
     interpreter: GraphQLInterpreter[R, E],
     keepAliveTime: Option[Duration],
-    webSocketHooks: WebSocketHooks[R, E]
+    webSocketHooks: ws.WebSocketHooks[R, E]
   )(implicit
     inputCodec: JsonCodec[GraphQLWSInput],
     outputCodec: JsonCodec[GraphQLWSOutput]
@@ -77,7 +77,7 @@ object WebSocketInterpreter {
   def apply[R, E](
     interpreter: GraphQLInterpreter[R, E],
     keepAliveTime: Option[Duration] = None,
-    webSocketHooks: WebSocketHooks[R, E] = WebSocketHooks.empty[R, E]
+    webSocketHooks: ws.WebSocketHooks[R, E] = ws.WebSocketHooks.empty[R, E]
   )(implicit
     inputCodec: JsonCodec[GraphQLWSInput],
     outputCodec: JsonCodec[GraphQLWSOutput]

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
@@ -2,7 +2,7 @@ package caliban.interop.tapir
 
 import caliban._
 import caliban.interop.tapir.TapirAdapter._
-import caliban.interop.tapir.ws.Protocol
+import caliban.ws.{ Protocol, WebSocketHooks }
 import sttp.capabilities.zio.ZioStreams
 import sttp.model.{ headers => _ }
 import sttp.tapir.Codec.JsonCodec

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -7,8 +7,8 @@ import sttp.capabilities.zio.ZioStreams
 import sttp.capabilities.{ Effect, WebSockets }
 import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
 import sttp.client3.httpclient.zio.SttpClient
-import sttp.client3.{ BasicRequestBody, DeserializationException, HttpError, ResponseException, SttpBackend }
 import sttp.client3.impl.zio.ZioServerSentEvents
+import sttp.client3.{ BasicRequestBody, DeserializationException, HttpError, ResponseException, SttpBackend }
 import sttp.model._
 import sttp.model.sse.ServerSentEvent
 import sttp.tapir.Codec.JsonCodec
@@ -340,7 +340,7 @@ object TapirAdapterSpec {
       runWS.map(runWS =>
         suite("test ws endpoint")(
           test("legacy ws") {
-            import caliban.interop.tapir.ws.Protocol.Legacy.Ops
+            import caliban.ws.Protocol.Legacy.Ops
             val io =
               for {
                 res         <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](
@@ -395,7 +395,7 @@ object TapirAdapterSpec {
             }
           } @@ TestAspect.timeout(60.seconds),
           test("graphql-ws") {
-            import caliban.interop.tapir.ws.Protocol.GraphQLWS.Ops
+            import caliban.ws.Protocol.GraphQLWS.Ops
             val io =
               for {
                 res         <- ZIO.serviceWithZIO[SttpBackend[Task, ZioStreams with WebSockets]](


### PR DESCRIPTION
Main changes:
1. Moved `Protocol`, `WebSocketHooks` and `StreamTransformer` into the core module
2. Added request handling for WS requests in the `caliban-quick` module and exposed methods to configure hooks & keep-alive duration
3. Deprecated the `ZHttpAdapter` object, signalling that it will be removed in a future release