### PR TITLE
Use `Either` instead of `ZPure` in `Validator` / `VariableCoercer`

### DIFF
--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -59,7 +59,7 @@ object VariablesCoercer {
                   s"Type of variable '$variableName' $e",
                   "Variables can only be input types. Objects, unions, and interfaces cannot be used as inputs."
                 )
-              case _       => unitR
+              case _       => unit
             }
           ) *> {
             variables

--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -9,13 +9,11 @@ import caliban.parsing.adt._
 import caliban.schema.RootType
 import caliban.validation.Validator.failValidation
 import caliban.{ GraphQLRequest, InputValue, Value }
-import zio._
-import zio.prelude.EReader
-import zio.prelude.fx.ZPure
 
 import scala.collection.compat._
 
 object VariablesCoercer {
+  import caliban.validation.ValidationOps._
 
   def coerceVariables(
     req: GraphQLRequest,
@@ -31,38 +29,54 @@ object VariablesCoercer {
     doc: Document,
     rootType: RootType,
     skipValidation: Boolean
+  ): Either[ValidationError, Map[String, InputValue]] =
+    try
+      coerceVariablesUnsafe(variables, doc, rootType, skipValidation)
+    catch {
+      case _: StackOverflowError => Left(ValidationError("max arguments depth exceeded", ""))
+    }
+
+  private def coerceVariablesUnsafe(
+    variables: Map[String, InputValue],
+    doc: Document,
+    rootType: RootType,
+    skipValidation: Boolean
   ): Either[ValidationError, Map[String, InputValue]] = {
     // Scala 2's compiler loves inferring `ZPure.succeed` as ZPure[Nothing, Nothing, Any, R, E, A] so we help it out
-    type F[+A] = EReader[Any, ValidationError, A]
+    type F[+A] = Either[ValidationError, A]
 
     val variableDefinitions = doc.operationDefinitions.flatMap(_.variableDefinitions)
 
     if (variableDefinitions.isEmpty) Right(variables)
     else
       variableDefinitions
-        .foldLeft[F[List[(String, InputValue)]]](ZPure.succeed(Nil)) { case (coercedValues, definition) =>
+        .foldLeft[F[List[(String, InputValue)]]](Right(Nil)) { case (coercedValues, definition) =>
           val variableName = definition.name
-          ZPure.unless[Nothing, Unit, Any, ValidationError, Unit](skipValidation)(
+          when(!skipValidation)(
             isInputType(definition.variableType, rootType) match {
               case Left(e) =>
                 failValidation(
                   s"Type of variable '$variableName' $e",
                   "Variables can only be input types. Objects, unions, and interfaces cannot be used as inputs."
                 )
-              case _       => ZPure.unit
+              case _       => unitR
             }
           ) *> {
             variables
               .get(definition.name)
-              .map[F[InputValue]](inputValue =>
+              .map { inputValue =>
                 rewriteValues(
                   inputValue,
                   definition.variableType,
                   rootType,
                   s"Variable '$variableName'"
-                ).catchSome { case _ if skipValidation => ZPure.succeed(inputValue) }
-              )
-              .orElse(definition.defaultValue.map[F[InputValue]](ZPure.succeed)) match {
+                ) match {
+                  case Right(v)                  => Right(v)
+                  case Left(_) if skipValidation => Right(inputValue)
+                  case Left(e)                   => Left(e)
+                }
+              }
+              .orElse(definition.defaultValue.map(Right(_))) match {
               case Some(v)                                                 =>
                 for {
                   values <- coercedValues
@@ -78,7 +92,6 @@ object VariablesCoercer {
           }
         }
         .map(_.toMap)
-        .runEither
   }
 
   // https://spec.graphql.org/June2018/#IsInputType()
@@ -107,10 +120,10 @@ object VariablesCoercer {
     `type`: Type,
     rootType: RootType,
     context: => String
-  ): EReader[Any, ValidationError, InputValue] =
+  ): Either[ValidationError, InputValue] =
     resolveType(rootType, `type`) match {
       case Some(typ) => coerceValues(value, typ, context)
-      case None      => ZPure.succeed(value)
+      case None      => Right(value)
     }
 
   private def resolveType(rootType: RootType, `type`: Type): Option[__Type] =
@@ -135,7 +148,7 @@ object VariablesCoercer {
     value: InputValue,
     typ: __Type,
     context: => String // Careful not to materialize unless we need to fail!
-  ): EReader[Any, ValidationError, InputValue] =
+  ): Either[ValidationError, InputValue] =
     typ.kind match {
       case __TypeKind.NON_NULL                     =>
         value match {
@@ -146,13 +159,13 @@ object VariablesCoercer {
             )
           case _         =>
             typ.ofType
-              .map(innerType => ZPure.suspend(coerceValues(value, innerType, context)))
-              .getOrElse(ZPure.succeed(value))
+              .map(innerType => coerceValues(value, innerType, context))
+              .getOrElse(Right(value))
         }
 
       // Break early
       case _ if value.isInstanceOf[NullValue.type] =>
-        ZPure.succeed(NullValue)
+        Right(NullValue)
 
       case __TypeKind.INPUT_OBJECT =>
         value match {
@@ -173,23 +186,21 @@ object VariablesCoercer {
 
       case __TypeKind.LIST =>
         typ.ofType match {
-          case None           => ZPure.succeed(value)
+          case None           => Right(value)
           case Some(itemType) =>
             value match {
               case ListValue(values) =>
-                ZPure
-                  .foreach(values.zipWithIndex) { case (value, i) =>
-                    coerceValues(value, itemType, s"$context at index '$i'")
-                  }
-                  .map(ListValue.apply)
+                validateAll(values.zipWithIndex) { case (value, i) =>
+                  coerceValues(value, itemType, s"$context at index '$i'")
+                }.map(ListValue.apply)
               case v                 =>
-                ZPure.suspend(coerceValues(v, itemType, context).map(iv => ListValue(List(iv))))
+                coerceValues(v, itemType, context).map(iv => ListValue(List(iv)))
             }
         }
 
       case __TypeKind.ENUM =>
         value match {
-          case StringValue(value) => ZPure.succeed(Value.EnumValue(value))
+          case StringValue(value) => Right(Value.EnumValue(value))
           case v                  =>
             failValidation(
               s"$context with value $v cannot be coerced into ${typ.toType()}.",
@@ -199,7 +210,7 @@ object VariablesCoercer {
 
       case __TypeKind.SCALAR if typ.name.contains("String") =>
         value match {
-          case v: StringValue => ZPure.succeed(v)
+          case v: StringValue => Right(v)
           case v              =>
             failValidation(
               s"$context with value $v cannot be coerced into String.",
@@ -209,7 +220,7 @@ object VariablesCoercer {
 
       case __TypeKind.SCALAR if typ.name.contains("Boolean") =>
         value match {
-          case v: BooleanValue => ZPure.succeed(v)
+          case v: BooleanValue => Right(v)
           case v               =>
             failValidation(
               s"$context with value $v cannot be coerced into Boolean.",
@@ -219,9 +230,9 @@ object VariablesCoercer {
 
       case __TypeKind.SCALAR if typ.name.contains("Int") =>
         value match {
-          case v: IntValue.IntNumber    => ZPure.succeed(v)
-          case v: IntValue.LongNumber   => ZPure.succeed(v)
-          case v: IntValue.BigIntNumber => ZPure.succeed(v)
+          case v: IntValue.IntNumber    => Right(v)
+          case v: IntValue.LongNumber   => Right(v)
+          case v: IntValue.BigIntNumber => Right(v)
           case v                        =>
             failValidation(
               s"$context with value $v cannot be coerced into Int.",
@@ -231,12 +242,12 @@ object VariablesCoercer {
 
       case __TypeKind.SCALAR if typ.name.contains("Float") =>
         value match {
-          case v: FloatValue.FloatNumber      => ZPure.succeed(v)
-          case v: FloatValue.DoubleNumber     => ZPure.succeed(v)
-          case v: FloatValue.BigDecimalNumber => ZPure.succeed(v)
-          case v: IntValue.IntNumber          => ZPure.succeed(Value.FloatValue(v.value.toDouble))
-          case v: IntValue.LongNumber         => ZPure.succeed(Value.FloatValue(v.value.toDouble))
-          case v: IntValue.BigIntNumber       => ZPure.succeed(Value.FloatValue(BigDecimal(v.value)))
+          case v: FloatValue.FloatNumber      => Right(v)
+          case v: FloatValue.DoubleNumber     => Right(v)
+          case v: FloatValue.BigDecimalNumber => Right(v)
+          case v: IntValue.IntNumber          => Right(Value.FloatValue(v.value.toDouble))
+          case v: IntValue.LongNumber         => Right(Value.FloatValue(v.value.toDouble))
+          case v: IntValue.BigIntNumber       => Right(Value.FloatValue(BigDecimal(v.value)))
           case v                              =>
             failValidation(
               s"$context with value $v cannot be coerced into Float.",
@@ -244,39 +255,38 @@ object VariablesCoercer {
             )
         }
       case _                                               =>
-        ZPure.succeed(value)
+        Right(value)
     }
 
-  private val emptyObjectValue =
-    ZPure.succeed[Unit, InputValue.ObjectValue](InputValue.ObjectValue(Map.empty))
+  private val emptyObjectValue: Either[ValidationError, InputValue.ObjectValue] =
+    Right(InputValue.ObjectValue(Map.empty))
 
   private def foreachObjectField(
     in: Map[String, InputValue]
   )(
-    f: (String, InputValue) => EReader[Any, ValidationError, InputValue]
-  ): EReader[Any, ValidationError, InputValue.ObjectValue] =
+    f: (String, InputValue) => Either[ValidationError, InputValue]
+  ): Either[ValidationError, InputValue.ObjectValue] =
     if (in.isEmpty) emptyObjectValue
     else if (in.size == 1) {
       val (k, v) = in.head
       f(k, v).map(v => InputValue.ObjectValue(Map(k -> v)))
-    } else
-      ZPure.suspend {
-        type Out = EReader[Any, ValidationError, InputValue.ObjectValue]
+    } else {
+      type Out = Either[ValidationError, InputValue.ObjectValue]
 
-        val iterator = in.iterator
-        val builder  = Map.newBuilder[String, InputValue]
+      val iterator = in.iterator
+      val builder  = Map.newBuilder[String, InputValue]
 
-        lazy val recurse: (String, InputValue) => Out = { (k, v) =>
-          builder += ((k, v))
-          loop()
-        }
-
-        def loop(): Out =
-          if (iterator.hasNext) {
-            val (k, v) = iterator.next()
-            f(k, v).flatMap(recurse(k, _))
-          } else ZPure.succeed(InputValue.ObjectValue(builder.result()))
-
+      lazy val recurse: (String, InputValue) => Out = { (k, v) =>
+        builder += ((k, v))
         loop()
       }
+
+      def loop(): Out =
+        if (iterator.hasNext) {
+          val (k, v) = iterator.next()
+          f(k, v).flatMap(recurse(k, _))
+        } else Right(InputValue.ObjectValue(builder.result()))
+
+      loop()
+    }
 }

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -16,7 +16,7 @@ object FragmentValidator {
     context: Context,
     parentType: __Type,
     selectionSet: List[Selection]
-  ): EReader[Any, ValidationError, Unit] = {
+  ): Either[ValidationError, Unit] = {
 
     // NOTE: We use the `hashCode()` as the key since it's much more performant
     val shapeCache   = mutable.Map.empty[Int, Chunk[String]]
@@ -123,9 +123,10 @@ object FragmentValidator {
     }
 
     val conflicts = sameResponseShapeByName(selectionSet) ++ sameForCommonParentsByName(selectionSet)
-    conflicts match {
-      case Chunk(head, _*) => ZPure.fail(ValidationError(head, ""))
-      case _               => ZPure.unit
+    if (conflicts.nonEmpty) {
+      Left(ValidationError(conflicts.head, ""))
+    } else {
+      ValidationOps.unitR
     }
   }
 }

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -126,7 +126,7 @@ object FragmentValidator {
     if (conflicts.nonEmpty) {
       Left(ValidationError(conflicts.head, ""))
     } else {
-      ValidationOps.unitR
+      ValidationOps.unit
     }
   }
 }

--- a/core/src/main/scala/caliban/validation/ValidationOps.scala
+++ b/core/src/main/scala/caliban/validation/ValidationOps.scala
@@ -79,13 +79,13 @@ private[caliban] object ValidationOps {
 
   final implicit class EitherOps[E, A](private val self: Either[E, A]) extends AnyVal {
     def *>[B](other: Either[E, B]): Either[E, B] =
-      self match {
+      (self: @unchecked) match {
         case _: Right[?, ?]                      => other
         case l: Left[E @unchecked, B @unchecked] => l
       }
 
     def as[B](a: B): Either[E, B] =
-      self match {
+      (self: @unchecked) match {
         case _: Right[?, ?]                      => Right(a)
         case l: Left[E @unchecked, B @unchecked] => l
       }

--- a/core/src/main/scala/caliban/validation/ValidationOps.scala
+++ b/core/src/main/scala/caliban/validation/ValidationOps.scala
@@ -6,10 +6,10 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 private[caliban] object ValidationOps {
-  val unitR: Either[ValidationError, Unit] = Right(())
+  val unit: Either[Nothing, Unit] = Right(())
 
   def when(cond: Boolean)(f: => Either[ValidationError, Unit]): Either[ValidationError, Unit] =
-    if (cond) f else unitR
+    if (cond) f else unit
 
   // NOTE: We overload instead of using `Iterable` to avoid interface method calls
   def validateAllDiscard[A](
@@ -21,7 +21,7 @@ private[caliban] object ValidationOps {
       if (res.isLeft) return res
       else rem = rem.tail
     }
-    unitR
+    unit
   }
 
   def validateAllDiscard[K, V](
@@ -33,7 +33,7 @@ private[caliban] object ValidationOps {
       val res    = f(k, v)
       if (res.isLeft) return res
     }
-    unitR
+    unit
   }
 
   def validateAllDiscard[A](
@@ -44,7 +44,7 @@ private[caliban] object ValidationOps {
       val res = f(it.next())
       if (res.isLeft) return res
     }
-    unitR
+    unit
   }
 
   def validateAllNonEmpty[A](
@@ -75,7 +75,7 @@ private[caliban] object ValidationOps {
   def failWhen(
     condition: Boolean
   )(msg: => String, explanatoryText: => String): Either[ValidationError, Unit] =
-    if (condition) Validator.failValidation(msg, explanatoryText) else unitR
+    if (condition) Validator.failValidation(msg, explanatoryText) else unit
 
   final implicit class EitherOps[E, A](private val self: Either[E, A]) extends AnyVal {
     def *>[B](other: Either[E, B]): Either[E, B] =
@@ -88,6 +88,12 @@ private[caliban] object ValidationOps {
       (self: @unchecked) match {
         case _: Right[?, ?]                      => Right(a)
         case l: Left[E @unchecked, B @unchecked] => l
+      }
+
+    def unit: Either[E, Unit] =
+      (self: @unchecked) match {
+        case _: Right[?, ?]                         => ValidationOps.unit
+        case l: Left[E @unchecked, Unit @unchecked] => l
       }
   }
 

--- a/core/src/main/scala/caliban/validation/ValidationOps.scala
+++ b/core/src/main/scala/caliban/validation/ValidationOps.scala
@@ -1,0 +1,99 @@
+package caliban.validation
+
+import caliban.CalibanError.ValidationError
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+private[caliban] object ValidationOps {
+  val unitR: Either[ValidationError, Unit] = Right(())
+
+  def when(cond: Boolean)(f: => Either[ValidationError, Unit]): Either[ValidationError, Unit] =
+    if (cond) f else unitR
+
+  // NOTE: We overload instead of using `Iterable` to avoid interface method calls
+  def validateAllDiscard[A](
+    in: List[A]
+  )(f: A => Either[ValidationError, Unit]): Either[ValidationError, Unit] = {
+    var rem = in
+    while (rem ne Nil) {
+      val res = f(rem.head)
+      if (res.isLeft) return res
+      else rem = rem.tail
+    }
+    unitR
+  }
+
+  def validateAllDiscard[K, V](
+    in: Map[K, V]
+  )(f: (K, V) => Either[ValidationError, Unit]): Either[ValidationError, Unit] = {
+    val it = in.iterator
+    while (it.hasNext) {
+      val (k, v) = it.next()
+      val res    = f(k, v)
+      if (res.isLeft) return res
+    }
+    unitR
+  }
+
+  def validateAllDiscard[A](
+    in: mutable.Set[A]
+  )(f: A => Either[ValidationError, Unit]): Either[ValidationError, Unit] = {
+    val it = in.iterator
+    while (it.hasNext) {
+      val res = f(it.next())
+      if (res.isLeft) return res
+    }
+    unitR
+  }
+
+  def validateAllNonEmpty[A](
+    in: List[A]
+  )(f: A => Either[ValidationError, Unit]): Option[Either[ValidationError, Unit]] =
+    if (in.isEmpty) None
+    else Some(validateAllDiscard(in)(f))
+
+  def validateAll[A, B](
+    in: List[A]
+  )(f: A => Either[ValidationError, B]): Either[ValidationError, List[B]] = {
+    var i       = 0
+    var rem     = in
+    var err     = null.asInstanceOf[ValidationError]
+    val builder = ListBuffer.empty[B]
+    while ((rem ne Nil) && (err eq null)) {
+      val value = rem.head
+      f(value) match {
+        case Right(v) => builder.addOne(v)
+        case Left(e)  => err = e
+      }
+      i += 1
+      rem = rem.tail
+    }
+    if (err eq null) Right(builder.result()) else Left(err)
+  }
+
+  def failWhen(
+    condition: Boolean
+  )(msg: => String, explanatoryText: => String): Either[ValidationError, Unit] =
+    if (condition) Validator.failValidation(msg, explanatoryText) else unitR
+
+  final implicit class EitherOps[E, A](private val self: Either[E, A]) extends AnyVal {
+    def *>[B](other: Either[E, B]): Either[E, B] =
+      self match {
+        case _: Right[?, ?]                      => other
+        case l: Left[E @unchecked, B @unchecked] => l
+      }
+
+    def as[B](a: B): Either[E, B] =
+      self match {
+        case _: Right[?, ?]                      => Right(a)
+        case l: Left[E @unchecked, B @unchecked] => l
+      }
+  }
+
+  implicit class EnrichedListBufferOps[A](private val lb: ListBuffer[A]) extends AnyVal {
+    // This method doesn't exist in Scala 2.12 so we just use `.map` for it instead
+    def addOne(elem: A): ListBuffer[A]            = lb += elem
+    def addAll(elems: Iterable[A]): ListBuffer[A] = lb ++= elems
+  }
+}

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -52,14 +52,14 @@ object Validator {
    * Fails with a [[caliban.CalibanError.ValidationError]] otherwise.
    */
   def validate(document: Document, rootType: RootType)(implicit trace: Trace): IO[ValidationError, Unit] =
-    Configurator.ref.getWith(v => Exit.fromEither(check(document, rootType, Map.empty, v.validations).map(_ => ())))
+    Configurator.ref.getWith(v => Exit.fromEither(check(document, rootType, Map.empty, v.validations).unit))
 
   /**
    * Verifies that the given document is valid for this type for all available validations.
    * Fails with a [[caliban.CalibanError.ValidationError]] otherwise.
    */
   def validateAll(document: Document, rootType: RootType): Either[ValidationError, Unit] =
-    check(document, rootType, Map.empty, AllValidations).map(_ => ())
+    check(document, rootType, Map.empty, AllValidations).unit
 
   /**
    * Verifies that the given schema is valid. Fails with a [[caliban.CalibanError.ValidationError]] otherwise.
@@ -76,10 +76,8 @@ object Validator {
     } yield schema
   }
 
-  private val unit: Either[ValidationError, Unit] = Right(())
-
   private[caliban] def validateType(t: __Type): Either[ValidationError, Unit] =
-    t.name.fold(unit)(name => checkName(name, s"Type '$name'")) *>
+    t.name.fold(unit: Either[ValidationError, Unit])(name => checkName(name, s"Type '$name'")) *>
       (t.kind match {
         case __TypeKind.ENUM         => validateEnum(t)
         case __TypeKind.UNION        => validateUnion(t)

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -70,7 +70,7 @@ private object ValueValidator {
                   validateType(inputType.ofType.getOrElse(inputType), v, context, s"List item in $errorContext")
                 )
               case NullValue         =>
-                unitR
+                unit
               case other             =>
                 // handle item as the first item in the list
                 validateType(inputType.ofType.getOrElse(inputType), other, context, s"List item in $errorContext")
@@ -86,11 +86,11 @@ private object ValueValidator {
                     case None if f.defaultValue.isEmpty =>
                       validateType(f._type, NullValue, context, s"Field ${f.name} in $errorContext")
                     case _                              =>
-                      unitR
+                      unit
                   }
                 }
               case NullValue           =>
-                unitR
+                unit
               case _                   =>
                 failValidation(
                   s"$errorContext has invalid type: $argValue",
@@ -102,7 +102,7 @@ private object ValueValidator {
               case EnumValue(value) =>
                 validateEnum(value, inputType, errorContext)
               case NullValue        =>
-                unitR
+                unit
               case _                =>
                 failValidation(
                   s"$errorContext has invalid type: $argValue",
@@ -141,31 +141,31 @@ private object ValueValidator {
     inputType.name.getOrElse("") match {
       case "String"  =>
         argValue match {
-          case _: StringValue | NullValue => unitR
+          case _: StringValue | NullValue => unit
           case t                          => failValidation(s"$errorContext has invalid type $t", "Expected 'String'")
         }
       case "ID"      =>
         argValue match {
-          case _: StringValue | NullValue => unitR
+          case _: StringValue | NullValue => unit
           case t                          => failValidation(s"$errorContext has invalid type $t", "Expected 'ID'")
         }
       case "Int"     =>
         argValue match {
-          case _: Value.IntValue | NullValue => unitR
+          case _: Value.IntValue | NullValue => unit
           case t                             => failValidation(s"$errorContext has invalid type $t", "Expected 'Int'")
         }
       case "Float"   =>
         argValue match {
-          case _: Value.FloatValue | _: Value.IntValue | NullValue => unitR
+          case _: Value.FloatValue | _: Value.IntValue | NullValue => unit
           case t                                                   => failValidation(s"$errorContext has invalid type $t", "Expected 'Float'")
         }
       case "Boolean" =>
         argValue match {
-          case _: BooleanValue | NullValue => unitR
+          case _: BooleanValue | NullValue => unit
           case t                           => failValidation(s"$errorContext has invalid type $t", "Expected 'Boolean'")
         }
       // We can't really validate custom scalars here (since we can't summon a correct ArgBuilder instance), so just pass them along
-      case _         => unitR
+      case _         => unit
     }
 
   def failValidation[T](msg: String, explanatoryText: String): Either[ValidationError, T] =


### PR DESCRIPTION
So far we've been using a ZPure in the Validator & VariableCoercer mainly to ensure stack-safety when validating queries. However, for a stack-overflow error to occur we need to either:
1. Have fragments that reference themselves or,
2. An extremely deep query (modern JVMs can handle thousands of recursive calls before throwing a SO error)

Since we already validate (1), the only "real" problem that remains is (2). However, I think that this is not a real issue because the real case where a query would be deep enough to trigger a SO error is for malicious purposes / to DDoS the server.

To guard against this possibility, users _should_ be using the `maxDepth` wrapper. But in the case they're not, we catch the SO error as a last resort and fail gracefully via a Validation error.

This approach is much more performant but also allows us to become "leaner", reducing our reliance on ZIO for most core operations

### Benchmark results:

series/2.x
```
[info] Benchmark                             Mode  Cnt        Score        Error  Units
[info] ValidationBenchmark.deep             thrpt    3   993038.766 ± 172816.842  ops/s
[info] ValidationBenchmark.introspection    thrpt    3    68131.837 ±  15473.702  ops/s
[info] ValidationBenchmark.multifield       thrpt    3  1120473.149 ± 198296.763  ops/s
[info] ValidationBenchmark.simple           thrpt    3  1587383.592 ±  68291.852  ops/s
[info] ValidationBenchmark.variableCoercer  thrpt    3    80349.172 ±   8376.846  ops/s
```

PR:
```
[info] Benchmark                             Mode  Cnt        Score        Error  Units
[info] ValidationBenchmark.deep             thrpt    6  2259244.590 ±  42814.904  ops/s
[info] ValidationBenchmark.introspection    thrpt    6   111222.161 ±  19679.459  ops/s
[info] ValidationBenchmark.multifield       thrpt    6  2663080.586 ±  32436.908  ops/s
[info] ValidationBenchmark.simple           thrpt    6  5988742.244 ± 239073.495  ops/s
[info] ValidationBenchmark.variableCoercer  thrpt    6   181029.042 ±  18279.451  ops/s
```

PS: I'll followup with another PR to remove `zio-prelude` as a dependency since it's not _really_ needed anymore