### PR TITLE
Support introspecting and client codegen of deprecated arguments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,7 +218,7 @@ lazy val tools = project
       "dev.zio"                       %% "zio-json"            % zioJsonVersion % Test
     )
   )
-  .dependsOn(core, clientJVM)
+  .dependsOn(core, clientJVM, quickAdapter % Test)
 
 lazy val tracing = project
   .in(file("tracing"))

--- a/client/src/main/scala/caliban/client/IntrospectionClient.scala
+++ b/client/src/main/scala/caliban/client/IntrospectionClient.scala
@@ -150,8 +150,17 @@ object IntrospectionClient {
         arguments = List(Argument("includeDeprecated", includeDeprecated, "Boolean"))
       )
     def inputFields[A](innerSelection: SelectionBuilder[__InputValue, A]): SelectionBuilder[__Type, Option[List[A]]] =
-      Field("inputFields", OptionOf(ListOf(Obj(innerSelection))))
-    def ofType[A](innerSelection: SelectionBuilder[__Type, A]): SelectionBuilder[__Type, Option[A]]                  =
+      inputFields(None)(innerSelection)
+    def inputFields[A](includeDeprecated: Option[Boolean])(
+      innerSelection: SelectionBuilder[__InputValue, A]
+    ): SelectionBuilder[__Type, Option[List[A]]] =
+      Field(
+        "inputFields",
+        OptionOf(ListOf(Obj(innerSelection))),
+        arguments = List(Argument("includeDeprecated", includeDeprecated, "Boolean"))
+      )
+
+    def ofType[A](innerSelection: SelectionBuilder[__Type, A]): SelectionBuilder[__Type, Option[A]] =
       Field("ofType", OptionOf(Obj(innerSelection)))
   }
 
