### PR TITLE
Add SemanticNonNull support

### DIFF
--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -94,7 +94,12 @@ trait CommonSchemaDerivation[R] {
                   else p.typeclass.toType_(isInput, isSubscription).nonNull,
                 p.annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
                 p.annotations.collectFirst { case GQLDeprecated(reason) => reason },
-                Option(p.annotations.collect { case GQLDirective(dir) => dir }.toList).filter(_.nonEmpty)
+                Option(
+                  p.annotations.collect { case GQLDirective(dir) => dir }.toList ++ {
+                    if (isOptional && p.typeclass.semanticNonNull) Some(Directive("semanticNonNull"))
+                    else None
+                  }
+                ).filter(_.nonEmpty)
               )
             }
             .toList,

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -106,7 +106,7 @@ trait CommonSchemaDerivation[R] {
                 Option(
                   p.annotations.collect { case GQLDirective(dir) => dir }.toList ++ {
                     if (enableSemanticNonNull && !isNullable && p.typeclass.canFail)
-                      Some(Directive("semanticNonNull"))
+                      Some(SchemaUtils.SemanticNonNull)
                     else None
                   }
                 ).filter(_.nonEmpty)

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -12,6 +12,14 @@ import scala.language.experimental.macros
 trait CommonSchemaDerivation[R] {
 
   /**
+   * Enables the `SemanticNonNull` feature on derivation.
+   * It is currently disabled by default since it is not yet stable.
+   *
+   * Override this method and return `true` to enable the feature.
+   */
+  def enableSemanticNonNull: Boolean = false
+
+  /**
    * Default naming logic for input types.
    * This is needed to avoid a name clash between a type used as an input and the same type used as an output.
    * GraphQL needs 2 different types, and they can't have the same name.
@@ -96,7 +104,8 @@ trait CommonSchemaDerivation[R] {
                 p.annotations.collectFirst { case GQLDeprecated(reason) => reason },
                 Option(
                   p.annotations.collect { case GQLDirective(dir) => dir }.toList ++ {
-                    if (isOptional && p.typeclass.semanticNonNull) Some(Directive("semanticNonNull"))
+                    if (enableSemanticNonNull && isOptional && p.typeclass.semanticNonNull)
+                      Some(Directive("semanticNonNull"))
                     else None
                   }
                 ).filter(_.nonEmpty)

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -76,7 +76,7 @@ trait CommonSchemaDerivation[R] {
                 getName(p),
                 getDescription(p),
                 () =>
-                  if (p.typeclass.optional || p.typeclass.canFail) p.typeclass.toType_(isInput, isSubscription)
+                  if (p.typeclass.optional) p.typeclass.toType_(isInput, isSubscription)
                   else p.typeclass.toType_(isInput, isSubscription).nonNull,
                 p.annotations.collectFirst { case GQLDefault(v) => v },
                 p.annotations.collectFirst { case GQLDeprecated(_) => () }.isDefined,
@@ -98,7 +98,7 @@ trait CommonSchemaDerivation[R] {
               val (isNullable, isNullabilityForced) = {
                 val hasNullableAnn = p.annotations.contains(GQLNullable())
                 val hasNonNullAnn  = p.annotations.contains(GQLNonNullable())
-                (!hasNonNullAnn && (hasNullableAnn || p.typeclass.optional), hasNullableAnn || hasNonNullAnn)
+                (!hasNonNullAnn && (hasNullableAnn || p.typeclass.nullable), hasNullableAnn || hasNonNullAnn)
               }
               Types.makeField(
                 getName(p),

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -100,8 +100,8 @@ trait CommonSchemaDerivation[R] {
                 val hasNonNullAnn  = p.annotations.contains(GQLNonNullable())
 
                 if (hasNonNullAnn) (false, false)
-                else if (hasNullableAnn || p.typeclass.nullable) (true, false)
-                else if (p.typeclass.canFail) (true, true)
+                else if (hasNullableAnn) (true, false)
+                else if (p.typeclass.optional) (true, !p.typeclass.nullable)
                 else (false, false)
               }
               Types.makeField(

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -11,13 +11,20 @@ import scala.language.experimental.macros
 
 trait CommonSchemaDerivation[R] {
 
+  case class DerivationConfig(
+    /**
+     * Whether to enable the `SemanticNonNull` feature on derivation.
+     * It is currently disabled by default since it is not yet stable.
+     */
+    enableSemanticNonNull: Boolean = false
+  )
+
   /**
-   * Enables the `SemanticNonNull` feature on derivation.
-   * It is currently disabled by default since it is not yet stable.
+   * Returns a configuration object that can be used to customize the derivation behavior.
    *
-   * Override this method and return `true` to enable the feature.
+   * Override this method to customize the configuration.
    */
-  def enableSemanticNonNull: Boolean = false
+  def config: DerivationConfig = DerivationConfig()
 
   /**
    * Default naming logic for input types.
@@ -105,7 +112,7 @@ trait CommonSchemaDerivation[R] {
                 p.annotations.collectFirst { case GQLDeprecated(reason) => reason },
                 Option(
                   p.annotations.collect { case GQLDirective(dir) => dir }.toList ++ {
-                    if (enableSemanticNonNull && !isNullable && p.typeclass.canFail)
+                    if (config.enableSemanticNonNull && !isNullable && p.typeclass.canFail)
                       Some(SchemaUtils.SemanticNonNull)
                     else None
                   }

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -140,7 +140,12 @@ private object DerivationUtils {
           else schema.toType_(isInput, isSubscription).nonNull,
         deprecatedReason.isDefined,
         deprecatedReason,
-        Option(getDirectives(fieldAnnotations)).filter(_.nonEmpty)
+        Option(
+          getDirectives(fieldAnnotations) ++ {
+            if (isOptional && schema.semanticNonNull) Some(Directive("semanticNonNull"))
+            else None
+          }
+        ).filter(_.nonEmpty)
       )
     },
     getDirectives(annotations),

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -105,7 +105,7 @@ private object DerivationUtils {
         name,
         getDescription(fieldAnnotations),
         () =>
-          if (schema.optional || schema.canFail) schema.toType_(isInput, isSubscription)
+          if (schema.optional) schema.toType_(isInput, isSubscription)
           else schema.toType_(isInput, isSubscription).nonNull,
         getDefaultValue(fieldAnnotations),
         getDeprecatedReason(fieldAnnotations).isDefined,
@@ -130,7 +130,7 @@ private object DerivationUtils {
       val (isNullable, isNullabilityForced) = {
         val hasNullableAnn = fieldAnnotations.contains(GQLNullable())
         val hasNonNullAnn  = fieldAnnotations.contains(GQLNonNullable())
-        (!hasNonNullAnn && (hasNullableAnn || schema.optional), hasNullableAnn || hasNonNullAnn)
+        (!hasNonNullAnn && (hasNullableAnn || schema.nullable), hasNullableAnn || hasNonNullAnn)
       }
       Types.makeField(
         name,

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -143,7 +143,7 @@ private object DerivationUtils {
         deprecatedReason,
         Option(
           getDirectives(fieldAnnotations) ++ {
-            if (enableSemanticNonNull && !isNullable && schema.canFail) Some(Directive("semanticNonNull"))
+            if (enableSemanticNonNull && !isNullable && schema.canFail) Some(SchemaUtils.SemanticNonNull)
             else None
           }
         ).filter(_.nonEmpty)

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -132,8 +132,8 @@ private object DerivationUtils {
         val hasNonNullAnn  = fieldAnnotations.contains(GQLNonNullable())
 
         if (hasNonNullAnn) (false, false)
-        else if (hasNullableAnn || schema.nullable) (true, false)
-        else if (schema.canFail) (true, true)
+        else if (hasNullableAnn) (true, false)
+        else if (schema.optional) (true, !schema.nullable)
         else (false, false)
       }
       Types.makeField(

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -120,7 +120,8 @@ private object DerivationUtils {
   def mkObject[R](
     annotations: List[Any],
     fields: List[(String, List[Any], Schema[R, Any])],
-    info: TypeInfo
+    info: TypeInfo,
+    enableSemanticNonNull: Boolean
   )(isInput: Boolean, isSubscription: Boolean): __Type = makeObject(
     Some(getName(annotations, info)),
     getDescription(annotations),
@@ -142,7 +143,7 @@ private object DerivationUtils {
         deprecatedReason,
         Option(
           getDirectives(fieldAnnotations) ++ {
-            if (isOptional && schema.semanticNonNull) Some(Directive("semanticNonNull"))
+            if (enableSemanticNonNull && isOptional && schema.semanticNonNull) Some(Directive("semanticNonNull"))
             else None
           }
         ).filter(_.nonEmpty)

--- a/core/src/main/scala-3/caliban/schema/EnumValueSchema.scala
+++ b/core/src/main/scala-3/caliban/schema/EnumValueSchema.scala
@@ -7,12 +7,13 @@ import magnolia1.TypeInfo
 
 final private class EnumValueSchema[R, A](
   info: TypeInfo,
-  anns: List[Any]
+  anns: List[Any],
+  enableSemanticNonNull: Boolean
 ) extends Schema[R, A] {
 
   def toType(isInput: Boolean, isSubscription: Boolean): __Type =
     if (isInput) mkInputObject[R](anns, Nil, info)(isInput, isSubscription)
-    else mkObject[R](anns, Nil, info)(isInput, isSubscription)
+    else mkObject[R](anns, Nil, info, enableSemanticNonNull)(isInput, isSubscription)
 
   private val step               = PureStep(EnumValue(getName(anns, info)))
   def resolve(value: A): Step[R] = step

--- a/core/src/main/scala-3/caliban/schema/ObjectSchema.scala
+++ b/core/src/main/scala-3/caliban/schema/ObjectSchema.scala
@@ -12,7 +12,8 @@ final private class ObjectSchema[R, A](
   _methodFields: => List[(String, List[Any], Schema[R, ?])],
   info: TypeInfo,
   anns: List[Any],
-  paramAnnotations: Map[String, List[Any]]
+  paramAnnotations: Map[String, List[Any]],
+  enableSemanticNonNull: Boolean
 )(using ct: ClassTag[A])
     extends Schema[R, A] {
 
@@ -48,7 +49,7 @@ final private class ObjectSchema[R, A](
   def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
     val _ = resolver // Init the lazy val
     if (isInput) mkInputObject[R](anns, fields.map(_._1), info)(isInput, isSubscription)
-    else mkObject[R](anns, fields.map(_._1), info)(isInput, isSubscription)
+    else mkObject[R](anns, fields.map(_._1), info, enableSemanticNonNull)(isInput, isSubscription)
   }
 
   def resolve(value: A): Step[R] = resolver.resolve(value)

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -23,6 +23,14 @@ object PrintDerived {
 trait CommonSchemaDerivation {
   export DerivationUtils.customizeInputTypeName
 
+  /**
+   * Enables the `SemanticNonNull` feature on derivation.
+   * It is currently disabled by default since it is not yet stable.
+   *
+   * Override this method and return `true` to enable the feature.
+   */
+  def enableSemanticNonNull: Boolean = false
+
   inline def recurseSum[R, P, Label, A <: Tuple](
     inline types: List[(String, __Type, List[Any])] = Nil,
     inline schemas: List[Schema[R, Any]] = Nil
@@ -95,7 +103,8 @@ trait CommonSchemaDerivation {
             new EnumValueSchema[R, A](
               MagnoliaMacro.typeInfo[A],
               // Workaround until we figure out why the macro uses the parent's annotations when the leaf is a Scala 3 enum
-              inline if (!MagnoliaMacro.isEnum[A]) MagnoliaMacro.anns[A] else Nil
+              inline if (!MagnoliaMacro.isEnum[A]) MagnoliaMacro.anns[A] else Nil,
+              enableSemanticNonNull
             )
           case _ if Macros.hasAnnotation[A, GQLValueType] =>
             new ValueTypeSchema[R, A](
@@ -109,7 +118,8 @@ trait CommonSchemaDerivation {
               Macros.fieldsFromMethods[R, A],
               MagnoliaMacro.typeInfo[A],
               MagnoliaMacro.anns[A],
-              MagnoliaMacro.paramAnns[A].toMap
+              MagnoliaMacro.paramAnns[A].toMap,
+              enableSemanticNonNull
             )(using summonInline[ClassTag[A]])
         }
 

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -23,13 +23,20 @@ object PrintDerived {
 trait CommonSchemaDerivation {
   export DerivationUtils.customizeInputTypeName
 
+  case class DerivationConfig(
+    /**
+     * Whether to enable the `SemanticNonNull` feature on derivation.
+     * It is currently disabled by default since it is not yet stable.
+     */
+    enableSemanticNonNull: Boolean = false
+  )
+
   /**
-   * Enables the `SemanticNonNull` feature on derivation.
-   * It is currently disabled by default since it is not yet stable.
+   * Returns a configuration object that can be used to customize the derivation behavior.
    *
-   * Override this method and return `true` to enable the feature.
+   * Override this method to customize the configuration.
    */
-  def enableSemanticNonNull: Boolean = false
+  def config: DerivationConfig = DerivationConfig()
 
   inline def recurseSum[R, P, Label, A <: Tuple](
     inline types: List[(String, __Type, List[Any])] = Nil,
@@ -104,7 +111,7 @@ trait CommonSchemaDerivation {
               MagnoliaMacro.typeInfo[A],
               // Workaround until we figure out why the macro uses the parent's annotations when the leaf is a Scala 3 enum
               inline if (!MagnoliaMacro.isEnum[A]) MagnoliaMacro.anns[A] else Nil,
-              enableSemanticNonNull
+              config.enableSemanticNonNull
             )
           case _ if Macros.hasAnnotation[A, GQLValueType] =>
             new ValueTypeSchema[R, A](
@@ -119,7 +126,7 @@ trait CommonSchemaDerivation {
               MagnoliaMacro.typeInfo[A],
               MagnoliaMacro.anns[A],
               MagnoliaMacro.paramAnns[A].toMap,
-              enableSemanticNonNull
+              config.enableSemanticNonNull
             )(using summonInline[ClassTag[A]])
         }
 

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -73,9 +73,16 @@ trait Schema[-R, T] { self =>
   def resolve(value: T): Step[R]
 
   /**
-   * Defines if the type is considered optional or non-null. Should be false except for `Option`.
+   * Defines if the type can resolve to null or not.
+   * It is true if the type is nullable or if it can fail.
    */
-  def optional: Boolean = false
+  @deprecatedOverriding("this method will be made final. Override canFail and nullable instead", "2.6.1")
+  def optional: Boolean = canFail || nullable
+
+  /**
+   * Defines if the underlying type represents a nullable value. Should be false except for `Option`.
+   */
+  def nullable: Boolean = false
 
   /**
    * Defines if the type can fail during resolution.
@@ -95,7 +102,7 @@ trait Schema[-R, T] { self =>
    * @param f a function from `A` to `T`.
    */
   def contramap[A](f: A => T): Schema[R, A] = new Schema[R, A] {
-    override def optional: Boolean                                         = self.optional
+    override def nullable: Boolean                                         = self.nullable
     override def canFail: Boolean                                          = self.canFail
     override def arguments: List[__InputValue]                             = self.arguments
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = self.toType_(isInput, isSubscription)
@@ -108,7 +115,7 @@ trait Schema[-R, T] { self =>
    * @param inputName new name for the type when it's an input type (by default "Input" is added after the name)
    */
   def rename(name: String, inputName: Option[String] = None): Schema[R, T] = new Schema[R, T] {
-    override def optional: Boolean                                         = self.optional
+    override def nullable: Boolean                                         = self.nullable
     override def canFail: Boolean                                          = self.canFail
     override def arguments: List[__InputValue]                             = self.arguments
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
@@ -349,7 +356,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     Schema.stringSchema.contramap(Cursor[Base64Cursor].encode)
 
   implicit def optionSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Option[A]]                                  = new Schema[R0, Option[A]] {
-    override def optional: Boolean                                         = true
+    override def nullable: Boolean                                         = true
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
 
     override def resolve(value: Option[A]): Step[R0] =
@@ -361,7 +368,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
   implicit def listSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, List[A]]                                      = new Schema[R0, List[A]] {
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
       val t = ev.toType_(isInput, isSubscription)
-      (if (ev.optional || ev.canFail) t else t.nonNull).list
+      (if (ev.nullable || ev.canFail) t else t.nonNull).list
     }
 
     override def resolve(value: List[A]): Step[R0] = ListStep(value.map(ev.resolve))
@@ -374,7 +381,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     listSchema[R0, A].contramap(_.toList)
   implicit def functionUnitSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, () => A]                              =
     new Schema[R0, () => A] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = ev.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: () => A): Step[R0]                         = FunctionStep(_ => ev.resolve(value()))
@@ -382,7 +389,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
   implicit def metadataFunctionSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Field => A]                       =
     new Schema[R0, Field => A] {
       override def arguments: List[__InputValue]                             = ev.arguments
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = ev.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: Field => A): Step[R0]                      = MetadataFunctionStep(field => ev.resolve(value(field)))
@@ -398,13 +405,13 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     val description: String = s"Either $typeAName or $typeBName"
 
     implicit val leftSchema: Schema[RA, A]  = new Schema[RA, A] {
-      override def optional: Boolean                                         = true
+      override def nullable: Boolean                                         = true
       override def canFail: Boolean                                          = evA.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = evA.toType_(isInput, isSubscription)
       override def resolve(value: A): Step[RA]                               = evA.resolve(value)
     }
     implicit val rightSchema: Schema[RB, B] = new Schema[RB, B] {
-      override def optional: Boolean                                         = true
+      override def nullable: Boolean                                         = true
       override def canFail: Boolean                                          = evB.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = evB.toType_(isInput, isSubscription)
       override def resolve(value: B): Step[RB]                               = evB.resolve(value)
@@ -473,14 +480,14 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
               __InputValue(
                 unwrappedArgumentName,
                 None,
-                () => if (ev1.optional || ev1.canFail) inputType else inputType.nonNull,
+                () => if (ev1.nullable || ev1.canFail) inputType else inputType.nonNull,
                 None
               )
             )
           )
       }
 
-      override def optional: Boolean                                         = ev2.optional
+      override def nullable: Boolean                                         = ev2.nullable
       override def canFail: Boolean                                          = ev2.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev2.toType_(isInput, isSubscription)
 
@@ -509,7 +516,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     effectSchema[R0, R0, R0, Throwable, A].contramap[Future[A]](future => ZIO.fromFuture(_ => future)(Trace.empty))
   implicit def infallibleEffectSchema[R0, R1 >: R0, R2 >: R0, A](implicit ev: Schema[R2, A]): Schema[R0, URIO[R1, A]] =
     new Schema[R0, URIO[R1, A]] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = ev.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: URIO[R1, A]): Step[R0]                     = QueryStep(ZQuery.fromZIONow(value.map(ev.resolve)))
@@ -518,7 +525,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     ev: Schema[R2, A]
   ): Schema[R0, ZIO[R1, E, A]] =
     new Schema[R0, ZIO[R1, E, A]] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: ZIO[R1, E, A]): Step[R0]                   = QueryStep(ZQuery.fromZIONow(value.map(ev.resolve)))
@@ -527,7 +534,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     ev: Schema[R2, A]
   ): Schema[R0, ZIO[R1, E, A]] =
     new Schema[R0, ZIO[R1, E, A]] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: ZIO[R1, E, A]): Step[R0]                   = QueryStep(
@@ -538,7 +545,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     ev: Schema[R2, A]
   ): Schema[R0, ZQuery[R1, Nothing, A]] =
     new Schema[R0, ZQuery[R1, Nothing, A]] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = ev.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: ZQuery[R1, Nothing, A]): Step[R0]          = QueryStep(value.map(ev.resolve))
