### PR TITLE
Make `allFieldsMap` private on __Type and use an accessor method

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -154,14 +154,15 @@ object Field {
 
       selectionSet.foreach {
         case F(alias, name, arguments, directives, selectionSet, index) =>
-          val selected = innerType.allFieldsMap.get(name)
+          val selected = innerType.getFieldOrNull(name)
 
-          val schemaDirectives   = selected.flatMap(_.directives).getOrElse(Nil)
+          val schemaDirectives   = if (selected eq null) Nil else selected.directives.getOrElse(Nil)
           val resolvedDirectives =
             (directives ::: schemaDirectives).map(resolveDirectiveVariables(variableValues, variableDefinitionsMap))
 
           if (checkDirectives(resolvedDirectives)) {
-            val t = selected.fold(Types.string)(_._type) // default only case where it's not found is __typename
+            // default only case where it's not found is __typename
+            val t = if (selected eq null) Types.string else selected._type
 
             val fields =
               if (selectionSet.nonEmpty) loop(selectionSet, t, None, None, None)

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -135,11 +135,14 @@ case class __Type(
   lazy val allEnumValues: List[__EnumValue] =
     enumValues(__DeprecatedArgs.include).getOrElse(Nil)
 
-  private[caliban] lazy val allFieldsMap: collection.Map[String, __Field] = {
+  private lazy val allFieldsMap = {
     val map = collection.mutable.HashMap.empty[String, __Field]
     allFields.foreach(f => map.update(f.name, f))
     map
   }
+
+  private[caliban] def getFieldOrNull(name: String): __Field =
+    allFieldsMap.getOrElse(name, null)
 
   lazy val innerType: __Type = Types.innerType(this)
 

--- a/core/src/main/scala/caliban/transformers/Transformer.scala
+++ b/core/src/main/scala/caliban/transformers/Transformer.scala
@@ -314,7 +314,7 @@ object Transformer {
           step.copy(fields =
             fieldName =>
               if (inner.contains(fieldName)) {
-                val args = field.fieldType.allFieldsMap(fieldName).allArgNames
+                val args = field.fieldType.getFieldOrNull(fieldName).allArgNames
                 mapFunctionStep(fields(fieldName))(_.filterNot { case (argName, _) => !args.contains(argName) })
               } else {
                 fields(fieldName)

--- a/core/src/main/scala/caliban/transformers/Transformer.scala
+++ b/core/src/main/scala/caliban/transformers/Transformer.scala
@@ -314,7 +314,10 @@ object Transformer {
           step.copy(fields =
             fieldName =>
               if (inner.contains(fieldName)) {
-                val args = field.fieldType.getFieldOrNull(fieldName).allArgNames
+                val args = field.fieldType.getFieldOrNull(fieldName) match {
+                  case null => Set.empty[String]
+                  case f    => f.allArgNames
+                }
                 mapFunctionStep(fields(fieldName))(_.filterNot { case (argName, _) => !args.contains(argName) })
               } else {
                 fields(fieldName)

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -36,10 +36,12 @@ object FieldMap {
     ): FieldMap = {
       val responseName = f.alias.getOrElse(f.name)
 
-      parentType.allFieldsMap.get(f.name).fold(self) { f1 =>
-        val sf    = SelectedField(parentType, selection, f1)
-        val entry = self.get(responseName).map(_ + sf).getOrElse(Set(sf))
-        self + (responseName -> entry)
+      parentType.getFieldOrNull(f.name) match {
+        case null => self
+        case f1   =>
+          val sf    = SelectedField(parentType, selection, f1)
+          val entry = self.get(responseName).map(_ + sf).getOrElse(Set(sf))
+          self + (responseName -> entry)
       }
     }
   }

--- a/core/src/main/scala/caliban/wrappers/Wrappers.scala
+++ b/core/src/main/scala/caliban/wrappers/Wrappers.scala
@@ -204,8 +204,13 @@ object Wrappers {
         query: ZQuery[R1, ExecutionError, ResponseValue],
         info: FieldInfo
       ): ZQuery[R1, ExecutionError, ResponseValue] = {
-        val directives = info.parent.flatMap(_.allFieldsMap.get(info.name)).flatMap(_.directives).getOrElse(Nil)
-        ZQuery.fromZIO(check(directives)) *> query
+        val directives = info.parent
+          .flatMap(_.getFieldOrNull(info.name) match {
+            case null => None
+            case f    => f.directives
+          })
+          .getOrElse(Nil)
+        ZQuery.fromZIONow(check(directives)) *> query
       }
     }
 }


### PR DESCRIPTION
In order to avoid mutability leaking, we made the type of the `allFieldsMap` the generic `collection.Map`. The issue with this is that all the methods on the Map are now megamorphic and add a small overhead.

Since we use this map multiple times in the lifetime of a request, and we usually end up getting all the requested fields from it, I think we should try and optimize a bit for it by making it private and using a getter method which returns `null` in cases that it's not found. That way we avoid the megamorphic call + the allocation of `Option` (which is for all fields except `__typename`)