### PR TITLE
Improve performance of `ApolloFederatedTracing` wrapper

### DIFF
--- a/core/src/main/scala/caliban/wrappers/Wrapper.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrapper.scala
@@ -39,7 +39,7 @@ sealed trait Wrapper[-R] extends GraphQLAspect[Nothing, R] { self =>
     that.withWrapper(self)
 
   // Disables tracing only for wrappers in the caliban package
-  final private[caliban] def trace: Trace = Trace.empty
+  final private[caliban] implicit def trace: Trace = Trace.empty
 }
 
 object Wrapper {

--- a/federation/src/main/scala/caliban/federation/tracing/ApolloFederatedTracing.scala
+++ b/federation/src/main/scala/caliban/federation/tracing/ApolloFederatedTracing.scala
@@ -98,6 +98,38 @@ object ApolloFederatedTracing {
     wrapPureValues: Boolean
   ): FieldWrapper[Any] =
     new FieldWrapper[Any](wrapPureValues) {
+
+      private def updateState(startTime: Long, fieldInfo: FieldInfo)(result: Either[ExecutionError, ResponseValue]) =
+        ZQuery.succeed {
+          val endTime = nanoTime
+          val path    = (PathValue.Key(fieldInfo.name) :: fieldInfo.path).toVector
+          val _       = ref.updateAndGet(state =>
+            state.copy(
+              root = state.root.insert(
+                path,
+                Node(
+                  id = Node.Id.ResponseName(fieldInfo.name),
+                  startTime = startTime - state.startTime,
+                  endTime = endTime - state.startTime,
+                  `type` = fieldInfo.details.fieldType.toType().toString,
+                  parentType = fieldInfo.details.parentType.map(_.toType().toString) getOrElse "",
+                  originalFieldName = fieldInfo.details.alias.map(_ => fieldInfo.details.name) getOrElse "",
+                  error = result.left.toOption.collectFirst { case e: ExecutionError =>
+                    Error(
+                      e.getMessage(),
+                      location = e.locationInfo.map(l => Location(l.line, l.column)).toSeq
+                    )
+                  }.toSeq
+                )
+              )
+            )
+          )
+          result match {
+            case Right(value) => value
+            case _            => null
+          }
+        }
+
       def wrap[R1](
         query: ZQuery[R1, CalibanError.ExecutionError, ResponseValue],
         fieldInfo: FieldInfo
@@ -105,34 +137,11 @@ object ApolloFederatedTracing {
         if (enabled.get())
           ZQuery.suspend {
             val startTime = nanoTime
-            query.either.flatMap { result =>
-              ZQuery.fromEither {
-                val endTime = nanoTime
-                val path    = (PathValue.Key(fieldInfo.name) :: fieldInfo.path).toVector
-                val _       = ref.updateAndGet(state =>
-                  state.copy(
-                    root = state.root.insert(
-                      path,
-                      Node(
-                        id = Node.Id.ResponseName(fieldInfo.name),
-                        startTime = startTime - state.startTime,
-                        endTime = endTime - state.startTime,
-                        `type` = fieldInfo.details.fieldType.toType().toString,
-                        parentType = fieldInfo.details.parentType.map(_.toType().toString) getOrElse "",
-                        originalFieldName = fieldInfo.details.alias.map(_ => fieldInfo.details.name) getOrElse "",
-                        error = result.left.toOption.collectFirst { case e: ExecutionError =>
-                          Error(
-                            e.getMessage(),
-                            location = e.locationInfo.map(l => Location(l.line, l.column)).toSeq
-                          )
-                        }.toSeq
-                      )
-                    )
-                  )
-                )
-                result
-              }
-            }
+            val update0   = updateState(startTime, fieldInfo) _
+            query.foldQuery(
+              error => update0(Left(error)) *> ZQuery.fail(error),
+              value => update0(Right(value))
+            )
           }
         else query
 

--- a/federation/src/main/scala/caliban/federation/tracing/ApolloFederatedTracing.scala
+++ b/federation/src/main/scala/caliban/federation/tracing/ApolloFederatedTracing.scala
@@ -110,10 +110,10 @@ object ApolloFederatedTracing {
                 id = Node.Id.ResponseName(fieldInfo.name),
                 startTime = startTime - state.startTime,
                 endTime = endTime - state.startTime,
-                `type` = fieldInfo.details.fieldType.toType().toString,
-                parentType = fieldInfo.details.parentType.map(_.toType().toString) getOrElse "",
+                `type` = fieldInfo.details.fieldType.typeNameRepr,
+                parentType = fieldInfo.details.parentType.map(_.typeNameRepr) getOrElse "",
                 originalFieldName = fieldInfo.details.alias.map(_ => fieldInfo.details.name) getOrElse "",
-                error = error.collectFirst { case e: ExecutionError =>
+                error = error.map { e =>
                   Error(
                     e.getMessage(),
                     location = e.locationInfo.map(l => Location(l.line, l.column)).toSeq


### PR DESCRIPTION
With these changes, we reduce the number of flatmaps performed in the ApolloFederatedTracing wrapper for the happy path (when fields are successes). Since this wrapper wraps pure values by default, this should see a noticeable improvement for users OOTB