### PR TITLE
Only run compatibility checks when certain paths change

### DIFF
--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - series/2.x
+    paths:
+      - apollo-compatibility/**
+      - federation/**
+      - adapters/quick/**
 
 jobs:
   compatibility:


### PR DESCRIPTION
Federation checks are likely not needed for every change. We should only run the compat checks for specific path changes (specifically the components that could alter the outcome of the compatibility).