### PR TITLE
upgrade scalafmt to 3.8.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,4 @@
-version = "3.1.2"
-
+version = "3.8.1"
 runner.dialect = scala213
 maxColumn = 120
 align.preset = most
@@ -22,3 +21,8 @@ fileOverride {
     runner.dialect = scala3
   }
 }
+
+project.excludePaths = [
+  "glob:**/target/**"
+  "glob:**/resources/**"
+]

--- a/build.sbt
+++ b/build.sbt
@@ -730,7 +730,8 @@ lazy val apiMappingSettings = Def.settings(
   apiMappings ++= {
     val depsByModule = (Compile / dependencyClasspathAsJars).value.flatMap { dep =>
       dep.get(moduleID.key).map((_, dep.data))
-    }.groupBy { case (moduleID, _) => (moduleID.organization, moduleID.name) }.mapValues(_.head)
+    }.groupBy { case (moduleID, _) => (moduleID.organization, moduleID.name) }
+      .mapValues(_.head)
 
     val cross = CrossVersion(crossVersion.value, scalaVersion.value, scalaBinaryVersion.value)
       .getOrElse((s: String) => s)

--- a/client/src/main/scala/caliban/client/GraphQLResponseError.scala
+++ b/client/src/main/scala/caliban/client/GraphQLResponseError.scala
@@ -26,11 +26,11 @@ case class GraphQLResponseError(
    */
   def render(includeExtensions: Boolean): String =
     s"${message} ${locations.getOrElse(Nil).map(loc => s"at line ${loc.line} and column ${loc.column}").mkString(" ")}${path.fold("")(p =>
-      s" at path ${p.map {
-        case Left(value)  => s"/$value"
-        case Right(value) => s"[$value]"
-      }.mkString("")}"
-    )}${if (includeExtensions) extensions.fold("")(ext => s" Extensions: $ext") else ""}"
+        s" at path ${p.map {
+            case Left(value)  => s"/$value"
+            case Right(value) => s"[$value]"
+          }.mkString("")}"
+      )}${if (includeExtensions) extensions.fold("")(ext => s" Extensions: $ext") else ""}"
 }
 
 object GraphQLResponseError {

--- a/client/src/main/scala/caliban/client/SelectionBuilder.scala
+++ b/client/src/main/scala/caliban/client/SelectionBuilder.scala
@@ -70,15 +70,16 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
    */
   def decode(payload: String): Either[CalibanClientError, (A, List[GraphQLResponseError], Option[__ObjectValue])] =
     for {
-      parsed      <- try Right(
-                       readFromString[GraphQLResponse](
-                         payload,
-                         // allow parsing of large payloads
-                         ReaderConfig
-                           .withMaxBufSize(max(payload.length, ReaderConfig.maxBufSize))
-                           .withMaxCharBufSize(max(payload.length, ReaderConfig.maxCharBufSize))
+      parsed      <- try
+                       Right(
+                         readFromString[GraphQLResponse](
+                           payload,
+                           // allow parsing of large payloads
+                           ReaderConfig
+                             .withMaxBufSize(max(payload.length, ReaderConfig.maxBufSize))
+                             .withMaxCharBufSize(max(payload.length, ReaderConfig.maxCharBufSize))
+                         )
                        )
-                     )
                      catch {
                        case NonFatal(ex) => Left(DecodingError("Json deserialization error", Some(ex)))
                      }

--- a/codegen-sbt/src/sbt-test/codegen/gen-client-task/project/Version.scala
+++ b/codegen-sbt/src/sbt-test/codegen/gen-client-task/project/Version.scala
@@ -3,5 +3,6 @@ object Version {
     sys.props.get("plugin.version") match {
       case Some(x) => x
       case _       => sys.error("""|The system property 'plugin.version' is not defined.
-                                   |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    }}
+                             |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+    }
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/project/Version.scala
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/project/Version.scala
@@ -3,5 +3,6 @@ object Version {
     sys.props.get("plugin.version") match {
       case Some(x) => x
       case _       => sys.error("""|The system property 'plugin.version' is not defined.
-                                   |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    }}
+                             |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+    }
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/project/plugins.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/project/plugins.sbt
@@ -1,5 +1,5 @@
 sys.props.get("plugin.version") match {
   case Some(x) => addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % x)
   case _       => sys.error("""|The system property 'plugin.version' is not defined.
-                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/clients/src/main/scala/poc/caliban/client/PotatoesClient.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/clients/src/main/scala/poc/caliban/client/PotatoesClient.scala
@@ -4,7 +4,7 @@ import poc.caliban.client.generated.potatoes._
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.SttpBackend
-import zio.{Task, ZIO}
+import zio.{ Task, ZIO }
 
 trait PotatoesClient {
   def eradicate(name: String): Task[Unit]

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/posts/src/main/scala/poc/caliban/posts/PostService.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/posts/src/main/scala/poc/caliban/posts/PostService.scala
@@ -25,9 +25,9 @@ trait PostService {
 }
 
 object PostService {
-  def findById(id: PostId) = ZIO.serviceWithZIO[PostService](_.findById(id))
+  def findById(id: PostId)                                                   = ZIO.serviceWithZIO[PostService](_.findById(id))
   def createPost(author: AuthorName, title: PostTitle, content: PostContent) =
     ZIO.serviceWithZIO[PostService](_.createPost(author, title, content))
-  def deletePost(id: PostId) = ZIO.serviceWithZIO[PostService](_.deletePost(id))
-  def all = ZStream.serviceWithStream[PostService](_.all)
+  def deletePost(id: PostId)                                                 = ZIO.serviceWithZIO[PostService](_.deletePost(id))
+  def all                                                                    = ZStream.serviceWithStream[PostService](_.all)
 }

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/potatoes/src/main/scala/poc/caliban/potatoes/PotatoesApi.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/potatoes/src/main/scala/poc/caliban/potatoes/PotatoesApi.scala
@@ -33,7 +33,7 @@ object Resolvers {
   private val queries =
     Query(
       byName = name => PotatoesService.findByName(name),
-      byColor = color => PotatoesService.findByColor(color),
+      byColor = color => PotatoesService.findByColor(color)
     )
 
   private val mutations =

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/potatoes/src/main/scala/poc/caliban/potatoes/PotatoesService.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/potatoes/src/main/scala/poc/caliban/potatoes/PotatoesService.scala
@@ -27,10 +27,10 @@ trait PotatoesService {
 }
 
 object PotatoesService {
-  def findByName(name: Potato.Name) = ZIO.serviceWithZIO[PotatoesService](_.findByName(name))
-  def findByColor(color: Potato.Color) = ZIO.serviceWithZIO[PotatoesService](_.findByColor(color))
+  def findByName(name: Potato.Name)                          = ZIO.serviceWithZIO[PotatoesService](_.findByName(name))
+  def findByColor(color: Potato.Color)                       = ZIO.serviceWithZIO[PotatoesService](_.findByColor(color))
   def makeNewSpecies(name: Potato.Name, color: Potato.Color) =
     ZIO.serviceWithZIO[PotatoesService](_.makeNewSpecies(name, color))
-  def eradicate(name: Potato.Name) = ZIO.serviceWithZIO[PotatoesService](_.eradicate(name))
-  def all = ZStream.serviceWithStream[PotatoesService](_.all)
+  def eradicate(name: Potato.Name)                           = ZIO.serviceWithZIO[PotatoesService](_.eradicate(name))
+  def all                                                    = ZStream.serviceWithStream[PotatoesService](_.all)
 }

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -143,15 +143,14 @@ object Executor {
         def reduceField(f: Field): (String, ReducedStep[R], FieldInfo) = {
           val aliasedName = f.aliasedName
           val fname       = f.name
-          val field       = {
+          val field       =
             if (fname == "__typename") PureStep(StringValue(objectName))
             else reduceStep(getFieldStep(fname), f, f.arguments, PathValue.Key(aliasedName) :: path)
-          }
           (aliasedName, field, fieldInfo(f, aliasedName, path, f.directives))
         }
 
         val filteredFields    = mergeFields(currentField, objectName)
-        val (deferred, eager) = {
+        val (deferred, eager) =
           if (isDeferredEnabled) {
             filteredFields.partitionMap { f =>
               val entry = reduceField(f)
@@ -163,7 +162,6 @@ object Executor {
               }
             }
           } else (Nil, filteredFields.map(reduceField))
-        }
 
         val eagerReduced = reduceObject(eager)
         deferred match {

--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -215,10 +215,12 @@ private[caliban] object ValueJsoniter {
     var digits = 0
     var b      = in.nextByte()
     if (b == '-') b = in.nextByte()
-    try while (b >= '0' && b <= '9') {
-      b = in.nextByte()
-      digits += 1
-    } catch {
+    try
+      while (b >= '0' && b <= '9') {
+        b = in.nextByte()
+        digits += 1
+      }
+    catch {
       case _: JsonReaderException => // ignore the end of input error for now
     }
     in.rollbackToMark()

--- a/core/src/main/scala/caliban/parsing/Parser.scala
+++ b/core/src/main/scala/caliban/parsing/Parser.scala
@@ -28,10 +28,12 @@ object Parser {
    */
   def parseQueryEither(query: String): Either[ParsingError, Document] = {
     val sm = SourceMapper(query)
-    try parse(query, document(_)) match {
-      case Parsed.Success(value, _) => Right(Document(value.definitions, sm))
-      case f: Parsed.Failure        => Left(ParsingError(f.msg, Some(sm.getLocation(f.index))))
-    } catch {
+    try
+      parse(query, document(_)) match {
+        case Parsed.Success(value, _) => Right(Document(value.definitions, sm))
+        case f: Parsed.Failure        => Left(ParsingError(f.msg, Some(sm.getLocation(f.index))))
+      }
+    catch {
       case NonFatal(ex) => Left(ParsingError(s"Internal parsing error", innerThrowable = Some(ex)))
     }
   }

--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -145,7 +145,7 @@ object VariablesCoercer {
     context: => String // Careful not to materialize unless we need to fail!
   ): EReader[Any, ValidationError, InputValue] =
     typ.kind match {
-      case __TypeKind.NON_NULL =>
+      case __TypeKind.NON_NULL                     =>
         value match {
           case NullValue =>
             failValidation(

--- a/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
@@ -12,7 +12,7 @@ import scala.annotation.nowarn
 private[caliban] trait SelectionParsers extends ValueParsers {
 
   @deprecated("Kept for bincompat only, scheduled to be removed")
-  def alias(implicit ev: P[Any]): P[String] = name ~ ":"
+  def alias(implicit ev: P[Any]): P[String]       = name ~ ":"
   def aliasOrName(implicit ev: P[Any]): P[String] = ":" ~/ name
 
   def argument(implicit ev: P[Any]): P[(String, InputValue)]     = name ~ ":" ~ value

--- a/core/src/main/scala/caliban/transformers/Transformer.scala
+++ b/core/src/main/scala/caliban/transformers/Transformer.scala
@@ -211,10 +211,9 @@ object Transformer {
     private def shouldKeep(typeName: String, fieldName: String): Boolean =
       !map.getOrElse(typeName, Set.empty).contains(fieldName)
 
-    val typeVisitor: TypeVisitor = {
+    val typeVisitor: TypeVisitor =
       TypeVisitor.fields.filterWith((t, field) => shouldKeep(t.name.getOrElse(""), field.name)) |+|
         TypeVisitor.inputFields.filterWith((t, field) => shouldKeep(t.name.getOrElse(""), field.name))
-    }
 
     protected val typeNames: Set[String] = map.keySet
 

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -34,7 +34,7 @@ object FragmentValidator {
               if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type)) {
                 Chunk(
                   s"$name has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
-                    .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
+                      .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
                 )
               } else
                 sameResponseShapeByName(f1.selection.selectionSet ::: f2.selection.selectionSet)

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -516,7 +516,7 @@ object Validator {
           if (applicableTypes.isEmpty)
             failValidation(
               s"${name.fold("Inline fragment spread")(n => s"Fragment spread '$n'")} is not possible: possible types are '${possibleTypes
-                .mkString(", ")}' and possible fragment types are '${possibleFragmentTypes.mkString(", ")}'.",
+                  .mkString(", ")}' and possible fragment types are '${possibleFragmentTypes.mkString(", ")}'.",
               "Fragments are declared on a type and will only apply when the runtime object type matches the type condition. They also are spread within the context of a parent type. A fragment spread is only valid if its type condition could ever apply within the parent type."
             )
           else validateFields(context, selectionSet, fragmentType)
@@ -568,13 +568,13 @@ object Validator {
         case (None, None) | (None, Some(NullValue)) =>
           failValidation(
             s"Required argument '${arg.name}' is null or missing on field '${field.name}' of type '${currentType.name
-              .getOrElse("")}'.",
+                .getOrElse("")}'.",
             "Arguments can be required. An argument is required if the argument type is non‐null and does not have a default value. Otherwise, the argument is optional."
           )
         case (Some(_), Some(NullValue))             =>
           failValidation(
             s"Required argument '${arg.name}' is null on '${field.name}' of type '${currentType.name
-              .getOrElse("")}'.",
+                .getOrElse("")}'.",
             "Arguments can be required. An argument is required if the argument type is non‐null and does not have a default value. Otherwise, the argument is optional."
           )
         case _                                      => zunit
@@ -714,7 +714,7 @@ object Validator {
         case Type.NamedType(name, _) =>
           failWhen(!locationType.name.contains(name))(
             s"Variable '$variableName' usage is not allowed because its type doesn't match the schema ($name instead of ${locationType.name
-              .getOrElse("")}).",
+                .getOrElse("")}).",
             explanation
           )
       }
@@ -785,7 +785,7 @@ object Validator {
 
   lazy val validateSubscriptionOperation: QueryValidation = ZPure.environmentWithPure { env =>
     val context = env.get[Context]
-    val error   = {
+    val error   =
       for {
         t           <- context.rootType.subscriptionType
         op          <- context.operations.find(_.operationType == OperationType.Subscription)
@@ -820,7 +820,6 @@ object Validator {
                            )
                        }
       } yield error
-    }
     ZPure.fromOption(error).flip
   }
 
@@ -1162,9 +1161,9 @@ object Validator {
       case Some((name, values)) =>
         failValidation(
           s"Type '$name' is defined multiple times (${values
-            .sortBy(v => v.origin.getOrElse(""))
-            .map(v => s"${v.kind}${v.origin.fold("")(a => s" in $a")}")
-            .mkString(", ")}).",
+              .sortBy(v => v.origin.getOrElse(""))
+              .map(v => s"${v.kind}${v.origin.fold("")(a => s" in $a")}")
+              .mkString(", ")}).",
           "Each type must be defined only once."
         )
     }

--- a/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/Scala3DerivesSpec.scala
@@ -133,7 +133,7 @@ object Scala3DerivesSpec extends ZIOSpecDefault {
           sealed trait Foo derives Schema.SemiAuto {
             val i: Instant
           }
-          object Foo {
+          object Foo                               {
             final case class FooA(i: Instant, s1: String) extends Foo derives Schema.SemiAuto, ArgBuilder
             final case class FooB(i: Instant, i1: Int)    extends Foo derives Schema.SemiAuto, ArgBuilder
           }

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -36,7 +36,7 @@ object TestUtils {
     case object MARS  extends Origin
     case object BELT  extends Origin
     @GQLDeprecated("Use: EARTH | MARS | BELT")
-    case object MOON extends Origin
+    case object MOON  extends Origin
   }
 
   @GQLDirective(Directive("uniondirective"))
@@ -393,7 +393,7 @@ object TestUtils {
       sealed trait FieldInterface {
         val a: String
       }
-      object FieldInterface {
+      object FieldInterface       {
         case class FieldObject(a: String, b: Int) extends FieldInterface
       }
       case class TestFieldObject(fieldInterface: FieldObject)

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -24,7 +24,7 @@ object ExecutionSpec extends ZIOSpecDefault {
     def id: String
     def name: String
   }
-  object Base {
+  object Base       {
     @GQLName("BaseOne")
     case class One(
       id: String,
@@ -885,7 +885,7 @@ object ExecutionSpec extends ZIOSpecDefault {
           def id: String
           def name: String
         }
-        object Character {
+        object Character       {
           case class Human(
             id: String,
             name: String,

--- a/core/src/test/scala/caliban/schema/OptionalSpec.scala
+++ b/core/src/test/scala/caliban/schema/OptionalSpec.scala
@@ -24,7 +24,7 @@ object OptionalSpec extends ZIOSpecDefault {
       implicit def wrapperSchema[A](implicit ev: Schema[Any, A]): Schema[Any, Wrapper[A]] =
         new Schema[Any, Wrapper[A]] {
           @annotation.nowarn
-          override def optional = ev.optional
+          override def optional                                 = ev.optional
           def toType(isInput: Boolean, isSubscription: Boolean) = ev.toType_(isInput, isSubscription)
           def resolve(value: Wrapper[A]): Step[Any]             =
             ev.resolve(value.value)

--- a/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaDerivationIssuesSpec.scala
@@ -575,7 +575,7 @@ object i2076 {
 
       @GQLName("WidgetAChild")
       case class Child(name: String, foo: String, bar: String)
-      object Child      {
+      object Child {
         implicit val schema: Schema[Any, Child] = Schema.gen
       }
     }
@@ -596,7 +596,7 @@ object i2076 {
 
       @GQLName("WidgetBChild")
       case class Child(name: String, foo: String)
-      object Child      {
+      object Child {
         implicit val schema: Schema[Any, Child] = Schema.gen
       }
     }

--- a/core/src/test/scala/caliban/schema/SchemaSpec.scala
+++ b/core/src/test/scala/caliban/schema/SchemaSpec.scala
@@ -397,7 +397,7 @@ object SchemaSpec extends ZIOSpecDefault {
 
   @GQLInterface
   sealed trait MyInterface
-  object MyInterface             {
+  object MyInterface {
     case class A(c1: Int, c2: Int => Int, d1: Int, d2: Int => Int, d3: Int => Int)      extends MyInterface
     case class B(c1: Int, c2: Int => Int, d1: Boolean, d2: Int, d3: Option[Int] => Int) extends MyInterface
   }
@@ -411,7 +411,7 @@ object SchemaSpec extends ZIOSpecDefault {
 
   @GQLUnion
   sealed trait EnumLikeUnion
-  object EnumLikeUnion           {
+  object EnumLikeUnion {
     case object A extends EnumLikeUnion
     case object B extends EnumLikeUnion
   }
@@ -419,7 +419,7 @@ object SchemaSpec extends ZIOSpecDefault {
   @GQLUnion
   sealed trait RedirectingUnion
 
-  object RedirectingUnion  {
+  object RedirectingUnion {
     case class B(common: Int)
 
     case class A(common: Int) extends RedirectingUnion

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -91,12 +91,12 @@ object ExampleApi {
         Subscriptions(exampleService.deletedEvents)
       )
     ) @@
-      maxFields(300) @@ // query analyzer that limit query fields
+      maxFields(300) @@               // query analyzer that limit query fields
       maxDepth(30) @@                 // query analyzer that limit query depth
       timeout(3 seconds) @@           // wrapper that fails slow queries
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       printErrors @@                  // wrapper that logs errors
-      apolloTracing() @@                // wrapper for https://github.com/apollographql/apollo-tracing
+      apolloTracing() @@              // wrapper for https://github.com/apollographql/apollo-tracing
       DeferSupport.defer              // wrapper that enables @defer directive support
   }
 

--- a/examples/src/main/scala/example/federation/FederatedApi.scala
+++ b/examples/src/main/scala/example/federation/FederatedApi.scala
@@ -22,7 +22,7 @@ object FederatedApi {
       maxDepth(30) |+|                 // query analyzer that limit query depth
       timeout(3 seconds) |+|           // wrapper that fails slow queries
       printSlowQueries(500 millis) |+| // wrapper that logs slow queries
-      ApolloFederatedTracing.wrapper()   // wrapper for https://github.com/apollographql/apollo-tracing
+      ApolloFederatedTracing.wrapper() // wrapper for https://github.com/apollographql/apollo-tracing
 
   object Characters extends GenericSchema[CharacterService] {
     import example.federation.FederationData.characters._

--- a/examples/src/main/scala/example/pekkohttp/ExampleApp.scala
+++ b/examples/src/main/scala/example/pekkohttp/ExampleApp.scala
@@ -4,7 +4,7 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.server.Directives._
 import caliban.interop.tapir.{ HttpInterpreter, WebSocketInterpreter }
-import caliban.{ PekkoHttpAdapter, GraphQL }
+import caliban.{ GraphQL, PekkoHttpAdapter }
 import example.ExampleData.sampleCharacters
 import example.{ ExampleApi, ExampleService }
 import sttp.tapir.json.circe._

--- a/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
+++ b/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
@@ -206,7 +206,7 @@ object FederationV2Spec extends ZIOSpecDefault {
     } yield document.definitions.flatMap {
       case Definition.TypeSystemDefinition.SchemaDefinition(d, _, _, _, _) =>
         d.map(_.copy(index = 0)) // Unset the index to make the test deterministic
-      case _ => Nil
+      case _                                                               => Nil
     }
   }
 }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
@@ -125,10 +125,10 @@ object HttpInterpreter {
     def queryFromQueryParams(queryParams: QueryParams): DecodeResult[GraphQLRequest] =
       for {
         req <- requestCodec.decode(s"""{"query":"","variables":${queryParams
-                 .get("variables")
-                 .getOrElse("null")},"extensions":${queryParams
-                 .get("extensions")
-                 .getOrElse("null")}}""")
+                   .get("variables")
+                   .getOrElse("null")},"extensions":${queryParams
+                   .get("extensions")
+                   .getOrElse("null")}}""")
 
       } yield req.copy(query = queryParams.get("query"), operationName = queryParams.get("operationName"))
 

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
@@ -81,7 +81,7 @@ object WebSocketInterpreter {
     interpreter: WebSocketInterpreter[R, E],
     path: List[String]
   ) extends WebSocketInterpreter[R, E] {
-    val endpoint: PublicEndpoint[(ServerRequest, String), TapirResponse, (String, CalibanPipe), ZioWebSockets] = {
+    val endpoint: PublicEndpoint[(ServerRequest, String), TapirResponse, (String, CalibanPipe), ZioWebSockets] =
       if (path.nonEmpty) {
         val p: List[EndpointInput[Unit]]   = path.map(stringToPath)
         val fixedPath: EndpointInput[Unit] = p.tail.foldLeft(p.head)(_ / _)
@@ -90,7 +90,6 @@ object WebSocketInterpreter {
       } else {
         interpreter.endpoint
       }
-    }
 
     def makeProtocol(
       serverRequest: ServerRequest,

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -508,10 +508,10 @@ object TapirAdapterSpec {
           httpUri.addParams(
             QueryParams.fromSeq(
               List(
-                request.query.map("query"                 -> _),
+                request.query.map("query" -> _),
                 request.operationName.map("operationName" -> _),
-                request.variables.map("variables"         -> _.toJson),
-                request.extensions.map("extensions"       -> _.toJson)
+                request.variables.map("variables" -> _.toJson),
+                request.extensions.map("extensions" -> _.toJson)
               ).flatten
             )
           )

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -306,123 +306,126 @@ object ClientWriter {
     ): String =
       s"type ${typedef.name} = _root_.caliban.client.Operations.RootQuery"
 
-    def writeRootQuery(typedef: ObjectTypeDefinition): String =
-      s"""object ${typedef.name} {
-         |  ${typedef.fields.flatMap { field =>
-          if (isOptionalInterfaceType(field)) {
-            Vector(
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootQuery",
-                optionalUnion = false,
-                optionalInterface = false,
-                commonInterface = false
-              ),
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootQuery",
-                optionalUnion = false,
-                optionalInterface = true,
-                commonInterface = false
-              )
+    def writeRootQuery(typedef: ObjectTypeDefinition): String = {
+      val formattedFields = typedef.fields.flatMap { field =>
+        if (isOptionalInterfaceType(field)) {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootQuery",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
+            ),
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootQuery",
+              optionalUnion = false,
+              optionalInterface = true,
+              commonInterface = false
             )
-          } else {
-            Vector(
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootQuery",
-                optionalUnion = false,
-                optionalInterface = false,
-                commonInterface = false
-              )
+          )
+        } else {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootQuery",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
             )
-          }
+          )
         }
-          .mkString("\n  ")}
+      }
+      s"""object ${typedef.name} {
+         |  ${formattedFields.mkString("\n  ")}
          |}
          |""".stripMargin
+    }
 
     def writeRootMutationType(
       typedef: ObjectTypeDefinition
     ): String =
       s"type ${typedef.name} = _root_.caliban.client.Operations.RootMutation"
 
-    def writeRootMutation(typedef: ObjectTypeDefinition): String =
-      s"""object ${typedef.name} {
-         |  ${typedef.fields.flatMap { field =>
-          if (isOptionalInterfaceType(field)) {
-            Vector(
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootMutation",
-                optionalUnion = false,
-                optionalInterface = false,
-                commonInterface = false
-              ),
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootMutation",
-                optionalUnion = false,
-                optionalInterface = true,
-                commonInterface = false
-              )
+    def writeRootMutation(typedef: ObjectTypeDefinition): String = {
+      val formattedFields = typedef.fields.flatMap { field =>
+        if (isOptionalInterfaceType(field)) {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootMutation",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
+            ),
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootMutation",
+              optionalUnion = false,
+              optionalInterface = true,
+              commonInterface = false
             )
-          } else {
-            Vector(
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootMutation",
-                optionalUnion = false,
-                optionalInterface = false,
-                commonInterface = false
-              )
+          )
+        } else {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootMutation",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
             )
-          }
+          )
         }
-          .mkString("\n  ")}
+      }
+      s"""object ${typedef.name} {
+         |  ${formattedFields.mkString("\n  ")}
          |}
          |""".stripMargin
+    }
 
     def writeRootSubscriptionType(
       typedef: ObjectTypeDefinition
     ): String =
       s"type ${typedef.name} = _root_.caliban.client.Operations.RootSubscription"
 
-    def writeRootSubscription(typedef: ObjectTypeDefinition): String =
-      s"""object ${typedef.name} {
-         |  ${typedef.fields.flatMap { field =>
-          if (isOptionalInterfaceType(field)) {
-            Vector(
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootSubscription",
-                optionalUnion = false,
-                optionalInterface = false,
-                commonInterface = false
-              ),
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootSubscription",
-                optionalUnion = false,
-                optionalInterface = true,
-                commonInterface = false
-              )
+    def writeRootSubscription(typedef: ObjectTypeDefinition): String = {
+      val formattedFields = typedef.fields.flatMap { field =>
+        if (isOptionalInterfaceType(field)) {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootSubscription",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
+            ),
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootSubscription",
+              optionalUnion = false,
+              optionalInterface = true,
+              commonInterface = false
             )
-          } else {
-            Vector(
-              writeField(
-                field,
-                "_root_.caliban.client.Operations.RootSubscription",
-                optionalUnion = false,
-                optionalInterface = false,
-                commonInterface = false
-              )
+          )
+        } else {
+          Vector(
+            writeField(
+              field,
+              "_root_.caliban.client.Operations.RootSubscription",
+              optionalUnion = false,
+              optionalInterface = false,
+              commonInterface = false
             )
-          }
+          )
         }
-          .mkString("\n  ")}
+      }
+      s"""object ${typedef.name} {
+         |  ${formattedFields.mkString("\n  ")}
          |}
          |""".stripMargin
+    }
 
     def writeObjectType(typedef: ObjectTypeDefinition): String = {
 
@@ -634,19 +637,19 @@ object ClientWriter {
       typedef: InputObjectTypeDefinition
     ): String = {
       val inputObjectName = safeTypeName(typedef.name)
+      val formattedFields = typedef.fields
+        .map(f =>
+          s""""${f.name}" -> ${writeInputValue(
+              f.ofType,
+              s"value.${safeName(f.name)}",
+              inputObjectName
+            )}"""
+        )
       s"""final case class $inputObjectName(${writeArgumentFields(typedef.fields)})
          |object $inputObjectName {
          |  implicit val encoder: ArgEncoder[$inputObjectName] = new ArgEncoder[$inputObjectName] {
          |    override def encode(value: $inputObjectName): __Value =
-         |      __ObjectValue(List(${typedef.fields
-          .map(f =>
-            s""""${f.name}" -> ${writeInputValue(
-                f.ofType,
-                s"value.${safeName(f.name)}",
-                inputObjectName
-              )}"""
-          )
-          .mkString(", ")}))
+         |      __ObjectValue(List(${formattedFields.mkString(", ")}))
          |  }
          |}""".stripMargin
     }
@@ -696,7 +699,8 @@ object ClientWriter {
         (if (extensibleEnums) Some(s"case ${typedef.name}.__Unknown (value) => __EnumValue(value)") else None)
 
       val enumObject =
-        if (typedef.enumValuesDefinition.nonEmpty)
+        if (typedef.enumValuesDefinition.nonEmpty) {
+          val formattedEnumValues = typedef.enumValuesDefinition.map(v => safeEnumValue(v.enumValue)).mkString(", ")
           s"""object $enumName {
             ${enumCases.mkString("\n")}
 
@@ -708,11 +712,9 @@ object ClientWriter {
               ${encoderCases.mkString("\n")}
             }
 
-            val values: scala.collection.immutable.Vector[$enumName] = scala.collection.immutable.Vector(${typedef.enumValuesDefinition
-              .map(v => safeEnumValue(v.enumValue))
-              .mkString(", ")})
+            val values: scala.collection.immutable.Vector[$enumName] = scala.collection.immutable.Vector($formattedEnumValues)
           }"""
-        else
+        } else
           ""
 
       s"""sealed trait $enumName extends scala.Product with scala.Serializable { def value: String }

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -179,8 +179,8 @@ object ClientWriter {
             (
               s"[$typeLetter]",
               s"(${unionTypes
-                .map(t => s"""${safeTypeName(s"on${t.name}")}: scala.Option[SelectionBuilder[${safeTypeName(t.name)}, $typeLetter]] = None""")
-                .mkString(", ")})",
+                  .map(t => s"""${safeTypeName(s"on${t.name}")}: scala.Option[SelectionBuilder[${safeTypeName(t.name)}, $typeLetter]] = None""")
+                  .mkString(", ")})",
               s"${writeType(field.ofType).replace(fieldType, s"scala.Option[$typeLetter]")}",
               writeTypeBuilder(
                 field.ofType,
@@ -210,8 +210,8 @@ object ClientWriter {
             (
               s"[$typeLetter]",
               s"(${interfaceTypes
-                .map(t => s"""${safeTypeName(s"on${t.name}")}: scala.Option[SelectionBuilder[${safeTypeName(t.name)}, $typeLetter]] = None""")
-                .mkString(", ")})",
+                  .map(t => s"""${safeTypeName(s"on${t.name}")}: scala.Option[SelectionBuilder[${safeTypeName(t.name)}, $typeLetter]] = None""")
+                  .mkString(", ")})",
               s"${writeType(field.ofType).replace(fieldType, s"""scala.Option[$typeLetter]""")}",
               writeTypeBuilder(
                 field.ofType,
@@ -245,15 +245,15 @@ object ClientWriter {
         case Nil  => ""
         case list =>
           s", arguments = List(${list.zipWithIndex.map { case (arg, idx) =>
-            s"""Argument("${arg.name}", ${safeName(arg.name)}, "${arg.ofType.toString}")(encoder$idx)"""
-          }.mkString(", ")})"
+              s"""Argument("${arg.name}", ${safeName(arg.name)}, "${arg.ofType.toString}")(encoder$idx)"""
+            }.mkString(", ")})"
       }
       val implicits                                        = field.args match {
         case Nil  => ""
         case list =>
           s"(implicit ${list.zipWithIndex.map { case (arg, idx) =>
-            s"""encoder$idx: ArgEncoder[${writeType(arg.ofType)}]"""
-          }.mkString(", ")})"
+              s"""encoder$idx: ArgEncoder[${writeType(arg.ofType)}]"""
+            }.mkString(", ")})"
       }
 
       val name          =
@@ -309,36 +309,36 @@ object ClientWriter {
     def writeRootQuery(typedef: ObjectTypeDefinition): String =
       s"""object ${typedef.name} {
          |  ${typedef.fields.flatMap { field =>
-        if (isOptionalInterfaceType(field)) {
-          Vector(
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootQuery",
-              optionalUnion = false,
-              optionalInterface = false,
-              commonInterface = false
-            ),
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootQuery",
-              optionalUnion = false,
-              optionalInterface = true,
-              commonInterface = false
+          if (isOptionalInterfaceType(field)) {
+            Vector(
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootQuery",
+                optionalUnion = false,
+                optionalInterface = false,
+                commonInterface = false
+              ),
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootQuery",
+                optionalUnion = false,
+                optionalInterface = true,
+                commonInterface = false
+              )
             )
-          )
-        } else {
-          Vector(
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootQuery",
-              optionalUnion = false,
-              optionalInterface = false,
-              commonInterface = false
+          } else {
+            Vector(
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootQuery",
+                optionalUnion = false,
+                optionalInterface = false,
+                commonInterface = false
+              )
             )
-          )
+          }
         }
