### PR TITLE
Allow excluding fields on input objects via transformers

### DIFF
--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -149,6 +149,15 @@ case class __Type(
       case __TypeKind.INTERFACE | __TypeKind.UNION => possibleTypes.fold(Set.empty[String])(_.flatMap(_.name).toSet)
       case _                                       => Set.empty
     }
+
+  private[caliban] def mapInnerType(f: __Type => __Type): __Type = {
+    def loop(t: __Type): __Type =
+      t.ofType match {
+        case None     => f(t)
+        case Some(t0) => t.copy(ofType = Some(loop(t0)))
+      }
+    loop(self)
+  }
 }
 
 sealed trait TypeVisitor { self =>

--- a/core/src/main/scala/caliban/transformers/Transformer.scala
+++ b/core/src/main/scala/caliban/transformers/Transformer.scala
@@ -229,7 +229,7 @@ object Transformer {
 
     /**
      * A transformer that allows excluding arguments from fields.
-     * Note that the field must be nullable, otherwise the filter will be silently ignored
+     * Note that the argument must be optional, otherwise the filter will be silently ignored
      *
      * {{{
      *   ExcludeArgument(

--- a/core/src/main/scala/caliban/transformers/Transformer.scala
+++ b/core/src/main/scala/caliban/transformers/Transformer.scala
@@ -244,7 +244,7 @@ object Transformer {
      *   ExcludeArgument("TypeA" -> "fieldA" -> "nested.arg")
      * }}}
      *
-     * '''WARNING''': Excluding arguments from inputs might is an experimental feature and might lead to unexpected behavior.
+     * '''WARNING''': Excluding arguments from inputs is an experimental feature and might lead to unexpected behavior.
      *                Use with extreme care.
      *
      * @param f tuples in the format of `(TypeName -> fieldName -> argumentToBeExcluded)`

--- a/core/src/test/scala/caliban/transformers/TransformerSpec.scala
+++ b/core/src/test/scala/caliban/transformers/TransformerSpec.scala
@@ -104,16 +104,16 @@ object TransformerSpec extends ZIOSpecDefault {
               |}""".stripMargin
         )
       },
-      test("filter field on input object") {
+      test("exclude field from input object") {
         case class Nested(a: String, b: Option[String], c: String)
         case class Args(a: String, b: String, l: List[String], nested: Nested)
         case class Query(foo: Args => String)
         val api: GraphQL[Any] = graphQL(RootResolver(Query(_ => "value")))
 
         val transformed: GraphQL[Any] = api.transform(
-          Transformer.ExcludeArgument(
-            "Query" -> "foo" -> "nested.b",
-            "Query" -> "foo" -> "nested.c" // Must not be filtered since it's non-nullable!
+          Transformer.ExcludeInputField(
+            "NestedInput" -> "b",
+            "NestedInput" -> "c" // non-nullable field can't be removed
           )
         )
 


### PR DESCRIPTION
~~Gave it a go with being able to exclude nested arguments. Added and existing tests seem to be passing.~~

~~@ghostdogpr what do you think of this approach? The one downside is that we're not doing the same for execution; validation should take care of it. It's only a problem in cases that validation isn't enabled~~

EDIT: Went with a different approach afterall. Instead of excluding nested arguments (which is really tricky because you have to make sure to exclude them from everywhere that the input type is used), instead I added a new transformer that allows excluding fields from input objects. The code is much cleaner and easier to reason with