@@ -547,7 +554,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     ev: Schema[R2, A]
   ): Schema[R0, ZQuery[R1, E, A]] =
     new Schema[R0, ZQuery[R1, E, A]] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: ZQuery[R1, E, A]): Step[R0]                = QueryStep(value.map(ev.resolve))
@@ -556,7 +563,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     ev: Schema[R2, A]
   ): Schema[R0, ZQuery[R1, E, A]] =
     new Schema[R0, ZQuery[R1, E, A]] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: ZQuery[R1, E, A]): Step[R0]                = QueryStep(value.mapBoth(convertError, ev.resolve))
@@ -565,11 +572,11 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     ev: Schema[R2, A]
   ): Schema[R1, ZStream[R1, Nothing, A]] =
     new Schema[R1, ZStream[R1, Nothing, A]] {
-      override def optional: Boolean                                         = false
+      override def nullable: Boolean                                         = false
       override def canFail: Boolean                                          = ev.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
         val t = ev.toType_(isInput, isSubscription)
-        if (isSubscription) t else (if (ev.optional || ev.canFail) t else t.nonNull).list
+        if (isSubscription) t else (if (ev.nullable || ev.canFail) t else t.nonNull).list
       }
       override def resolve(value: ZStream[R1, Nothing, A]): Step[R1]         = StreamStep(value.map(ev.resolve))
     }