-      }
-        .mkString("\n  ")}
+          .mkString("\n  ")}
          |}
          |""".stripMargin
 
@@ -350,36 +350,36 @@ object ClientWriter {
     def writeRootMutation(typedef: ObjectTypeDefinition): String =
       s"""object ${typedef.name} {
          |  ${typedef.fields.flatMap { field =>
-        if (isOptionalInterfaceType(field)) {
-          Vector(
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootMutation",
-              optionalUnion = false,
-              optionalInterface = false,
-              commonInterface = false
-            ),
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootMutation",
-              optionalUnion = false,
-              optionalInterface = true,
-              commonInterface = false
+          if (isOptionalInterfaceType(field)) {
+            Vector(
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootMutation",
+                optionalUnion = false,
+                optionalInterface = false,
+                commonInterface = false
+              ),
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootMutation",
+                optionalUnion = false,
+                optionalInterface = true,
+                commonInterface = false
+              )
             )
-          )
-        } else {
-          Vector(
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootMutation",
-              optionalUnion = false,
-              optionalInterface = false,
-              commonInterface = false
+          } else {
+            Vector(
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootMutation",
+                optionalUnion = false,
+                optionalInterface = false,
+                commonInterface = false
+              )
             )
-          )
+          }
         }
-      }
-        .mkString("\n  ")}
+          .mkString("\n  ")}
          |}
          |""".stripMargin
 
@@ -391,36 +391,36 @@ object ClientWriter {
     def writeRootSubscription(typedef: ObjectTypeDefinition): String =
       s"""object ${typedef.name} {
          |  ${typedef.fields.flatMap { field =>
-        if (isOptionalInterfaceType(field)) {
-          Vector(
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootSubscription",
-              optionalUnion = false,
-              optionalInterface = false,
-              commonInterface = false
-            ),
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootSubscription",
-              optionalUnion = false,
-              optionalInterface = true,
-              commonInterface = false
+          if (isOptionalInterfaceType(field)) {
+            Vector(
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootSubscription",
+                optionalUnion = false,
+                optionalInterface = false,
+                commonInterface = false
+              ),
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootSubscription",
+                optionalUnion = false,
+                optionalInterface = true,
+                commonInterface = false
+              )
             )
-          )
-        } else {
-          Vector(
-            writeField(
-              field,
-              "_root_.caliban.client.Operations.RootSubscription",
-              optionalUnion = false,
-              optionalInterface = false,
-              commonInterface = false
+          } else {
+            Vector(
+              writeField(
+                field,
+                "_root_.caliban.client.Operations.RootSubscription",
+                optionalUnion = false,
+                optionalInterface = false,
+                commonInterface = false
+              )
             )
-          )
+          }
         }
-      }
-        .mkString("\n  ")}
+          .mkString("\n  ")}
          |}
          |""".stripMargin
 
@@ -639,14 +639,14 @@ object ClientWriter {
          |  implicit val encoder: ArgEncoder[$inputObjectName] = new ArgEncoder[$inputObjectName] {
          |    override def encode(value: $inputObjectName): __Value =
          |      __ObjectValue(List(${typedef.fields
-        .map(f =>
-          s""""${f.name}" -> ${writeInputValue(
-               f.ofType,
-               s"value.${safeName(f.name)}",
-               inputObjectName
-             )}"""
-        )
-        .mkString(", ")}))
+          .map(f =>
+            s""""${f.name}" -> ${writeInputValue(
+                f.ofType,
+                s"value.${safeName(f.name)}",
+                inputObjectName
+              )}"""
+          )
+          .mkString(", ")}))
          |  }
          |}""".stripMargin
     }
