### PR TITLE
Add federation 2.8, fix federation v2 introspection

### DIFF
--- a/examples/src/main/resources/gateway_v2/package.json
+++ b/examples/src/main/resources/gateway_v2/package.json
@@ -10,8 +10,8 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@apollo/server": "4.9.5",
-    "@apollo/gateway": "2.6.2",
+    "@apollo/gateway": "2.8.0",
+    "@apollo/server": "4.10.4",
     "graphql": "16.8.1"
   }
 }

--- a/federation/src/main/scala/caliban/federation/package.scala
+++ b/federation/src/main/scala/caliban/federation/package.scala
@@ -4,6 +4,7 @@ import caliban.federation.v2x.{
   FederationDirectivesV2_3,
   FederationDirectivesV2_5,
   FederationDirectivesV2_6,
+  FederationDirectivesV2_8,
   FederationV2,
   Versions
 }
@@ -17,5 +18,7 @@ package object federation {
   lazy val v2_4 = new FederationV2(List(Versions.v2_4)) with FederationDirectivesV2_3
   lazy val v2_5 = new FederationV2(List(Versions.v2_5)) with FederationDirectivesV2_5
   lazy val v2_6 = new FederationV2(List(Versions.v2_6)) with FederationDirectivesV2_6
+  lazy val v2_7 = new FederationV2(List(Versions.v2_7)) with FederationDirectivesV2_6
+  lazy val v2_8 = new FederationV2(List(Versions.v2_8)) with FederationDirectivesV2_8
 
 }

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_8.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_8.scala
@@ -1,0 +1,16 @@
+package caliban.federation.v2x
+
+import caliban.Value.StringValue
+import caliban.parsing.adt.Directive
+import caliban.schema.Annotations.GQLDirective
+
+trait FederationDirectivesV2_8 extends FederationDirectivesV2_6 {
+
+  def Context(context: String) = Directive("context", Map("context" -> StringValue(context)))
+
+  case class GQLContext(context: String) extends GQLDirective(Context(context))
+
+  def FromContext(context: String) = Directive("fromContext", Map("context" -> StringValue(context)))
+
+  case class GQLFromContext(context: String) extends GQLDirective(FromContext(context))
+}

--- a/federation/src/main/scala/caliban/federation/v2x/FederationV2.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationV2.scala
@@ -52,4 +52,14 @@ object FederationV2 {
     `import` = v2_5.`import` :+ Import("@policy")
   )
 
+  private[v2x] val v2_7 = Link(
+    url = s"$federationV2Url/v2.7",
+    `import` = v2_6.`import`
+  )
+
+  private[v2x] val v2_8 = Link(
+    url = s"$federationV2Url/v2.8",
+    `import` = v2_7.`import` :+ Import("@context") :+ Import("@fromContext")
+  )
+
 }

--- a/federation/src/main/scala/caliban/federation/v2x/Versions.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/Versions.scala
@@ -8,5 +8,7 @@ object Versions {
   val v2_4 = FederationV2.v2_4
   val v2_5 = FederationV2.v2_5
   val v2_6 = FederationV2.v2_6
+  val v2_7 = FederationV2.v2_7
+  val v2_8 = FederationV2.v2_8
 
 }

--- a/federation/src/test/scala/caliban/federation/FederationV1Spec.scala
+++ b/federation/src/test/scala/caliban/federation/FederationV1Spec.scala
@@ -150,6 +150,30 @@ object FederationV1Spec extends ZIOSpecDefault {
           )
         )
       }
+    },
+    test("introspection should include _Any and _FieldSet scalars") {
+      val interpreter = (graphQL(resolver) @@ federated(entityResolver)).interpreter
+
+      val query = gqldoc("""{ __schema { types { name } } }""")
+      interpreter
+        .flatMap(_.execute(query))
+        .map(d =>
+          ResponseValue.at(
+            PathValue.Key("__schema") :: PathValue.Key("types") :: PathValue.Key("name") :: Nil
+          )(d.data)
+        )
+        .map(responseValue =>
+          assertTrue(
+            responseValue
+              .is(_.subtype[ListValue])
+              .values
+              .contains(StringValue("_Any")),
+            responseValue
+              .is(_.subtype[ListValue])
+              .values
+              .contains(StringValue("_FieldSet"))
+          )
+        )
     }
   )
 }

--- a/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
+++ b/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
@@ -2,6 +2,7 @@ package caliban.federation.v2x
 
 import caliban.InputValue.{ ListValue, ObjectValue }
 import caliban.Macros.gqldoc
+import caliban.TestUtils._
 import caliban.Value.StringValue
 import caliban.parsing.Parser
 import caliban.parsing.adt.{ Definition, Directive }
@@ -11,7 +12,6 @@ import io.circe.Json
 import io.circe.parser.decode
 import zio.ZIO
 import zio.test.Assertion.{ hasSameElements, isSome }
-import zio.test.{ assertTrue, ZIOSpecDefault }
 import zio.test._
 
 object FederationV2Spec extends ZIOSpecDefault {
@@ -182,6 +182,30 @@ object FederationV2Spec extends ZIOSpecDefault {
             )
           )
         }
+      },
+      test("introspection doesn't contain _FieldSet scalar") {
+        import caliban.federation.v2_8._
+        val interpreter = (graphQL(resolver) @@ federated).interpreter
+        val query       = gqldoc("""{ __schema { types { name } } }""")
+        interpreter
+          .flatMap(_.execute(query))
+          .map(d =>
+            ResponseValue.at(
+              PathValue.Key("__schema") :: PathValue.Key("types") :: PathValue.Key("name") :: Nil
+            )(d.data)
+          )
+          .map(responseValue =>
+            assertTrue(
+              !responseValue
+                .is(_.subtype[ResponseValue.ListValue])
+                .values
+                .contains(StringValue("_Any")),
+              !responseValue
+                .is(_.subtype[ResponseValue.ListValue])
+                .values
+                .contains(StringValue("_FieldSet"))
+            )
+          )
       }
     )
 


### PR DESCRIPTION
Adds support for the new federation [2.8 directives](https://www.apollographql.com/docs/federation/federated-types/federated-directives#saving-and-referencing-data-with-contexts)

Also fixes an issue where the `_FieldSet` type was getting added to the schema in federation v2