### PR TITLE
Minor code readability improvements and micro-optimizations

### DIFF
--- a/core/src/main/scala/caliban/HttpUtils.scala
+++ b/core/src/main/scala/caliban/HttpUtils.scala
@@ -60,11 +60,10 @@ private[caliban] object HttpUtils {
       }).map(v => toSse(v.toResponseValue)) ++ ZStream.succeed(done)
   }
 
-  def computeCacheDirective(extensions: Option[ResponseValue.ObjectValue]): Option[String] =
-    extensions
-      .flatMap(_.fields.collectFirst { case (Caching.DirectiveName, ResponseValue.ObjectValue(fields)) =>
-        fields.collectFirst { case ("httpHeader", Value.StringValue(cacheHeader)) => cacheHeader }
-      }.flatten)
+  def computeCacheDirective(extensions: ResponseValue.ObjectValue): Option[String] =
+    extensions.fields.collectFirst { case (Caching.DirectiveName, ResponseValue.ObjectValue(fields)) =>
+      fields.collectFirst { case ("httpHeader", Value.StringValue(cacheHeader)) => cacheHeader }
+    }.flatten
 
   final class AcceptsGqlEncodings(header0: Option[String]) {
     private val isEmpty     = header0.isEmpty

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -105,7 +105,8 @@ object TapirAdapter {
     streamConstructor: StreamConstructor[BS],
     responseCodec: JsonCodec[ResponseValue]
   ): (MediaType, StatusCode, Option[String], CalibanBody[BS]) = {
-    val accepts = new HttpUtils.AcceptsGqlEncodings(request.header(HeaderNames.Accept))
+    val accepts        = new HttpUtils.AcceptsGqlEncodings(request.header(HeaderNames.Accept))
+    val cacheDirective = response.extensions.flatMap(HttpUtils.computeCacheDirective)
 
     response match {
       case resp @ GraphQLResponse(StreamValue(stream), _, _, _) =>
@@ -116,15 +117,14 @@ object TapirAdapter {
           encodeMultipartMixedResponse(resp, stream)
         )
       case resp if accepts.graphQLJson                          =>
-        val isBadRequest   = response.errors.collectFirst {
+        val isBadRequest = response.errors.exists {
           case _: CalibanError.ParsingError | _: CalibanError.ValidationError => true
-        }.getOrElse(false)
-        val code           = if (isBadRequest) StatusCode.BadRequest else StatusCode.Ok
-        val cacheDirective = HttpUtils.computeCacheDirective(response.extensions)
+          case _                                                              => false
+        }
         (
           GraphqlResponseJson.mediaType,
-          code,
-          HttpUtils.computeCacheDirective(response.extensions),
+          if (isBadRequest) StatusCode.BadRequest else StatusCode.Ok,
+          cacheDirective,
           encodeSingleResponse(
             resp,
             keepDataOnErrors = !isBadRequest,
@@ -139,12 +139,10 @@ object TapirAdapter {
           encodeTextEventStreamResponse(resp)
         )
       case resp                                                 =>
-        val code           = response.errors.collectFirst { case HttpRequestMethod.MutationOverGetError => StatusCode.BadRequest }
-          .getOrElse(StatusCode.Ok)
-        val cacheDirective = HttpUtils.computeCacheDirective(response.extensions)
+        val isBadRequest = response.errors.contains(HttpRequestMethod.MutationOverGetError)
         (
           MediaType.ApplicationJson,
-          code,
+          if (isBadRequest) StatusCode.BadRequest else StatusCode.Ok,
           cacheDirective,
           encodeSingleResponse(
             resp,

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -139,7 +139,7 @@ object TapirAdapter {
           encodeTextEventStreamResponse(resp)
         )
       case resp                                                 =>
-        val isBadRequest = response.errors.contains(HttpRequestMethod.MutationOverGetError)
+        val isBadRequest = response.errors.contains(HttpRequestMethod.MutationOverGetError: Any)
         (
           MediaType.ApplicationJson,
           if (isBadRequest) StatusCode.BadRequest else StatusCode.Ok,


### PR DESCRIPTION
Most changes are ultra-micro optimizations to reduce allocations or to improve readability.

Also changed usages of `ZIO.fail` to `Exit.fail` in the `QuickAdapter` since `ZIO.fail` generates a (zio) stack-trace. Since we merge the value and error channels and map them to a `Response`, this is adding unnecessary overhead to failed requests