### PR TITLE
Add Client / Schema codegen for `oneOf` inputs

### DIFF
--- a/codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/genview/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/genview/schema.graphql
@@ -1,3 +1,5 @@
+directive @oneOf on INPUT_OBJECT
+
 # Schema
 schema {
     query: Q
@@ -9,6 +11,8 @@ type Q {
     characters: [Character!]!
     # nested object type with argument
     character(name: String!): Character
+    # oneOf input object
+    character2(oneOfThese: CharacterOneOfInput!): Character
 
     # default arguments for optional and list arguments
     characters2(
@@ -35,6 +39,17 @@ input CharacterInput {
     # reserved name
     wait: String!
 }
+
+# Input object oneOf
+input CharacterOneOfInput @oneOf {
+    name: String
+    nickname: String
+    origin: Origin
+
+    # reserved name
+    wait: String
+}
+
 
 # Object
 type Character {

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/schema.graphql
@@ -12,7 +12,7 @@ type Q {
     characters: [Character!]!
     # nested object type with argument
     character(name: String!): Character
-
+    # oneOf input object
     character2(oneOfThese: CharacterOneOfInput!): Character
 
     # default arguments for optional and list arguments

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/src/main/graphql/schema.graphql
@@ -1,4 +1,5 @@
 directive @lazy on FIELD_DEFINITION
+directive @oneOf on INPUT_OBJECT
 
 # Schema
 schema {
@@ -11,6 +12,8 @@ type Q {
     characters: [Character!]!
     # nested object type with argument
     character(name: String!): Character
+
+    character2(oneOfThese: CharacterOneOfInput!): Character
 
     # default arguments for optional and list arguments
     characters2(
@@ -41,6 +44,16 @@ input CharacterInput {
     wait: String!
 }
 
+# Input object
+input CharacterOneOfInput @oneOf {
+    name: String
+    nickname: String
+    origin: Origin
+
+    # reserved name
+    wait: String
+}
+
 # Object
 type Character {
     name: String!
@@ -63,12 +76,12 @@ type Character {
     # Deprecated field + comment with double quotes and newlines
     """a deprecated field"""
     oldName3: String!
-      @deprecated(reason: """
-        This field is deprecated for the following reasons:
-        1. "Outdated data model": The field relies on an outdated data model.
-        2. "Performance issues": Queries using this field have performance issues.
-        Please use `name` instead.
-      """)
+    @deprecated(reason: """
+    This field is deprecated for the following reasons:
+    1. "Outdated data model": The field relies on an outdated data model.
+    2. "Performance issues": Queries using this field have performance issues.
+    Please use `name` instead.
+    """)
 }
 
 # Enum
@@ -110,14 +123,14 @@ type Product {
 }
 
 type Canterbury {
-  officer: Officer!
+    officer: Officer!
 }
 
 type Officer {
-  dossier: Dossier! @lazy
+    dossier: Dossier! @lazy
 }
 
 type Dossier {
-  homeWorld: String!
-  faction: String! @lazy
+    homeWorld: String!
+    faction: String! @lazy
 }

--- a/codegen-sbt/src/sbt-test/codegen/test-compile/test
+++ b/codegen-sbt/src/sbt-test/codegen/test-compile/test
@@ -5,3 +5,4 @@ $ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/genview/Client.s
 $ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/schema.scala
 $ exec sh verify.sh CharacterView target/scala-2.12/src_managed/main/caliban-codegen-sbt/genview/Client.scala
 $ exec sh verify.sh OptionView target/scala-2.12/src_managed/main/caliban-codegen-sbt/genview/Client.scala
+$ exec sh verify.sh CharacterOneOfInput target/scala-2.12/src_managed/main/caliban-codegen-sbt/genview/Client.scala

--- a/core/src/main/scala/caliban/parsing/adt/Type.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Type.scala
@@ -12,10 +12,16 @@ sealed trait Type extends Serializable { self =>
     case Type.ListType(ofType, nonNull) => if (nonNull) s"[$ofType]!" else s"[$ofType]"
   }
 
-  def toNullable: Type =
+  final def toNullable: Type =
     self match {
       case Type.NamedType(name, _)  => Type.NamedType(name, nonNull = false)
       case Type.ListType(ofType, _) => Type.ListType(ofType, nonNull = false)
+    }
+
+  final def toNonNullable: Type =
+    self match {
+      case Type.NamedType(name, _)  => Type.NamedType(name, nonNull = true)
+      case Type.ListType(ofType, _) => Type.ListType(ofType, nonNull = true)
     }
 }
 

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -673,7 +673,6 @@ object ClientWriter {
       s"""sealed trait $inputObjectName {
          |  protected def encode: __Value
          |}
-         |
          |object $inputObjectName {
          |  $leafTypes
          |

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/input object oneOf.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/input object oneOf.scala
@@ -6,8 +6,7 @@ object Client {
   sealed trait CharacterInput {
     protected def encode: __Value
   }
-
-  object CharacterInput {
+  object CharacterInput       {
     final case class Name(name: String)                       extends CharacterInput {
       protected def encode: __Value = __ObjectValue(List("name" -> implicitly[ArgEncoder[String]].encode(name)))
     }

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/input object oneOf.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/input object oneOf.scala
@@ -1,0 +1,25 @@
+import caliban.client._
+import caliban.client.__Value._
+
+object Client {
+
+  sealed trait CharacterInput {
+    protected def encode: __Value
+  }
+
+  object CharacterInput {
+    final case class Name(name: String)                       extends CharacterInput {
+      protected def encode: __Value = __ObjectValue(List("name" -> implicitly[ArgEncoder[String]].encode(name)))
+    }
+    final case class Nicknames(nicknames: List[String] = Nil) extends CharacterInput {
+      protected def encode: __Value = __ObjectValue(
+        List("nicknames" -> __ListValue(nicknames.map(value => implicitly[ArgEncoder[String]].encode(value))))
+      )
+    }
+
+    implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
+      override def encode(value: CharacterInput): __Value = value.encode
+    }
+  }
+
+}

--- a/tools/src/test/resources/snapshots/SchemaWriterSpec/input type oneOf.scala
+++ b/tools/src/test/resources/snapshots/SchemaWriterSpec/input type oneOf.scala
@@ -1,0 +1,14 @@
+import caliban.schema.Annotations._
+
+object Types {
+
+  final case class Character(name: String)
+
+  @GQLOneOfInput
+  sealed trait CharacterArgs extends scala.Product with scala.Serializable
+  object CharacterArgs {
+    final case class Foo(foo: String) extends CharacterArgs
+    final case class Bar(bar: Int)    extends CharacterArgs
+  }
+
+}

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -421,5 +421,5 @@ object ClientWriterSpec extends SnapshotTest {
              }
             """)
       }
-    ) @@ TestAspect.parallelN(8)
+    ) @@ TestAspect.parallelN(4)
 }

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -203,6 +203,14 @@ object ClientWriterSpec extends SnapshotTest {
              }
             """)
       },
+      snapshotTest("input object oneOf") {
+        gen("""
+             input CharacterInput @oneOf {
+               name: String
+               nicknames: [String!]
+             }
+            """)
+      },
       snapshotTest("input object with reserved name") {
         gen("""
              input CharacterInput {
@@ -413,5 +421,5 @@ object ClientWriterSpec extends SnapshotTest {
              }
             """)
       }
-    ) @@ TestAspect.sequential
+    ) @@ TestAspect.parallelN(8)
 }

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -200,5 +200,5 @@ object ClientWriterViewSpec extends SnapshotTest {
           }
           """)
       }
-    ) @@ TestAspect.sequential
+    ) @@ TestAspect.parallelN(8)
 }

