### PR TITLE
Use `Either` instead of `ZIO` for methods that don't require it

### DIFF
--- a/benchmarks/src/main/scala/caliban/ParserBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/ParserBenchmark.scala
@@ -25,7 +25,7 @@ class ParserBenchmark {
 
   @Benchmark
   def runCaliban(): Document =
-    Parser.parseQueryEither(fullIntrospectionQuery).fold(throw _, identity)
+    Parser.parseQuery(fullIntrospectionQuery).fold(throw _, identity)
 
   @Benchmark
   def runSangria(): sangria.ast.Document =

--- a/benchmarks/src/main/scala/caliban/validation/ValidationBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/validation/ValidationBenchmark.scala
@@ -19,14 +19,14 @@ class ValidationBenchmark {
 
   def run[A](either: Either[Throwable, A]): A = either.fold(throw _, identity)
 
-  def toRootType[R](graphQL: GraphQL[R]): Either[CalibanError, RootType] =
-    graphQL.validateRootSchema.map { schema =>
+  def toRootType[R](graphQL: GraphQL[R]): RootType =
+    run(graphQL.validateRootSchema.map { schema =>
       RootType(
         schema.query.opType,
         schema.mutation.map(_.opType),
         schema.subscription.map(_.opType)
       )
-    }
+    })
 
   import NestedZQueryBenchmarkSchema._
 
@@ -36,34 +36,27 @@ class ValidationBenchmark {
   val parsedDeepWithArgsQuery  = run(Parser.parseQuery(deepWithArgsQuery))
   val parsedIntrospectionQuery = run(Parser.parseQuery(ComplexQueryBenchmark.fullIntrospectionQuery))
 
-  val simpleType = run(
+  val simpleType =
     toRootType(graphQL[Any, SimpleRoot, Unit, Unit](RootResolver(NestedZQueryBenchmarkSchema.simple100Elements)))
-  )
 
   val multifieldType =
-    run(
-      toRootType(
-        graphQL[Any, MultifieldRoot, Unit, Unit](
-          RootResolver(NestedZQueryBenchmarkSchema.multifield100Elements)
-        )
+    toRootType(
+      graphQL[Any, MultifieldRoot, Unit, Unit](
+        RootResolver(NestedZQueryBenchmarkSchema.multifield100Elements)
       )
     )
 
   val deepType =
-    run(
-      toRootType(
-        graphQL[Any, DeepRoot, Unit, Unit](
-          RootResolver[DeepRoot](NestedZQueryBenchmarkSchema.deep100Elements)
-        )
+    toRootType(
+      graphQL[Any, DeepRoot, Unit, Unit](
+        RootResolver[DeepRoot](NestedZQueryBenchmarkSchema.deep100Elements)
       )
     )
 
   val deepWithArgsType =
-    run(
-      toRootType(
-        graphQL[Any, DeepWithArgsRoot, Unit, Unit](
-          RootResolver[DeepWithArgsRoot](NestedZQueryBenchmarkSchema.deepWithArgs100Elements)
-        )
+    toRootType(
+      graphQL[Any, DeepWithArgsRoot, Unit, Unit](
+        RootResolver[DeepWithArgsRoot](NestedZQueryBenchmarkSchema.deepWithArgs100Elements)
       )
     )
 

--- a/benchmarks/src/test/scala/caliban/CalibanSpec.scala
+++ b/benchmarks/src/test/scala/caliban/CalibanSpec.scala
@@ -22,8 +22,9 @@ object CalibanSpec extends ZIOSpecDefault {
         assertTrue(Caliban.run(io).errors.isEmpty)
       },
       test("Parser") {
-        val io = Parser.parseQuery(fullIntrospectionQuery)
-        assertTrue(Caliban.run(io).definitions.nonEmpty)
+        Parser.parseQuery(fullIntrospectionQuery).map { doc =>
+          assertTrue(doc.definitions.nonEmpty)
+        }
       }
     )
 }

--- a/core/src/main/scala/caliban/parsing/Parser.scala
+++ b/core/src/main/scala/caliban/parsing/Parser.scala
@@ -4,8 +4,6 @@ import caliban.CalibanError.ParsingError
 import caliban.InputValue
 import caliban.parsing.adt._
 import fastparse._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{ IO, Trace, ZIO }
 
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -14,19 +12,10 @@ object Parser {
   import caliban.parsing.parsers.Parsers._
 
   /**
-   * Parses the given string into a [[caliban.parsing.adt.Document]] object or fails with a [[caliban.CalibanError.ParsingError]].
-   *
-   * @see [[parseQueryEither]] for a version that returns an `Either` instead of an `IO`.
-   */
-  def parseQuery(query: String)(implicit trace: Trace): IO[ParsingError, Document] = ZIO.fromEither {
-    parseQueryEither(query)
-  }
-
-  /**
    * Parses the given string into a [[caliban.parsing.adt.Document]] object or returns a [[caliban.CalibanError.ParsingError]]
    * if the string is not a valid GraphQL document.
    */
-  def parseQueryEither(query: String): Either[ParsingError, Document] = {
+  def parseQuery(query: String): Either[ParsingError, Document] = {
     val sm = SourceMapper(query)
     try
       parse(query, document(_)) match {

--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -22,19 +22,11 @@ object VariablesCoercer {
     doc: Document,
     rootType: RootType,
     skipValidation: Boolean
-  )(implicit trace: Trace): IO[ValidationError, GraphQLRequest] =
+  ): Either[ValidationError, GraphQLRequest] =
     coerceVariables(req.variables.getOrElse(Map.empty), doc, rootType, skipValidation)
       .map(m => req.copy(variables = Some(m)))
 
   def coerceVariables(
-    variables: Map[String, InputValue],
-    doc: Document,
-    rootType: RootType,
-    skipValidation: Boolean
-  )(implicit trace: Trace): IO[ValidationError, Map[String, InputValue]] =
-    ZIO.fromEither(coerceVariablesEither(variables, doc, rootType, skipValidation))
-
-  def coerceVariablesEither(
     variables: Map[String, InputValue],
     doc: Document,
     rootType: RootType,

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -57,7 +57,7 @@ object RenderingSpec extends ZIOSpecDefault {
       case other                                                            => other
     }
 
-  def checkApi[R](api: GraphQL[R]): IO[ParsingError, TestResult] = {
+  def checkApi[R](api: GraphQL[R]): Either[ParsingError, TestResult] = {
     val definitions = fixDefinitions(api.toDocument.definitions.filter {
       case d: Definition.TypeSystemDefinition.TypeDefinition.ScalarTypeDefinition =>
         !DocumentRenderer.isBuiltinScalar(d.name)
@@ -230,10 +230,10 @@ object RenderingSpec extends ZIOSpecDefault {
 
   private def roundTrip(file: String, isCompact: Boolean = false) =
     ZIO.scoped(for {
-      input    <- ZIO.fromAutoCloseable(ZIO.attempt(Source.fromResource(file))).map(_.mkString)
-      doc      <- Parser.parseQuery(input)
-      rendered  = if (isCompact) DocumentRenderer.renderCompact(doc) else DocumentRenderer.render(doc)
-      reparsed <- Parser.parseQuery(rendered).either
+      input   <- ZIO.fromAutoCloseable(ZIO.attempt(Source.fromResource(file))).map(_.mkString)
+      doc     <- ZIO.fromEither(Parser.parseQuery(input))
+      rendered = if (isCompact) DocumentRenderer.renderCompact(doc) else DocumentRenderer.render(doc)
+      reparsed = Parser.parseQuery(rendered)
     } yield assertTrue(input == rendered, reparsed.isRight))
 
   @GQLOneOfInput

--- a/core/src/test/scala/caliban/parsing/DocumentSpec.scala
+++ b/core/src/test/scala/caliban/parsing/DocumentSpec.scala
@@ -2,7 +2,6 @@ package caliban.parsing
 
 import caliban.TestUtils
 import org.apache.commons.lang3.SerializationUtils
-import zio._
 import zio.test._
 
 object DocumentSpec extends ZIOSpecDefault {
@@ -10,7 +9,7 @@ object DocumentSpec extends ZIOSpecDefault {
     test("is serializable") {
       for {
         doc1 <- Parser.parseQuery(TestUtils.introspectionQuery)
-        doc2 <- ZIO.attempt(SerializationUtils.roundtrip(doc1))
+        doc2  = SerializationUtils.roundtrip(doc1)
       } yield assertTrue(doc1 == doc2)
     }
   )

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -465,16 +465,12 @@ object ParserSpec extends ZIOSpecDefault {
                       |    name(
                       |  }
                       |}""".stripMargin
-        Parser
-          .parseQuery(query)
-          .exit
-          .map(
-            assert(_)(
-              fails(
-                isSubtype[ParsingError](hasField("locationInfo", _.locationInfo, isSome(equalTo(LocationInfo(3, 4)))))
-              )
-            )
+
+        assert(Parser.parseQuery(query))(
+          isLeft(
+            isSubtype[ParsingError](hasField("locationInfo", _.locationInfo, isSome(equalTo(LocationInfo(3, 4)))))
           )
+        )
       },
       test("type") {
         val gqltype =

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -531,7 +531,7 @@ object ValidationSpec extends ZIOSpecDefault {
               )
           },
           test("schema is valid") {
-            api.validateRootSchema.as(assertCompletes)
+            api.validateRootSchema.map(_ => assertCompletes)
           }
         )
       }

--- a/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
+++ b/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
@@ -226,7 +226,7 @@ object FederationV2Spec extends ZIOSpecDefault {
       interpreter <- f(api).interpreter
       data        <- interpreter.execute(query).map(resp => decode[Json](resp.data.toString)).absolve
       sdl         <- ZIO.fromEither(data.hcursor.downField("_service").downField("sdl").as[String])
-      document    <- Parser.parseQuery(sdl)
+      document    <- ZIO.fromEither(Parser.parseQuery(sdl))
     } yield document.definitions.flatMap {
       case Definition.TypeSystemDefinition.SchemaDefinition(d, _, _, _, _) =>
         d.map(_.copy(index = 0)) // Unset the index to make the test deterministic

--- a/tools/src/main/scala/caliban/tools/SchemaLoader.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaLoader.scala
@@ -22,10 +22,10 @@ object SchemaLoader {
       ZIO
         .attempt(scala.io.Source.fromFile(path))
         .acquireReleaseWithAuto(f => ZIO.attempt(f.mkString))
-    }.flatMap(Parser.parseQuery)
+    }.map(Parser.parseQuery).absolve
   }
   case class FromString private[SchemaLoader] (schema: String)   extends SchemaLoader {
-    override def load: Task[Document] = Parser.parseQuery(schema)
+    override def load: Task[Document] = ZIO.fromEither(Parser.parseQuery(schema))
   }
   case class FromIntrospection private[SchemaLoader] (
     url: String,

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -1,7 +1,7 @@
 package caliban.tools
 
 import caliban.parsing.Parser
-import zio.Task
+import zio.{ Task, ZIO }
 import zio.test._
 
 object ClientWriterSpec extends SnapshotTest {
@@ -13,8 +13,8 @@ object ClientWriterSpec extends SnapshotTest {
     extensibleEnums: Boolean = false,
     excludeDeprecated: Boolean = false,
     genView: Boolean = false
-  ): Task[String] = Parser
-    .parseQuery(schema)
+  ): Task[String] = ZIO
+    .fromEither(Parser.parseQuery(schema))
     .flatMap(doc =>
       Formatter.format(
         ClientWriter
@@ -35,8 +35,8 @@ object ClientWriterSpec extends SnapshotTest {
   def genSplit(
     schema: String,
     scalarMappings: Map[String, String] = Map.empty
-  ): Task[List[(String, String)]] = Parser
-    .parseQuery(schema)
+  ): Task[List[(String, String)]] = ZIO
+    .fromEither(Parser.parseQuery(schema))
     .flatMap(doc =>
       Formatter.format(
         ClientWriter.write(doc, packageName = Some("test"), splitFiles = true, scalarMappings = Some(scalarMappings)),

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -1,15 +1,15 @@
 package caliban.tools
 
 import caliban.parsing.Parser
-import zio.Task
 import zio.test._
+import zio.{ Task, ZIO }
 
 object ClientWriterViewSpec extends SnapshotTest {
   override val testName: String = "ClientWriterViewSpec"
 
   val gen: String => Task[String] = (schema: String) =>
-    Parser
-      .parseQuery(schema)
+    ZIO
+      .fromEither(Parser.parseQuery(schema))
       .flatMap(doc => Formatter.format(ClientWriter.write(doc, genView = true, scalarMappings = None).head._2, None))
 
   override def spec =

--- a/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
@@ -16,7 +16,7 @@ object SchemaComparisonSpec extends ZIOSpecDefault {
     schema1: String,
     schema2: String,
     expected: List[String]
-  ): ZIO[Any, CalibanError.ParsingError, TestResult] =
+  ): Either[CalibanError.ParsingError, TestResult] =
     for {
       s1  <- Parser.parseQuery(schema1)
       s2  <- Parser.parseQuery(schema2)
@@ -27,7 +27,7 @@ object SchemaComparisonSpec extends ZIOSpecDefault {
     schema1: String,
     schema2: String,
     expected: List[SchemaComparisonChange]
-  ): ZIO[Any, CalibanError.ParsingError, TestResult] =
+  ): Either[CalibanError.ParsingError, TestResult] =
     for {
       s1  <- Parser.parseQuery(schema1)
       s2  <- Parser.parseQuery(schema2)
@@ -253,8 +253,9 @@ object SchemaComparisonSpec extends ZIOSpecDefault {
 
           val expected = SchemaComparisonChange.DirectiveDefinitionRepeatableChanged("test", from = false, to = true)
 
-          compareChanges(nonRepeatable, repeatable, List(expected)) &&
-          assertTrue(!expected.breaking)
+          compareChanges(nonRepeatable, repeatable, List(expected)).map(
+            _ && assertTrue(!expected.breaking)
+          )
         },
         test("becomes non-repeatable") {
           val repeatable    = "directive @test repeatable on FIELD_DEFINITION"
@@ -262,9 +263,9 @@ object SchemaComparisonSpec extends ZIOSpecDefault {
 
           val expected = SchemaComparisonChange.DirectiveDefinitionRepeatableChanged("test", from = true, to = false)
 
-          compareChanges(repeatable, nonRepeatable, List(expected)) &&
-          assertTrue(expected.breaking)
-
+          compareChanges(repeatable, nonRepeatable, List(expected)).map {
+            _ && assertTrue(expected.breaking)
+          }
         },
         test("changes in base interfaces") {
           val schema1: String =

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -2,7 +2,7 @@ package caliban.tools
 
 import caliban.parsing.Parser
 import caliban.parsing.adt.Directives.NewtypeDirective
-import zio.Task
+import zio.{ Task, ZIO }
 import zio.test._
 
 object SchemaWriterSpec extends SnapshotTest {
@@ -17,8 +17,8 @@ object SchemaWriterSpec extends SnapshotTest {
     isEffectTypeAbstract: Boolean = false,
     preserveInputNames: Boolean = false,
     addDerives: Boolean = false
-  ): Task[String] = Parser
-    .parseQuery(schema.stripMargin)
+  ): Task[String] = ZIO
+    .fromEither(Parser.parseQuery(schema.stripMargin))
     .flatMap(doc =>
       Formatter
         .format(


### PR DESCRIPTION
Since we're breaking a lot of things in the next release, we might as well make the public API a bit "leaner" by having methods return Either instead of ZIO that don't require it. I've only changed methods that wouldn't regularly be used by users, like the ones in `Parser`, `Validator` and `VariableCoercer`. I didn't touch ones that are very likely to be used by users like `GraphQL#intepreter` as we probably don't want to break things _that much_