### PR TITLE
Set release flag to 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -668,7 +668,9 @@ lazy val commonSettings = Def.settings(
     "-language:higherKinds",
     "-language:existentials",
     "-unchecked",
-    "-Xfatal-warnings"
+    "-Xfatal-warnings",
+    "-release",
+    "11"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 12)) =>
       Seq(


### PR DESCRIPTION
With ZIO no longer supporting / working on JDK8, it makes sense for us to enforce it as well