@@ -577,11 +584,11 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     ev: Schema[R2, A]
   ): Schema[R0, ZStream[R1, E, A]] =
     new Schema[R0, ZStream[R1, E, A]] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
         val t = ev.toType_(isInput, isSubscription)
-        if (isSubscription) t else (if (ev.optional || ev.canFail) t else t.nonNull).list
+        if (isSubscription) t else (if (ev.nullable || ev.canFail) t else t.nonNull).list
       }
       override def resolve(value: ZStream[R1, E, A]): Step[R0]               = StreamStep(value.map(ev.resolve))
     }
@@ -589,11 +596,11 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
     ev: Schema[R2, A]
   ): Schema[R0, ZStream[R1, E, A]] =
     new Schema[R0, ZStream[R1, E, A]] {
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
         val t = ev.toType_(isInput, isSubscription)
-        if (isSubscription) t else (if (ev.optional || ev.canFail) t else t.nonNull).list
+        if (isSubscription) t else (if (ev.nullable || ev.canFail) t else t.nonNull).list
       }
       override def resolve(value: ZStream[R1, E, A]): Step[R0]               = StreamStep(value.mapBoth(convertError, ev.resolve))
     }
@@ -726,7 +733,7 @@ abstract class PartiallyAppliedFieldBase[V](
       description,
       _ => Nil,
       () =>
-        if (ev.optional || ev.canFail) ev.toType_(ft.isInput, ft.isSubscription)
+        if (ev.nullable || ev.canFail) ev.toType_(ft.isInput, ft.isSubscription)
         else ev.toType_(ft.isInput, ft.isSubscription).nonNull,
       isDeprecated = Directives.isDeprecated(directives),
       deprecationReason = Directives.deprecationReason(directives),
@@ -770,7 +777,7 @@ case class PartiallyAppliedFieldWithArgs[V, A](
         description,
         ev1.arguments,
         () =>
-          if (ev1.optional || ev1.canFail) ev1.toType_(fa.isInput, fa.isSubscription)
+          if (ev1.nullable || ev1.canFail) ev1.toType_(fa.isInput, fa.isSubscription)
           else ev1.toType_(fa.isInput, fa.isSubscription).nonNull,
         isDeprecated = Directives.isDeprecated(directives),
         deprecationReason = Directives.deprecationReason(directives),

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -76,7 +76,7 @@ trait Schema[-R, T] { self =>
    * Defines if the type can resolve to null or not.
    * It is true if the type is nullable or if it can fail.
    */
-  @deprecatedOverriding("this method will be made final. Override canFail and nullable instead", "2.6.1")
+  @deprecatedOverriding("this method will be made final. Override canFail and nullable instead", "2.7.0")
   def optional: Boolean = canFail || nullable
 
   /**

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -257,7 +257,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
   def field[V](
     name: String,
     description: Option[String] = None,
-    directives: List[Directive] = List.empty,
+    directives: List[Directive] = List.empty
   ): PartiallyAppliedField[V] =
     PartiallyAppliedField[V](name, description, directives)
 
@@ -267,7 +267,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
   def fieldLazy[V](
     name: String,
     description: Option[String] = None,
-    directives: List[Directive] = List.empty,
+    directives: List[Directive] = List.empty
   ): PartiallyAppliedFieldLazy[V] =
     PartiallyAppliedFieldLazy[V](name, description, directives)
 
@@ -277,7 +277,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
   def fieldWithArgs[V, A](
     name: String,
     description: Option[String] = None,
-    directives: List[Directive] = Nil,
+    directives: List[Directive] = Nil
   ): PartiallyAppliedFieldWithArgs[V, A] =
     PartiallyAppliedFieldWithArgs[V, A](name, description, directives)
 

--- a/core/src/main/scala/caliban/schema/SchemaUtils.scala
+++ b/core/src/main/scala/caliban/schema/SchemaUtils.scala
@@ -4,8 +4,15 @@ import caliban.ResponseValue.ObjectValue
 import caliban.Value.{ EnumValue, NullValue, StringValue }
 import caliban.introspection.adt.{ __DeprecatedArgs, __Field, __Type }
 import caliban.schema.Step.MetadataFunctionStep
+import caliban.parsing.adt.Directive
 
 private[schema] object SchemaUtils {
+
+  /**
+   * Directive used to mark a field as semantically non-nullable.
+   */
+  val SemanticNonNull = Directive("semanticNonNull")
+
   private val fakeField =
     Some(
       List(

--- a/core/src/test/scala/caliban/TriState.scala
+++ b/core/src/test/scala/caliban/TriState.scala
@@ -15,7 +15,7 @@ object TriState {
 
   def schemaCustom[R, A](undefined: PureStep)(implicit ev: Schema[R, A]): Schema[R, TriState[A]] =
     new Schema[R, TriState[A]] {
-      override val optional = true
+      override val nullable = true
 
       override def toType(isInput: Boolean, isSubscription: Boolean) = ev.toType_(isInput, isSubscription)
 

--- a/core/src/test/scala/caliban/schema/OptionalSpec.scala
+++ b/core/src/test/scala/caliban/schema/OptionalSpec.scala
@@ -1,0 +1,57 @@
+package caliban.schema
+
+import caliban.{ graphQL, RootResolver }
+import zio._
+import zio.test._
+
+object OptionalSpec extends ZIOSpecDefault {
+  import caliban.schema.Schema._
+
+  override def spec = suite("OptionalSpec")(
+    test("Semantic of Schema.optional is kept consistent across various nullable/canFail combinations") {
+      val expected =
+        """schema {
+          |  query: Query
+          |}
+          |
+          |type Query {
+          |  a: String!
+          |  b: String
+          |  c: String
+          |  d: String
+          |}""".stripMargin
+
+      implicit def wrapperSchema[A](implicit ev: Schema[Any, A]): Schema[Any, Wrapper[A]] =
+        new Schema[Any, Wrapper[A]] {
+          @annotation.nowarn
+          override def optional = ev.optional
+          def toType(isInput: Boolean, isSubscription: Boolean) = ev.toType_(isInput, isSubscription)
+          def resolve(value: Wrapper[A]): Step[Any]             =
+            ev.resolve(value.value)
+        }
+
+      implicit def querySchema: Schema[Any, Query] = Schema.gen[Any, Query]
+
+      val resolver = RootResolver(
+        Query(
+          Wrapper("a"),
+          Wrapper(Some("b")),
+          Wrapper(ZIO.succeed("c")),
+          Wrapper(ZIO.succeed(Some("d")))
+        )
+      )
+      val gql      = graphQL(resolver)
+
+      assertTrue(gql.render == expected)
+    }
+  )
+
+  case class Wrapper[A](value: A)
+
+  case class Query(
+    a: Wrapper[String],
+    b: Wrapper[Option[String]],
+    c: Wrapper[Task[String]],
+    d: Wrapper[Task[Option[String]]]
+  )
+}

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -26,31 +26,9 @@ object SchemaSpec extends ZIOSpecDefault {
           isSome(hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR)))
         )
       },
-      test("effectful field as semanticNonNull") {
-        assert(introspect[EffectfulFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption)(
-          isSome(
-            hasField[__Field, Option[List[Directive]]](
-              "directives",
-              _.directives,
-              isSome(contains((Directive("semanticNonNull"))))
-            )
-          )
-        )
-      },
       test("effectful field as non-nullable") {
         assert(introspect[EffectfulFieldSchema].fields(__DeprecatedArgs()).toList.flatten.apply(1)._type)(
           hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL))
-        )
-      },
-      test("optional effectful field") {
-        assert(introspect[OptionalEffectfulFieldSchema].fields(__DeprecatedArgs()).toList.flatten.headOption)(
-          isSome(
-            hasField[__Field, Option[List[Directive]]](
-              "directives",
-              _.directives.map(_.filter(_.name == "semanticNonNull")).filter(_.nonEmpty),
-              isNone
-            )
-          )
         )
       },
       test("infallible effectful field") {
@@ -322,7 +300,7 @@ object SchemaSpec extends ZIOSpecDefault {
                          |}
                          |
                          |type EnvironmentSchema {
-                         |  test: Int @semanticNonNull
+                         |  test: Int
                          |  box: Box!
                          |}
                          |

--- a/core/src/test/scala/caliban/schema/SemanticNonNullSchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SemanticNonNullSchemaSpec.scala
@@ -21,7 +21,7 @@ object SemanticNonNullSchemaSpec extends ZIOSpecDefault {
             hasField[__Field, Option[List[Directive]]](
               "directives",
               _.directives,
-              isSome(contains((Directive("semanticNonNull"))))
+              isSome(contains(SchemaUtils.SemanticNonNull))
             )
           )
         )
@@ -31,7 +31,7 @@ object SemanticNonNullSchemaSpec extends ZIOSpecDefault {
           isSome(
             hasField[__Field, Option[List[Directive]]](
               "directives",
-              _.directives.map(_.filter(_.name == "semanticNonNull")).filter(_.nonEmpty),
+              _.directives.map(_.filter(_ == SchemaUtils.SemanticNonNull)).filter(_.nonEmpty),
               isNone
             )
           )

--- a/core/src/test/scala/caliban/schema/SemanticNonNullSchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SemanticNonNullSchemaSpec.scala
@@ -1,7 +1,7 @@
 package caliban.schema
 
 import caliban._
-import caliban.introspection.adt.{ __DeprecatedArgs, __Field }
+import caliban.introspection.adt.{ __DeprecatedArgs, __Field, __Type, __TypeKind }
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations._
 import zio._
@@ -16,34 +16,93 @@ object SemanticNonNullSchemaSpec extends ZIOSpecDefault {
   override def spec =
     suite("SemanticNonNullSchemaSpec")(
       test("effectful field as semanticNonNull") {
-        assert(effectfulFieldObjectSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.headOption)(
-          isSome(
-            hasField[__Field, Option[List[Directive]]](
-              "directives",
-              _.directives,
-              isSome(contains(SchemaUtils.SemanticNonNull))
-            )
+        val field = effectfulFieldObjectSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.apply(0)
+        assert(field)(
+          hasField[__Field, Option[List[Directive]]](
+            "directives",
+            _.directives,
+            isSome(contains(SchemaUtils.SemanticNonNull))
           )
         )
+        assert(field._type)(
+          hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR))
+        )
       },
-      test("optional effectful field") {
-        assert(optionalEffectfulFieldObjectSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.headOption)(
-          isSome(
-            hasField[__Field, Option[List[Directive]]](
-              "directives",
-              _.directives.map(_.filter(_ == SchemaUtils.SemanticNonNull)).filter(_.nonEmpty),
-              isNone
-            )
+      test("effectful field as non-nullable") {
+        val field = effectfulFieldObjectSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.apply(1)
+        assert(field)(
+          hasField[__Field, Option[List[Directive]]](
+            "directives",
+            _.directives.map(_.filter(_ == SchemaUtils.SemanticNonNull)).filter(_.nonEmpty),
+            isNone
           )
+        )
+        assert(field._type)(
+          hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL))
+        )
+      },
+      test("nullable effectful field") {
+        val field = nullableEffectfulFieldObjectSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.apply(0)
+        assert(field)(
+          hasField[__Field, Option[List[Directive]]](
+            "directives",
+            _.directives.map(_.filter(_ == SchemaUtils.SemanticNonNull)).filter(_.nonEmpty),
+            isNone
+          )
+        )
+        assert(field._type)(
+          hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR))
+        )
+      },
+      test("nullable effectful field as non-nullable") {
+        val field = nullableEffectfulFieldObjectSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.apply(1)
+        assert(field)(
+          hasField[__Field, Option[List[Directive]]](
+            "directives",
+            _.directives,
+            isNone
+          )
+        )
+        assert(field._type)(
+          hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL))
+        )
+      },
+      test("infallible effectful field") {
+        val field = infallibleEffectfulFieldSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.apply(0)
+        assert(field)(
+          hasField[__Field, Option[List[Directive]]](
+            "directives",
+            _.directives,
+            isNone
+          )
+        )
+        assert(field._type)(
+          hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.NON_NULL))
+        )
+      },
+      test("infallible effectful field as nullable") {
+        val field = infallibleEffectfulFieldSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.apply(1)
+        assert(field)(
+          hasField[__Field, Option[List[Directive]]](
+            "directives",
+            _.directives,
+            isNone
+          )
+        )
+        assert(field._type)(
+          hasField[__Type, __TypeKind]("kind", _.kind, equalTo(__TypeKind.SCALAR))
         )
       }
     )
 
   case class EffectfulFieldObject(q: Task[Int], @GQLNonNullable qAnnotated: Task[Int])
