### PR TITLE
Improve jsoniter encoding performance

### DIFF
--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -173,7 +173,14 @@ object Value {
     def apply(v: Float): FloatValue      = FloatNumber(v)
     def apply(v: Double): FloatValue     = DoubleNumber(v)
     def apply(v: BigDecimal): FloatValue = BigDecimalNumber(v)
-    def apply(s: String): FloatValue     = BigDecimalNumber(BigDecimal(s))
+
+    @deprecated("Use `fromStringUnsafe` instead", "2.6.0")
+    def apply(s: String): FloatValue = fromStringUnsafe(s)
+
+    @throws[NumberFormatException]("if the string is not a valid representation of a float")
+    def fromStringUnsafe(s: String): FloatValue =
+      try DoubleNumber(s.toDouble)
+      catch { case NonFatal(_) => BigDecimalNumber(BigDecimal(s)) }
 
     final case class FloatNumber(value: Float)           extends FloatValue {
       override def toFloat: Float           = value

--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -5,6 +5,7 @@ import caliban._
 import caliban.parsing.adt.LocationInfo
 import com.github.plokhotnyuk.jsoniter_scala.core._
 
+import scala.annotation.nowarn
 import scala.collection.immutable.TreeMap
 
 /**
@@ -40,20 +41,22 @@ private[caliban] object ValueJsoniter {
     if (depth == 0) out.encodeError("depth limit exceeded")
     else depth - 1
 
+  /**
+   * @see [[encodeResponseValue]] for performance note
+   */
   private def encodeInputValue(x: InputValue, out: JsonWriter, depth: Int): Unit = x match {
-    case StringValue(value)                 => out.writeVal(value)
-    case BooleanValue(value)                => out.writeVal(value)
-    case IntValue.IntNumber(value)          => out.writeVal(value)
-    case IntValue.LongNumber(value)         => out.writeVal(value)
-    case IntValue.BigIntNumber(value)       => out.writeVal(value)
-    case FloatValue.FloatNumber(value)      => out.writeVal(value)
-    case FloatValue.DoubleNumber(value)     => out.writeVal(value)
-    case FloatValue.BigDecimalNumber(value) => out.writeVal(value)
-    case NullValue                          => out.writeNull()
-    case EnumValue(value)                   => out.writeVal(value)
-    case InputValue.ObjectValue(o)          => writeInputObject(o, out, decrDepth(depth, out))
-    case InputValue.ListValue(l)            => writeInputArray(l, out, decrDepth(depth, out))
-    case InputValue.VariableValue(v)        => out.writeVal(v)
+    case v: StringValue              => out.writeVal(v.value)
+    case v: BooleanValue             => out.writeVal(v.value)
+    case v: IntValue.IntNumber       => out.writeVal(v.value)
+    case NullValue                   => out.writeNull()
+    case v: EnumValue                => out.writeVal(v.value)
+    case v: InputValue.ObjectValue   => writeInputObject(v.fields, out, decrDepth(depth, out))
+    case v: InputValue.ListValue     => writeInputArray(v.values, out, decrDepth(depth, out))
+    case v: IntValue.LongNumber      => out.writeVal(v.value)
+    case v: IntValue.BigIntNumber    => out.writeVal(v.value)
+    case v: FloatValue.DoubleNumber  => out.writeVal(v.value)
+    case v: FloatValue               => writeFloatValue(v, out)
+    case v: InputValue.VariableValue => out.writeVal(v.name)
   }
 
   private def writeInputArray(l: List[InputValue], out: JsonWriter, depth: Int): Unit = {
@@ -78,20 +81,35 @@ private[caliban] object ValueJsoniter {
     out.writeObjectEnd()
   }
 
+  /**
+   * Note on performance:
+   *
+   * Keep number of cases at 12 or less, and avoid using unapply methods in the pattern-matching.
+   * This number was manually determined based on trial-and-error and was found that adding more cases reduces performance
+   * noticeably.
+   */
   private def encodeResponseValue(x: ResponseValue, out: JsonWriter, depth: Int): Unit = x match {
-    case StringValue(value)                 => out.writeVal(value)
-    case BooleanValue(value)                => out.writeVal(value)
-    case IntValue.IntNumber(value)          => out.writeVal(value)
-    case IntValue.LongNumber(value)         => out.writeVal(value)
-    case IntValue.BigIntNumber(value)       => out.writeVal(value)
-    case FloatValue.FloatNumber(value)      => out.writeVal(value)
-    case FloatValue.DoubleNumber(value)     => out.writeVal(value)
-    case FloatValue.BigDecimalNumber(value) => out.writeVal(value)
-    case NullValue                          => out.writeNull()
-    case EnumValue(value)                   => out.writeVal(value)
-    case ResponseValue.ObjectValue(o)       => writeResponseObject(o, out, decrDepth(depth, out))
-    case ResponseValue.ListValue(l)         => writeResponseArray(l, out, decrDepth(depth, out))
-    case s: ResponseValue.StreamValue       => out.writeVal(s.toString)
+    case v: StringValue               => out.writeVal(v.value)
+    case v: BooleanValue              => out.writeVal(v.value)
+    case v: IntValue.IntNumber        => out.writeVal(v.value)
+    case NullValue                    => out.writeNull()
+    case v: EnumValue                 => out.writeVal(v.value)
+    case v: ResponseValue.ObjectValue => writeResponseObject(v.fields, out, decrDepth(depth, out))
+    case v: ResponseValue.ListValue   => writeResponseArray(v.values, out, decrDepth(depth, out))
+    case v: IntValue.LongNumber       => out.writeVal(v.value)
+    case v: IntValue.BigIntNumber     => out.writeVal(v.value)
+    case v: FloatValue.DoubleNumber   => out.writeVal(v.value)
+    case v: FloatValue                => writeFloatValue(v, out)
+    case s: ResponseValue.StreamValue => out.writeVal(s.toString)
+  }
+
+  /**
+   * Floats and BigDecimalNumber are not common, so we extract their matching in a separate method to keep cases below 12
+   */
+  private def writeFloatValue(value: FloatValue, out: JsonWriter): Unit = value match {
+    case FloatValue.FloatNumber(v)      => out.writeVal(v)
+    case FloatValue.DoubleNumber(v)     => out.writeVal(v)
+    case FloatValue.BigDecimalNumber(v) => out.writeVal(v)
   }
 
   private def writeResponseArray(l: List[ResponseValue], out: JsonWriter, depth: Int): Unit = {

--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -5,7 +5,6 @@ import caliban._
 import caliban.parsing.adt.LocationInfo
 import com.github.plokhotnyuk.jsoniter_scala.core._
 
-import scala.annotation.nowarn
 import scala.collection.immutable.TreeMap
 
 /**

--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -80,28 +80,44 @@ private[caliban] object ValueJsoniter {
     out.writeObjectEnd()
   }
 
-  /**
-   * Note on performance:
-   *
-   * Keep number of cases at 12 (+1 default) or less, and avoid using unapply methods in the pattern-matching.
-   * This number was manually determined based on trial-and-error and was found that adding more cases reduces performance
-   * noticeably.
-   */
-  private def encodeResponseValue(x: ResponseValue, out: JsonWriter, depth: Int): Unit = x match {
-    case v: StringValue                 => out.writeVal(v.value)
-    case v: BooleanValue                => out.writeVal(v.value)
-    case v: IntValue.IntNumber          => out.writeVal(v.value)
-    case NullValue                      => out.writeNull()
-    case v: EnumValue                   => out.writeVal(v.value)
-    case v: ResponseValue.ObjectValue   => writeResponseObject(v.fields, out, decrDepth(depth, out))
-    case v: ResponseValue.ListValue     => writeResponseArray(v.values, out, decrDepth(depth, out))
-    // Not very common, so we leave them last
-    case v: IntValue.LongNumber         => out.writeVal(v.value)
-    case v: IntValue.BigIntNumber       => out.writeVal(v.value)
-    case v: FloatValue.FloatNumber      => out.writeVal(v.value)
-    case v: FloatValue.DoubleNumber     => out.writeVal(v.value)
-    case v: FloatValue.BigDecimalNumber => out.writeVal(v.value)
-    case v                              => out.writeVal(v.toString)
+  private def encodeResponseValue(x: ResponseValue, out: JsonWriter, depth: Int): Unit = {
+
+    /**
+     * Note on performance:
+     *
+     * We keep the number of cases low (less than 12) for the most commonly used types and avoid using unapply methods in the pattern-matching.
+     * This way we can better utilize JVM inlining, while still preserving match safety via the compiler if we ever extend ResponseValue with more cases.
+     *
+     * If our value is not one of the common ones, we fallback to the full encoder.
+     */
+    def fullEncoder(): Unit = x match {
+      case v: StringValue                 => out.writeVal(v.value)
+      case v: BooleanValue                => out.writeVal(v.value)
+      case v: IntValue.IntNumber          => out.writeVal(v.value)
+      case v: IntValue.LongNumber         => out.writeVal(v.value)
+      case v: IntValue.BigIntNumber       => out.writeVal(v.value)
+      case v: FloatValue.FloatNumber      => out.writeVal(v.value)
+      case v: FloatValue.DoubleNumber     => out.writeVal(v.value)
+      case v: FloatValue.BigDecimalNumber => out.writeVal(v.value)
+      case NullValue                      => out.writeNull()
+      case v: EnumValue                   => out.writeVal(v.value)
+      case v: ResponseValue.ObjectValue   => writeResponseObject(v.fields, out, decrDepth(depth, out))
+      case v: ResponseValue.ListValue     => writeResponseArray(v.values, out, decrDepth(depth, out))
+      case v: ResponseValue.StreamValue   => out.writeVal(v.toString)
+    }
+
+    x match {
+      case v: StringValue               => out.writeVal(v.value)
+      case v: BooleanValue              => out.writeVal(v.value)
+      case v: IntValue.IntNumber        => out.writeVal(v.value)
+      case NullValue                    => out.writeNull()
+      case v: ResponseValue.ObjectValue => writeResponseObject(v.fields, out, decrDepth(depth, out))
+      case v: ResponseValue.ListValue   => writeResponseArray(v.values, out, decrDepth(depth, out))
+      case v: EnumValue                 => out.writeVal(v.value)
+      case v: IntValue.LongNumber       => out.writeVal(v.value)
+      case v: FloatValue.DoubleNumber   => out.writeVal(v.value)
+      case _                            => fullEncoder()
+    }
   }
 
   private def writeResponseArray(l: List[ResponseValue], out: JsonWriter, depth: Int): Unit = {

--- a/core/src/main/scala/caliban/parsing/parsers/NumberParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/NumberParsers.scala
@@ -19,5 +19,5 @@ private[caliban] trait NumberParsers extends StringParsers {
   def floatValue(implicit ev: P[Any]): P[FloatValue]  =
     (
       integerPart ~~ (fractionalPart | exponentPart | (fractionalPart ~~ exponentPart))
-    ).!.map(FloatValue(_))
+    ).!.map(FloatValue.fromStringUnsafe)
 }

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -154,7 +154,7 @@ object ParserSpec extends ZIOSpecDefault {
                     arguments = Map(
                       "id"    -> StringValue("1000"),
                       "int"   -> IntValue(3),
-                      "float" -> FloatValue("3.14"),
+                      "float" -> FloatValue(3.14),
                       "bool"  -> BooleanValue(true),
                       "nope"  -> NullValue,
                       "enum"  -> EnumValue("YES"),


### PR DESCRIPTION
TIL that the number of cases in when pattern-matching affects performance in an interesting way:

1. When the number of cases is relatively low (~less than 10), the cost of pattern-matching is relatively constant.
2. When using type-checking instead of unapply methods, we can increase the number of cases a bit while keeping the cost constant
3. When the number of cases increases above a threshold (which is not always constant!), then the cost of pattern-matching increases by a fair bit

I'm not sure exactly why this happens, but my guess is that the JVM manages to JIT/inline the pattern matching when the number of cases is relatively low.

Unfortunately, the only way to keep the number of cases below this threshold (12 type-checked cases in our case) was to remove the type-checking on StreamValue and use the `.toString` method. This should work OK as long as we don't need to extend ResponseValue with another kind of value, and forget to add it to the pattern matching. Given that the chances of adding another kind of ResponseValue type are very very small, I think this approach should be okay

With these changes, we see ~20% improvement in throughput when encoding `ResponseValue`s 🎉 🚀

PS: I also noticed that we were parsing floats into a `BigDecimalNumber` for all floats, so I changed it to first try and parse them into a `Double` which is more memory efficient, and fallback to `BigDecimalNumber` only in case of an error