### PR TITLE
Remove usage of `ZIO.scoped` from APQ wrapper

### DIFF
--- a/core/src/main/scala/caliban/Configurator.scala
+++ b/core/src/main/scala/caliban/Configurator.scala
@@ -40,6 +40,13 @@ object Configurator {
   ): ZIO[R, E, A] =
     configRef.locally(cfg)(f)
 
+  private[caliban] def locallyWith[R, E, A](
+    cfg: ExecutionConfiguration => ExecutionConfiguration
+  )(
+    f: ZIO[R, E, A]
+  ): ZIO[R, E, A] =
+    configRef.locallyWith(cfg)(f)
+
   /**
    * Skip validation of the query.
    * @param skip if true, the query will not be validated (in that case, the `validations` field is ignored).

--- a/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
@@ -62,7 +62,7 @@ object ApolloPersistedQueries {
       ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
         (doc: Document) =>
           docVar.await.flatMap {
-            case Some((_, Some(_))) => ZIO.scoped[R1](Configurator.setSkipValidation(true) *> f(doc))
+            case Some((_, Some(_))) => Configurator.locallyWith(_.copy(skipValidation = true))(f(doc))
             case Some((hash, None)) => f(doc) <* ApolloPersistence.add(hash, doc)
             case None               => f(doc)
           }


### PR DESCRIPTION
`ZIO.scoped` causes the ZEnvironment to be recreated, which can be expensive on large environments