### PR TITLE
Parser microoptimizations

### DIFF
--- a/benchmarks/src/main/scala/caliban/ComplexQueryBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/ComplexQueryBenchmark.scala
@@ -58,97 +58,94 @@ class ComplexQueryBenchmark {
 }
 
 object ComplexQueryBenchmark {
-  val fullIntrospectionQuery = """
-              query IntrospectionQuery {
-                __schema {
-                  queryType { name }
-                  mutationType { name }
-                  subscriptionType { name }
-                  types {
-                    ...FullType
-                  }
-                  directives {
-                    name
-                    description
-                    locations
-                    args {
-                      ...InputValue
-                    }
-                  }
-                }
-              }
-
-              fragment FullType on __Type {
-                kind
-                name
-                description
-                fields(includeDeprecated: true) {
-                  name
-                  description
-                  args {
-                    ...InputValue
-                  }
-                  type {
-                    ...TypeRef
-                  }
-                  isDeprecated
-                  deprecationReason
-                }
-                inputFields {
-                  ...InputValue
-                }
-                interfaces {
-                  ...TypeRef
-                }
-                enumValues(includeDeprecated: true) {
-                  name
-                  description
-                  isDeprecated
-                  deprecationReason
-                }
-                possibleTypes {
-                  ...TypeRef
-                }
-              }
-
-              fragment InputValue on __InputValue {
-                name
-                description
-                type { ...TypeRef }
-                defaultValue
-              }
-
-              fragment TypeRef on __Type {
-                kind
-                name
-                ofType {
-                  kind
-                  name
-                  ofType {
-                    kind
-                    name
-                    ofType {
-                      kind
-                      name
-                      ofType {
-                        kind
-                        name
-                        ofType {
-                          kind
-                          name
-                          ofType {
-                            kind
-                            name
-                            ofType {
-                              kind
-                              name
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-                """
+  val fullIntrospectionQuery =
+    """query IntrospectionQuery {
+      |  __schema {
+      |    queryType { name }
+      |    mutationType { name }
+      |    subscriptionType { name }
+      |    types {
+      |      ...FullType
+      |    }
+      |    directives {
+      |      name
+      |      description
+      |      locations
+      |      args {
+      |        ...InputValue
+      |      }
+      |    }
+      |  }
+      |}
+      |fragment FullType on __Type {
+      |  kind
+      |  name
+      |  description
+      |  fields(includeDeprecated: true) {
+      |    name
+      |    description
+      |    args {
+      |      ...InputValue
+      |    }
+      |    type {
+      |      ...TypeRef
+      |    }
+      |    isDeprecated
+      |    deprecationReason
+      |  }
+      |  inputFields {
+      |    ...InputValue
+      |  }
+      |  interfaces {
+      |    ...TypeRef
+      |  }
+      |  enumValues(includeDeprecated: true) {
+      |    name
+      |    description
+      |    isDeprecated
+      |    deprecationReason
+      |  }
+      |  possibleTypes {
+      |    ...TypeRef
+      |  }
+      |}
+      |fragment InputValue on __InputValue {
+      |  name
+      |  description
+      |  type { ...TypeRef }
+      |  defaultValue
+      |}
+      |fragment TypeRef on __Type {
+      |  kind
+      |  name
+      |  ofType {
+      |    kind
+      |    name
+      |    ofType {
+      |      kind
+      |      name
+      |      ofType {
+      |        kind
+      |        name
+      |        ofType {
+      |          kind
+      |          name
+      |          ofType {
+      |            kind
+      |            name
+      |            ofType {
+      |              kind
+      |              name
+      |              ofType {
+      |                kind
+      |                name
+      |              }
+      |            }
+      |          }
+      |        }
+      |      }
+      |    }
+      |  }
+      |}
+      |""".stripMargin
 }

--- a/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
@@ -13,9 +13,6 @@ import caliban.parsing.adt.Type._
 import caliban.parsing.adt._
 import fastparse._
 
