### PR TITLE
World's smallest micro-optimization

### DIFF
--- a/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
+++ b/core/src/main/scala/caliban/wrappers/ApolloPersistedQueries.scala
@@ -120,15 +120,26 @@ object ApolloPersistedQueries {
         case _                              => None
       }
 
-  private def hex(bytes: Array[Byte]): String = {
-    val builder = new mutable.StringBuilder(bytes.length * 2)
-    bytes.foreach(byte => builder.append(f"$byte%02x".toLowerCase))
-    builder.mkString
-  }
+  private val HexArray: Array[Char] = "0123456789abcdef".toCharArray
 
   private def checkHash(hash: String, query: String): Boolean = {
     val sha256 = java.security.MessageDigest.getInstance("SHA-256")
     val digest = sha256.digest(query.getBytes(StandardCharsets.UTF_8))
-    hex(digest) == hash
+    digestMatchesHash(digest, hash)
   }
+
+  private def digestMatchesHash(digest: Array[Byte], hash: String): Boolean = {
+    val chars = hash.toCharArray
+    val size  = digest.length
+    var j     = 0
+    var res   = chars.length == size * 2
+    while (j < size && res) {
+      val v = digest(j) & 0xff
+      if (chars(j * 2) == HexArray(v >>> 4) && chars(j * 2 + 1) == HexArray(v & 0xf)) ()
+      else res = false
+      j += 1
+    }
+    res
+  }
+
 }


### PR DESCRIPTION
Full disclosure. This will probably have 0 meaningful impact to anyone's application, but I saw it the other day and couldn't help myself 🥲 I wouldn't be doing this is the previous code was intuitive or more readable, but I think they're both equally bad when it comes to readability.

Anyways, in APQs, instead of converting each byte into a string and extracting its 4-bit representation (hex), we just do the comparison on the fly avoiding materialising anything in memory.