--- a/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterViewSpec.scala
@@ -200,5 +200,5 @@ object ClientWriterViewSpec extends SnapshotTest {
           }
           """)
       }
-    ) @@ TestAspect.parallelN(8)
+    ) @@ TestAspect.parallelN(4)
 }

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -469,5 +469,5 @@ object SchemaWriterSpec extends SnapshotTest {
   )
 
   override def spec =
-    suite("SchemaWriterSpec")(assertions) @@ TestAspect.parallelN(8)
+    suite("SchemaWriterSpec")(assertions) @@ TestAspect.parallelN(4)
 }

--- a/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaWriterSpec.scala
@@ -186,6 +186,16 @@ object SchemaWriterSpec extends SnapshotTest {
                name: String!
              }
             """)),
+    snapshotTest("input type oneOf")(gen("""
+             type Character {
+                name: String!
+             }
+
+             input CharacterArgs @oneOf {
+               foo: String
+               bar: Int
+             }
+            """)),
     snapshotTest("input type with preserved input")(
       gen(
         """
@@ -459,5 +469,5 @@ object SchemaWriterSpec extends SnapshotTest {
   )
 
   override def spec =
-    suite("SchemaWriterSpec")(assertions) @@ TestAspect.parallelN(4)
+    suite("SchemaWriterSpec")(assertions) @@ TestAspect.parallelN(8)
 }


### PR DESCRIPTION
When an input contains the `oneOf` directive, the codegen now generates a sealed trait as the input, extended by case classes with 1 field