### PR TITLE
Temporary fix for zio-http flaky tests

### DIFF
--- a/adapters/quick/src/test/scala/caliban/QuickAdapterSpec.scala
+++ b/adapters/quick/src/test/scala/caliban/QuickAdapterSpec.scala
@@ -6,7 +6,7 @@ import caliban.uploads.Uploads
 import sttp.client3.UriContext
 import zio._
 import zio.http._
-import zio.test.{ Live, ZIOSpecDefault }
+import zio.test.{ Live, TestAspect, ZIOSpecDefault }
 
 import scala.language.postfixOps
 
@@ -39,7 +39,7 @@ object QuickAdapterSpec extends ZIOSpecDefault {
       uri"http://localhost:8090/api/graphql",
       wsUri = Some(uri"ws://localhost:8090/ws/graphql"),
       uploadUri = Some(uri"http://localhost:8090/upload/graphql")
-    )
+    ) @@ TestAspect.blocking // Temporary, remove on next zio-http release
     suite.provideShared(
       apiLayer,
       Scope.default,

--- a/adapters/zio-http/src/test/scala/caliban/ZHttpAdapterSpec.scala
+++ b/adapters/zio-http/src/test/scala/caliban/ZHttpAdapterSpec.scala
@@ -13,7 +13,7 @@ import caliban.uploads.Uploads
 import sttp.client3.UriContext
 import zio._
 import zio.http._
-import zio.test.{ Live, ZIOSpecDefault }
+import zio.test.{ Live, TestAspect, ZIOSpecDefault }
 
 import scala.annotation.nowarn
 import scala.language.postfixOps
@@ -51,7 +51,7 @@ object ZHttpAdapterSpec extends ZIOSpecDefault {
       "ZHttpAdapterSpec",
       uri"http://localhost:8089/api/graphql",
       wsUri = Some(uri"ws://localhost:8089/ws/graphql")
-    )
+    ) @@ TestAspect.blocking // Temporary, remove on next zio-http release
     suite.provideShared(
       apiLayer,
       Scope.default,


### PR DESCRIPTION
Seems that the websocket test suites some times block indefinitely during tests. We wrap them in blocking till it's fixed in zio-http