@@ -709,8 +709,8 @@ object ClientWriter {
             }
 
             val values: scala.collection.immutable.Vector[$enumName] = scala.collection.immutable.Vector(${typedef.enumValuesDefinition
-            .map(v => safeEnumValue(v.enumValue))
-            .mkString(", ")})
+              .map(v => safeEnumValue(v.enumValue))
+              .mkString(", ")})
           }"""
         else
           ""
@@ -977,7 +977,7 @@ object ClientWriter {
            |
            |package object ${packageName.get.reverse.takeWhile(_ != '.').reverse} {
            |  ${(scalars ::: interfaceTypes ::: objectTypes ::: queryTypes ::: mutationTypes ::: subscriptionTypes)
-          .mkString("\n")}
+            .mkString("\n")}
            |}
            |""".stripMargin
       val classFiles        =
@@ -995,23 +995,23 @@ object ClientWriter {
     } else {
       val imports =
         s"""${if (enums.nonEmpty)
-          """import caliban.client.CalibanClientError.DecodingError
-            |""".stripMargin
-        else ""}${if (
-          interfaces.nonEmpty || objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty
-        )
-          """import caliban.client.FieldBuilder._
-            |""".stripMargin
-        else
-          ""}${if (
-          enums.nonEmpty || interfaces.nonEmpty || objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty || inputs.nonEmpty
-        )
-          """import caliban.client._
-            |""".stripMargin
-        else ""}${if (enums.nonEmpty || inputs.nonEmpty)
-          """import caliban.client.__Value._
-            |""".stripMargin
-        else ""}"""
+            """import caliban.client.CalibanClientError.DecodingError
+              |""".stripMargin
+          else ""}${if (
+            interfaces.nonEmpty || objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty
+          )
+            """import caliban.client.FieldBuilder._
+              |""".stripMargin
+          else
+            ""}${if (
+            enums.nonEmpty || interfaces.nonEmpty || objects.nonEmpty || queries.nonEmpty || mutations.nonEmpty || subscriptions.nonEmpty || inputs.nonEmpty
+          )
+            """import caliban.client._
+              |""".stripMargin
+          else ""}${if (enums.nonEmpty || inputs.nonEmpty)
+            """import caliban.client.__Value._
+              |""".stripMargin
+          else ""}"""
 
       List(objectName -> s"""${packageName.fold("")(p => s"package $p\n\n")}$imports\n
                             |$additionalImportsString

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field + comment.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field + comment.scala
@@ -10,7 +10,7 @@ object Client {
      * name
      */
     @deprecated("blah", "")
-    def name: SelectionBuilder[Character, String] = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
+    def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
     @deprecated("", "")
     def nicknames: SelectionBuilder[Character, List[String]] =
       _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))