-  case class OptionalEffectfulFieldObject(q: Task[Option[String]], @GQLNonNullable qAnnotated: Task[Option[String]])
+  case class NullableEffectfulFieldObject(q: Task[Option[String]], @GQLNonNullable qAnnotated: Task[Option[String]])
+  case class InfallibleFieldObject(q: UIO[Int], @GQLNullable qAnnotated: UIO[Int])
 
   implicit val effectfulFieldObjectSchema: Schema[Any, EffectfulFieldObject]                 =
     SemanticNonNullSchema.gen[Any, EffectfulFieldObject]
-  implicit val optionalEffectfulFieldObjectSchema: Schema[Any, OptionalEffectfulFieldObject] =
-    SemanticNonNullSchema.gen[Any, OptionalEffectfulFieldObject]
+  implicit val nullableEffectfulFieldObjectSchema: Schema[Any, NullableEffectfulFieldObject] =
+    SemanticNonNullSchema.gen[Any, NullableEffectfulFieldObject]
+  implicit val infallibleEffectfulFieldSchema: Schema[Any, InfallibleFieldObject]            =
+    SemanticNonNullSchema.gen[Any, InfallibleFieldObject]
 }

--- a/core/src/test/scala/caliban/schema/SemanticNonNullSchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SemanticNonNullSchemaSpec.scala
@@ -1,0 +1,49 @@
+package caliban.schema
+
+import caliban._
+import caliban.introspection.adt.{ __DeprecatedArgs, __Field }
+import caliban.parsing.adt.Directive
+import caliban.schema.Annotations._
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+object SemanticNonNullSchema extends SchemaDerivation[Any] {
+  override def enableSemanticNonNull: Boolean = true
+}
+
+object SemanticNonNullSchemaSpec extends ZIOSpecDefault {
+  override def spec =
+    suite("SemanticNonNullSchemaSpec")(
+      test("effectful field as semanticNonNull") {
+        assert(effectfulFieldObjectSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.headOption)(
+          isSome(
+            hasField[__Field, Option[List[Directive]]](
+              "directives",
+              _.directives,
+              isSome(contains((Directive("semanticNonNull"))))
+            )
+          )
+        )
+      },
+      test("optional effectful field") {
+        assert(optionalEffectfulFieldObjectSchema.toType_().fields(__DeprecatedArgs()).toList.flatten.headOption)(
+          isSome(
+            hasField[__Field, Option[List[Directive]]](
+              "directives",
+              _.directives.map(_.filter(_.name == "semanticNonNull")).filter(_.nonEmpty),
+              isNone
+            )
+          )
+        )
+      }
+    )
+
+  case class EffectfulFieldObject(q: Task[Int], @GQLNonNullable qAnnotated: Task[Int])
+  case class OptionalEffectfulFieldObject(q: Task[Option[String]], @GQLNonNullable qAnnotated: Task[Option[String]])
+
+  implicit val effectfulFieldObjectSchema: Schema[Any, EffectfulFieldObject]                 =
+    SemanticNonNullSchema.gen[Any, EffectfulFieldObject]
+  implicit val optionalEffectfulFieldObjectSchema: Schema[Any, OptionalEffectfulFieldObject] =
+    SemanticNonNullSchema.gen[Any, OptionalEffectfulFieldObject]
+}

