### PR TITLE
Remove unneccessary inheritance in `__DeprecatedArgs`

### DIFF
--- a/core/src/main/scala/caliban/introspection/adt/__DeprecatedArgs.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__DeprecatedArgs.scala
@@ -1,13 +1,7 @@
 package caliban.introspection.adt
 
-import scala.runtime.AbstractFunction1
-
 case class __DeprecatedArgs(includeDeprecated: Option[Boolean] = None)
 
-// NOTE: This object extends AbstractFunction1 to maintain binary compatibility for Scala 2.13.
-// TODO: Remove inheritance in the next major version
-object __DeprecatedArgs extends AbstractFunction1[Option[Boolean], __DeprecatedArgs] {
+object __DeprecatedArgs {
   val include: __DeprecatedArgs = __DeprecatedArgs(Some(true))
-
-  def apply(v: Option[Boolean] = None): __DeprecatedArgs = new __DeprecatedArgs(v)
 }


### PR DESCRIPTION
This was needed in a previous patch release to make MiMa happy and forgot to remove it in 2.6.0.

Since we're going for a majr release next, we can now remove that