### PR TITLE
Upgrade default scalafmt config to support scala 3

### DIFF
--- a/tools/src/main/resources/default.scalafmt.conf
+++ b/tools/src/main/resources/default.scalafmt.conf
@@ -1,1 +1,2 @@
-version=2.7.5
+version=3.8.1
+runner.dialect=scala3


### PR DESCRIPTION
The current default doesn't support Scala 3. I think it's okay to use the scala 3 dialect since scala 2 code should still be okay.