### PR TITLE
`ExcludeArgument` transformer shouldn't exclude non-nullable arguments

### DIFF
--- a/core/src/main/scala/caliban/introspection/adt/__Field.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Field.scala
@@ -35,4 +35,7 @@ case class __Field(
     args(__DeprecatedArgs.include)
 
   private[caliban] lazy val _type: __Type = `type`()
+
+  private[caliban] lazy val allArgNames: Set[String] =
+    allArgs.view.map(_.name).toSet
 }

--- a/core/src/main/scala/caliban/transformers/Transformer.scala
+++ b/core/src/main/scala/caliban/transformers/Transformer.scala
@@ -1,6 +1,5 @@
 package caliban.transformers
 
-import caliban.CalibanError.ValidationError
 import caliban.InputValue
 import caliban.execution.Field
 import caliban.introspection.adt._


### PR DESCRIPTION
There is a small bug in the `ExcludeArgument` that allows excluding non-nullable arguments, which then leads to a runtime error when a non-nullable argument is excluded from a field

While the bug can be quite bad, since we only just released Transformers and adding an exclusion on a non-nullable argument is to some degree a user error as well, I don't think we need to create a patch release immediately