### PR TITLE
Avoid repeating validations on Fragments

### DIFF
--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -285,7 +285,7 @@ object Validator {
           if (directives.nonEmpty)
             builder addOne directives.map((_, __DirectiveLocation.FIELD))
           loop(selectionSet)
-        case FragmentSpread(name, directives)            =>
+        case FragmentSpread(_, directives)               =>
           if (directives.nonEmpty)
             builder addOne directives.map((_, __DirectiveLocation.FRAGMENT_SPREAD))
         case InlineFragment(_, directives, selectionSet) =>


### PR DESCRIPTION
One of the pesky things about Fragments is that it's very "easy" to end up repeating doing the same work, especially when it comes to validation. This happens as a field's selection set will contain a fragment, and we end up re-validating the fragment all-over again.

This PR adds caching for fragment validation in a few places in the Validator. Note that we've already been doing this in some other parts.

With these changes, there's ~60% throughput increase for validating fragments based on the `introspection` query from this very "simple" optimization :)