### PR TITLE
Fix IDE settings for apollo-compatibility module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -606,7 +606,7 @@ lazy val apolloCompatibility =
     )
     .settings(
       skip                                                 := (scalaVersion.value == scala212),
-      ideSkipProject                                       := (scalaVersion.value != scala212),
+      ideSkipProject                                       := (scalaVersion.value == scala212),
       crossScalaVersions                                   := Seq(scala213, scala3),
       libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % "always"
     )


### PR DESCRIPTION
I realised that code highlighting wasn't working for the `apollo-compatibility` module; seems that it was accidentally excluded for Scala 2.13 and 3