### PR TITLE
Micro-optimize usages of Configurator

### DIFF
--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -26,7 +26,7 @@ final private class QuickRequestHandler[R](
 
   def configure(config: ExecutionConfiguration)(implicit trace: Trace): QuickRequestHandler[R] =
     new QuickRequestHandler[R](
-      interpreter.wrapExecutionWith[R, Any](Configurator.setWith(config)(_)),
+      interpreter.wrapExecutionWith[R, Any](Configurator.ref.locally(config)(_)),
       wsConfig
     )
 

--- a/adapters/quick/src/main/scala/caliban/quick/package.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/package.scala
@@ -152,7 +152,7 @@ package object quick {
       val run: RIO[R, Nothing] =
         QuickAdapter(interpreter)
           .runServer(port, apiPath, graphiqlPath, uploadPath)
-          .provideSomeLayer[R](ZLayer.scoped[Any](Configurator.set(executionConfig)))
+          .provideSomeLayer[R](ZLayer.scoped[Any](Configurator.ref.locallyScoped(executionConfig)))
 
       ZIOApp.fromZIO(run.asInstanceOf[RIO[Any, Nothing]]).main(Array.empty)
     }

--- a/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/execution/NestedZQueryBenchmark.scala
@@ -89,7 +89,7 @@ class NestedZQueryBenchmark {
   def simpleParallelQuery100(): Any = {
     val io =
       simple100
-        .wrapExecutionWith(Configurator.setWith(parallel)(_))
+        .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -98,7 +98,7 @@ class NestedZQueryBenchmark {
   def simpleParallelQuery1000(): Any = {
     val io =
       simple1000
-        .wrapExecutionWith(Configurator.setWith(parallel)(_))
+        .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -107,7 +107,7 @@ class NestedZQueryBenchmark {
   def simpleParallelQuery10000(): Any = {
     val io =
       simple10000
-        .wrapExecutionWith(Configurator.setWith(parallel)(_))
+        .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -116,7 +116,7 @@ class NestedZQueryBenchmark {
   def simpleSequentialQuery100(): Any = {
     val io =
       simple100
-        .wrapExecutionWith(Configurator.setWith(sequential)(_))
+        .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -125,7 +125,7 @@ class NestedZQueryBenchmark {
   def simpleSequentialQuery1000(): Any = {
     val io =
       simple1000
-        .wrapExecutionWith(Configurator.setWith(sequential)(_))
+        .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -134,7 +134,7 @@ class NestedZQueryBenchmark {
   def simpleSequentialQuery10000(): Any = {
     val io =
       simple10000
-        .wrapExecutionWith(Configurator.setWith(sequential)(_))
+        .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -143,7 +143,7 @@ class NestedZQueryBenchmark {
   def simpleBatchedQuery100(): Any = {
     val io =
       simple100
-        .wrapExecutionWith(Configurator.setWith(batched)(_))
+        .wrapExecutionWith(Configurator.ref.locally(batched)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -152,7 +152,7 @@ class NestedZQueryBenchmark {
   def simpleBatchedQuery1000(): Any = {
     val io =
       simple1000
-        .wrapExecutionWith(Configurator.setWith(batched)(_))
+        .wrapExecutionWith(Configurator.ref.locally(batched)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -161,7 +161,7 @@ class NestedZQueryBenchmark {
   def simpleBatchedQuery10000(): Any = {
     val io =
       simple10000
-        .wrapExecutionWith(Configurator.setWith(batched)(_))
+        .wrapExecutionWith(Configurator.ref.locally(batched)(_))
         .execute(simpleQuery)
     run(io)
   }
@@ -169,7 +169,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldParallelQuery100(): Any = {
     val io = multifield100
-      .wrapExecutionWith(Configurator.setWith(parallel)(_))
+      .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -177,7 +177,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldParallelQuery1000(): Any = {
     val io = multifield1000
-      .wrapExecutionWith(Configurator.setWith(parallel)(_))
+      .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -185,7 +185,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldParallelQuery10000(): Any = {
     val io = multifield10000
-      .wrapExecutionWith(Configurator.setWith(parallel)(_))
+      .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -193,7 +193,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldSequentialQuery100(): Any = {
     val io = multifield100
-      .wrapExecutionWith(Configurator.setWith(sequential)(_))
+      .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -201,7 +201,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldSequentialQuery1000(): Any = {
     val io = multifield1000
-      .wrapExecutionWith(Configurator.setWith(sequential)(_))
+      .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -209,7 +209,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldSequentialQuery10000(): Any = {
     val io = multifield10000
-      .wrapExecutionWith(Configurator.setWith(sequential)(_))
+      .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -217,7 +217,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldBatchedQuery100(): Any = {
     val io = multifield100
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -225,7 +225,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldBatchedQuery1000(): Any = {
     val io = multifield1000
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -233,7 +233,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def multifieldBatchedQuery10000(): Any = {
     val io = multifield10000
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -241,7 +241,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def deepParallelQuery100(): Any = {
     val io = deep100
-      .wrapExecutionWith(Configurator.setWith(parallel)(_))
+      .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
       .execute(deepQuery)
     run(io)
   }
@@ -249,7 +249,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def deepParallelQuery1000(): Any = {
     val io = deep1000
-      .wrapExecutionWith(Configurator.setWith(parallel)(_))
+      .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
       .execute(deepQuery)
     run(io)
   }
@@ -258,7 +258,7 @@ class NestedZQueryBenchmark {
   def deepParallelQuery10000(): Any = {
     val io =
       deep10000
-        .wrapExecutionWith(Configurator.setWith(parallel)(_))
+        .wrapExecutionWith(Configurator.ref.locally(parallel)(_))
         .execute(deepQuery)
     run(io)
   }
@@ -267,7 +267,7 @@ class NestedZQueryBenchmark {
   def deepSequentialQuery100(): Any = {
     val io =
       deep100
-        .wrapExecutionWith(Configurator.setWith(sequential)(_))
+        .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
         .execute(deepQuery)
     run(io)
   }
@@ -276,7 +276,7 @@ class NestedZQueryBenchmark {
   def deepSequentialQuery1000(): Any = {
     val io =
       deep1000
-        .wrapExecutionWith(Configurator.setWith(sequential)(_))
+        .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
         .execute(deepQuery)
     run(io)
   }
@@ -285,7 +285,7 @@ class NestedZQueryBenchmark {
   def deepSequentialQuery10000(): Any = {
     val io =
       deep10000
-        .wrapExecutionWith(Configurator.setWith(sequential)(_))
+        .wrapExecutionWith(Configurator.ref.locally(sequential)(_))
         .execute(deepQuery)
     run(io)
   }
@@ -293,7 +293,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def deepBatchedQuery100(): Any = {
     val io = deep100
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(deepQuery)
     run(io)
   }
@@ -301,7 +301,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def deepBatchedQuery1000(): Any = {
     val io = deep1000
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(deepQuery)
     run(io)
   }
@@ -309,7 +309,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def deepBatchedQuery10000(): Any = {
     val io = deep10000
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(deepQuery)
     run(io)
   }
@@ -317,7 +317,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def noWrappersBenchmark(): Any = {
     val io = multifield1000
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -325,7 +325,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def apolloTracingBenchmark(): Any = {
     val io = apolloInterpreter
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(multifieldQuery)
     run(io)
   }
@@ -333,7 +333,7 @@ class NestedZQueryBenchmark {
   @Benchmark
   def metricsBenchmark(): Any = {
     val io = metricsInterpreter
-      .wrapExecutionWith(Configurator.setWith(batched)(_))
+      .wrapExecutionWith(Configurator.ref.locally(batched)(_))
       .execute(multifieldQuery)
     run(io)
   }

--- a/core/src/main/scala/caliban/HttpRequestMethod.scala
+++ b/core/src/main/scala/caliban/HttpRequestMethod.scala
@@ -1,7 +1,8 @@
 package caliban
 
 import caliban.CalibanError.ValidationError
-import zio.{ FiberRef, Scope, UIO, URIO, Unsafe, ZIO }
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.{ FiberRef, Trace, Unsafe, ZIO }
 
 private[caliban] sealed trait HttpRequestMethod
 
@@ -13,9 +14,10 @@ private[caliban] object HttpRequestMethod {
 
   private val fiberRef: FiberRef[HttpRequestMethod] = Unsafe.unsafe(implicit u => FiberRef.unsafe.make(POST))
 
-  val get: UIO[HttpRequestMethod] = fiberRef.get
+  def getWith[R, E, A](zio: HttpRequestMethod => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+    fiberRef.getWith(zio)
 
-  def setWith[R, E, B](method: HttpRequestMethod)(zio: ZIO[R, E, B]): ZIO[R, E, B] =
+  def setWith[R, E, B](method: HttpRequestMethod)(zio: ZIO[R, E, B])(implicit trace: Trace): ZIO[R, E, B] =
     method match {
       case POST => zio
       case GET  => fiberRef.locally(method)(zio)

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -52,8 +52,7 @@ object Validator {
    * Verifies that the given document is valid for this type. Fails with a [[caliban.CalibanError.ValidationError]] otherwise.
    */
   def validate(document: Document, rootType: RootType)(implicit trace: Trace): IO[ValidationError, Unit] =
-    Configurator.configuration
-      .flatMap(v => ZIO.fromEither(check(document, rootType, Map.empty, v.validations).map(_ => ())))
+    Configurator.ref.getWith(v => ZIO.fromEither(check(document, rootType, Map.empty, v.validations).map(_ => ())))
 
   /**
    * Verifies that the given schema is valid. Fails with a [[caliban.CalibanError.ValidationError]] otherwise.

--- a/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
@@ -62,7 +62,7 @@ object ApolloPersistedQueries {
       ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
         (doc: Document) =>
           docVar.await.flatMap {
-            case Some((_, Some(_))) => Configurator.locallyWith(_.copy(skipValidation = true))(f(doc))
+            case Some((_, Some(_))) => Configurator.ref.locallyWith(_.copy(skipValidation = true))(f(doc))
             case Some((hash, None)) => f(doc) <* ApolloPersistence.add(hash, doc)
             case None               => f(doc)
           }

--- a/core/src/main/scala/caliban/wrappers/CostEstimation.scala
+++ b/core/src/main/scala/caliban/wrappers/CostEstimation.scala
@@ -190,7 +190,7 @@ object CostEstimation {
       ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
         (doc: Document) =>
           process(doc).tap { req =>
-            ZIO.unlessZIO(ZIO.succeed(skipForPersistedQueries) && Configurator.configuration.map(_.skipValidation)) {
+            ZIO.unlessZIO(ZIO.succeed(skipForPersistedQueries) && Configurator.skipValidation) {
               val cost = computeCost(req.field)(f)
               ZIO.when(cost > maxCost)(ZIO.fail(error(cost)))
             }
@@ -213,7 +213,7 @@ object CostEstimation {
       ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
         (doc: Document) =>
           process(doc).tap { req =>
-            ZIO.unlessZIO(ZIO.succeed(skipForPersistedQueries) && Configurator.configuration.map(_.skipValidation)) {
+            ZIO.unlessZIO(ZIO.succeed(skipForPersistedQueries) && Configurator.skipValidation) {
               computeCostZIO(req.field)(f).flatMap { cost =>
                 ZIO.when(cost > maxCost)(
                   ZIO.fail(ValidationError(s"Query costs too much: $cost. Max cost: $maxCost.", ""))

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -109,7 +109,7 @@ object Wrappers {
       ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
         (doc: Document) =>
           process(doc).tap { req =>
-            ZIO.unlessZIO(Configurator.configuration.map(_.skipValidation)) {
+            ZIO.unlessZIO(Configurator.skipValidation) {
               calculateDepth(req.field).flatMap { depth =>
                 ZIO.when(depth > maxDepth)(
                   ZIO.fail(ValidationError(s"Query is too deep: $depth. Max depth: $maxDepth.", ""))
@@ -141,7 +141,7 @@ object Wrappers {
       ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
         (doc: Document) =>
           process(doc).tap { req =>
-            ZIO.unlessZIO(Configurator.configuration.map(_.skipValidation)) {
+            ZIO.unlessZIO(Configurator.skipValidation) {
               countFields(req.field).flatMap { fields =>
                 ZIO.when(fields > maxFields)(
                   ZIO.fail(ValidationError(s"Query has too many fields: $fields. Max fields: $maxFields.", ""))

--- a/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
+++ b/core/src/test/scala/caliban/wrappers/WrappersSpec.scala
@@ -301,7 +301,7 @@ object WrappersSpec extends ZIOSpecDefault {
           ): Document => ZIO[R1, ValidationError, ExecutionRequest] =
             (doc: Document) =>
               f(doc) <* {
-                ZIO.unlessZIO(Configurator.configuration.map(_.skipValidation)) {
+                ZIO.unlessZIO(Configurator.skipValidation) {
                   ZIO.whenZIO(fail.get)(ZIO.fail(ValidationError("boom", "boom")))
                 }
               }


### PR DESCRIPTION
Just some small cleanups  / micro-optimizations that have been bugging me for a while.

1. Make `Configurator.ref` package-private so that we can use it directly across the codebase without creating proxy methods
2. Use `FiberRef#getWith` instead of `FiberRef.get.flatMap`
