### PR TITLE
Reduce derivation codegen size for Scala 3

### DIFF
--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -12,7 +12,7 @@ import scala.deriving.Mirror
 import scala.util.NotGiven
 
 trait CommonArgBuilderDerivation {
-  inline def recurseSum[P, Label, A <: Tuple](
+  transparent inline def recurseSum[P, Label <: Tuple, A <: Tuple](
     inline values: List[(String, List[Any], ArgBuilder[Any])] = Nil
   ): List[(String, List[Any], ArgBuilder[Any])] =
     inline erasedValue[(Label, A)] match {
@@ -36,7 +36,7 @@ trait CommonArgBuilderDerivation {
         }
     }
 
-  inline def recurseProduct[P, Label, A <: Tuple](
+  transparent inline def recurseProduct[P, Label <: Tuple, A <: Tuple](
     inline values: List[(String, ArgBuilder[Any])] = Nil
   ): List[(String, ArgBuilder[Any])] =
     inline erasedValue[(Label, A)] match {

--- a/core/src/main/scala-3/caliban/schema/ObjectSchema.scala
+++ b/core/src/main/scala-3/caliban/schema/ObjectSchema.scala
@@ -8,7 +8,7 @@ import scala.annotation.threadUnsafe
 import scala.reflect.ClassTag
 
 final private class ObjectSchema[R, A](
-  _constructorFields: => List[(String, Schema[R, Any], Int)],
+  _constructorFields: => List[ProductFieldInfo[R]],
   _methodFields: => List[(String, List[Any], Schema[R, ?])],
   info: TypeInfo,
   anns: List[Any],
@@ -19,7 +19,7 @@ final private class ObjectSchema[R, A](
 
   @threadUnsafe
   private lazy val fields = {
-    val fromConstructor = _constructorFields.view.map { (label, schema, index) =>
+    val fromConstructor = _constructorFields.view.map { case ProductFieldInfo(label, schema, index) =>
       val fieldAnns = paramAnnotations.getOrElse(label, Nil)
       ((getName(fieldAnns, label), fieldAnns, schema), Left(index))
     }

--- a/core/src/main/scala-3/caliban/schema/ProductFieldInfo.scala
+++ b/core/src/main/scala-3/caliban/schema/ProductFieldInfo.scala
@@ -1,0 +1,7 @@
+package caliban.schema
+
+private final case class ProductFieldInfo[R](
+  name: String,
+  schema: Schema[R, Any],
+  index: Int
+)

--- a/core/src/main/scala-3/caliban/schema/macros/Macros.scala
+++ b/core/src/main/scala-3/caliban/schema/macros/Macros.scala
@@ -13,7 +13,8 @@ object Macros {
   inline def implicitExists[T]: Boolean     = ${ implicitExistsImpl[T] }
   inline def hasAnnotation[T, Ann]: Boolean = ${ hasAnnotationImpl[T, Ann] }
 
-  inline def fieldsFromMethods[R, T]: List[(String, List[Any], Schema[R, ?])] = ${ fieldsFromMethodsImpl[R, T] }
+  transparent inline def fieldsFromMethods[R, T]: List[(String, List[Any], Schema[R, ?])] =
+    ${ fieldsFromMethodsImpl[R, T] }
 
   /**
    * Tests whether type argument [[FieldT]] in [[Parent]] is annotated with [[GQLExcluded]]


### PR DESCRIPTION
It seems that the recent addition of `semanticNonNull` to SchemaDerivation contributed to an increase in generated code size. While this PR doesn't directly address that, it does produce a smaller codegen output.

Tested using a service at $WORK, the SBT module that contains the caliban schemas results in a JAR of 3.1MB with series/2.x vs 2.1MB with the changes in this PR