### PR TITLE
Remove dependency on `zio-prelude`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,6 @@ val zqueryVersion             = "0.7.2"
 val zioJsonVersion            = "0.7.0"
 val zioHttpVersion            = "3.0.0-RC8"
 val zioOpenTelemetryVersion   = "3.0.0-RC21"
-val zioPreludeVersion         = "1.0.0-RC27"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -176,7 +175,6 @@ lazy val core = project
         "dev.zio"                               %% "zio"                     % zioVersion,
         "dev.zio"                               %% "zio-streams"             % zioVersion,
         "dev.zio"                               %% "zio-query"               % zqueryVersion,
-        "dev.zio"                               %% "zio-prelude"             % zioPreludeVersion,
         "dev.zio"                               %% "zio-test"                % zioVersion      % Test,
         "dev.zio"                               %% "zio-test-sbt"            % zioVersion      % Test,
         "dev.zio"                               %% "zio-json"                % zioJsonVersion  % Optional,

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -5,8 +5,6 @@ import caliban.introspection.adt._
 import caliban.parsing.adt.Selection
 import caliban.validation.Utils._
 import zio.Chunk
-import zio.prelude._
-import zio.prelude.fx.ZPure
 
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
@@ -64,12 +62,12 @@ object FragmentValidator {
 
     def doTypesConflict(t1: __Type, t2: __Type): Boolean =
       if (isNonNull(t1))
-        if (isNonNull(t2)) (t1.ofType, t2.ofType).mapN((p1, p2) => doTypesConflict(p1, p2)).getOrElse(true)
+        if (isNonNull(t2)) t1.ofType.flatMap(p1 => t2.ofType.map(p2 => doTypesConflict(p1, p2))).getOrElse(true)
         else true
       else if (isNonNull(t2))
         true
       else if (isListType(t1))
-        if (isListType(t2)) (t1.ofType, t2.ofType).mapN((p1, p2) => doTypesConflict(p1, p2)).getOrElse(true)
+        if (isListType(t2)) t1.ofType.flatMap(p1 => t2.ofType.map(p2 => doTypesConflict(p1, p2))).getOrElse(true)
         else true
       else if (isListType(t2))
         true

--- a/core/src/main/scala/caliban/wrappers/Caching.scala
+++ b/core/src/main/scala/caliban/wrappers/Caching.scala
@@ -9,9 +9,8 @@ import caliban.parsing.adt.{ Directive, Document }
 import caliban.schema.Annotations.{ GQLDirective, GQLName }
 import caliban.schema.Types
 import caliban.wrappers.Wrapper.{ EffectfulWrapper, FieldWrapper, OverallWrapper, ValidationWrapper }
-import zio.prelude._
 import zio.query.ZQuery
-import zio.{ durationInt, Duration, Exit, FiberRef, Ref, UIO, Unsafe, ZIO }
+import zio.{ duration2DurationOps, durationInt, Duration, Exit, FiberRef, Ref, UIO, Unsafe, ZIO }
 
 import java.util.concurrent.{ ConcurrentHashMap, TimeUnit }
 
@@ -167,14 +166,12 @@ object Caching {
       override def toString: String = "PUBLIC"
     }
 
-    implicit val ord: Ord[CacheScope] = Ord.make {
-      case (Private, Private) => Ordering.Equals
-      case (Public, Public)   => Ordering.Equals
-      case (Private, Public)  => Ordering.LessThan
-      case (Public, Private)  => Ordering.GreaterThan
+    implicit val ordering: Ordering[CacheScope] = {
+      case (Private, Private) => 0
+      case (Public, Public)   => 0
+      case (Private, Public)  => -1
+      case (Public, Private)  => 1
     }
-
-    implicit val ordering: scala.math.Ordering[CacheScope] = ord.toScala
 
     val _type = __Type(
       __TypeKind.ENUM,

--- a/core/src/main/scala/caliban/wrappers/Caching.scala
+++ b/core/src/main/scala/caliban/wrappers/Caching.scala
@@ -13,6 +13,7 @@ import zio.query.ZQuery
 import zio.{ duration2DurationOps, durationInt, Duration, Exit, FiberRef, Ref, UIO, Unsafe, ZIO }
 
 import java.util.concurrent.{ ConcurrentHashMap, TimeUnit }
+import scala.collection.compat._
 
 object Caching {
   val DirectiveName     = "cacheControl"


### PR DESCRIPTION
Now that validation works based on Either, we don't really need it as a dependency.

@ghostdogpr we'll need to mention in the release notes that users who use both might need to add an explicit dependency on it