--- a/core/src/test/scala/caliban/schema/SemanticNonNullSchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SemanticNonNullSchemaSpec.scala
@@ -9,7 +9,7 @@ import zio.test.Assertion._
 import zio.test._
 
 object SemanticNonNullSchema extends SchemaDerivation[Any] {
-  override def enableSemanticNonNull: Boolean = true
+  override def config = DerivationConfig(enableSemanticNonNull = true)
 }
 
 object SemanticNonNullSchemaSpec extends ZIOSpecDefault {

--- a/federation/src/main/scala/caliban/federation/FederationSupport.scala
+++ b/federation/src/main/scala/caliban/federation/FederationSupport.scala
@@ -60,7 +60,7 @@ abstract class FederationSupport(
     import genericSchema.auto._
 
     implicit val entitySchema: Schema[R, _Entity] = new Schema[R, _Entity] {
-      override def optional: Boolean                                         = true
+      override def nullable: Boolean                                         = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         __Type(
           __TypeKind.UNION,

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -190,8 +190,8 @@ object CatsInterop {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         ev.toType_(isInput, isSubscription)
 
-      override def optional: Boolean =
-        ev.optional
+      override def nullable: Boolean =
+        ev.nullable
       override def canFail: Boolean  = true
 
       override def resolve(value: F[A]): Step[R] =

--- a/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/cats/CatsInterop.scala
@@ -192,6 +192,7 @@ object CatsInterop {
 
       override def optional: Boolean =
         ev.optional
+      override def canFail: Boolean  = true
 
       override def resolve(value: F[A]): Step[R] =
         QueryStep(ZQuery.fromZIO(interop.fromEffect(value).map(ev.resolve)))

--- a/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
@@ -14,7 +14,7 @@ object Fs2Interop {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         ev.toType_(isInput, isSubscription)
 
-      override def optional: Boolean = ev.optional
+      override def nullable: Boolean = ev.nullable
       override def canFail: Boolean  = true
 
       override def resolve(value: Stream[RIO[R, *], A]): Step[R] =
@@ -29,7 +29,7 @@ object Fs2Interop {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
         ev.toType_(isInput, isSubscription)
 
-      override def optional: Boolean = ev.optional
+      override def nullable: Boolean = ev.nullable
       override def canFail: Boolean  = true
 
       override def resolve(value: Stream[F, A]): Step[R] =

--- a/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
+++ b/interop/cats/src/main/scala/caliban/interop/fs2/Fs2Interop.scala
@@ -15,6 +15,7 @@ object Fs2Interop {
         ev.toType_(isInput, isSubscription)
 
       override def optional: Boolean = ev.optional
+      override def canFail: Boolean  = true
 
       override def resolve(value: Stream[RIO[R, *], A]): Step[R] =
         ev.resolve(value.toZStream())
@@ -29,6 +30,7 @@ object Fs2Interop {
         ev.toType_(isInput, isSubscription)
 
       override def optional: Boolean = ev.optional
+      override def canFail: Boolean  = true
 
       override def resolve(value: Stream[F, A]): Step[R] =
         ev.resolve(value.translate(interop.fromEffectK))

--- a/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
+++ b/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
@@ -60,7 +60,7 @@ object MonixInterop {
   def taskSchema[R, A](implicit ev: Schema[R, A], ev2: ConcurrentEffect[MonixTask]): Schema[R, MonixTask[A]] =
     new Schema[R, MonixTask[A]] {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
-      override def optional: Boolean                                         = ev.optional
+      override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = true
       override def resolve(value: MonixTask[A]): Step[R]                     =
         QueryStep(ZQuery.fromZIO(value.to[Task].map(ev.resolve)))
@@ -70,10 +70,10 @@ object MonixInterop {
     queueSize: Int
   )(implicit ev: Schema[R, A], ev2: ConcurrentEffect[MonixTask]): Schema[R, Observable[A]] =
     new Schema[R, Observable[A]] {
-      override def optional: Boolean                                         = true
+      override def nullable: Boolean                                         = true
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
         val t = ev.toType_(isInput, isSubscription)
-        if (isSubscription) t else (if (ev.optional) t else t.nonNull).list
+        if (isSubscription) t else (if (ev.nullable) t else t.nonNull).list
       }
       override def resolve(value: Observable[A]): Step[R]                    =
         StreamStep(

--- a/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
+++ b/interop/monix/src/main/scala/caliban/interop/monix/MonixInterop.scala
@@ -61,6 +61,7 @@ object MonixInterop {
     new Schema[R, MonixTask[A]] {
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def optional: Boolean                                         = ev.optional
+      override def canFail: Boolean                                          = true
       override def resolve(value: MonixTask[A]): Step[R]                     =
         QueryStep(ZQuery.fromZIO(value.to[Task].map(ev.resolve)))
     }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -107,7 +107,7 @@ package object tapir {
             Types.makeField(
               extractPath(serverEndpoint.endpoint.info.name, serverEndpoint.endpoint.input),
               serverEndpoint.endpoint.info.description,
-              getArgs(inputSchema.toType_(isInput = true), inputSchema.optional || inputSchema.canFail),
+              getArgs(inputSchema.toType_(isInput = true), inputSchema.optional),
               () =>
                 if (serverEndpoint.endpoint.errorOutput == EndpointOutput.Void[E]())
                   outputSchema.toType_().nonNull

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/package.scala
@@ -107,7 +107,7 @@ package object tapir {
             Types.makeField(
               extractPath(serverEndpoint.endpoint.info.name, serverEndpoint.endpoint.input),
               serverEndpoint.endpoint.info.description,
-              getArgs(inputSchema.toType_(isInput = true), inputSchema.optional),
+              getArgs(inputSchema.toType_(isInput = true), inputSchema.optional || inputSchema.canFail),
               () =>
                 if (serverEndpoint.endpoint.errorOutput == EndpointOutput.Void[E]())
                   outputSchema.toType_().nonNull


### PR DESCRIPTION
Adds `SemanticNonNull` support for every effectful types.

Currently, the support is implemented to add `@semanticNonNull` directives to fields that are semantically non-null. However, as [the spec](https://github.com/graphql/graphql-spec/pull/1065) evolves and merges, it's very likely to have a separate syntax to annotate the semantic nullability of a field.

The implementation is very clear for Caliban since we know all the possibilities of errors and nulls. `@semanticNonNull` is only applied when 1. the resolver is faillible 2. the field is optional 3. the result type is not optional.

Although [the spec also supports more detailed configuration of semantic nullability for list fields](https://github.com/apollographql/specs/blob/cc241dc3759513f0fef3ec077ae5b4a84b45c66a/nullability/v0.3/nullability-v0.3.graphql#L14-L27), it was not applicable to Caliban's case since as it [currently doesn't resolve error inside stream to `null`](https://github.com/ghostdogpr/caliban/blob/7ddba86ea5881543df3eed69b74bc4eb0ead5983/core/src/main/scala/caliban/execution/Executor.scala#L248). (actually it feels a bit odd considering the decision of having effects with `E <: Throwable` as nullable)

While I think that the feature should be blocked by default with a feature flag, I have no idea how that would be implemented. Any ideas?