### PR TITLE
Use `AtomicReference` instead of `Ref` in the `Executor`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.typesafe.tools.mima.core.{ DirectMissingMethodProblem, MissingClassProblem, ProblemFilters }
+import com.typesafe.tools.mima.core.*
 import org.scalajs.linker.interface.ModuleSplitStyle
 import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 
@@ -752,7 +752,9 @@ lazy val enableMimaSettingsJVM =
   Def.settings(
     mimaFailOnProblem     := enforceMimaCompatibility,
     mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet,
-    mimaBinaryIssueFilters ++= Seq()
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("caliban.execution.Executor#ReducedStepExecutor.makeQuery")
+    )
   )
 
 lazy val enableMimaSettingsJS =

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -83,7 +83,7 @@ object Executor {
               )
             }
           } else
-            Exit.succeed(GraphQLResponse(result, resultErrors, hasNext = None))
+            ZIO.succeed(GraphQLResponse(result, resultErrors, hasNext = None))
 
         }
     }


### PR DESCRIPTION
Was having a look at the Executor today and realised that we can substitute the `Ref`s for errors / deferred fields with an `AtomicRefererence`. It's mostly a micro-optimization to reduce the number of flatmaps and the ZIO stack depth since they pretty much do the same thing.

Note that MiMa was complaining, but I'm very certain it's a false positive since the class is private within the Executor object