### PR TITLE
Add derivation of `Schema` for union types (towards #1926)

### DIFF
--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -140,6 +140,8 @@ trait SchemaDerivation[R] extends CommonSchemaDerivation {
 
   inline def genDebug[R, A]: Schema[R, A] = PrintDerived(derived[R, A])
 
+  inline def unionType[T]: Schema[R, T] = ${ TypeUnionDerivation.typeUnionSchema[R, T] }
+
   final lazy val auto = new AutoSchemaDerivation[Any] {}
 
   final class SemiAuto[A](impl: Schema[R, A]) extends Schema[R, A] {

--- a/core/src/main/scala-3/caliban/schema/TypeUnionDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/TypeUnionDerivation.scala
@@ -1,0 +1,76 @@
+package caliban.schema
+
+import caliban.introspection.adt.__Type
+
+import scala.quoted.*
+
+object TypeUnionDerivation {
+  inline def derived[R, T]: Schema[R, T] = ${ typeUnionSchema[R, T] }
+
+  def typeUnionSchema[R: Type, T: Type](using quotes: Quotes): Expr[Schema[R, T]] = {
+    import quotes.reflect.*
+
+    class TypeAndSchema[A](val typeRef: String, val schema: Expr[Schema[R, A]], val tpe: Type[A])
+
+    def rec[A](using tpe: Type[A]): List[TypeAndSchema[?]] =
+      TypeRepr.of(using tpe).dealias match {
+        case OrType(l, r) =>
+          rec(using l.asType.asInstanceOf[Type[Any]]) ++ rec(using r.asType.asInstanceOf[Type[Any]])
+        case otherRepr    =>
+          val otherString: String    = otherRepr.show
+          val expr: TypeAndSchema[A] =
+            Expr.summon[Schema[R, A]] match {
+              case Some(foundSchema) =>
+                TypeAndSchema[A](otherString, foundSchema, otherRepr.asType.asInstanceOf[Type[A]])
+              case None              =>
+                quotes.reflect.report.errorAndAbort(s"Couldn't resolve Schema[Any, $otherString]")
+            }
+
+          List(expr)
+      }
+
+    val typeAndSchemas: List[TypeAndSchema[?]] = rec[T]
+
+    val schemaByTypeNameList: Expr[List[(String, Schema[R, Any])]] = Expr.ofList(
+      typeAndSchemas.map { case (tas: TypeAndSchema[a]) =>
+        given Type[a] = tas.tpe
+        '{ (${ Expr(tas.typeRef) }, ${ tas.schema }.asInstanceOf[Schema[R, Any]]) }
+      }
+    )
+    val name                                                       = TypeRepr.of[T].show
+
+    if (name.contains("|")) {
+      report.error(
+        s"You must explicitly add type parameter to derive Schema for a union type in order to capture the name of the type alias"
+      )
+    }
+
+    '{
+      val schemaByName: Map[String, Schema[R, Any]] = ${ schemaByTypeNameList }.toMap
+      new Schema[R, T] {
+
+        def resolve(value: T): Step[R] = {
+          var ret: Step[R] = null
+          ${
+            Expr.block(
+              typeAndSchemas.map { case (tas: TypeAndSchema[a]) =>
+                given Type[a] = tas.tpe
+
+                '{ if value.isInstanceOf[a] then ret = schemaByName(${ Expr(tas.typeRef) }).resolve(value) }
+              },
+              '{ require(ret != null, s"no schema for ${value}") }
+            )
+          }
+          ret
+        }
+
+        def toType(isInput: Boolean, isSubscription: Boolean): __Type =
+          Types.makeUnion(
+            Some(${ Expr(name) }),
+            None,
+            schemaByName.values.map(_.toType_(isInput, isSubscription)).toList
+          )
+      }
+    }
+  }
+}

--- a/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
@@ -1,7 +1,8 @@
 package caliban.schema
 
 import caliban.*
-import caliban.schema.Annotations.{ GQLDescription, GQLField, GQLInterface, GQLName }
+import caliban.parsing.adt.Directive
+import caliban.schema.Annotations.{ GQLDescription, GQLDirective, GQLField, GQLInterface, GQLName }
 import zio.test.{ assertTrue, ZIOSpecDefault }
 import zio.{ RIO, Task, ZIO }
 
@@ -278,8 +279,10 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
         final case class Foo(value: String) derives Schema.SemiAuto
         final case class Bar(foo: Int) derives Schema.SemiAuto
         final case class Baz(bar: Int) derives Schema.SemiAuto
+        @GQLName("Payload2")
+        @GQLDescription("Union type Payload")
+        @GQLDirective(Directive.apply("mydirective", Map("arg" -> Value.StringValue("value"))))
         type Payload = Foo | Bar | Baz
-
         given Schema[Any, Payload] = Schema.unionType[Payload]
 
         final case class QueryInput(isFoo: Boolean) derives ArgBuilder, Schema.SemiAuto
@@ -292,7 +295,8 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
   query: Query
 }
 
-union Payload = Foo | Bar | Baz
+"Union type Payload"
+union Payload2 @mydirective(arg: "value") = Foo | Bar | Baz
 
 type Bar {
   foo: Int!
@@ -307,7 +311,7 @@ type Foo {
 }
 
 type Query {
-  testQuery(isFoo: Boolean!): Payload!
+  testQuery(isFoo: Boolean!): Payload2!
 }""".stripMargin
         val interpreter    = gql.interpreterUnsafe
 


### PR DESCRIPTION
Finally found time to implement a first iteration of this this. 
A patch for the codegen will probably be forthcoming, but this at least allows us to use union types with a bit more ease than before.

Usage looks like this:
```scala
final case class Foo(value: String) derives Schema.SemiAuto
final case class Bar(foo: Int) derives Schema.SemiAuto
type Payload = Foo | Bar
given Schema[Any, Payload] = Schema.unionType[Payload]
```

This will produce a schema like this:
```graphql
schema {
  query: Query
}

union Payload = Foo | Bar

type Bar {
  foo: Int!
}

type Foo {
  value: String!
}

type Query {
  testQuery(isFoo: Boolean!): Payload!
}

```


### Limitations:
- in order to capture the name of the type alias, users will need to explicitly provide a type name to `Schema.unionType`. The compile will fail otherwise.
- ~~No annotations are picked up yet. It probably works the same as for the other cases, but I didn't have time to implement it now.~~
