### PR TITLE
Add excludeDeprecated option to client codegen

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
@@ -28,6 +28,7 @@ sealed trait CalibanSettings {
   final def preserveInputNames(value: Boolean): Self              = withSettings(_.preserveInputNames(value))
   final def addDerives(value: Boolean): Self                      = withSettings(_.addDerives(value))
   final def envForDerives(value: String): Self                    = withSettings(_.envForDerives(value))
+  final def excludeDeprecated(value: Boolean): Self               = withSettings(_.excludeDeprecated(value))
 }
 
 final case class CalibanFileSettings(file: File, settings: CalibanCommonSettings) extends CalibanSettings {

--- a/codegen-sbt/src/main/scala/caliban/codegen/OptionsParser.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/OptionsParser.scala
@@ -22,7 +22,8 @@ object OptionsParser {
     preserveInputNames: Option[Boolean],
     supportIsRepeatable: Option[Boolean],
     addDerives: Option[Boolean],
-    envForDerives: Option[String]
+    envForDerives: Option[String],
+    excludeDeprecated: Option[Boolean]
   )
 
   private object DescriptorUtils {
@@ -74,7 +75,8 @@ object OptionsParser {
             rawOpts.preserveInputNames,
             rawOpts.supportIsRepeatable,
             rawOpts.addDerives,
-            rawOpts.envForDerives
+            rawOpts.envForDerives,
+            rawOpts.excludeDeprecated
           )
         }.option
       case _                             => ZIO.none

--- a/codegen-sbt/src/test/scala/caliban/codegen/OptionsParserSpec.scala
+++ b/codegen-sbt/src/test/scala/caliban/codegen/OptionsParserSpec.scala
@@ -30,6 +30,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -59,6 +60,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -74,6 +76,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 Options(
                   "schema",
                   "output",
+                  None,
                   None,
                   None,
                   None,
@@ -137,6 +140,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -156,6 +160,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some("GraphqlClient.scala"),
+                  None,
                   None,
                   None,
                   None,
@@ -197,6 +202,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -217,6 +223,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(true),
+                  None,
                   None,
                   None,
                   None,
@@ -257,6 +264,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -279,6 +287,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(Map("Long" -> "scala.Long")),
+                  None,
                   None,
                   None,
                   None,
@@ -317,6 +326,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -341,6 +351,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(true),
+                  None,
                   None,
                   None,
                   None,
@@ -377,6 +388,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   Some(true),
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -407,7 +419,39 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
+                )
+              )
+          )
+        }
+      },
+      test("provide excludeDeprecated") {
+        val input = List("schema", "output", "--excludeDeprecated", "true")
+        OptionsParser.fromArgs(input).map { result =>
+          assertTrue(
+            result ==
+              Some(
+                Options(
+                  "schema",
+                  "output",
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  Some(true)
                 )
               )
           )

--- a/tools/src/main/scala/caliban/tools/CalibanCommonSettings.scala
+++ b/tools/src/main/scala/caliban/tools/CalibanCommonSettings.scala
@@ -19,7 +19,8 @@ final case class CalibanCommonSettings(
   preserveInputNames: Option[Boolean],
   supportIsRepeatable: Option[Boolean],
   addDerives: Option[Boolean],
-  envForDerives: Option[String]
+  envForDerives: Option[String],
+  excludeDeprecated: Option[Boolean]
 ) {
 
   private[caliban] def toOptions(schemaPath: String, toPath: String): Options =
@@ -41,7 +42,8 @@ final case class CalibanCommonSettings(
       preserveInputNames = preserveInputNames,
       supportIsRepeatable = supportIsRepeatable,
       addDerives = addDerives,
-      envForDerives = envForDerives
+      envForDerives = envForDerives,
+      excludeDeprecated = excludeDeprecated
     )
 
   private[caliban] def combine(r: => CalibanCommonSettings): CalibanCommonSettings =
@@ -62,7 +64,8 @@ final case class CalibanCommonSettings(
       preserveInputNames = r.preserveInputNames.orElse(this.preserveInputNames),
       supportIsRepeatable = r.supportIsRepeatable.orElse(this.supportIsRepeatable),
       addDerives = r.addDerives.orElse(this.addDerives),
-      envForDerives = r.envForDerives.orElse(this.envForDerives)
+      envForDerives = r.envForDerives.orElse(this.envForDerives),
+      excludeDeprecated = r.excludeDeprecated.orElse(this.excludeDeprecated)
     )
 
   def clientName(value: String): CalibanCommonSettings                         = this.copy(clientName = Some(value))
@@ -86,6 +89,7 @@ final case class CalibanCommonSettings(
     this.copy(supportIsRepeatable = Some(supportIsRepeatable))
   def addDerives(addDerives: Boolean): CalibanCommonSettings                   = this.copy(addDerives = Some(addDerives))
   def envForDerives(envForDerives: String): CalibanCommonSettings              = this.copy(envForDerives = Some(envForDerives))
+  def excludeDeprecated(value: Boolean): CalibanCommonSettings                 = this.copy(excludeDeprecated = Some(value))
 }
 
 object CalibanCommonSettings {
@@ -107,6 +111,7 @@ object CalibanCommonSettings {
       preserveInputNames = None,
       supportIsRepeatable = None,
       addDerives = None,
-      envForDerives = None
+      envForDerives = None,
+      excludeDeprecated = None
     )
 }

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -109,7 +109,7 @@ object ClientWriter {
       ) =
         fieldInfo
 
-        s"""$description${deprecated}def $safeName$typeParam$args$innerSelection$implicits: SelectionBuilder[$typeName, $outputType] = _root_.caliban.client.SelectionBuilder.Field("$name", $builder$argBuilder)"""
+      s"""$description${deprecated}def $safeName$typeParam$args$innerSelection$implicits: SelectionBuilder[$typeName, $outputType] = _root_.caliban.client.SelectionBuilder.Field("$name", $builder$argBuilder)"""
     }
 
     def collectFieldInfo(
@@ -865,10 +865,10 @@ object ClientWriter {
       .map {
         case typedef if excludeDeprecated =>
           val valuesWithoutDeprecated =
-            typedef.enumValuesDefinition.filterNot(_.directives.find(_.name == "deprecated").isDefined)
+            typedef.enumValuesDefinition.filterNot(value => value.directives.find(_.name == "deprecated").isDefined)
 
           typedef.copy(enumValuesDefinition = valuesWithoutDeprecated)
-        case typedef => typedef
+        case typedef                      => typedef
       }
       .map { typedef =>
         val content     = writeEnum(typedef, extensibleEnums = extensibleEnums)

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -20,7 +20,8 @@ object ClientWriter {
     additionalImports: Option[List[String]] = None,
     splitFiles: Boolean = false,
     extensibleEnums: Boolean = false,
-    scalarMappings: Option[Map[String, String]] = None
+    scalarMappings: Option[Map[String, String]] = None,
+    excludeDeprecated: Boolean = false
   ): List[(String, String)] = {
     require(packageName.isDefined || !splitFiles, "splitFiles option requires a package name")
 
@@ -108,7 +109,7 @@ object ClientWriter {
       ) =
         fieldInfo
 
-      s"""$description${deprecated}def $safeName$typeParam$args$innerSelection$implicits: SelectionBuilder[$typeName, $outputType] = _root_.caliban.client.SelectionBuilder.Field("$name", $builder$argBuilder)"""
+        s"""$description${deprecated}def $safeName$typeParam$args$innerSelection$implicits: SelectionBuilder[$typeName, $outputType] = _root_.caliban.client.SelectionBuilder.Field("$name", $builder$argBuilder)"""
     }
 
     def collectFieldInfo(
@@ -430,11 +431,16 @@ object ClientWriter {
       s"type $objectName"
     }
 
-    def writeObject(typedef: ObjectTypeDefinition, genView: Boolean): String = {
+    def writeObject(typedef: ObjectTypeDefinition, genView: Boolean, excludeDeprecated: Boolean): String = {
+      val allFields =
+        if (excludeDeprecated)
+          typedef.fields.filterNot(field => field.directives.find(_.name == "deprecated").isDefined)
+        else
+          typedef.fields
 
       val objectName: String = safeTypeName(typedef.name)
 
-      val optionalUnionTypeFields = typedef.fields.flatMap { field =>
+      val optionalUnionTypeFields = allFields.flatMap { field =>
         if (isOptionalUnionType(field))
           Some(
             collectFieldInfo(
@@ -448,7 +454,7 @@ object ClientWriter {
         else None
       }
 
-      val optionalInterfaceTypeFields = typedef.fields.flatMap { field =>
+      val optionalInterfaceTypeFields = allFields.flatMap { field =>
         if (isOptionalInterfaceType(field))
           Vector(
             collectFieldInfo(
@@ -469,15 +475,14 @@ object ClientWriter {
         else Vector.empty
       }
 
-      val fields = typedef.fields.map(
-        collectFieldInfo(_, objectName, optionalUnion = false, optionalInterface = false, commonInterface = false)
-      )
-      val view   = if (genView) "\n  " + writeView(typedef.name, fields.map(_.typeInfo)) else ""
+      val fields = allFields
+        .map(collectFieldInfo(_, objectName, optionalUnion = false, optionalInterface = false, commonInterface = false))
+      val view   = if (genView && fields.nonEmpty) "\n  " + writeView(typedef.name, fields.map(_.typeInfo)) else ""
 
-      val allFields = fields ++ optionalUnionTypeFields ++ optionalInterfaceTypeFields
+      val objectFields = fields ++ optionalUnionTypeFields ++ optionalInterfaceTypeFields
 
       s"""object $objectName {$view
-         |  ${allFields.distinct.map(writeFieldInfo).mkString("\n  ")}
+         |  ${objectFields.distinct.map(writeFieldInfo).mkString("\n  ")}
          |}
          |""".stripMargin
     }
@@ -690,22 +695,28 @@ object ClientWriter {
         .map(v => s"""case ${typedef.name}.${safeEnumValue(v.enumValue)} => __EnumValue("${v.enumValue}")""") ++
         (if (extensibleEnums) Some(s"case ${typedef.name}.__Unknown (value) => __EnumValue(value)") else None)
 
+      val enumObject =
+        if (typedef.enumValuesDefinition.nonEmpty)
+          s"""object $enumName {
+            ${enumCases.mkString("\n")}
+
+            implicit val decoder: ScalarDecoder[$enumName] = {
+              ${decoderCases.mkString("\n")}
+              case other => Left(DecodingError(s"Can't build ${typedef.name} from input $$other"))
+            }
+            implicit val encoder: ArgEncoder[${typedef.name}] = {
+              ${encoderCases.mkString("\n")}
+            }
+
+            val values: scala.collection.immutable.Vector[$enumName] = scala.collection.immutable.Vector(${typedef.enumValuesDefinition
+            .map(v => safeEnumValue(v.enumValue))
+            .mkString(", ")})
+          }"""
+        else
+          ""
+
       s"""sealed trait $enumName extends scala.Product with scala.Serializable { def value: String }
-        object $enumName {
-          ${enumCases.mkString("\n")}
-
-          implicit val decoder: ScalarDecoder[$enumName] = {
-            ${decoderCases.mkString("\n")}
-            case other => Left(DecodingError(s"Can't build ${typedef.name} from input $$other"))
-          }
-          implicit val encoder: ArgEncoder[${typedef.name}] = {
-            ${encoderCases.mkString("\n")}
-          }
-
-          val values: scala.collection.immutable.Vector[$enumName] = scala.collection.immutable.Vector(${typedef.enumValuesDefinition
-        .map(v => safeEnumValue(v.enumValue))
-        .mkString(", ")})
-        }
+          $enumObject
        """
     }
 
@@ -785,7 +796,7 @@ object ClientWriter {
         directives = typedef.directives,
         fields = typedef.fields
       )
-      val content     = writeObject(objDef, genView)
+      val content     = writeObject(objDef, genView, excludeDeprecated)
       val fullContent =
         if (splitFiles)
           s"""import caliban.client.FieldBuilder._
@@ -820,7 +831,7 @@ object ClientWriter {
           schemaDef.exists(_.subscription.getOrElse("Subscription") == obj.name)
       )
       .map { typedef =>
-        val content     = writeObject(typedef, genView)
+        val content     = writeObject(typedef, genView, excludeDeprecated)
         val fullContent =
           if (splitFiles)
             s"""import caliban.client.FieldBuilder._
@@ -851,6 +862,14 @@ object ClientWriter {
 
     val enums = schema.enumTypeDefinitions
       .filter(e => !scalarMappingsWithDefaults.contains(e.name))
+      .map {
+        case typedef if excludeDeprecated =>
+          val valuesWithoutDeprecated =
+            typedef.enumValuesDefinition.filterNot(_.directives.find(_.name == "deprecated").isDefined)
+
+          typedef.copy(enumValuesDefinition = valuesWithoutDeprecated)
+        case typedef => typedef
+      }
       .map { typedef =>
         val content     = writeEnum(typedef, extensibleEnums = extensibleEnums)
         val fullContent =

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -34,6 +34,7 @@ object Codegen {
       splitFiles                = arguments.splitFiles.getOrElse(false)
       enableFmt                 = arguments.enableFmt.getOrElse(true)
       extensibleEnums           = arguments.extensibleEnums.getOrElse(false)
+      excludeDeprecated         = arguments.excludeDeprecated.getOrElse(false)
       code                      = genType match {
                                     case GenType.Schema =>
                                       List(
@@ -58,7 +59,8 @@ object Codegen {
                                         arguments.imports,
                                         splitFiles,
                                         extensibleEnums,
-                                        scalarMappings
+                                        scalarMappings,
+                                        excludeDeprecated
                                       )
                                   }
       formatted                <- if (enableFmt) Formatter.format(code, arguments.fmtPath) else ZIO.succeed(code)

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -18,7 +18,8 @@ final case class Options(
   preserveInputNames: Option[Boolean],
   supportIsRepeatable: Option[Boolean],
   addDerives: Option[Boolean],
-  envForDerives: Option[String]
+  envForDerives: Option[String],
+  excludeDeprecated: Option[Boolean]
 )
 
 object Options {

--- a/tools/src/main/scala/caliban/tools/compiletime/Config.scala
+++ b/tools/src/main/scala/caliban/tools/compiletime/Config.scala
@@ -52,7 +52,8 @@ trait Config {
          |  splitFiles = $splitFiles,
          |  enableFmt = $enableFmt,
          |  extensibleEnums = $extensibleEnums,
-         |  supportIsRepeatable = $supportIsRepeatable
+         |  supportIsRepeatable = $supportIsRepeatable,
+         |  excludeDeprecated = $excludeDeprecated
          |)
       """.stripMargin.trim
     }

--- a/tools/src/main/scala/caliban/tools/compiletime/Config.scala
+++ b/tools/src/main/scala/caliban/tools/compiletime/Config.scala
@@ -14,7 +14,8 @@ trait Config {
     splitFiles: Boolean = false,
     enableFmt: Boolean = true,
     extensibleEnums: Boolean = false,
-    supportIsRepeatable: Boolean = true
+    supportIsRepeatable: Boolean = true,
+    excludeDeprecated: Boolean = false
   ) {
     private[caliban] def toCalibanCommonSettings: CalibanCommonSettings =
       CalibanCommonSettings(
@@ -34,7 +35,8 @@ trait Config {
         preserveInputNames = None,
         supportIsRepeatable = Some(supportIsRepeatable),
         addDerives = None,
-        envForDerives = None
+        envForDerives = None,
+        excludeDeprecated = Some(excludeDeprecated)
       )
 
     private[caliban] def asScalaCode: String = {

--- a/tools/src/test/scala/caliban/tools/CodegenSpec.scala
+++ b/tools/src/test/scala/caliban/tools/CodegenSpec.scala
@@ -67,7 +67,8 @@ object CodegenSpec extends ZIOSpecDefault {
       preserveInputNames = None,
       supportIsRepeatable = None,
       addDerives = None,
-      envForDerives = None
+      envForDerives = None,
+      excludeDeprecated = None
     )
 
     getPackageAndObjectName(arguments)

--- a/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
+++ b/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
@@ -43,7 +43,8 @@ object ConfigSpec extends ZIOSpecDefault {
               preserveInputNames = None,
               supportIsRepeatable = Some(true),
               addDerives = None,
-              envForDerives = None
+              envForDerives = None,
+              excludeDeprecated = None
             )
         )
       )

--- a/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
+++ b/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
@@ -18,7 +18,8 @@ object ConfigSpec extends ZIOSpecDefault {
       splitFiles = true,
       enableFmt = false,
       extensibleEnums = true,
-      supportIsRepeatable = true
+      supportIsRepeatable = true,
+      excludeDeprecated = true
     )
 
   private val toCalibanCommonSettingsSpec =
@@ -44,7 +45,7 @@ object ConfigSpec extends ZIOSpecDefault {
               supportIsRepeatable = Some(true),
               addDerives = None,
               envForDerives = None,
-              excludeDeprecated = None
+              excludeDeprecated = Some(true)
             )
         )
       )
@@ -66,7 +67,8 @@ object ConfigSpec extends ZIOSpecDefault {
                |  splitFiles = false,
                |  enableFmt = true,
                |  extensibleEnums = false,
-               |  supportIsRepeatable = true
+               |  supportIsRepeatable = true,
+               |  excludeDeprecated = false
                |)
             """.stripMargin.trim
         )
@@ -85,7 +87,8 @@ object ConfigSpec extends ZIOSpecDefault {
                |  splitFiles = true,
                |  enableFmt = false,
                |  extensibleEnums = true,
-               |  supportIsRepeatable = true
+               |  supportIsRepeatable = true,
+               |  excludeDeprecated = true
                |)
             """.stripMargin.trim
         )
@@ -106,7 +109,8 @@ object ConfigSpec extends ZIOSpecDefault {
               imports = List.empty,
               splitFiles = false,
               enableFmt = true,
-              extensibleEnums = false
+              extensibleEnums = false,
+              excludeDeprecated = false
             )
         )
       )


### PR DESCRIPTION
Add excludeDeprecated option to client codegen, when enabled excludes deprecated fields and enum values. Resolves https://github.com/ghostdogpr/caliban/issues/645

Note: not quite sure about codegen-sbt part 🔢 