--- a/tools/src/test/resources/snapshots/ClientWriterViewSpec/type with more than 22 fields _ function args _ selection args.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterViewSpec/type with more than 22 fields _ function args _ selection args.scala
@@ -130,31 +130,34 @@ object Client {
       User21Selection,
       User22Selection,
       User23Selection
-    ] = SelectionBuilder[Big, BigView[
-      User1Selection,
-      User2Selection,
-      User3Selection,
-      User4Selection,
-      User5Selection,
-      User6Selection,
-      User7Selection,
-      User8Selection,
-      User9Selection,
-      User10Selection,
-      User11Selection,
-      User12Selection,
-      User13Selection,
-      User14Selection,
-      User15Selection,
-      User16Selection,
-      User17Selection,
-      User18Selection,
-      User19Selection,
-      User20Selection,
-      User21Selection,
-      User22Selection,
-      User23Selection
-    ]]
+    ] = SelectionBuilder[
+      Big,
+      BigView[
+        User1Selection,
+        User2Selection,
+        User3Selection,
+        User4Selection,
+        User5Selection,
+        User6Selection,
+        User7Selection,
+        User8Selection,
+        User9Selection,
+        User10Selection,
+        User11Selection,
+        User12Selection,
+        User13Selection,
+        User14Selection,
+        User15Selection,
+        User16Selection,
+        User17Selection,
+        User18Selection,
+        User19Selection,
+        User20Selection,
+        User21Selection,
+        User22Selection,
+        User23Selection
+      ]
+    ]
 
     def view[
       User1Selection,

--- a/tools/src/test/scala/caliban/tools/CodegenSpec.scala
+++ b/tools/src/test/scala/caliban/tools/CodegenSpec.scala
@@ -8,7 +8,7 @@ object CodegenSpec extends ZIOSpecDefault {
   override def spec =
     suite("CodegenSpec")(
       test("Package name is empty or default if path doesn't follow correct format") {
-        assertTrue(packageAndObject("a/b/c", None, None) == None                       -> "Client") &&
+        assertTrue(packageAndObject("a/b/c", None, None) == None -> "Client") &&
         assertTrue(packageAndObject("a/b/c", Some("package"), None) == Some("package") -> "Client")
       },
       test("Package name is extracted correctly when set") {
@@ -30,21 +30,21 @@ object CodegenSpec extends ZIOSpecDefault {
         )
       },
       test("Package name is extracted correctly for play and app") {
-        assertTrue(packageAndObject("app/dirA/dirB/model.scala", None, None) == Some("dirA.dirB")  -> "model") &&
+        assertTrue(packageAndObject("app/dirA/dirB/model.scala", None, None) == Some("dirA.dirB") -> "model") &&
         assertTrue(packageAndObject("play/dirA/dirB/model.scala", None, None) == Some("dirA.dirB") -> "model") &&
         assertTrue(
           packageAndObject("play/src/main/scala/dirA/dirB/model.scala", None, None) == Some("dirA.dirB") -> "model"
         )
       },
       test("Object name is extracted correctly when package is missing") {
-        assertTrue(packageAndObject("a/b/c/src/main/scala/model.scala", None, None) == None              -> "model") &&
+        assertTrue(packageAndObject("a/b/c/src/main/scala/model.scala", None, None) == None -> "model") &&
         assertTrue(
           packageAndObject("a/b/c/src/main/scala/model.scala", Some("package"), None) == Some("package") -> "model"
         )
       },
       test("Object name is set to passed value") {
         assertTrue(packageAndObject("src/main/scala/client.scala", None, Some("model")) == None -> "model") &&
-        assertTrue(packageAndObject("", None, Some("model")) == None                            -> "model")
+        assertTrue(packageAndObject("", None, Some("model")) == None -> "model")
       }
     )
 


### PR DESCRIPTION
#2215 won't build until there is a newer scalafmt, because of some quote/splice syntax.

I think most of the changes are for the worse - would you be willing to remove the `align.preset = most` from `.scalafmt`?
If you think it's a good idea I'll push a new PR with a commit doing just that.
