### PR TITLE
Allow providing a custom `zio.query.Cache` when executing queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val zioInteropCats2Version    = "22.0.0.0"
 val zioInteropCats3Version    = "23.1.0.1"
 val zioInteropReactiveVersion = "2.0.2"
 val zioConfigVersion          = "3.0.7"
-val zqueryVersion             = "0.6.1"
+val zqueryVersion             = "0.7.0"
 val zioJsonVersion            = "0.6.2"
 val zioHttpVersion            = "3.0.0-RC6"
 val zioOpenTelemetryVersion   = "3.0.0-RC21"
@@ -289,7 +289,6 @@ lazy val catsInterop = project
   .settings(name := "caliban-cats")
   .settings(commonSettings)
   .settings(enableMimaSettingsJVM)
-  .settings(apiMappingSettings)
   .settings(
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= {
@@ -660,6 +659,7 @@ lazy val docs = project
   .dependsOn(core, catsInterop, tapirInterop, http4s, tools, quickAdapter)
 
 lazy val commonSettings = Def.settings(
+  apiMappingSettings,
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding",
@@ -743,7 +743,8 @@ lazy val apiMappingSettings = Def.settings(
     def javadocIO(org: String, name: String) = depFile(org, name).map { case (id, f) => f -> javadocIOUrl(id) }
 
     Seq(
-      javadocIO("dev.zio", "zio")
+      javadocIO("dev.zio", "zio"),
+      javadocIO("dev.zio", "zio-query")
     ).flatten.toMap
   }
 )

--- a/core/src/main/scala/caliban/Configurator.scala
+++ b/core/src/main/scala/caliban/Configurator.scala
@@ -26,7 +26,7 @@ object Configurator {
     allowMutationsOverGetRequests: Boolean = false,
     queryExecution: QueryExecution = QueryExecution.Parallel,
     validations: List[QueryValidation] = AllValidations,
-    queryCache: UIO[Cache] = Cache.empty
+    queryCache: UIO[Cache] = Cache.empty(Trace.empty)
   )
 
   private val configRef: FiberRef[ExecutionConfiguration] =

--- a/core/src/main/scala/caliban/Configurator.scala
+++ b/core/src/main/scala/caliban/Configurator.scala
@@ -73,8 +73,10 @@ object Configurator {
     configRef.locallyScopedWith(_.copy(allowMutationsOverGetRequests = allow))
 
   /**
-   * Sets an effect which will be used to create a new ZQuery [[Cache]].
-   * This allows customizing the initial cache parameters or providing a custom implementation
+   * Sets an effect which will be used to create a new ZQuery [[Cache]] for each query execution.
+   * This allows customizing the initial cache parameters or providing a custom implementation.
+   *
+   * @see [[ExecutionConfiguration]] for more details
    */
   def setQueryCache(mkCache: UIO[Cache]): URIO[Scope, Unit] =
     configRef.locallyScopedWith(_.copy(queryCache = mkCache))

--- a/core/src/main/scala/caliban/Configurator.scala
+++ b/core/src/main/scala/caliban/Configurator.scala
@@ -3,7 +3,7 @@ package caliban
 import caliban.execution.QueryExecution
 import caliban.validation.Validator.{ AllValidations, QueryValidation }
 import zio._
-import zio.query.{ Cache, DataSource }
+import zio.query.Cache
 
 object Configurator {
 
@@ -14,7 +14,7 @@ object Configurator {
    * @param allowMutationsOverGetRequests if true, mutations are allowed for GET requests. Note that this is highly discouraged as it goes against the recommended practices. Default: false.
    * @param queryExecution the execution strategy to use (sequential, parallel, batched). Default: parallel.
    * @param validations the validations to run on the query during the validation phase. Default: all available validations.
-   * @param queryCache An effect used to create a [[Cache]] to use with [[DataSource]]-backed ZQueries.
+   * @param queryCache An effect used to create a [[zio.query.Cache]] to use with [[zio.query.DataSource]]-backed ZQueries.
    *                   The effect will be run for each query execution to create a new cache, so ensure that any side-effects are properly captured in the provided effect.
    *                   Default: The default empty cache implementation from zio-query
    */
@@ -73,7 +73,7 @@ object Configurator {
     configRef.locallyScopedWith(_.copy(allowMutationsOverGetRequests = allow))
 
   /**
-   * Sets an effect which will be used to create a new ZQuery [[Cache]] for each query execution.
+   * Sets an effect which will be used to create a new ZQuery [[zio.query.Cache]] for each query execution.
    * This allows customizing the initial cache parameters or providing a custom implementation.
    *
    * @see [[ExecutionConfiguration]] for more details

--- a/core/src/main/scala/caliban/Configurator.scala
+++ b/core/src/main/scala/caliban/Configurator.scala
@@ -4,8 +4,10 @@ import caliban.execution.QueryExecution
 import caliban.validation.Validator.{ AllValidations, QueryValidation }
 import zio._
 import zio.query.Cache
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object Configurator {
+  private implicit val trace: Trace = Trace.empty
 
   /**
    * Configuration for the execution of a GraphQL query.
@@ -24,14 +26,14 @@ object Configurator {
     allowMutationsOverGetRequests: Boolean = false,
     queryExecution: QueryExecution = QueryExecution.Parallel,
     validations: List[QueryValidation] = AllValidations,
-    queryCache: UIO[Cache] = Cache.empty(Trace.empty)
+    queryCache: UIO[Cache] = Cache.empty
   )
 
   private val configRef: FiberRef[ExecutionConfiguration] =
     Unsafe.unsafe(implicit u => FiberRef.unsafe.make(ExecutionConfiguration()))
 
   private[caliban] val configuration: UIO[ExecutionConfiguration] =
-    configRef.get(Trace.empty)
+    configRef.get
 
   private[caliban] def setWith[R, E, A](cfg: ExecutionConfiguration)(f: ZIO[R, E, A])(implicit
     trace: Trace

--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -159,7 +159,14 @@ trait GraphQL[-R] { self =>
             case OperationType.Subscription => schemaToExecute.subscription.getOrElse(schemaToExecute.query)
           }
           Configurator.configuration.flatMap { config =>
-            Executor.executeRequest(request, op.plan, fieldWrappers, config.queryExecution, features)
+            Executor.executeRequest(
+              request,
+              op.plan,
+              fieldWrappers,
+              config.queryExecution,
+              features,
+              config.queryCache
+            )
           }
         }
 

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -30,7 +30,7 @@ object Executor {
    * @param plan an execution plan
    * @param fieldWrappers a list of field wrappers
    * @param queryExecution a strategy for executing queries in parallel or not
-   * @param makeCache the initial size to use for the ZQuery cache
+   * @param makeCache effect used to create a new cache for the query execution
    */
   def executeRequest[R](
     request: ExecutionRequest,

--- a/examples/src/main/scala/example/optimizations/OptimizedTest.scala
+++ b/examples/src/main/scala/example/optimizations/OptimizedTest.scala
@@ -57,11 +57,11 @@ object OptimizedTest extends ZIOAppDefault {
   val UserDataSource: DataSource[Any, GetUser] = DataSource.Batched.make("UserDataSource") { requests =>
     requests.toList match {
       case head :: Nil =>
-        printLine("getUser").orDie.as(CompletedRequestMap.empty.insert(head, Exit.succeed(fakeUser(head.id))))
+        printLine("getUser").orDie.as(CompletedRequestMap.single(head, Exit.succeed(fakeUser(head.id))))
       case list        =>
-        printLine("getUsers").orDie.as(list.foldLeft(CompletedRequestMap.empty) { case (map, req) =>
-          map.insert(req, Exit.succeed(fakeUser(req.id)))
-        })
+        printLine("getUsers").orDie.as(
+          CompletedRequestMap.fromIterableWith(list)(identity, req => Exit.succeed(fakeUser(req.id)))
+        )
     }
   }
 

--- a/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
+++ b/tracing/src/test/scala/caliban/tracing/TracingWrapperSpec.scala
@@ -16,9 +16,9 @@ object TracingWrapperSpec extends ZIOSpecDefault {
   val NamesDatasource = new DataSource.Batched[Any, GetName] {
     override val identifier: String                                                                               = "NamesDatasource"
     override def run(requests: Chunk[GetName])(implicit trace: zio.Trace): ZIO[Any, Nothing, CompletedRequestMap] =
-      ZIO.succeed(requests.foldLeft(CompletedRequestMap.empty) { case (map, req) =>
-        map.insert(req, Exit.succeed(req.name))
-      })
+      ZIO.succeed {
+        CompletedRequestMap.fromIterableWith(requests)(identity, req => Exit.succeed(req.name))
+      }
   }
 
   case class PersonArgs(name: String)


### PR DESCRIPTION
Initially I wanted to add a param to configure the initial size of the ZQuery cache (e.g `Cache.empty(128)`), but then I realised it might be better to allow providing a custom Cache implementation altogether.

Having said that, I'm slightly conflicted about this change as it could potentially be a huge foot-gun if users were to provide an effect that uses a globally initialised `Cache`. I'm _hoping_ that people won't go on and do that without understanding the potential implications of it.