### PR TITLE
Fix incorrect wrapping of pure values by some `FieldWrapper`s

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -159,7 +159,7 @@ object Executor {
           } else (Nil, filteredFields.map(reduceField))
         }
 
-        val eagerReduced = reduceObject(eager, wrapPureValues)
+        val eagerReduced = reduceObject(eager)
         deferred match {
           case Nil => eagerReduced
           case d   =>
@@ -167,7 +167,7 @@ object Executor {
               eagerReduced,
               d.groupBy(_._1).toList.map { case (label, labelAndFields) =>
                 val (_, fields) = labelAndFields.unzip
-                reduceObject(fields, wrapPureValues) -> label
+                reduceObject(fields) -> label
               },
               path
             )
@@ -327,10 +327,7 @@ object Executor {
     ): FieldInfo =
       FieldInfo(aliasedName, field, path, fieldDirectives, field.parentType)
 
-    private def reduceObject(
-      items: List[(String, ReducedStep[R], FieldInfo)],
-      wrapPureValues: Boolean
-    ): ReducedStep[R] = {
+    private def reduceObject(items: List[(String, ReducedStep[R], FieldInfo)]): ReducedStep[R] = {
       var hasPures   = false
       var hasQueries = false
       val nil        = Nil

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -218,6 +218,8 @@ object Executor {
         if (steps.isEmpty) PureStep(ListValue(Nil))
         else {
           reduceStep(steps.head, currentField, arguments, PathValue.Index(0) :: path) match {
+            // In 99.99% of the cases, if the head is pure, all the other elements will be pure as well but we catch that error just in case
+            // NOTE: Our entire test suite passes without catching the error
             case step: PureStep =>
               try reduceToPureStep(step, steps.tail)
               catch { case _: ClassCastException => reduceToListStep(step, steps.tail) }

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -82,26 +82,32 @@ sealed abstract class ReducedStep[-R] { self =>
 }
 
 object ReducedStep {
-  case class ListStep[-R](steps: List[ReducedStep[R]], areItemsNullable: Boolean, isPure: Boolean)
-      extends ReducedStep[R]
+  final case class ListStep[-R](
+    steps: List[ReducedStep[R]],
+    areItemsNullable: Boolean,
+    isPure: Boolean
+  ) extends ReducedStep[R]
 
-  case class ObjectStep[-R](fields: List[(String, ReducedStep[R], FieldInfo)], hasPureFields: Boolean, isPure: Boolean)
-      extends ReducedStep[R]
+  final case class ObjectStep[-R](
+    fields: List[(String, ReducedStep[R], FieldInfo)],
+    hasPureFields: Boolean,
+    isPure: Boolean
+  ) extends ReducedStep[R]
 
-  case class QueryStep[-R](query: ZQuery[R, ExecutionError, ReducedStep[R]]) extends ReducedStep[R] {
-    def isPure: Boolean = false
+  final case class QueryStep[-R](query: ZQuery[R, ExecutionError, ReducedStep[R]]) extends ReducedStep[R] {
+    final val isPure = false
   }
 
-  case class StreamStep[-R](inner: ZStream[R, ExecutionError, ReducedStep[R]]) extends ReducedStep[R] {
-    def isPure: Boolean = false
+  final case class StreamStep[-R](inner: ZStream[R, ExecutionError, ReducedStep[R]]) extends ReducedStep[R] {
+    final val isPure = false
   }
 
-  case class DeferStep[-R](
+  final case class DeferStep[-R](
     obj: ReducedStep[R],
     deferred: List[(ReducedStep[R], Option[String])],
     path: List[PathValue]
   ) extends ReducedStep[R] {
-    def isPure: Boolean = false
+    final val isPure = false
   }
 
   // PureStep is both a Step and a ReducedStep so it is defined outside this object
@@ -116,6 +122,6 @@ object ReducedStep {
  *
  * @param value the response value to return for that step
  */
-case class PureStep(value: ResponseValue) extends ReducedStep[Any] with Step[Any] {
-  def isPure: Boolean = true
+final case class PureStep(value: ResponseValue) extends ReducedStep[Any] with Step[Any] {
+  final val isPure = true
 }

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -78,20 +78,31 @@ object Step {
 }
 
 sealed abstract class ReducedStep[-R] { self =>
-  final def isPure: Boolean = self.isInstanceOf[PureStep]
+  def isPure: Boolean
 }
 
 object ReducedStep {
-  case class ListStep[-R](steps: List[ReducedStep[R]], areItemsNullable: Boolean) extends ReducedStep[R]
-  case class ObjectStep[-R](fields: List[(String, ReducedStep[R], FieldInfo)], hasPureFields: Boolean)
+  case class ListStep[-R](steps: List[ReducedStep[R]], areItemsNullable: Boolean, isPure: Boolean)
       extends ReducedStep[R]
-  case class QueryStep[-R](query: ZQuery[R, ExecutionError, ReducedStep[R]])      extends ReducedStep[R]
-  case class StreamStep[-R](inner: ZStream[R, ExecutionError, ReducedStep[R]])    extends ReducedStep[R]
+
+  case class ObjectStep[-R](fields: List[(String, ReducedStep[R], FieldInfo)], hasPureFields: Boolean, isPure: Boolean)
+      extends ReducedStep[R]
+
+  case class QueryStep[-R](query: ZQuery[R, ExecutionError, ReducedStep[R]]) extends ReducedStep[R] {
+    def isPure: Boolean = false
+  }
+
+  case class StreamStep[-R](inner: ZStream[R, ExecutionError, ReducedStep[R]]) extends ReducedStep[R] {
+    def isPure: Boolean = false
+  }
+
   case class DeferStep[-R](
     obj: ReducedStep[R],
     deferred: List[(ReducedStep[R], Option[String])],
     path: List[PathValue]
-  ) extends ReducedStep[R]
+  ) extends ReducedStep[R] {
+    def isPure: Boolean = false
+  }
 
   // PureStep is both a Step and a ReducedStep so it is defined outside this object
   // This is to avoid boxing/unboxing pure values during step reduction
@@ -105,4 +116,6 @@ object ReducedStep {
  *
  * @param value the response value to return for that step
  */
-case class PureStep(value: ResponseValue) extends ReducedStep[Any] with Step[Any]
+case class PureStep(value: ResponseValue) extends ReducedStep[Any] with Step[Any] {
+  def isPure: Boolean = true
+}


### PR DESCRIPTION
Fixes #2161

The issue is that in case that a FieldWrapper exists which wraps pure values, all FieldWrappers will wrap pure values when the step is not a `PureStep`. This happens because our `isStep` method doesn't consider `ObjectStep`s and `ListStep`s that only contain pure values as "pure" steps