### PR TITLE
Allow prepending input path to HttpInterpreter generated Tapir endpoints

### DIFF
--- a/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
@@ -8,7 +8,6 @@ import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.model.ServerRequest
 import sttp.tapir._
 import zio._
-import sttp.tapir.EndpointInput.FixedPath
 
 sealed trait HttpInterpreter[-R, E] { self =>
   protected def endpoints[S](streams: Streams[S]): List[

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
@@ -28,6 +28,9 @@ sealed trait WebSocketInterpreter[-R, E] { self =>
   def intercept[R1](interceptor: Interceptor[R1, R]): WebSocketInterpreter[R1, E] =
     WebSocketInterpreter.Intercepted(self, interceptor)
 
+  def prependPath(path: List[String]): WebSocketInterpreter[R, E] =
+    WebSocketInterpreter.Prepended(self, path)
+
   def configure[R1](configurator: Configurator[R1]): WebSocketInterpreter[R & R1, E] =
     intercept[R & R1](ZLayer.scopedEnvironment[R & R1 & ServerRequest](configurator *> ZIO.environment[R]))
 }
@@ -72,6 +75,28 @@ object WebSocketInterpreter {
         .makeProtocol(serverRequest, protocol)
         .provideSome[R1](ZLayer.succeed(serverRequest), layer)
         .catchAll(ZIO.left(_))
+  }
+
+  private case class Prepended[R, E](
+    interpreter: WebSocketInterpreter[R, E],
+    path: List[String]
+  ) extends WebSocketInterpreter[R, E] {
+    val endpoint: PublicEndpoint[(ServerRequest, String), TapirResponse, (String, CalibanPipe), ZioWebSockets] = {
+      if (path.nonEmpty) {
+        val p: List[EndpointInput[Unit]]   = path.map(stringToPath)
+        val fixedPath: EndpointInput[Unit] = p.tail.foldLeft(p.head)(_ / _)
+
+        interpreter.endpoint.prependIn(fixedPath)
+      } else {
+        interpreter.endpoint
+      }
+    }
+
+    def makeProtocol(
+      serverRequest: ServerRequest,
+      protocol: String
+    ): URIO[R, Either[TapirResponse, (String, CalibanPipe)]] =
+      interpreter.makeProtocol(serverRequest, protocol)
   }
 
   def apply[R, E](


### PR DESCRIPTION
Hi,

I did not manage to implement full endpoints mapping because mapping over endpoints would depend on `Streams` and I can't figure out the type parameters 😞, since streams instance is provided only when `.serverEndpoints` is called (last step in the builder).

But I managed to expose Tapir's `.prependIn` endpoint combinator to add an extra `EndpointInput[Unit]` for the `PublicEndpoint` that `HttpInterpreter` makes.

It does the job, I can use `HttpInterpreter` like this now (tested with real project):

```scala
val status = ...
val api = ...
val graphql = HttpInterpreter(gqlInterpreter)
  .prependInput("graphql" / "api")
  .intercept[Any](myInterceptor)
  .serverEndpoints[Env, ZioStreams](ZioStreams)
  
 NettyZioSever[Env]()
   .addEndpoints(status)
   .addEndpoints(api)
   .addEndpoints(swagger)
   ...
   .start()
```

Any help / feedback is very welcome 🙏 

Issue #2185

Oleksii