### PR TITLE
Optimize `Field` creation when the SelectionSet doesn't contain fragments

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -162,8 +162,9 @@ object Field {
             val t = if (selected eq null) Types.string else selected._type
 
             val fields =
-              if (selectionSet.nonEmpty) loop(selectionSet, t, None, None, None)
-              else leftNil // Fragments apply on to the direct children of the fragment spread
+              if (selectionSet.nonEmpty)
+                loop(selectionSet, t, None, None, None).fold(identityFnList, _.map(_._1))
+              else Nil
 
             builder.addField(
               new Field(
@@ -171,7 +172,7 @@ object Field {
                 t,
                 Some(innerType),
                 alias,
-                fields.fold(identityFnList, _.map(_._1)),
+                fields,
                 targets = targets,
                 arguments = resolveVariables(arguments, variableDefinitionsMap, variableValues),
                 directives = resolvedDirectives,
@@ -244,7 +245,6 @@ object Field {
   }
 
   private val identityFnList: List[Field] => List[Field] = l => l
-  private val leftNil                                    = Left(List.empty[Field])
 
   private def resolveDirectiveVariables(
     variableValues: Map[String, InputValue],


### PR DESCRIPTION
During `Field` creation, we use a `LinkedHashMap` in order to deduplicate and combine fields depending on the field aliased name and the condition. I have no idea why this never occurred to me before, but this is only necessary when the SelectionSet contains fragments. In cases that it doesn't contain any fragments, we can simply just add just the `Field`s in a `ListBuffer` which is _much_ cheaper.

Based on the newly added benchmarks, we see a 50-90% improvement in this post-validation phase.

PS: This phase was quite fast already, so I don't think we'll see much of this improvement reflected to the total execution time, but it's still nice not having to waste CPU cycles especially for services deployed in a k8s cluster

series/2.x:
```
[info] Benchmark                                         Mode  Cnt        Score       Error  Units
[info] ValidationBenchmark.postValidationDeep           thrpt   10  1919896.457 ± 16097.774  ops/s
[info] ValidationBenchmark.postValidationIntrospection  thrpt   10   227253.553 ±  1415.620  ops/s
[info] ValidationBenchmark.postValidationMultifield     thrpt   10  2223595.997 ± 12263.328  ops/s
[info] ValidationBenchmark.postValidationSimple         thrpt   10  5760613.925 ± 88803.131  ops/s
```

PR:
```
[info] Benchmark                                         Mode  Cnt        Score        Error  Units
[info] ValidationBenchmark.postValidationDeep           thrpt   10  3570988.986 ± 251199.323  ops/s
[info] ValidationBenchmark.postValidationIntrospection  thrpt   10   332137.620 ±  10887.654  ops/s
[info] ValidationBenchmark.postValidationMultifield     thrpt   10  4128116.557 ±   8987.987  ops/s
[info] ValidationBenchmark.postValidationSimple         thrpt   10  9185483.477 ±  80255.025  ops/s
```