-import scala.annotation.nowarn
-
-@nowarn("msg=NoWhitespace") // False positive warning in Scala 2.x
 object Parsers extends SelectionParsers {
   def argumentDefinition(implicit ev: P[Any]): P[InputValueDefinition]        =
     (stringValue.? ~ name ~ ":" ~ type_ ~ defaultValue.? ~ directives.?).map {
@@ -348,7 +345,7 @@ object Parsers extends SelectionParsers {
     schemaExtension | typeExtension
 
   def definition(implicit ev: P[Any]): P[Definition] =
-    executableDefinition | typeSystemDefinition | typeSystemExtension
+    typeSystemDefinition | typeSystemExtension
 
   def document(implicit ev: P[Any]): P[ParsedDocument] =
     ((Start ~ executableDefinition.rep ~ End) | (Start ~ definition.rep ~ End)).map(seq => ParsedDocument(seq.toList))

--- a/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
@@ -348,7 +348,7 @@ object Parsers extends SelectionParsers {
     schemaExtension | typeExtension
 
   def definition(implicit ev: P[Any]): P[Definition] =
-    typeSystemDefinition | typeSystemExtension
+    executableDefinition | typeSystemDefinition | typeSystemExtension
 
   def document(implicit ev: P[Any]): P[ParsedDocument] =
     ((Start ~ executableDefinition.rep ~ End) | (Start ~ definition.rep ~ End)).map(seq => ParsedDocument(seq.toList))

--- a/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
@@ -13,6 +13,9 @@ import caliban.parsing.adt.Type._
 import caliban.parsing.adt._
 import fastparse._
 
+import scala.annotation.nowarn
+
+@nowarn("msg=NoWhitespace") // False positive warning in Scala 2.12.x
 object Parsers extends SelectionParsers {
   def argumentDefinition(implicit ev: P[Any]): P[InputValueDefinition]        =
     (stringValue.? ~ name ~ ":" ~ type_ ~ defaultValue.? ~ directives.?).map {

--- a/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
@@ -6,6 +6,9 @@ import caliban.parsing.adt.Type._
 import caliban.parsing.adt._
 import fastparse._
 
+import scala.annotation.nowarn
+
+@nowarn("msg=NoWhitespace") // False positive warning in Scala 2.12.x
 private[caliban] trait SelectionParsers extends ValueParsers {
 
   def aliasOrName(implicit ev: P[Any]): P[String] = ":" ~/ name

--- a/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/SelectionParsers.scala
@@ -6,13 +6,8 @@ import caliban.parsing.adt.Type._
 import caliban.parsing.adt._
 import fastparse._
 
-import scala.annotation.nowarn
-
-@nowarn("msg=NoWhitespace") // False positive warning in Scala 2.x
 private[caliban] trait SelectionParsers extends ValueParsers {
 
-  @deprecated("Kept for bincompat only, scheduled to be removed")
-  def alias(implicit ev: P[Any]): P[String]       = name ~ ":"
   def aliasOrName(implicit ev: P[Any]): P[String] = ":" ~/ name
 
   def argument(implicit ev: P[Any]): P[(String, InputValue)]     = name ~ ":" ~ value
@@ -30,19 +25,13 @@ private[caliban] trait SelectionParsers extends ValueParsers {
   def namedType(implicit ev: P[Any]): P[NamedType] = name.filter(_ != "null").map(NamedType(_, nonNull = false))
   def listType(implicit ev: P[Any]): P[ListType]   = ("[" ~ type_ ~ "]").map(t => ListType(t, nonNull = false))
 
-  @deprecated("Kept for bincompat only, scheduled to be removed")
-  def nonNullType(implicit ev: P[Any]): P[Type] = ((namedType | listType) ~ "!").map {
-    case t: NamedType => t.copy(nonNull = true)
-    case t: ListType  => t.copy(nonNull = true)
-  }
-
   def type_(implicit ev: P[Any]): P[Type] = ((namedType | listType) ~ "!".!.?).map {
     case (t: NamedType, nn) => if (nn.isDefined) t.copy(nonNull = true) else t
     case (t: ListType, nn)  => if (nn.isDefined) t.copy(nonNull = true) else t
   }
 
   def field(implicit ev: P[Any]): P[Field] =
-    (Index ~ name ~ aliasOrName.? ~ arguments.? ~ directives.? ~ selectionSet.?).map {
+    (Index ~~ name ~ aliasOrName.? ~ arguments.? ~ directives.? ~ selectionSet.?).map {
       case (index, alias, Some(name), args, dirs, sels) =>
         Field(Some(alias), name, args.getOrElse(Map()), dirs.getOrElse(Nil), sels.getOrElse(Nil), index)
       case (index, name, _, args, dirs, sels)           =>

--- a/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
@@ -57,7 +57,7 @@ private[caliban] trait StringParsers {
 
   def sourceCharacter(implicit ev: P[Any]): P[Unit]                      = CharIn("\u0009\u000A\u000D\u0020-\uFFFF")
   def sourceCharacterWithoutLineTerminator(implicit ev: P[Any]): P[Unit] = CharIn("\u0009\u0020-\uFFFF")
-  def name(implicit ev: P[Any]): P[String]                               = (CharIn("_A-Za-z") ~~ CharIn("_0-9A-Za-z").repX).!
+  def name(implicit ev: P[Any]): P[String]                               = !CharIn("0-9") ~~ CharsWhileIn("_0-9A-Za-z", 1).!
   def nameOnly(implicit ev: P[Any]): P[String]                           = Start ~ name ~ End
 
   def hexDigit(implicit ev: P[Any]): P[Unit]         = CharIn("0-9a-fA-F")

--- a/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
@@ -57,7 +57,12 @@ private[caliban] trait StringParsers {
 
   def sourceCharacter(implicit ev: P[Any]): P[Unit]                      = CharIn("\u0009\u000A\u000D\u0020-\uFFFF")
   def sourceCharacterWithoutLineTerminator(implicit ev: P[Any]): P[Unit] = CharIn("\u0009\u0020-\uFFFF")
-  def name(implicit ev: P[Any]): P[String]                               = !CharIn("0-9") ~~ CharsWhileIn("_0-9A-Za-z", 1).!
+  def name(implicit ev: P[Any]): P[String]                               =
+    CharsWhileIn("_0-9A-Za-z", 1).!.flatMap { s =>
+      // Less efficient in case of an error, but more efficient in case of success (happy path)
+      if (s.charAt(0) <= '9') ev.freshFailure()
+      else ev.freshSuccess(s)
+    }
   def nameOnly(implicit ev: P[Any]): P[String]                           = Start ~ name ~ End
 
   def hexDigit(implicit ev: P[Any]): P[Unit]         = CharIn("0-9a-fA-F")

--- a/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
@@ -5,9 +5,6 @@ import caliban.InputValue._
 import caliban.Value._
 import fastparse._
 
-import scala.annotation.nowarn
-
-@nowarn("msg=NoWhitespace") // False positive warning in Scala 2.x
 private[caliban] trait ValueParsers extends NumberParsers {
   def booleanValue(implicit ev: P[Any]): P[BooleanValue] =
     StringIn("true", "false").!.map(v => BooleanValue(v.toBoolean))

--- a/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
@@ -5,6 +5,9 @@ import caliban.InputValue._
 import caliban.Value._
 import fastparse._
 
+import scala.annotation.nowarn
+
+@nowarn("msg=NoWhitespace") // False positive warning in Scala 2.12.x
 private[caliban] trait ValueParsers extends NumberParsers {
   def booleanValue(implicit ev: P[Any]): P[BooleanValue] =
     StringIn("true", "false").!.map(v => BooleanValue(v.toBoolean))


### PR DESCRIPTION
I was implementing a parser using fastparse today at $WORK and found out that `CharsWhileIn("xx", minChars)` is _much_ more efficient than using `.repX`. With these changes we get ~5-10% performance increase in our ParserBenchmark.

Note that I also changed the `fullIntrospectionQuery` val to strip the margins of the query. I realised that we were benchmarking too heavily the whitespace parser