### PR TITLE
build.sbt cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,6 @@ inThisBuild(
     organization             := "com.github.ghostdogpr",
     homepage                 := Some(url("https://github.com/ghostdogpr/caliban")),
     licenses                 := List(License.Apache2),
-    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     Test / parallelExecution := false,
     scmInfo                  := Some(
       ScmInfo(
@@ -61,12 +60,7 @@ inThisBuild(
       )
     ),
     versionScheme            := Some("pvp"),
-    ConsoleHelper.welcomeMessage(scala212, scala213, scala3),
-    // See https://github.com/playframework/playframework/issues/11461#issuecomment-1276028512
-    // Can be removed when the entire Scala ecosystem has migrated to Scala 2.12.17+, sbt 1.8.x, and moved away from scala-xml v1 in general.
-    libraryDependencySchemes ++= Seq(
-      "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-    )
+    ConsoleHelper.welcomeMessage(scala212, scala213, scala3)
   )
 )
 
@@ -174,7 +168,6 @@ lazy val core = project
   .settings(enableMimaSettingsJVM)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++=
       Seq(
         "com.lihaoyi"                           %% "fastparse"               % "3.1.0",
@@ -217,7 +210,6 @@ lazy val tools = project
     buildInfoObject  := "BuildInfo"
   )
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "org.scalameta"                  % "scalafmt-interfaces" % scalafmtVersion,
       "io.get-coursier"                % "interface"           % "1.0.19",
@@ -241,7 +233,6 @@ lazy val tracing = project
     buildInfoObject  := "BuildInfo"
   )
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "dev.zio"         %% "zio-opentelemetry"         % zioOpenTelemetryVersion,
       "dev.zio"         %% "zio-test"                  % zioVersion % Test,
@@ -267,7 +258,6 @@ lazy val codegenSbt = project
   .settings(
     sbtPlugin          := true,
     crossScalaVersions := Seq(scala212),
-    testFrameworks     := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio-config"          % zioConfigVersion,
       "dev.zio" %% "zio-config-magnolia" % zioConfigVersion,
@@ -298,7 +288,6 @@ lazy val catsInterop = project
   .settings(enableMimaSettingsJVM)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= {
       if (scalaVersion.value == scala3) Seq()
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.3").cross(CrossVersion.full)))
@@ -334,7 +323,6 @@ lazy val tapirInterop = project
   .settings(enableMimaSettingsJVM)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= {
       if (scalaVersion.value == scala3) Seq()
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.3").cross(CrossVersion.full)))
@@ -358,7 +346,6 @@ lazy val http4s = project
   .settings(enableMimaSettingsJVM)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= {
       if (scalaVersion.value == scala3) Seq()
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.3").cross(CrossVersion.full)))
@@ -386,8 +373,6 @@ lazy val zioHttp = project
   .settings(enableMimaSettingsJVM)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "dev.zio"                     %% "zio-http"              % zioHttpVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server" % tapirVersion,
@@ -404,7 +389,6 @@ lazy val quickAdapter = project
   .settings(enableMimaSettingsJVM)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "dev.zio"                               %% "zio-http"              % zioHttpVersion,
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % jsoniterVersion,
@@ -424,7 +408,6 @@ lazy val akkaHttp = project
     skip           := (scalaVersion.value == scala3),
     ideSkipProject := (scalaVersion.value == scala3),
     crossScalaVersions -= scala3,
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "com.typesafe.akka"             %% "akka-http"                  % "10.2.10",
       "com.typesafe.akka"             %% "akka-serialization-jackson" % akkaVersion,
@@ -442,7 +425,6 @@ lazy val pekkoHttp = project
   .settings(enableMimaSettingsJVM)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= {
       if (scalaVersion.value == scala3) Seq()
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.3").cross(CrossVersion.full)))
@@ -464,7 +446,6 @@ lazy val play = project
     skip           := (scalaVersion.value == scala212),
     ideSkipProject := (scalaVersion.value == scala212),
     crossScalaVersions -= scala212,
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= {
       if (scalaVersion.value == scala3) Seq()
       else Seq(compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.3").cross(CrossVersion.full)))
@@ -488,7 +469,6 @@ lazy val client    = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(commonSettings)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "com.softwaremill.sttp.client3"        %%% "core"                  % sttpVersion,
       "com.softwaremill.sttp.client3"        %%% "jsoniter"              % sttpVersion,
@@ -533,7 +513,6 @@ lazy val clientLaminext = crossProject(JSPlatform)
   .dependsOn(clientJS)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks                         := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) },
     Test / scalaJSLinkerConfig ~= { _.withModuleSplitStyle(ModuleSplitStyle.FewestModules) },
     Test / scalaJSLinkerConfig ~= { _.withSourceMap(false) },
@@ -633,7 +612,6 @@ lazy val reporting = project
   .dependsOn(clientJVM, core)
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "dev.zio"                       %% "zio"          % zioVersion,
       "com.softwaremill.sttp.client3" %% "core"         % sttpVersion,
@@ -680,7 +658,6 @@ lazy val federation = project
   .dependsOn(core % "compile->compile;test->test")
   .disablePlugins(AssemblyPlugin)
   .settings(
-    testFrameworks       := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio"          % zioVersion,
       "dev.zio" %% "zio-test"     % zioVersion % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ inThisBuild(
     organization             := "com.github.ghostdogpr",
     homepage                 := Some(url("https://github.com/ghostdogpr/caliban")),
     licenses                 := List(License.Apache2),
+    // resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     Test / parallelExecution := false,
     scmInfo                  := Some(
       ScmInfo(


### PR DESCRIPTION
Remove explicit ZIO test framework as it is built into sbt.

Remove snapshot resolvers to avoid depending on snapshots.

Remove scala-xml v1 workaround as it is no longer required.