### PR TITLE
support the @stream directive

### DIFF
--- a/core/src/main/scala/caliban/GraphQL.scala
+++ b/core/src/main/scala/caliban/GraphQL.scala
@@ -311,6 +311,14 @@ trait GraphQL[-R] { self =>
     override protected val transformer: Transformer[R]             = self.transformer
   }
 
+  final def enableAll(features0: Set[Feature]): GraphQL[R] = new GraphQL[R] {
+    override protected val schemaBuilder: RootSchemaBuilder[R]     = self.schemaBuilder
+    override protected val wrappers: List[Wrapper[R]]              = self.wrappers
+    override protected val additionalDirectives: List[__Directive] = self.additionalDirectives
+    override protected val features: Set[Feature]                  = self.features ++ features0
+    override protected val transformer: Transformer[R]             = self.transformer
+  }
+
   /**
    * Transforms the schema using the given transformer.
    * This can be used to rename or filter types, fields and arguments.

--- a/core/src/main/scala/caliban/GraphQLAspect.scala
+++ b/core/src/main/scala/caliban/GraphQLAspect.scala
@@ -33,5 +33,4 @@ object GraphQLAspect {
   def withTypes(types: List[__Type]): GraphQLAspect[Nothing, Any] = new GraphQLAspect[Nothing, Any] {
     def apply[R](gql: GraphQL[R]): GraphQL[R] = gql.withAdditionalTypes(types)
   }
-
 }

--- a/core/src/main/scala/caliban/execution/Deferred.scala
+++ b/core/src/main/scala/caliban/execution/Deferred.scala
@@ -3,8 +3,20 @@ package caliban.execution
 import caliban.PathValue
 import caliban.schema.ReducedStep
 
-case class Deferred[-R](
+sealed trait Deferred[-R] {
+  def path: List[PathValue]
+  def label: Option[String]
+}
+
+case class DeferredFragment[-R](
   path: List[PathValue],
   step: ReducedStep[R],
   label: Option[String]
-)
+) extends Deferred[R]
+
+case class DeferredStream[-R](
+  path: List[PathValue],
+  step: ReducedStep.StreamStep[R],
+  label: Option[String],
+  startFrom: Int
+) extends Deferred[R]

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -14,7 +14,7 @@ import caliban.wrappers.Wrapper.FieldWrapper
 import zio._
 import zio.query._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.stream.ZStream
+import zio.stream.{ ZSink, ZStream }
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.{ switch, tailrec }
@@ -48,8 +48,9 @@ object Executor {
       new StepReducer[R](
         transformer,
         request.operationType eq OperationType.Subscription,
-        featureSet(Feature.Defer),
-        wrapPureValues
+        isDeferredEnabled = featureSet(Feature.Defer),
+        isStreamEnabled = featureSet(Feature.Stream),
+        wrapPureValues = wrapPureValues
       )
     val reducedStepExecutor =
       new ReducedStepExecutor[R](
@@ -62,6 +63,7 @@ object Executor {
     def runQuery(step: ReducedStep[R], cache: Cache) = {
       val deferred = new AtomicReference(List.empty[Deferred[R]])
       val errors   = new AtomicReference(List.empty[CalibanError])
+
       reducedStepExecutor
         .makeQuery(step, errors, deferred)
         .runCache(cache)
@@ -91,36 +93,62 @@ object Executor {
       defers: List[Deferred[R]],
       cache: Cache
     ): ZStream[R, Nothing, Incremental[CalibanError]] = {
-      def run(d: Deferred[R]) =
-        ZStream.unwrap(runIncrementalQuery(d.step, cache, d.path, d.label).map {
-          case (resp, Nil)  =>
-            ZStream.succeed(resp)
-          case (resp, more) =>
-            ZStream.succeed(resp) ++ makeDeferStream(more, cache)
+      def runDefer(d: DeferredFragment[R]) =
+        ZStream.unwrap(runIncrementalQuery(d.step, cache).map { case (result, errors, more) =>
+          val resp = ZStream.succeed(
+            Incremental.Defer(
+              result,
+              errors = errors,
+              path = ListValue(d.path.reverse),
+              label = d.label
+            )
+          )
+          more match {
+            case Nil => resp
+            case _   => resp ++ makeDeferStream(more, cache)
+          }
         })
 
-      ZStream.mergeAllUnbounded()(defers.map(run): _*)
+      def runStream(d: DeferredStream[R]) =
+        d.step.inner.orDie.chunks.flatMap { steps =>
+          ZStream.unwrap(ZIO.foreach(steps)(runIncrementalQuery(_, cache)).map { results =>
+            val (values, errors, more) = results.unzip3
+            val resp                   = ZStream.succeed(
+              Incremental.Stream(
+                values.toList,
+                ListValue((IntValue(d.startFrom) :: d.path).reverse),
+                errors.toList.flatten,
+                d.label
+              )
+            )
+
+            more.toList.flatten match {
+              case Nil  => resp
+              case rest => resp ++ makeDeferStream(rest, cache)
+            }
+          })
+        }
+
+      ZStream.mergeAllUnbounded()(defers.map {
+        case d: DeferredFragment[R] => runDefer(d)
+        case d: DeferredStream[R]   => runStream(d)
+      }: _*)
     }
 
     def runIncrementalQuery(
       step: ReducedStep[R],
-      cache: Cache,
-      path: List[PathValue],
-      label: Option[String]
+      cache: Cache
     ) = {
       val deferred = new AtomicReference(List.empty[Deferred[R]])
       val errors   = new AtomicReference(List.empty[CalibanError])
+
       reducedStepExecutor
         .makeQuery(step, errors, deferred)
         .runCache(cache)
         .map { result =>
           (
-            Incremental.Defer(
-              result,
-              errors = errors.get().reverse,
-              path = ListValue(path.reverse),
-              label = label
-            ),
+            result,
+            errors.get().reverse,
             deferred.get()
           )
         }
@@ -141,6 +169,7 @@ object Executor {
     transformer: Transformer[R],
     isSubscription: Boolean,
     isDeferredEnabled: Boolean,
+    isStreamEnabled: Boolean,
     wrapPureValues: Boolean
   )(implicit trace: Trace) {
 
@@ -262,12 +291,53 @@ object Executor {
               .map(reduceStep(_, currentField, arguments, path))
           )
         } else {
-          reduceStep(
-            QueryStep(ZQuery.fromZIONow(stream.runCollect.map(chunk => ListStep(chunk.toList)))),
-            currentField,
-            arguments,
-            path
-          )
+          currentField match {
+            case IsStream(label, Some(initialCount)) if initialCount > 0 && isStreamEnabled =>
+              ReducedStep.QueryStep(
+                ZQuery.fromZIONow(
+                  for {
+                    scope               <- Scope.make
+                    initialAndRemaining <-
+                      stream
+                        .mapErrorCause(effectfulExecutionError(path, Some(currentField.locationInfo), _))
+                        .peel(ZSink.take[Step[R]](initialCount))
+                        .provideSomeEnvironment[R](_.add[Scope](scope))
+                  } yield {
+                    val (initial, remaining) = initialAndRemaining
+                    ReducedStep.DeferStreamStep(
+                      reduceListStep(initial.toList),
+                      ReducedStep.StreamStep(
+                        ZStream.acquireReleaseExitWith(ZIO.unit)((_, exit) => scope.close(exit)) *>
+                          remaining.map(reduceStep(_, currentField, arguments, path))
+                      ),
+                      label,
+                      path,
+                      initialCount
+                    )
+                  }
+                )
+              )
+            case IsStream(label, _) if isStreamEnabled                                      =>
+              ReducedStep.DeferStreamStep(
+                reduceStep(PureStep(ListValue(Nil)), currentField, arguments, path),
+                ReducedStep.StreamStep(
+                  stream
+                    .mapErrorCause(effectfulExecutionError(path, Some(currentField.locationInfo), _))
+                    .map(reduceStep(_, currentField, arguments, path))
+                ),
+                label,
+                path,
+                0
+              )
+
+            case _ =>
+              reduceStep(
+                QueryStep(ZQuery.fromZIONow(stream.runCollect.map(chunk => ListStep(chunk.toList)))),
+                currentField,
+                arguments,
+                path
+              )
+          }
         }
 
       def wrapFn[A](step: A => Step[R], input: A): Step[R] =
@@ -509,11 +579,11 @@ object Executor {
 
       def loop(step: ReducedStep[R], isTopLevelField: Boolean = false): ExecutionQuery[ResponseValue] =
         step match {
-          case PureStep(value)                                  => ZQuery.succeedNow(value)
-          case ReducedStep.QueryStep(step)                      => step.flatMap(loop(_))
-          case ReducedStep.ObjectStep(steps, hasPureFields, _)  => makeObjectQuery(steps, hasPureFields, isTopLevelField)
-          case ReducedStep.ListStep(steps, areItemsNullable, _) => makeListQuery(steps, areItemsNullable)
-          case ReducedStep.StreamStep(stream)                   =>
+          case PureStep(value)                                                         => ZQuery.succeedNow(value)
+          case ReducedStep.QueryStep(step)                                             => step.flatMap(loop(_))
+          case ReducedStep.ObjectStep(steps, hasPureFields, _)                         => makeObjectQuery(steps, hasPureFields, isTopLevelField)
+          case ReducedStep.ListStep(steps, areItemsNullable, _)                        => makeListQuery(steps, areItemsNullable)
+          case ReducedStep.StreamStep(stream)                                          =>
             ZQuery
               .environmentWith[R](env =>
                 ResponseValue.StreamValue(
@@ -522,12 +592,16 @@ object Executor {
                   }.provideEnvironment(env)
                 )
               )
-          case ReducedStep.DeferStep(obj, nextSteps, path)      =>
+          case ReducedStep.DeferStep(obj, nextSteps, path)                             =>
             val deferredSteps = nextSteps.map { case (step, label) =>
-              Deferred(path, step, label)
+              DeferredFragment(path, step, label)
             }
             deferred.updateAndGet(deferredSteps ::: _)
             loop(obj)
+          case ReducedStep.DeferStreamStep(initial, remaining, label, path, startFrom) =>
+            val streamStep = DeferredStream(path, remaining, label, startFrom)
+            deferred.updateAndGet(streamStep :: _)
+            loop(initial)
         }
 
       loop(step, isTopLevelField = true).catchAll(handleError)

--- a/core/src/main/scala/caliban/execution/Feature.scala
+++ b/core/src/main/scala/caliban/execution/Feature.scala
@@ -1,8 +1,62 @@
 package caliban.execution
 
-sealed trait Feature
+import caliban.introspection.adt.{ __Directive, __DirectiveLocation, __InputValue }
+import caliban.parsing.adt.Directives
+import caliban.schema.Types
+
+sealed trait Feature {
+  def index: Int
+  def mask: Int
+  def directives: List[__Directive]
+}
 
 object Feature {
-  case object Defer  extends Feature
-  case object Stream extends Feature
+  type Flags = Int
+
+  private def isEnabled(flags: Flags, feature: Feature): Boolean = (flags & feature.mask) != 0
+  def isDeferEnabled(flags: Flags): Boolean                      = isEnabled(flags, Defer)
+  def isStreamEnabled(flags: Flags): Boolean                     = isEnabled(flags, Stream)
+
+  case object Defer extends Feature {
+    final val index: Int = 0
+    final val mask: Int  = 1 << index
+
+    final val directives: List[__Directive] = List(
+      __Directive(
+        Directives.Defer,
+        Some(
+          "Marks a fragment as being optionally deferrable. Allowing the backend to split the query and return non-deferred parts first. This implicitly uses a streaming transport protocol which requires client support."
+        ),
+        Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
+        _ =>
+          List(
+            __InputValue("if", None, () => Types.boolean, None),
+            __InputValue("label", None, () => Types.string, None)
+          ),
+        isRepeatable = false
+      )
+    )
+  }
+
+  case object Stream extends Feature {
+    final val index: Int = 1
+    final val mask: Int  = 1 << index
+
+    final val directives: List[__Directive] = List(
+      __Directive(
+        Directives.Stream,
+        Some(
+          "Marks a field as being optionally streamable. Allowing the backend to split the returned list value into separate payloads, only returning the first part of the list immediately. This implicitly uses a streaming transport protocol which requires client support."
+        ),
+        Set(__DirectiveLocation.FIELD),
+        _ =>
+          List(
+            __InputValue("if", None, () => Types.boolean, None),
+            __InputValue("initialCount", None, () => Types.int, None),
+            __InputValue("label", None, () => Types.string, None)
+          ),
+        isRepeatable = false
+      )
+    )
+  }
 }

--- a/core/src/main/scala/caliban/execution/Feature.scala
+++ b/core/src/main/scala/caliban/execution/Feature.scala
@@ -13,9 +13,9 @@ sealed trait Feature {
 object Feature {
   type Flags = Int
 
-  private def isEnabled(flags: Flags, feature: Feature): Boolean = (flags & feature.mask) != 0
-  def isDeferEnabled(flags: Flags): Boolean                      = isEnabled(flags, Defer)
-  def isStreamEnabled(flags: Flags): Boolean                     = isEnabled(flags, Stream)
+  private def isEnabled(flags: Flags, mask: Int): Boolean = (flags & mask) != 0
+  def isDeferEnabled(flags: Flags): Boolean               = isEnabled(flags, Defer.mask)
+  def isStreamEnabled(flags: Flags): Boolean              = isEnabled(flags, Stream.mask)
 
   case object Defer extends Feature {
     final val index: Int = 0

--- a/core/src/main/scala/caliban/execution/Fragment.scala
+++ b/core/src/main/scala/caliban/execution/Fragment.scala
@@ -7,7 +7,7 @@ case class Fragment(name: Option[String], directives: List[Directive]) {}
 
 object Fragment {
   object IsDeferred {
-    def unapply(fragment: Fragment): Option[(Option[String])] =
+    def unapply(fragment: Fragment): Option[Option[String]] =
       fragment.directives.collectFirst {
         case Directive(Directives.Defer, args, _, _) if args.get("if").forall {
               case BooleanValue(v) => v

--- a/core/src/main/scala/caliban/execution/Fragment.scala
+++ b/core/src/main/scala/caliban/execution/Fragment.scala
@@ -7,7 +7,7 @@ case class Fragment(name: Option[String], directives: List[Directive]) {}
 
 object Fragment {
   object IsDeferred {
-    def unapply(fragment: Fragment): Option[Option[String]] =
+    def unapply(fragment: Fragment): Option[(Option[String])] =
       fragment.directives.collectFirst {
         case Directive(Directives.Defer, args, _, _) if args.get("if").forall {
               case BooleanValue(v) => v
@@ -20,10 +20,14 @@ object Fragment {
 
 object IsStream {
   def unapply(field: Field): Option[(Option[String], Option[Int])] =
-    field.directives.collectFirst { case Directive(Directives.Stream, args, _, _) =>
-      (
-        args.get("label").collect { case StringValue(v) => v },
-        args.get("initialCount").collect { case v: IntValue => v.toInt }
-      )
+    field.directives.collectFirst {
+      case Directive(Directives.Stream, args, _, _) if args.get("if").forall {
+            case BooleanValue(v) => v
+            case _               => true
+          } =>
+        (
+          args.get("label").collect { case StringValue(v) => v },
+          args.get("initialCount").collect { case v: IntValue => v.toInt }
+        )
     }
 }

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -127,6 +127,13 @@ case class __Type(
       case _                   => true
     }
 
+  def isList: Boolean =
+    kind match {
+      case __TypeKind.LIST     => true
+      case __TypeKind.NON_NULL => ofType.exists(_.isList)
+      case _                   => false
+    }
+
   lazy val list: __Type    = __Type(__TypeKind.LIST, ofType = Some(self))
   lazy val nonNull: __Type = __Type(__TypeKind.NON_NULL, ofType = Some(self))
 

--- a/core/src/main/scala/caliban/schema/Step.scala
+++ b/core/src/main/scala/caliban/schema/Step.scala
@@ -116,6 +116,16 @@ object ReducedStep {
     def apply(error: Cause[ExecutionError]): ReducedStep[Any] = QueryStep(ZQuery.failCauseNow(error))
   }
 
+  final case class DeferStreamStep[-R](
+    initial: ReducedStep[R],
+    remaining: StreamStep[R],
+    label: Option[String],
+    path: List[PathValue],
+    startFrom: Int
+  ) extends ReducedStep[R] {
+    final val isPure = false
+  }
+
   // PureStep is both a Step and a ReducedStep so it is defined outside this object
   // This is to avoid boxing/unboxing pure values during step reduction
   type PureStep = caliban.schema.PureStep

--- a/core/src/main/scala/caliban/wrappers/DeferSupport.scala
+++ b/core/src/main/scala/caliban/wrappers/DeferSupport.scala
@@ -1,23 +1,13 @@
 package caliban.wrappers
 
+import caliban.GraphQLAspect
 import caliban.execution.Feature
-import caliban.introspection.adt.{ __Directive, __DirectiveLocation, __InputValue }
-import caliban.parsing.adt.Directives
-import caliban.schema.Types
-import caliban.{ GraphQL, GraphQLAspect }
+import caliban.introspection.adt.__Directive
 
 object DeferSupport {
-  private[caliban] val deferDirective = __Directive(
-    Directives.Defer,
-    Some(""),
-    Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
-    _ =>
-      List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None)),
-    isRepeatable = false
-  )
+  @deprecated("Use IncrementalDelivery.deferDirective instead", "2.9.0")
+  private[caliban] val deferDirective: __Directive = IncrementalDelivery.deferDirective
 
-  val defer = new GraphQLAspect[Nothing, Any] {
-    override def apply[R](gql: GraphQL[R]): GraphQL[R] =
-      gql.withAdditionalDirectives(List(deferDirective)).enable(Feature.Defer)
-  }
+  @deprecated("Use IncrementalDelivery.aspect(Feature.Defer) instead", "2.9.0")
+  val defer: GraphQLAspect[Nothing, Any] = IncrementalDelivery.aspect(Feature.Defer)
 }

--- a/core/src/main/scala/caliban/wrappers/DeferSupport.scala
+++ b/core/src/main/scala/caliban/wrappers/DeferSupport.scala
@@ -5,9 +5,9 @@ import caliban.execution.Feature
 import caliban.introspection.adt.__Directive
 
 object DeferSupport {
-  @deprecated("Use IncrementalDelivery.deferDirective instead", "2.9.0")
-  private[caliban] val deferDirective: __Directive = IncrementalDelivery.deferDirective
+  @deprecated("Use Feature.Defer.directives instead", "2.9.0")
+  private[caliban] val deferDirective: __Directive = Feature.Defer.directives.head
 
-  @deprecated("Use IncrementalDelivery.aspect(Feature.Defer) instead", "2.9.0")
-  val defer: GraphQLAspect[Nothing, Any] = IncrementalDelivery.aspect(Feature.Defer)
+  @deprecated("Use IncrementalDelivery.defer instead", "2.9.0")
+  val defer: GraphQLAspect[Nothing, Any] = IncrementalDelivery.defer
 }

--- a/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
+++ b/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
@@ -1,15 +1,15 @@
 package caliban.wrappers
 
-import caliban.{ CalibanError, Configurator, GraphQL, GraphQLAspect, InputValue, Value }
 import caliban.execution.{ ExecutionRequest, Feature }
 import caliban.introspection.adt.{ __Directive, __DirectiveLocation, __InputValue, __Type }
-import caliban.parsing.SourceMapper
-import caliban.parsing.adt.Selection.{ Field, FragmentSpread }
-import caliban.parsing.adt.{ Directive, Directives, Document, OperationType, Selection, VariableDefinition }
+import caliban.parsing.adt.Definition.ExecutableDefinition.FragmentDefinition
+import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
+import caliban.parsing.adt._
 import caliban.schema.Types
 import caliban.validation.ValidationOps.validateAllDiscard
-import caliban.validation.Validator.QueryValidation
+import caliban.validation.Validator.{ failValidation, QueryValidation }
 import caliban.wrappers.Wrapper.ValidationWrapper
+import caliban._
 import zio.ZIO
 
 import scala.annotation.tailrec
@@ -19,7 +19,9 @@ object IncrementalDelivery {
 
   private[caliban] val deferDirective = __Directive(
     Directives.Defer,
-    Some(""),
+    Some(
+      "Marks a fragment as being optionally deferrable. Allowing the backend to split the query and return non-deferred parts first. This implicitly uses a streaming transport protocol which requires client support."
+    ),
     Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
     _ =>
       List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None)),
@@ -27,8 +29,10 @@ object IncrementalDelivery {
   )
 
   private[caliban] val streamDirective = __Directive(
-    "stream",
-    Some(""),
+    Directives.Stream,
+    Some(
+      "Marks a field as being optionally streamable. Allowing the backend to split the returned list value into separate payloads, only returning the first part of the list immediately. This implicitly uses a streaming transport protocol which requires client support."
+    ),
     Set(__DirectiveLocation.FIELD),
     _ =>
       List(
@@ -69,54 +73,60 @@ object IncrementalDelivery {
   }
 
   private val appearsOnlyOnLists: QueryValidation = context => {
-    var error: CalibanError.ValidationError            = null
     val checked: mutable.Set[(String, Option[String])] = mutable.Set.empty
-    val iter                                           = context.operations.iterator
 
-    def validateFields(selectionSet: List[Selection], currentType: __Type) =
+    def validateFields(selectionSet: List[Selection], currentType: __Type): Either[CalibanError.ValidationError, Unit] =
       validateAllDiscard(selectionSet) {
-        case f: Field                         =>
+        case f: Field                                          =>
           validateField(f, currentType)
-        case FragmentSpread(name, directives) =>
-          context.fragments.getOrElse(name, null) match {
-            case null                                              => Left(CalibanError.ValidationError(s"Fragment $name not found", ""))
-            case fragment if checked.add((name, currentType.name)) =>
-              validateSpread()
+        case FragmentSpread(name, directives)                  =>
+          if (directives.exists(_.name == Directives.Stream))
+            Left(CalibanError.ValidationError("Stream directive was used on a fragment spread", ""))
+          else {
+            context.fragments.getOrElse(name, null) match {
+              case null                                              => Left(CalibanError.ValidationError(s"Fragment $name not found", ""))
+              case fragment if checked.add((name, currentType.name)) =>
+                validateSpread(fragment, currentType)
+              case _                                                 => Right(())
+            }
+          }
+        case InlineFragment(typeCondition, dirs, selectionSet) =>
+          if (dirs.exists(_.name == Directives.Stream))
+            Left(CalibanError.ValidationError("Stream directive was used on an inline fragment", ""))
+          else {
+            if (typeCondition.exists(_.name.contains(currentType.typeNameRepr)))
+              validateFields(selectionSet, currentType)
+            else Right(())
           }
 
       }
 
-    def validateSpread()
+    def validateSpread(fragment: FragmentDefinition, currentType: __Type): Either[CalibanError.ValidationError, Unit] =
+      validateFields(fragment.selectionSet, currentType)
 
-    def validateField(field: Field, currentType: __Type): Either[CalibanError.ValidationError, Unit] = {}
+    def validateField(field: Field, currentType: __Type): Either[CalibanError.ValidationError, Unit] = {
+      val selected = currentType.allFields.find(_.name == field.name)
+      Either.cond(
+        selected.isDefined && !selected.get._type.isList && field.directives.forall(_.name != Directives.Stream),
+        (),
+        CalibanError.ValidationError("Stream directive was used on a non-list field", "")
+      )
+    }
 
-//    @tailrec
-//    def loop(selectionSet: List[Selection], currentType: __Type): Boolean = fields match {
-//      case field :: rest =>
-//        !field.fieldType.isList && field.directives.exists(_.name == Directives.Stream) || loop(field.fields ++ rest)
-//      case Nil           =>
-//        false
-//    }
-//
-//    while (iter.hasNext && (error eq null)) {
-//      val op    = iter.next()
-//      val field = Field(
-//        op.selectionSet,
-//        context.fragments,
-//        Map.empty[String, InputValue],
-//        List.empty[VariableDefinition],
-//        context.rootType.queryType,
-//        SourceMapper.empty,
-//        Nil,
-//        context.rootType
-//      )
-//
-//      if (loop(List(field))) {
-//        error = CalibanError.ValidationError("Stream directive was used on a non-list field", "")
-//      }
-//    }
-
-    if (error ne null) Left(error) else Right(())
+    validateAllDiscard(context.operations) { op =>
+      op.operationType match {
+        case OperationType.Query        =>
+          validateFields(op.selectionSet, context.rootType.queryType)
+        case OperationType.Mutation     =>
+          context.rootType.mutationType.fold[Either[CalibanError.ValidationError, Unit]](
+            failValidation("Mutation operations are not supported on this schema.", "")
+          )(validateFields(op.selectionSet, _))
+        case OperationType.Subscription =>
+          context.rootType.subscriptionType.fold[Either[CalibanError.ValidationError, Unit]](
+            failValidation("Subscription operations are not supported on this schema.", "")
+          )(validateFields(op.selectionSet, _))
+      }
+    }
   }
 
   private val uniqueLabels: QueryValidation = context => {
@@ -164,7 +174,7 @@ object IncrementalDelivery {
     List(onlyTopLevelQuery, uniqueLabels) ++ streamValidations
   }
 
-  private def withValidations(features: Set[Feature]): GraphQLAspect[Nothing, Any] = new ValidationWrapper[Any] {
+  private def withValidations(features: Set[Feature]): Wrapper[Any] = new ValidationWrapper[Any] {
     private val validations = additionalValidations(features)
 
     override def wrap[R1 <: Any](
@@ -176,17 +186,17 @@ object IncrementalDelivery {
   }
 
   def aspect(feature: Feature, others: Feature*): GraphQLAspect[Nothing, Any] = new GraphQLAspect[Nothing, Any] {
-    private val featureSet = Set(feature) ++ others
+    private val featureSet    = Set(feature) ++ others
+    private val directiveList = List(
+      Some(deferDirective).filter(_ => featureSet(Feature.Defer)),
+      Some(streamDirective).filter(_ => featureSet(Feature.Stream))
+    ).flatten
 
     override def apply[R](gql: GraphQL[R]): GraphQL[R] =
-      (gql @@ withValidations(featureSet))
+      gql
         .enableAll(featureSet)
-        .withAdditionalDirectives(
-          List(
-            Some(deferDirective).filter(_ => featureSet(Feature.Defer)),
-            Some(streamDirective).filter(_ => featureSet(Feature.Stream))
-          ).flatten
-        )
+        .withAdditionalDirectives(directiveList)
+        .withWrapper(withValidations(featureSet))
   }
 
 }

--- a/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
+++ b/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
@@ -1,0 +1,172 @@
+package caliban.wrappers
+
+import caliban.{ CalibanError, Configurator, GraphQL, GraphQLAspect, InputValue, Value }
+import caliban.execution.{ ExecutionRequest, Feature, Field }
+import caliban.introspection.adt.{ __Directive, __DirectiveLocation, __InputValue }
+import caliban.parsing.SourceMapper
+import caliban.parsing.adt.{ Directive, Directives, Document, OperationType, Selection, VariableDefinition }
+import caliban.schema.Types
+import caliban.validation.Validator.QueryValidation
+import caliban.wrappers.Wrapper.ValidationWrapper
+import zio.ZIO
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+object IncrementalDelivery {
+
+  private[caliban] val deferDirective = __Directive(
+    Directives.Defer,
+    Some(""),
+    Set(__DirectiveLocation.FRAGMENT_SPREAD, __DirectiveLocation.INLINE_FRAGMENT),
+    _ =>
+      List(__InputValue("if", None, () => Types.boolean, None), __InputValue("label", None, () => Types.string, None)),
+    isRepeatable = false
+  )
+
+  private[caliban] val streamDirective = __Directive(
+    "stream",
+    Some(""),
+    Set(__DirectiveLocation.FIELD),
+    _ =>
+      List(
+        __InputValue("if", None, () => Types.boolean, None),
+        __InputValue("initialCount", None, () => Types.int, None),
+        __InputValue("label", None, () => Types.string, None)
+      ),
+    isRepeatable = false
+  )
+
+  private val onlyTopLevelQuery: QueryValidation = context => {
+    @tailrec
+    def hasStreamOrDirective(selection: List[Selection]): Boolean =
+      selection match {
+        case Selection.Field(_, _, _, directives, _, _) :: rest   =>
+          directives.exists(d => d.name == Directives.Stream || d.name == Directives.Defer) || hasStreamOrDirective(
+            rest
+          )
+        case Selection.InlineFragment(_, _, selectionSet) :: rest =>
+          hasStreamOrDirective(rest ++ selectionSet)
+        case Selection.FragmentSpread(name, _) :: rest            =>
+          hasStreamOrDirective(rest ++ context.fragments(name).selectionSet)
+        case Nil                                                  => false
+      }
+
+    if (
+      context.operations.exists(op => op.operationType != OperationType.Query && hasStreamOrDirective(op.selectionSet))
+    ) {
+      Left(
+        CalibanError.ValidationError(
+          "Stream or defer directive was used on a root field in a mutation or subscription",
+          "Defer and stream may not be used on root fields of mutations or subscriptions"
+        )
+      )
+    } else {
+      Right(())
+    }
+  }
+
+  private val appearsOnlyOnLists: QueryValidation = context => {
+    var error: CalibanError.ValidationError = null
+    val iter                                = context.operations.iterator
+
+    @tailrec
+    def loop(fields: List[Field]): Boolean = fields match {
+      case field :: rest =>
+        !field.fieldType.isList && field.directives.exists(_.name == Directives.Stream) || loop(field.fields ++ rest)
+      case Nil           =>
+        false
+    }
+
+    while (iter.hasNext && (error eq null)) {
+      val op    = iter.next()
+      val field = Field(
+        op.selectionSet,
+        context.fragments,
+        Map.empty[String, InputValue],
+        List.empty[VariableDefinition],
+        context.rootType.queryType,
+        SourceMapper.empty,
+        Nil,
+        context.rootType
+      )
+
+      if (loop(List(field))) {
+        error = CalibanError.ValidationError("Stream directive was used on a non-list field", "")
+      }
+    }
+
+    if (error ne null) Left(error) else Right(())
+  }
+
+  private val uniqueLabels: QueryValidation = context => {
+    val labels = mutable.Set[String]()
+
+    def extractLabel(directives: List[Directive], directiveName: String): Option[InputValue] =
+      directives.collectFirst {
+        case d if d.name == directiveName =>
+          d.arguments.get("label")
+      }.flatten
+
+    def isLabelUnique(label: Option[InputValue]): Boolean = label.forall {
+      case Value.StringValue(value) => labels.add(value)
+      case _                        => true
+    }
+
+    @tailrec
+    def allLabelsUnique(selections: List[Selection]): Boolean = selections match {
+      case Selection.Field(_, _, _, directives, children, _) :: rest     =>
+        val label = extractLabel(directives, Directives.Stream)
+
+        isLabelUnique(label) && allLabelsUnique(rest ++ children)
+      case Selection.InlineFragment(_, directives, selectionSet) :: rest =>
+        val label = extractLabel(directives, Directives.Defer)
+
+        isLabelUnique(label) && allLabelsUnique(rest ++ selectionSet)
+      case Selection.FragmentSpread(name, directives) :: rest            =>
+        val label = extractLabel(directives, Directives.Defer)
+
+        isLabelUnique(label) && allLabelsUnique(rest ++ context.fragments(name).selectionSet)
+      case Nil                                                           => true
+    }
+
+    if (!allLabelsUnique(context.operations.flatMap(_.selectionSet))) {
+      Left(CalibanError.ValidationError("Stream directive labels must be unique", ""))
+    } else {
+      Right(())
+    }
+  }
+
+  private def additionalValidations(features: Set[Feature]) = {
+    val streamValidations =
+      if (features(Feature.Stream)) List(appearsOnlyOnLists) else Nil
+
+    List(onlyTopLevelQuery, uniqueLabels) ++ streamValidations
+  }
+
+  private def withValidations(features: Set[Feature]): GraphQLAspect[Nothing, Any] = new ValidationWrapper[Any] {
+    private val validations = additionalValidations(features)
+
+    override def wrap[R1 <: Any](
+      f: Document => ZIO[R1, CalibanError.ValidationError, ExecutionRequest]
+    ): Document => ZIO[R1, CalibanError.ValidationError, ExecutionRequest] = { doc =>
+      Configurator.ref
+        .locallyWith(config => config.copy(validations = config.validations ++ validations))(f(doc))
+    }
+  }
+
+  def aspect(feature: Feature, others: Feature*): GraphQLAspect[Nothing, Any] = new GraphQLAspect[Nothing, Any] {
+    private val featureSet = Set(feature) ++ others
+
+    override def apply[R](gql: GraphQL[R]): GraphQL[R] =
+      (gql @@ withValidations(featureSet))
+        .enableAll(featureSet)
+        .withAdditionalDirectives(
+          List(
+            Some(deferDirective).filter(_ => featureSet(Feature.Defer)),
+            Some(streamDirective).filter(_ => featureSet(Feature.Stream))
+          ).flatten
+        )
+  }
+
+}

--- a/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/DeferredExecutionSpec.scala
@@ -1,19 +1,21 @@
 package caliban.execution
 
+import caliban.CalibanError.ValidationError
 import caliban.Macros.gqldoc
 import caliban.ResponseValue.StreamValue
 import caliban.TestUtils.{ characters, Character }
-import caliban.{ CalibanError, GraphQLResponse, ResponseValue, Value }
+import caliban.{ CalibanError, GraphQLResponse, HttpUtils, ResponseValue, Value }
 import zio.test.Assertion.hasSameElements
-import zio.test.{ assert, assertTrue, TestAspect, TestClock, ZIOSpecDefault }
+import zio.test._
 import zio._
+import zio.stream.ZStream
 
 trait CharacterService {
   def characterBy(pred: Character => Boolean): UIO[List[Character]]
 }
 
 object CharacterService {
-  val test = ZLayer.succeed(new CharacterService {
+  val test: ULayer[CharacterService] = ZLayer.succeed(new CharacterService {
     override def characterBy(pred: Character => Boolean): UIO[List[Character]] =
       ZIO.succeed(characters.filter(pred))
   })
@@ -24,9 +26,10 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
   import TestDeferredSchema._
 
   override def spec = suite("Defer Execution")(
-    test("don't defer pure fields") {
+    suite("@defer")(
+      test("don't defer pure fields") {
 
-      val query = gqldoc("""
+        val query = gqldoc("""
         {
            character(name: "Roberta Draper") {
              ... @defer {
@@ -36,13 +39,13 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
         }
           """)
 
-      for {
-        response <- interpreter.flatMap(_.execute(query))
-        data     <- runIncrementalResponses(response)
-      } yield assertTrue(data.size == 1, data.head.toString == """{"character":{"name":"Roberta Draper"}}""")
-    },
-    test("don't stream if no defer present") {
-      val query = gqldoc("""
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          data     <- runIncrementalResponses(response)
+        } yield assertTrue(data.size == 1, data.head.toString == """{"data":{"character":{"name":"Roberta Draper"}}}""")
+      },
+      test("don't stream if no defer present") {
+        val query = gqldoc("""
         {
            character(name: "Roberta Draper") {
              name
@@ -51,28 +54,28 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
         }
           """)
 
-      for {
-        response <- interpreter.flatMap(_.execute(query))
-      } yield assertTrue(
-        response.data == ResponseValue.ObjectValue(
-          List(
-            "character" -> ResponseValue.ObjectValue(
-              List(
-                "name"      -> Value.StringValue("Roberta Draper"),
-                "nicknames" -> ResponseValue.ListValue(
-                  List(
-                    Value.StringValue("Bobbie"),
-                    Value.StringValue("Gunny")
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+        } yield assertTrue(
+          response.data == ResponseValue.ObjectValue(
+            List(
+              "character" -> ResponseValue.ObjectValue(
+                List(
+                  "name"      -> Value.StringValue("Roberta Draper"),
+                  "nicknames" -> ResponseValue.ListValue(
+                    List(
+                      Value.StringValue("Bobbie"),
+                      Value.StringValue("Gunny")
+                    )
                   )
                 )
               )
             )
           )
         )
-      )
-    },
-    test("inline fragments") {
-      val query = gqldoc("""
+      },
+      test("inline fragments") {
+        val query = gqldoc("""
         {
            character(name: "Roberta Draper") {
              ... @defer {
@@ -83,19 +86,19 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
         }
           """)
 
-      for {
-        resp <- interpreter.flatMap(_.execute(query))
-        rest <- runIncrementalResponses(resp)
-      } yield assertTrue(
-        rest.head.toString == """{"character":{"name":"Roberta Draper"}}""",
-        rest.tail.toList.map(_.toString) == List(
-          """{"incremental":[{"data":{"nicknames":["Bobbie","Gunny"]},"path":["character"]}],"hasNext":true}""",
-          """{"hasNext":false}"""
+        for {
+          resp <- interpreter.flatMap(_.execute(query))
+          rest <- runIncrementalResponses(resp)
+        } yield assertTrue(
+          rest.head.toString == """{"data":{"character":{"name":"Roberta Draper"}},"hasNext":true}""",
+          rest.tail.toList.map(_.toString) == List(
+            """{"incremental":[{"data":{"nicknames":["Bobbie","Gunny"]},"path":["character"]}],"hasNext":true}""",
+            """{"hasNext":false}"""
+          )
         )
-      )
-    },
-    test("named fragments") {
-      val query = gqldoc("""
+      },
+      test("named fragments") {
+        val query = gqldoc("""
         {
            character(name: "Roberta Draper") {
              ...Fragment @defer
@@ -108,19 +111,21 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
         }
           """)
 
-      for {
-        resp <- interpreter.flatMap(_.execute(query))
-        rest <- runIncrementalResponses(resp)
-      } yield assertTrue(
-        rest.head.toString == """{"character":{"name":"Roberta Draper"}}""",
-        rest.tail.toList.map(_.toString) == List(
-          """{"incremental":[{"data":{"nicknames":["Bobbie","Gunny"]},"path":["character"]}],"hasNext":true}""",
-          """{"hasNext":false}"""
+        for {
+          resp <- interpreter.flatMap(_.execute(query))
+          rest <- runIncrementalResponses(resp)
+          head  = rest.head.toString
+          tail  = rest.tail.map(_.toString)
+        } yield assertTrue(
+          head == """{"data":{"character":{"name":"Roberta Draper"}},"hasNext":true}""",
+          tail == Chunk(
+            """{"incremental":[{"data":{"nicknames":["Bobbie","Gunny"]},"path":["character"]}],"hasNext":true}""",
+            """{"hasNext":false}"""
+          )
         )
-      )
-    },
-    test("disable") {
-      val query = gqldoc("""
+      },
+      test("disable") {
+        val query = gqldoc("""
         {
            character(name: "Roberta Draper") {
              ... @defer(if: false, label: "first") { nicknames }
@@ -128,13 +133,18 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
         }
           """)
 
-      for {
-        resp <- interpreter.flatMap(_.execute(query))
-        rest <- runIncrementalResponses(resp)
-      } yield assertTrue(rest.head.toString == """{"character":{"nicknames":["Bobbie","Gunny"]}}""", rest.tail.isEmpty)
-    },
-    test("different labels") {
-      val query = gqldoc("""
+        for {
+          resp <- interpreter.flatMap(_.execute(query))
+          rest <- runIncrementalResponses(resp)
+          head  = rest.head.toString
+          tail  = rest.tail.map(_.toString)
+        } yield assertTrue(
+          head == """{"data":{"character":{"nicknames":["Bobbie","Gunny"]}}}""",
+          tail.isEmpty
+        )
+      },
+      test("different labels") {
+        val query = gqldoc("""
         {
            character(name: "Roberta Draper") {
              ... @defer(label: "first") { n1: nicknames }
@@ -143,23 +153,25 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
         }
           """)
 
-      for {
-        resp <- interpreter.flatMap(_.execute(query))
-        rest <- runIncrementalResponses(resp)
-      } yield assertTrue(
-        rest.head.toString == """{"character":{}}"""
-      ) && assert(rest.tail.toList.map(_.toString))(
-        hasSameElements(
-          List(
-            """{"incremental":[{"data":{"n1":["Bobbie","Gunny"]},"path":["character"],"label":"first"}],"hasNext":true}""",
-            """{"incremental":[{"data":{"n2":["Bobbie","Gunny"]},"path":["character"],"label":"second"}],"hasNext":true}""",
-            """{"hasNext":false}"""
+        for {
+          resp <- interpreter.flatMap(_.execute(query))
+          rest <- runIncrementalResponses(resp)
+          head  = rest.head.toString
+          tail  = rest.tail.map(_.toString)
+        } yield assertTrue(
+          head == """{"data":{"character":{}},"hasNext":true}"""
+        ) && assert(tail)(
+          hasSameElements(
+            List(
+              """{"incremental":[{"data":{"n1":["Bobbie","Gunny"]},"path":["character"],"label":"first"}],"hasNext":true}""",
+              """{"incremental":[{"data":{"n2":["Bobbie","Gunny"]},"path":["character"],"label":"second"}],"hasNext":true}""",
+              """{"hasNext":false}"""
+            )
           )
         )
-      )
-    },
-    test("nested defers") {
-      val query = gqldoc("""
+      },
+      test("nested defers") {
+        val query = gqldoc("""
            query test {
              character(name: "Roberta Draper") {
                name
@@ -177,48 +189,157 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
            }
           """)
 
-      for {
-        first <- interpreter.flatMap(_.execute(query))
-        rest  <- runIncrementalResponses(first)
-      } yield assertTrue(
-        rest.head.toString == """{"character":{"name":"Roberta Draper"}}""",
-        rest.tail.toList.map(_.toString) == List(
-          """{"incremental":[{"data":{"connections":[{"name":"Alex Kamal"}]},"path":["character"],"label":"outer"}],"hasNext":true}""",
-          """{"incremental":[{"data":{"nicknames":[]},"path":["character","connections",0],"label":"inner"}],"hasNext":true}""",
-          """{"hasNext":false}"""
+        for {
+          first <- interpreter.flatMap(_.execute(query))
+          rest  <- runIncrementalResponses(first)
+          values = rest.map(_.toString)
+        } yield assertTrue(
+          values == Chunk(
+            """{"data":{"character":{"name":"Roberta Draper"}},"hasNext":true}""",
+            """{"incremental":[{"data":{"connections":[{"name":"Alex Kamal"}]},"path":["character"],"label":"outer"}],"hasNext":true}""",
+            """{"incremental":[{"data":{"nicknames":[]},"path":["character","connections",0],"label":"inner"}],"hasNext":true}""",
+            """{"hasNext":false}"""
+          )
         )
-      )
-    },
-    test("deferred fields backed by a datasource") {
-      import TestDatasourceDeferredSchema._
-      val query = gqldoc("""
+      },
+      test("deferred fields backed by a datasource") {
+        import TestDatasourceDeferredSchema._
+        val query = gqldoc("""
         {
           foo {
             bar { ... @defer { value } }
           }
         }""")
 
-      for {
-        resp <- interpreter.flatMap(_.execute(query))
-        rest <- runIncrementalResponses(resp)
-        head  = rest.head.toString
-        mid   = rest.tail.init.toList.map(_.toString)
-        last  = rest.last.toString
-      } yield assertTrue(
-        head == """{"foo":{"bar":[{},{},{}]}}""",
-        mid.sorted == List(
-          """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",0]}],"hasNext":true}""",
-          """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",1]}],"hasNext":true}""",
-          """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",2]}],"hasNext":true}"""
-        ),
-        last == """{"hasNext":false}"""
-      )
-    } @@ TestAspect.nonFlaky(50)
-  ).provide(CharacterService.test)
+        for {
+          resp <- interpreter.flatMap(_.execute(query))
+          rest <- runIncrementalResponses(resp)
+          head  = rest.head.toString
+          mid   = rest.tail.init.toList.map(_.toString)
+          last  = rest.last.toString
+        } yield assertTrue(
+          head == """{"data":{"foo":{"bar":[{},{},{}]}},"hasNext":true}""",
+          mid.sorted == List(
+            """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",0]}],"hasNext":true}""",
+            """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",1]}],"hasNext":true}""",
+            """{"incremental":[{"data":{"value":"value"},"path":["foo","bar",2]}],"hasNext":true}"""
+          ),
+          last == """{"hasNext":false}"""
+        )
+      } @@ TestAspect.nonFlaky(50)
+    ),
+    suite("@stream")(
+      test("don't stream pure values") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             name
+             nicknames @stream(label: "nicknames", initialCount: 2)
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+        } yield assertTrue(
+          response.data == ResponseValue.ObjectValue(
+            List(
+              "character" -> ResponseValue.ObjectValue(
+                List(
+                  "name"      -> Value.StringValue("Roberta Draper"),
+                  "nicknames" -> ResponseValue.ListValue(
+                    List(
+                      Value.StringValue("Bobbie"),
+                      Value.StringValue("Gunny")
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      },
+      test("respect the initial count") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             name
+             quotes @stream(label: "quotes", initialCount: 1) {
+               line
+             }
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          data     <- runIncrementalResponses(response)
+          head      = data.map(_.toString)
+        } yield assertTrue(
+          data.size == 3,
+          head == Chunk(
+            """{"data":{"character":{"name":"Roberta Draper","quotes":[{"line":"You just have to believe that what you’re doing really matters, and then the fear can’t control you."}]}},"hasNext":true}""",
+            """{"incremental":[{"items":[{"line":"I'm Roberta, you can call me Bobby."}],"path":["character","quotes",1],"label":"quotes"}],"hasNext":true}""",
+            """{"hasNext":false}"""
+          )
+        )
+      },
+      test("validate step occurs on on lists only") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             name
+             quotes @stream(label: "quotes", initialCount: 1) {
+               line
+             }
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          data     <- runIncrementalResponses(response)
+          head      = data.map(_.toString)
+        } yield assertTrue(
+          data.size == 3,
+          head == Chunk(
+            """{"data":{"character":{"name":"Roberta Draper","quotes":[{"line":"You just have to believe that what you’re doing really matters, and then the fear can’t control you."}]}},"hasNext":true}""",
+            """{"incremental":[{"items":[{"line":"I'm Roberta, you can call me Bobby."}],"path":["character","quotes",1],"label":"quotes"}],"hasNext":true}""",
+            """{"hasNext":false}"""
+          )
+        )
+      },
+      test("labels must be unique") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             name
+             quotes @stream(label: "quotes") {
+               line
+             }
+             other: quotes @stream(label: "quotes") {
+               line
+             }
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          errors    = response.errors
+        } yield assertTrue(
+          errors.size == 1,
+          errors.head.is(_.subtype[ValidationError]).msg == "Stream directive labels must be unique"
+        )
+      }
+    )
+  ).provide(CharacterService.test, QuoteService.test)
 
   def runIncrementalResponses(response: GraphQLResponse[CalibanError]) =
-    response.data match {
-      case StreamValue(stream) => stream.runCollect
-      case value               => ZIO.succeed(Chunk.single(value))
-    }
+    (response match {
+      case resp @ GraphQLResponse(StreamValue(stream), _, _, _) =>
+        stream.via(HttpUtils.DeferMultipart.createPipeline(resp))
+      case resp                                                 =>
+        ZStream.succeed(resp.toResponseValue)
+    }).runCollect
 }

--- a/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
+++ b/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
@@ -21,11 +21,11 @@ object CharacterService {
   })
 }
 
-object DeferredExecutionSpec extends ZIOSpecDefault {
+object IncrementalDeliverySpec extends ZIOSpecDefault {
 
   import TestDeferredSchema._
 
-  override def spec = suite("Defer Execution")(
+  override def spec = suite("Incremental Delivery")(
     suite("@defer")(
       test("don't defer pure fields") {
 
@@ -329,7 +329,7 @@ object DeferredExecutionSpec extends ZIOSpecDefault {
           errors    = response.errors
         } yield assertTrue(
           errors.size == 1,
-          errors.head.is(_.subtype[ValidationError]).msg == "Stream directive labels must be unique"
+          errors.head.is(_.subtype[ValidationError]).msg == "Stream and defer directive labels must be unique"
         )
       }
     )

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -150,7 +150,7 @@ object TestDeferredSchema extends SchemaDerivation[CharacterService with QuoteSe
       )
     )
 
-  val interpreter = (graphQL(resolver) @@ IncrementalDelivery.aspect(Feature.Defer, Feature.Stream)).interpreter
+  val interpreter = (graphQL(resolver) @@ IncrementalDelivery.all).interpreter
 }
 
 object TestDatasourceDeferredSchema extends GenericSchema[Any] {
@@ -169,5 +169,5 @@ object TestDatasourceDeferredSchema extends GenericSchema[Any] {
     Foo(bar = ZIO.succeed(List(makeBar(1), makeBar(3), makeBar(3))))
   }))
 
-  val interpreter = (graphQL(resolver) @@ IncrementalDelivery.aspect(Feature.Defer)).interpreter
+  val interpreter = (graphQL(resolver) @@ IncrementalDelivery.defer).interpreter
 }

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -2,14 +2,51 @@ package caliban.execution
 
 import caliban.TestUtils.Role.{ Captain, Engineer, Mechanic, Pilot }
 import caliban.TestUtils.{ CaptainShipName, Character, CharacterArgs, Origin, Role }
-import caliban.{ graphQL, RootResolver }
 import caliban.schema.Annotations.GQLName
-import caliban.schema.{ GenericSchema, Schema }
-import caliban.wrappers.DeferSupport
+import caliban.schema.{ GenericSchema, Schema, SchemaDerivation }
+import caliban.wrappers.IncrementalDelivery
+import caliban.{ graphQL, RootResolver }
 import zio.query.{ DataSource, Request, UQuery, ZQuery }
-import zio.{ UIO, URIO, ZIO }
+import zio.stream.ZStream
+import zio.{ UIO, ULayer, URIO, ZIO, ZLayer }
 
-object TestDeferredSchema extends GenericSchema[CharacterService] {
+case class Episode(
+  season: Int,
+  episode: Int,
+  title: String
+)
+
+trait QuoteService {
+  def quotesBy(character: Character): ZStream[Any, Nothing, QuoteService.Quote]
+}
+
+object QuoteService {
+  val test: ULayer[QuoteService] = ZLayer.succeed(new QuoteService {
+    val quoteDB = Map(
+      "Roberta Draper" -> List(
+        Quote(
+          "You just have to believe that what you’re doing really matters, and then the fear can’t control you.",
+          from = Episode(4, 1, "New Terra")
+        ),
+        Quote(
+          "I'm Roberta, you can call me Bobby.",
+          from = Episode(4, 1, "New Terra")
+        )
+      )
+    )
+
+    override def quotesBy(character: Character): ZStream[Any, Nothing, Quote] =
+      ZStream.fromIterable(quoteDB.getOrElse(character.name, Nil))
+
+  })
+
+  case class Quote(
+    line: String,
+    from: Episode
+  )
+}
+
+object TestDeferredSchema extends SchemaDerivation[CharacterService with QuoteService] {
   import auto._
   import caliban.schema.ArgBuilder.auto._
 
@@ -23,17 +60,24 @@ object TestDeferredSchema extends GenericSchema[CharacterService] {
 
   case class ConnectionArgs(by: By)
 
+  case class Quote(
+    line: String,
+    from: Episode,
+    character: UIO[CharacterZIO]
+  )
+
   @GQLName("Character")
   case class CharacterZIO(
     name: String,
     nicknames: UIO[List[UIO[String]]],
     origin: Origin,
     role: Option[Role],
-    connections: ConnectionArgs => URIO[CharacterService, List[CharacterZIO]]
+    connections: ConnectionArgs => URIO[CharacterService with QuoteService, List[CharacterZIO]],
+    quotes: ZStream[CharacterService with QuoteService, Nothing, Quote] = ZStream.empty
   )
 
   case class Query(
-    character: CharacterArgs => URIO[CharacterService, Option[CharacterZIO]]
+    character: CharacterArgs => URIO[CharacterService with QuoteService, Option[CharacterZIO]]
   )
 
   def character2CharacterZIO(ch: Character): CharacterZIO =
@@ -60,11 +104,41 @@ object TestDeferredSchema extends GenericSchema[CharacterService] {
             case Engineer(shipName)                 => maybeShip.contains(shipName)
             case Mechanic(shipName)                 => maybeShip.contains(shipName)
           }).map(_.filter(_ != ch).map(character2CharacterZIO)))
-      }
+      },
+      quotes = ZStream.serviceWithStream[QuoteService](_.quotesBy(ch).map { q =>
+        Quote(
+          q.line,
+          q.from,
+          ZIO.succeed(character2CharacterZIO(ch))
+        )
+      })
     )
 
-  implicit lazy val characterSchema: Schema[CharacterService, CharacterZIO] = genAll[CharacterService, CharacterZIO]
-  implicit val querySchema: Schema[CharacterService, Query]                 = gen[CharacterService, Query]
+  implicit val characterArgsSchema: Schema[CharacterService with QuoteService, CharacterArgs] =
+    genAll[CharacterService with QuoteService, CharacterArgs]
+  implicit val roleSchema: Schema[CharacterService with QuoteService, Role]                   =
+    gen[CharacterService with QuoteService, Role]
+  implicit val originSchema: Schema[CharacterService with QuoteService, Origin]               =
+    gen[CharacterService with QuoteService, Origin]
+  implicit val episodeSchema: Schema[CharacterService with QuoteService, Episode]             =
+    gen[CharacterService with QuoteService, Episode]
+  implicit val quoteSchema: Schema[CharacterService with QuoteService, Quote]                 =
+    gen[CharacterService with QuoteService, Quote]
+  implicit lazy val characterSchema: Schema[CharacterService with QuoteService, CharacterZIO] =
+    obj(
+      "Character"
+    )(implicit fa =>
+      List(
+        field("name")(_.name),
+        field("nicknames")(_.nicknames),
+        field("origin")(_.origin),
+        field("role")(_.role),
+        fieldWithArgs("connections")(_.connections),
+        field("quotes")(_.quotes)
+      )
+    )
+  implicit val querySchema: Schema[CharacterService with QuoteService, Query]                 =
+    genAll[CharacterService with QuoteService, Query]
 
   val resolver =
     RootResolver(
@@ -76,7 +150,7 @@ object TestDeferredSchema extends GenericSchema[CharacterService] {
       )
     )
 
-  val interpreter = (graphQL(resolver) @@ DeferSupport.defer).interpreter
+  val interpreter = (graphQL(resolver) @@ IncrementalDelivery.aspect(Feature.Defer, Feature.Stream)).interpreter
 }
 
 object TestDatasourceDeferredSchema extends GenericSchema[Any] {
@@ -95,5 +169,5 @@ object TestDatasourceDeferredSchema extends GenericSchema[Any] {
     Foo(bar = ZIO.succeed(List(makeBar(1), makeBar(3), makeBar(3))))
   }))
 
-  val interpreter = (graphQL(resolver) @@ DeferSupport.defer).interpreter
+  val interpreter = (graphQL(resolver) @@ IncrementalDelivery.aspect(Feature.Defer)).interpreter
 }

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -92,13 +92,13 @@ object ExampleApi {
         Subscriptions(exampleService.deletedEvents)
       )
     ) @@
-      maxFields(300) @@                         // query analyzer that limit query fields
-      maxDepth(30) @@                           // query analyzer that limit query depth
-      timeout(3 seconds) @@                     // wrapper that fails slow queries
-      printSlowQueries(500 millis) @@           // wrapper that logs slow queries
-      printErrors @@                            // wrapper that logs errors
-      apolloTracing() @@                        // wrapper for https://github.com/apollographql/apollo-tracing
-      IncrementalDelivery.aspect(Feature.Defer) // wrapper that enables @defer directive support
+      maxFields(300) @@               // query analyzer that limit query fields
+      maxDepth(30) @@                 // query analyzer that limit query depth
+      timeout(3 seconds) @@           // wrapper that fails slow queries
+      printSlowQueries(500 millis) @@ // wrapper that logs slow queries
+      printErrors @@                  // wrapper that logs errors
+      apolloTracing() @@              // wrapper for https://github.com/apollographql/apollo-tracing
+      IncrementalDelivery.defer       // wrapper that enables @defer directive support
   }
 
   val layer: ZLayer[ExampleService, Nothing, GraphQL[Any]] =

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -2,13 +2,12 @@ package example
 
 import example.ExampleData._
 import caliban._
-import caliban.execution.Feature
 import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLName }
 import caliban.schema.Schema
 import caliban.schema.ArgBuilder.auto._
 import caliban.schema.Schema.auto._
 import caliban.wrappers.ApolloTracing.apolloTracing
-import caliban.wrappers.{ DeferSupport, IncrementalDelivery }
+import caliban.wrappers.IncrementalDelivery
 import caliban.wrappers.Wrappers._
 import zio._
 import zio.stream.ZStream

--- a/examples/src/main/scala/example/ExampleApi.scala
+++ b/examples/src/main/scala/example/ExampleApi.scala
@@ -2,12 +2,13 @@ package example
 
 import example.ExampleData._
 import caliban._
+import caliban.execution.Feature
 import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription, GQLName }
 import caliban.schema.Schema
 import caliban.schema.ArgBuilder.auto._
 import caliban.schema.Schema.auto._
 import caliban.wrappers.ApolloTracing.apolloTracing
-import caliban.wrappers.DeferSupport
+import caliban.wrappers.{ DeferSupport, IncrementalDelivery }
 import caliban.wrappers.Wrappers._
 import zio._
 import zio.stream.ZStream
@@ -91,13 +92,13 @@ object ExampleApi {
         Subscriptions(exampleService.deletedEvents)
       )
     ) @@
-      maxFields(300) @@               // query analyzer that limit query fields
-      maxDepth(30) @@                 // query analyzer that limit query depth
-      timeout(3 seconds) @@           // wrapper that fails slow queries
-      printSlowQueries(500 millis) @@ // wrapper that logs slow queries
-      printErrors @@                  // wrapper that logs errors
-      apolloTracing() @@              // wrapper for https://github.com/apollographql/apollo-tracing
-      DeferSupport.defer              // wrapper that enables @defer directive support
+      maxFields(300) @@                         // query analyzer that limit query fields
+      maxDepth(30) @@                           // query analyzer that limit query depth
+      timeout(3 seconds) @@                     // wrapper that fails slow queries
+      printSlowQueries(500 millis) @@           // wrapper that logs slow queries
+      printErrors @@                            // wrapper that logs errors
+      apolloTracing() @@                        // wrapper for https://github.com/apollographql/apollo-tracing
+      IncrementalDelivery.aspect(Feature.Defer) // wrapper that enables @defer directive support
   }
 
   val layer: ZLayer[ExampleService, Nothing, GraphQL[Any]] =

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
@@ -66,6 +66,6 @@ object TestApi extends GenericSchema[TestService with Uploads] {
       timeout(3 seconds) @@           // wrapper that fails slow queries
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       apolloTracing() @@              // wrapper for https://github.com/apollographql/apollo-tracing
-      IncrementalDelivery.aspect(Feature.Defer) @@
+      IncrementalDelivery.defer @@
       Caching.extension()
 }

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
@@ -1,14 +1,13 @@
 package caliban.interop.tapir
 
 import caliban._
-import caliban.execution.Feature
 import caliban.interop.tapir.TestData._
 import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._
 import caliban.uploads.{ Upload, Uploads }
 import caliban.wrappers.ApolloTracing.apolloTracing
-import caliban.wrappers.{ Caching, DeferSupport, IncrementalDelivery }
+import caliban.wrappers.{ Caching, IncrementalDelivery }
 import caliban.wrappers.Wrappers._
 import zio._
 import zio.stream.ZStream

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TestApi.scala
@@ -1,13 +1,14 @@
 package caliban.interop.tapir
 
 import caliban._
+import caliban.execution.Feature
 import caliban.interop.tapir.TestData._
 import caliban.schema.Annotations.{ GQLDeprecated, GQLDescription }
 import caliban.schema.{ GenericSchema, Schema }
 import caliban.schema.ArgBuilder.auto._
 import caliban.uploads.{ Upload, Uploads }
 import caliban.wrappers.ApolloTracing.apolloTracing
-import caliban.wrappers.{ Caching, DeferSupport }
+import caliban.wrappers.{ Caching, DeferSupport, IncrementalDelivery }
 import caliban.wrappers.Wrappers._
 import zio._
 import zio.stream.ZStream
@@ -65,6 +66,6 @@ object TestApi extends GenericSchema[TestService with Uploads] {
       timeout(3 seconds) @@           // wrapper that fails slow queries
       printSlowQueries(500 millis) @@ // wrapper that logs slow queries
       apolloTracing() @@              // wrapper for https://github.com/apollographql/apollo-tracing
-      DeferSupport.defer @@
+      IncrementalDelivery.aspect(Feature.Defer) @@
       Caching.extension()
 }


### PR DESCRIPTION
Adds support for the `@stream` directive which seems to have stabilized a bit. I attempted to merge the two concepts of defer and stream but they are just too different conceptually.

TODO:

- [x] Add validation for the stream and defer directives per spec
- [x] Add more unit tests for stream