### PR TITLE
Fix for ArgBuilder with when input is a value type

### DIFF
--- a/core/src/main/scala-2/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/ArgBuilderDerivation.scala
@@ -46,7 +46,7 @@ trait CommonArgBuilderDerivation {
     def build(input: InputValue): Either[ExecutionError, T] =
       input match {
         case InputValue.ObjectValue(fields) => fromFields(fields)
-        case _                              => Left(ExecutionError("expected an input object"))
+        case value                          => ctx.constructMonadic(p => p.typeclass.build(value))
       }
 
     private[this] def fromFields(fields: Map[String, InputValue]): Either[ExecutionError, T] =

--- a/core/src/test/scala-2/caliban/schema/ArgBuilderScala2Spec.scala
+++ b/core/src/test/scala-2/caliban/schema/ArgBuilderScala2Spec.scala
@@ -1,0 +1,27 @@
+package caliban.schema
+
+import caliban.Value.StringValue
+import caliban.schema.ArgBuilder.auto._
+import zio.test.Assertion._
+import zio.test._
+
+import java.util.UUID
+
+object ArgBuilderScala2Spec extends ZIOSpecDefault {
+  def spec = suite("ArgBuilderScala2")(
+    suite("AnyVal") {
+      test("ArgBuilder that extends AnyVal") {
+        val id    = UUID.randomUUID()
+        val value = ArgBuilder[UUIDId].build(StringValue(id.toString))
+        assert(value)(isRight(equalTo(UUIDId(id))))
+      }
+    }
+  )
+
+  trait Ids[T] extends Any {
+    self: AnyVal =>
+    def value: T
+  }
+
+  final case class UUIDId(value: UUID) extends AnyVal with Ids[UUID]
+}


### PR DESCRIPTION
Seems that we can't assume all the inputs will be an `ObjectValue`. I'm actually not even sure at which point we do the conversion, but the fix is to allow handling of `InputValue` types other than `ObjectValue`. PS: This implementation isn't strictly correct as we would need to ensure that there's only 1 param. However, instead of adding that restriction and making the behaviour non-backwards compatible, I left it relaxed (same as v2.7.x)