@@ -160,7 +169,15 @@ object IntrospectionClient {
     def name: SelectionBuilder[__Field, String]                                                        = Field("name", Scalar())
     def description: SelectionBuilder[__Field, Option[String]]                                         = Field("description", OptionOf(Scalar()))
     def args[A](innerSelection: SelectionBuilder[__InputValue, A]): SelectionBuilder[__Field, List[A]] =
-      Field("args", ListOf(Obj(innerSelection)))
+      args(None)(innerSelection)
+    def args[A](
+      includeDeprecated: Option[Boolean]
+    )(innerSelection: SelectionBuilder[__InputValue, A]): SelectionBuilder[__Field, List[A]] =
+      Field(
+        "args",
+        ListOf(Obj(innerSelection)),
+        arguments = List(Argument("includeDeprecated", includeDeprecated, "Boolean"))
+      )
     def `type`[A](innerSelection: SelectionBuilder[__Type, A]): SelectionBuilder[__Field, A]           =
       Field("type", Obj(innerSelection))
     def isDeprecated: SelectionBuilder[__Field, Boolean]                                               = Field("isDeprecated", Scalar())
@@ -173,6 +190,9 @@ object IntrospectionClient {
     def description: SelectionBuilder[__InputValue, Option[String]]                               = Field("description", OptionOf(Scalar()))
     def `type`[A](innerSelection: SelectionBuilder[__Type, A]): SelectionBuilder[__InputValue, A] =
       Field("type", Obj(innerSelection))
+    def isDeprecated: SelectionBuilder[__InputValue, Boolean]                                     = Field("isDeprecated", Scalar())
+    def deprecationReason: SelectionBuilder[__InputValue, Option[String]]                         =
+      Field("deprecationReason", OptionOf(Scalar()))
     def defaultValue: SelectionBuilder[__InputValue, Option[String]]                              = Field("defaultValue", OptionOf(Scalar()))
   }
 

--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
@@ -24,6 +24,7 @@ sealed trait CalibanSettings {
   final def effect(effect: String): Self                          = withSettings(_.effect(effect))
   final def abstractEffectType(abstractEffectType: Boolean): Self =
     withSettings(_.abstractEffectType(abstractEffectType))
+  final def supportDeprecatedArgs(value: Boolean): Self           = withSettings(_.supportDeprecatedArgs(value))
   final def supportIsRepeatable(value: Boolean): Self             = withSettings(_.supportIsRepeatable(value))
   final def preserveInputNames(value: Boolean): Self              = withSettings(_.preserveInputNames(value))
   final def addDerives(value: Boolean): Self                      = withSettings(_.addDerives(value))

--- a/codegen-sbt/src/main/scala/caliban/codegen/OptionsParser.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/OptionsParser.scala
@@ -23,7 +23,8 @@ object OptionsParser {
     supportIsRepeatable: Option[Boolean],
     addDerives: Option[Boolean],
     envForDerives: Option[String],
-    excludeDeprecated: Option[Boolean]
+    excludeDeprecated: Option[Boolean],
+    supportDeprecatedArgs: Option[Boolean]
   )
 
   private object DescriptorUtils {
@@ -76,7 +77,8 @@ object OptionsParser {
             rawOpts.supportIsRepeatable,
             rawOpts.addDerives,
             rawOpts.envForDerives,
-            rawOpts.excludeDeprecated
+            rawOpts.excludeDeprecated,
+            rawOpts.supportDeprecatedArgs
           )
         }.option
       case _                             => ZIO.none

--- a/codegen-sbt/src/test/scala/caliban/codegen/OptionsParserSpec.scala
+++ b/codegen-sbt/src/test/scala/caliban/codegen/OptionsParserSpec.scala
@@ -31,6 +31,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -61,6 +62,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -76,6 +78,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 Options(
                   "schema",
                   "output",
+                  None,
                   None,
                   None,
                   None,
@@ -141,6 +144,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -160,6 +164,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some("GraphqlClient.scala"),
+                  None,
                   None,
                   None,
                   None,
@@ -203,6 +208,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -223,6 +229,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(true),
+                  None,
                   None,
                   None,
                   None,
@@ -265,6 +272,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -287,6 +295,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(Map("Long" -> "scala.Long")),
+                  None,
                   None,
                   None,
                   None,
@@ -327,6 +336,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -351,6 +361,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(true),
+                  None,
                   None,
                   None,
                   None,
@@ -389,6 +400,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -406,6 +418,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   "output",
                   Some("fmtPath"),
                   Some(List(Header("aaa", "bbb:ccc"))),
+                  None,
                   None,
                   None,
                   None,
@@ -451,7 +464,40 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
-                  Some(true)
+                  Some(true),
+                  None
+                )
+              )
+          )
+        }
+      },
+      test("provide supportDeprecatedArgs & supportIsRepeatable") {
+        val input = List("schema", "output", "--supportDeprecatedArgs", "false", "--supportIsRepeatable", "false")
+        OptionsParser.fromArgs(input).map { result =>
+          assertTrue(
+            result ==
+              Some(
+                Options(
+                  "schema",
+                  "output",
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  Some(false),
+                  None,
+                  None,
+                  None,
+                  Some(false)
                 )
               )
           )

--- a/core/src/main/scala/caliban/parsing/adt/Definition.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Definition.scala
@@ -81,7 +81,11 @@ object Definition {
       def name: String
       def description: Option[String]
       def directives: List[Directive]
+
+      final def isDeprecated: Boolean             = Directives.isDeprecated(directives)
+      final def deprecationReason: Option[String] = Directives.deprecationReason(directives)
     }
+
     object TypeDefinition {
 
       final case class ObjectTypeDefinition(
@@ -142,7 +146,10 @@ object Definition {
         ofType: Type,
         defaultValue: Option[InputValue],
         directives: List[Directive]
-      )
+      ) {
+        def isDeprecated: Boolean             = Directives.isDeprecated(directives)
+        def deprecationReason: Option[String] = Directives.deprecationReason(directives)
+      }
 
       final case class FieldDefinition(
         description: Option[String],
@@ -150,9 +157,19 @@ object Definition {
         args: List[InputValueDefinition],
         ofType: Type,
         directives: List[Directive]
-      )
+      ) {
+        def isDeprecated: Boolean             = Directives.isDeprecated(directives)
+        def deprecationReason: Option[String] = Directives.deprecationReason(directives)
+      }
 
-      final case class EnumValueDefinition(description: Option[String], enumValue: String, directives: List[Directive])
+      final case class EnumValueDefinition(
+        description: Option[String],
+        enumValue: String,
+        directives: List[Directive]
+      ) {
+        def isDeprecated: Boolean             = Directives.isDeprecated(directives)
+        def deprecationReason: Option[String] = Directives.deprecationReason(directives)
+      }
 
     }
 

--- a/tools/src/main/scala/caliban/tools/CalibanCommonSettings.scala
+++ b/tools/src/main/scala/caliban/tools/CalibanCommonSettings.scala
@@ -20,7 +20,8 @@ final case class CalibanCommonSettings(
   supportIsRepeatable: Option[Boolean],
   addDerives: Option[Boolean],
   envForDerives: Option[String],
-  excludeDeprecated: Option[Boolean]
+  excludeDeprecated: Option[Boolean],
+  supportDeprecatedArgs: Option[Boolean]
 ) {
 
   private[caliban] def toOptions(schemaPath: String, toPath: String): Options =
@@ -43,7 +44,8 @@ final case class CalibanCommonSettings(
       supportIsRepeatable = supportIsRepeatable,
       addDerives = addDerives,
       envForDerives = envForDerives,
-      excludeDeprecated = excludeDeprecated
+      excludeDeprecated = excludeDeprecated,
+      supportDeprecatedArgs = supportDeprecatedArgs
     )
 
   private[caliban] def combine(r: => CalibanCommonSettings): CalibanCommonSettings =
@@ -65,7 +67,8 @@ final case class CalibanCommonSettings(
       supportIsRepeatable = r.supportIsRepeatable.orElse(this.supportIsRepeatable),
       addDerives = r.addDerives.orElse(this.addDerives),
       envForDerives = r.envForDerives.orElse(this.envForDerives),
-      excludeDeprecated = r.excludeDeprecated.orElse(this.excludeDeprecated)
+      excludeDeprecated = r.excludeDeprecated.orElse(this.excludeDeprecated),
+      supportDeprecatedArgs = r.supportDeprecatedArgs.orElse(this.supportDeprecatedArgs)
     )
 
   def clientName(value: String): CalibanCommonSettings                         = this.copy(clientName = Some(value))
@@ -90,6 +93,8 @@ final case class CalibanCommonSettings(
   def addDerives(addDerives: Boolean): CalibanCommonSettings                   = this.copy(addDerives = Some(addDerives))
   def envForDerives(envForDerives: String): CalibanCommonSettings              = this.copy(envForDerives = Some(envForDerives))
   def excludeDeprecated(value: Boolean): CalibanCommonSettings                 = this.copy(excludeDeprecated = Some(value))
+  def supportDeprecatedArgs(value: Boolean): CalibanCommonSettings             =
+    this.copy(supportDeprecatedArgs = Some(value))
 }
 
 object CalibanCommonSettings {
@@ -112,6 +117,7 @@ object CalibanCommonSettings {
       supportIsRepeatable = None,
       addDerives = None,
       envForDerives = None,
-      excludeDeprecated = None
+      excludeDeprecated = None,
+      supportDeprecatedArgs = None
     )
 }

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -80,7 +80,16 @@ object Codegen {
 
   def generate(arguments: Options, genType: GenType): Task[List[File]] =
     generate(
-      getSchemaLoader(arguments.schemaPath, arguments.headers, arguments.supportIsRepeatable.getOrElse(true)),
+      getSchemaLoader(
+        arguments.schemaPath,
+        arguments.headers, {
+          val default = IntrospectionClient.Config.default
+          IntrospectionClient.Config(
+            supportDeprecatedArgs = arguments.supportDeprecatedArgs.getOrElse(default.supportDeprecatedArgs),
+            supportIsRepeatable = arguments.supportIsRepeatable.getOrElse(default.supportIsRepeatable)
+          )
+        }
+      ),
       arguments,
       genType
     )
@@ -88,9 +97,9 @@ object Codegen {
   private def getSchemaLoader(
     path: String,
     schemaPathHeaders: Option[List[Options.Header]],
-    supportIsRepeatable: Boolean
+    config: IntrospectionClient.Config
   ): SchemaLoader =
-    if (path.startsWith("http")) SchemaLoader.fromIntrospection(path, schemaPathHeaders, supportIsRepeatable)
+    if (path.startsWith("http")) SchemaLoader.fromIntrospection(path, schemaPathHeaders, config)
     else SchemaLoader.fromFile(path)
 
   def getPackageAndObjectName(arguments: Options): (Option[String], String) = {

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -19,7 +19,8 @@ final case class Options(
   supportIsRepeatable: Option[Boolean],
   addDerives: Option[Boolean],
   envForDerives: Option[String],
-  excludeDeprecated: Option[Boolean]
+  excludeDeprecated: Option[Boolean],
+  supportDeprecatedArgs: Option[Boolean]
 )
 
 object Options {

--- a/tools/src/main/scala/caliban/tools/RemoteSchema.scala
+++ b/tools/src/main/scala/caliban/tools/RemoteSchema.scala
@@ -181,6 +181,8 @@ object RemoteSchema {
       name = definition.name,
       description = definition.description,
       `type` = toType(definition.ofType, definitions),
+      isDeprecated = isDeprecated(definition.directives),
+      deprecationReason = deprecationReason(definition.directives),
       defaultValue = definition.defaultValue.map(_.toInputString),
       directives = toDirectives(definition.directives)
     )
@@ -266,8 +268,7 @@ object RemoteSchema {
       case e: EnumTypeDefinition        => toEnumType(e)
       case u: UnionTypeDefinition       => toUnionType(u, definitions)
       case i: InterfaceTypeDefinition   => toInterfaceType(i, definitions)
-      case i: InputObjectTypeDefinition =>
-        toInputObjectType(i, definitions)
+      case i: InputObjectTypeDefinition => toInputObjectType(i, definitions)
     }
 
   private def toDirective(

--- a/tools/src/main/scala/caliban/tools/compiletime/Config.scala
+++ b/tools/src/main/scala/caliban/tools/compiletime/Config.scala
@@ -15,7 +15,8 @@ trait Config {
     enableFmt: Boolean = true,
     extensibleEnums: Boolean = false,
     supportIsRepeatable: Boolean = true,
-    excludeDeprecated: Boolean = false
+    excludeDeprecated: Boolean = false,
+    supportDeprecatedArgs: Boolean = true
   ) {
     private[caliban] def toCalibanCommonSettings: CalibanCommonSettings =
       CalibanCommonSettings(
@@ -36,7 +37,8 @@ trait Config {
         supportIsRepeatable = Some(supportIsRepeatable),
         addDerives = None,
         envForDerives = None,
-        excludeDeprecated = Some(excludeDeprecated)
+        excludeDeprecated = Some(excludeDeprecated),
+        supportDeprecatedArgs = Some(supportDeprecatedArgs)
       )
 
     private[caliban] def asScalaCode: String = {
@@ -53,7 +55,8 @@ trait Config {
          |  enableFmt = $enableFmt,
          |  extensibleEnums = $extensibleEnums,
          |  supportIsRepeatable = $supportIsRepeatable,
-         |  excludeDeprecated = $excludeDeprecated
+         |  excludeDeprecated = $excludeDeprecated,
+         |  supportDeprecatedArgs = $supportDeprecatedArgs
          |)
       """.stripMargin.trim
     }

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field + comment newline.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field + comment newline.scala
@@ -9,11 +9,8 @@ object Client {
     /**
      * name
      */
-    @deprecated(
-      """foo
-bar""",
-      ""
-    )
+    @deprecated("""foo
+bar""")
     def name: SelectionBuilder[Character, String] = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
   }
 

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field + comment.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field + comment.scala
@@ -9,9 +9,9 @@ object Client {
     /**
      * name
      */
-    @deprecated("blah", "")
+    @deprecated("blah")
     def name: SelectionBuilder[Character, String]            = _root_.caliban.client.SelectionBuilder.Field("name", Scalar())
-    @deprecated("", "")
+    @deprecated
     def nicknames: SelectionBuilder[Character, List[String]] =
       _root_.caliban.client.SelectionBuilder.Field("nicknames", ListOf(Scalar()))
   }

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field argument + comment newline.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field argument + comment newline.scala
@@ -1,0 +1,31 @@
+import caliban.client.FieldBuilder._
+import caliban.client._
+
+object Client {
+
+  type Query = _root_.caliban.client.Operations.RootQuery
+  object Query {
+    def characters(
+      first: Int,
+      @deprecated("""foo
+bar""")
+      last: scala.Option[Int] = None,
+      @deprecated
+      origins: scala.Option[List[scala.Option[String]]] = None
+    )(implicit
+      encoder0: ArgEncoder[Int],
+      encoder1: ArgEncoder[scala.Option[Int]],
+      encoder2: ArgEncoder[scala.Option[List[scala.Option[String]]]]
+    ): SelectionBuilder[_root_.caliban.client.Operations.RootQuery, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field(
+        "characters",
+        OptionOf(Scalar()),
+        arguments = List(
+          Argument("first", first, "Int!")(encoder0),
+          Argument("last", last, "Int")(encoder1),
+          Argument("origins", origins, "[String]")(encoder2)
+        )
+      )
+  }
+
+}

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field argument + comment.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/deprecated field argument + comment.scala
@@ -1,0 +1,30 @@
+import caliban.client.FieldBuilder._
+import caliban.client._
+
+object Client {
+
+  type Query = _root_.caliban.client.Operations.RootQuery
+  object Query {
+    def characters(
+      first: Int,
+      @deprecated("foo bar")
+      last: scala.Option[Int] = None,
+      @deprecated
+      origins: scala.Option[List[scala.Option[String]]] = None
+    )(implicit
+      encoder0: ArgEncoder[Int],
+      encoder1: ArgEncoder[scala.Option[Int]],
+      encoder2: ArgEncoder[scala.Option[List[scala.Option[String]]]]
+    ): SelectionBuilder[_root_.caliban.client.Operations.RootQuery, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field(
+        "characters",
+        OptionOf(Scalar()),
+        arguments = List(
+          Argument("first", first, "Int!")(encoder0),
+          Argument("last", last, "Int")(encoder1),
+          Argument("origins", origins, "[String]")(encoder2)
+        )
+      )
+  }
+
+}

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/input object with deprecated fields.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/input object with deprecated fields.scala
@@ -1,0 +1,28 @@
+import caliban.client._
+import caliban.client.__Value._
+
+object Client {
+
+  final case class CharacterInput(
+    name: String,
+    @deprecated
+    nickname: scala.Option[String] = None,
+    @deprecated("no longer used")
+    address: scala.Option[String] = None
+  )
+  object CharacterInput {
+    implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
+      override def encode(value: CharacterInput): __Value =
+        __ObjectValue(
+          List(
+            "name"     -> implicitly[ArgEncoder[String]].encode(value.name),
+            "nickname" -> value.nickname.fold(__NullValue: __Value)(value =>
+              implicitly[ArgEncoder[String]].encode(value)
+            ),
+            "address"  -> value.address.fold(__NullValue: __Value)(value => implicitly[ArgEncoder[String]].encode(value))
+          )
+        )
+    }
+  }
+
+}

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -218,6 +218,15 @@ object ClientWriterSpec extends SnapshotTest {
              }
             """)
       },
+      snapshotTest("input object with deprecated fields") {
+        gen("""
+             input CharacterInput {
+               name: String!
+               nickname: String @deprecated
+               address: String @deprecated(reason: "no longer used")
+             }
+            """)
+      },
       snapshotTest("union") {
         gen("""
              union Role = Captain_ | Pilot
@@ -251,6 +260,26 @@ object ClientWriterSpec extends SnapshotTest {
                name: String! @deprecated(reason: "foo\nbar")
              }
             """)
+      },
+      snapshotTest("deprecated field argument + comment") {
+        gen("""
+             type Query {
+                characters(
+                  first: Int!,
+                  last: Int @deprecated(reason: "foo bar"),
+                  origins: [String] @deprecated
+                ): String
+            }""")
+      },
+      snapshotTest("deprecated field argument + comment newline") {
+        gen("""
+             type Query {
+                characters(
+                  first: Int!,
+                  last: Int @deprecated(reason: "foo\nbar"),
+                  origins: [String] @deprecated
+                ): String
+            }""")
       },
       snapshotTest("default arguments for optional and list arguments") {
         gen("""

--- a/tools/src/test/scala/caliban/tools/CodegenSpec.scala
+++ b/tools/src/test/scala/caliban/tools/CodegenSpec.scala
@@ -68,7 +68,8 @@ object CodegenSpec extends ZIOSpecDefault {
       supportIsRepeatable = None,
       addDerives = None,
       envForDerives = None,
-      excludeDeprecated = None
+      excludeDeprecated = None,
+      supportDeprecatedArgs = None
     )
 
     getPackageAndObjectName(arguments)

--- a/tools/src/test/scala/caliban/tools/IntrospectionClientSpec.scala
+++ b/tools/src/test/scala/caliban/tools/IntrospectionClientSpec.scala
@@ -1,0 +1,38 @@
+package caliban.tools
+
+import caliban._
+import caliban.introspection.Introspector
+import caliban.quick._
+import caliban.schema.Annotations._
+import caliban.schema.Schema.auto._
+import caliban.schema.ArgBuilder.auto._
+import zio.test._
+import zio.{ durationInt, Clock }
+
+object IntrospectionClientSpec extends ZIOSpecDefault {
+
+  case class Args(@GQLDeprecated("Use nameV2") name: Option[String] = Some("defaultValue"), nameV2: String)
+  case class Queries(getObject: Args => String)
+
+  object Resolvers {
+    def getObject(@GQLDeprecated("foobar") args: Args): String = args.name.getOrElse("")
+  }
+
+  val queries = Queries(getObject = Resolvers.getObject)
+  val api     = graphQL(RootResolver(queries)).withAdditionalDirectives(Introspector.directives)
+
+  def spec = suite("IntrospectionClientSpec")(
+    test("is isomorphic") {
+      val port = 8091
+      for {
+        _                 <- api.runServer(port = port, apiPath = "/api/graphql").fork
+        _                 <- Clock.ClockLive.sleep(2.seconds)
+        introspectedSchema =
+          SchemaLoader.fromIntrospectionWith(s"http://localhost:$port/api/graphql", None)(_.supportDeprecatedArgs(true))
+        codeSchema         = SchemaLoader.fromCaliban(api)
+        res               <- SchemaComparison.compare(introspectedSchema, codeSchema)
+      } yield assertTrue(res.isEmpty)
+    }
+  )
+
+}

--- a/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
+++ b/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
@@ -4,10 +4,11 @@ import caliban._
 import caliban.introspection.adt._
 import caliban.schema._
 import caliban.schema.Schema.auto._
+import caliban.schema.ArgBuilder.auto._
 import zio._
 import zio.test.Assertion._
 import zio.test._
-import schema.Annotations._
+import caliban.schema.Annotations._
 import caliban.Macros.gqldoc
 import caliban.execution.Feature
 import caliban.transformers.Transformer
@@ -20,6 +21,8 @@ object RemoteSchemaSpec extends ZIOSpecDefault {
   sealed trait UnionType                extends Product with Serializable
   case class UnionValue1(field: String) extends UnionType
 
+  case class Args(@GQLDeprecated("Use nameV2") name: String = "defaultValue", nameV2: String)
+
   case class Object(
     field: Int,
     optionalField: Option[Float],
@@ -29,7 +32,7 @@ object RemoteSchemaSpec extends ZIOSpecDefault {
   )
 
   object Resolvers {
-    def getObject(arg: String = "defaultValue"): Object =
+    def getObject(args: Args): Object =
       Object(
         field = 1,
         optionalField = None,
@@ -39,7 +42,7 @@ object RemoteSchemaSpec extends ZIOSpecDefault {
   }
 
   case class Queries(
-    getObject: String => Object
+    getObject: Args => Object
   )
 
   val queries = Queries(
@@ -47,12 +50,10 @@ object RemoteSchemaSpec extends ZIOSpecDefault {
   )
 
   val api = graphQL(
-    RootResolver(
-      queries
-    )
+    RootResolver(queries)
   )
 
-  def spec = suite("ParserSpec")(
+  def spec = suite("RemoteSchemaSpec")(
     test("is isomorphic") {
       for {
         introspected <- SchemaLoader.fromCaliban(api).load
@@ -60,7 +61,11 @@ object RemoteSchemaSpec extends ZIOSpecDefault {
         remoteAPI    <- ZIO.succeed(fromRemoteSchema(remoteSchema))
         sdl           = api.render
         remoteSDL     = remoteAPI.render
-      } yield assertTrue(remoteSDL == sdl)
+        res          <- SchemaComparison.compare(
+                          SchemaLoader.fromCaliban(api),
+                          SchemaLoader.fromCaliban(remoteAPI)
+                        )
+      } yield assertTrue(res.isEmpty, sdl == remoteSDL)
     },
     test("properly resolves interface types") {
       @GQLInterface

--- a/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
+++ b/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
@@ -19,7 +19,8 @@ object ConfigSpec extends ZIOSpecDefault {
       enableFmt = false,
       extensibleEnums = true,
       supportIsRepeatable = true,
-      excludeDeprecated = true
+      excludeDeprecated = true,
+      supportDeprecatedArgs = true
     )
 
   private val toCalibanCommonSettingsSpec =
@@ -45,7 +46,8 @@ object ConfigSpec extends ZIOSpecDefault {
               supportIsRepeatable = Some(true),
               addDerives = None,
               envForDerives = None,
-              excludeDeprecated = Some(true)
+              excludeDeprecated = Some(true),
+              supportDeprecatedArgs = Some(true)
             )
         )
       )
@@ -68,7 +70,8 @@ object ConfigSpec extends ZIOSpecDefault {
                |  enableFmt = true,
                |  extensibleEnums = false,
                |  supportIsRepeatable = true,
-               |  excludeDeprecated = false
+               |  excludeDeprecated = false,
+               |  supportDeprecatedArgs = true
                |)
             """.stripMargin.trim
         )
@@ -88,7 +91,8 @@ object ConfigSpec extends ZIOSpecDefault {
                |  enableFmt = false,
                |  extensibleEnums = true,
                |  supportIsRepeatable = true,
-               |  excludeDeprecated = true
+               |  excludeDeprecated = true,
+               |  supportDeprecatedArgs = true
                |)
             """.stripMargin.trim
         )
@@ -110,7 +114,8 @@ object ConfigSpec extends ZIOSpecDefault {
               splitFiles = false,
               enableFmt = true,
               extensibleEnums = false,
-              excludeDeprecated = false
+              excludeDeprecated = false,
+              supportDeprecatedArgs = true
             )
         )
       )


### PR DESCRIPTION
/closes #2345

Couple of remarks:
1. I used `true` as the default for this option for both codegen and introspection. Should we be using `false`?
2. I used a class instead of case class for `IntrospectionClient.Config`. This is because classes are much easier to extend without breaking binary compatibility in the future. Should we care about this since it's in tools?