### PR TITLE
Improve performance of response encoding for jsoniter

### DIFF
--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -67,7 +67,7 @@ private[caliban] object ValueJsoniter {
     val iter = m.iterator
     while (iter.hasNext) {
       val (k, v) = iter.next()
-      out.writeKey(k)
+      out.writeNonEscapedAsciiKey(k)
       encodeInputValue(v, out)
     }
     out.writeObjectEnd()
@@ -117,7 +117,7 @@ private[caliban] object ValueJsoniter {
     while (remaining ne Nil) {
       val (k, v) = remaining.head
       remaining = remaining.tail
-      out.writeKey(k)
+      out.writeNonEscapedAsciiKey(k)
       encodeResponseValue(v, out)
     }
     out.writeObjectEnd()


### PR DESCRIPTION
GraphQL field names (which are used as keys in the JSON object) need to be one of the following: `_0-9A-Za-z`. Since none of these characters require escaping, we can use the _much_ more efficient `writeNonEscapedAsciiKey` method when writing object keys.

This seems to improve performance by ~5-10% for encoding responses based on our benchmarks. Weirdly enough, it seems that Scala 3 benefits much more than Scala 2 from this improvement 🤔