### PR TITLE
Optimize `Function0` allocations

### DIFF
--- a/core/src/main/scala-2/caliban/Scala3Annotations.scala
+++ b/core/src/main/scala-2/caliban/Scala3Annotations.scala
@@ -1,0 +1,10 @@
+package caliban
+
+import scala.annotation.StaticAnnotation
+
+/**
+ * Stubs for annotations that exist in Scala 3 but not in Scala 2
+ */
+private[caliban] object Scala3Annotations {
+  final class static extends StaticAnnotation
+}

--- a/core/src/main/scala-2/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/ArgBuilderDerivation.scala
@@ -10,6 +10,7 @@ import scala.collection.compat._
 import scala.language.experimental.macros
 
 trait CommonArgBuilderDerivation {
+  import caliban.syntax._
 
   type Typeclass[T] = ArgBuilder[T]
 
@@ -53,7 +54,7 @@ trait CommonArgBuilderDerivation {
       ctx.constructMonadic { p =>
         val idx              = p.index
         val (label, default) = params(idx)
-        val field            = fields.getOrElse(label, null)
+        val field            = fields.getOrElseNull(label)
         if (field ne null) p.typeclass.build(field) else default
       }
   }

--- a/core/src/main/scala-2/caliban/syntax.scala
+++ b/core/src/main/scala-2/caliban/syntax.scala
@@ -1,0 +1,15 @@
+package caliban
+
+import scala.collection.mutable
+
+private[caliban] object syntax {
+  val NullFn: () => AnyRef = () => null
+
+  implicit class EnrichedImmutableMapOps[K, V <: AnyRef](private val self: Map[K, V]) extends AnyVal {
+    def getOrElseNull(key: K): V = self.getOrElse(key, NullFn()).asInstanceOf[V]
+  }
+
+  implicit class EnrichedHashMapOps[K, V <: AnyRef](private val self: mutable.HashMap[K, V]) extends AnyVal {
+    def getOrElseNull(key: K): V = self.getOrElse(key, NullFn()).asInstanceOf[V]
+  }
+}

--- a/core/src/main/scala-3/caliban/Scala3Annotations.scala
+++ b/core/src/main/scala-3/caliban/Scala3Annotations.scala
@@ -1,0 +1,10 @@
+package caliban
+
+import scala.annotation
+
+/**
+ * Proxies for annotations that exist in Scala 3 but not in Scala 2
+ */
+private[caliban] object Scala3Annotations {
+  type static = annotation.static
+}

--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -13,6 +13,8 @@ import scala.deriving.Mirror
 import scala.util.NotGiven
 
 trait CommonArgBuilderDerivation {
+  import caliban.syntax.*
+
   transparent inline def recurseSum[P, Label <: Tuple, A <: Tuple](
     inline values: List[(String, List[Any], ArgBuilder[Any])] = Nil
   ): List[(String, List[Any], ArgBuilder[Any])] =
@@ -150,7 +152,7 @@ trait CommonArgBuilderDerivation {
       val arr = Array.ofDim[Any](l)
       while (i < l) {
         val (label, default, builder) = params(i)
-        val field                     = fields.getOrElse(label, null)
+        val field                     = fields.getOrElseNull(label)
         val value                     = if (field ne null) builder.build(field) else default
         value match {
           case Right(v) => arr(i) = v

--- a/core/src/main/scala-3/caliban/schema/SumSchema.scala
+++ b/core/src/main/scala-3/caliban/schema/SumSchema.scala
@@ -20,7 +20,7 @@ final private class SumSchema[R, A](
     val (m, s) = _members
     (
       m.sortBy(_._1),
-      s.toVector,
+      s.toArray,
       s.map(s0 => SchemaUtils.isEmptyUnionObject(s0.toType_())).toArray[Boolean]
     )
   }

--- a/core/src/main/scala-3/caliban/syntax.scala
+++ b/core/src/main/scala-3/caliban/syntax.scala
@@ -1,0 +1,20 @@
+package caliban
+
+import scala.annotation.static
+
+import scala.collection.mutable
+
+private[caliban] object syntax {
+  @static val NullFn: () => AnyRef = () => null
+
+  extension [K, V <: AnyRef](inline map: Map[K, V]) {
+    transparent inline def getOrElseNull(key: K): V = map.getOrElse(key, NullFn()).asInstanceOf[V]
+  }
+
+  extension [K, V <: AnyRef](inline map: mutable.HashMap[K, V]) {
+    transparent inline def getOrElseNull(key: K): V = map.getOrElse(key, NullFn()).asInstanceOf[V]
+  }
+}
+
+// Required for @static fields
+private final class syntax private

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -24,6 +24,8 @@ case class __Type(
   @GQLExcluded origin: Option[String] = None,
   isOneOf: Option[Boolean] = None
 ) { self =>
+  import caliban.syntax._
+
   final override lazy val hashCode: Int = super.hashCode()
 
   private[caliban] lazy val typeNameRepr: String = DocumentRenderer.renderTypeName(this)
@@ -144,7 +146,7 @@ case class __Type(
   }
 
   private[caliban] def getFieldOrNull(name: String): __Field =
-    allFieldsMap.getOrElse(name, null)
+    allFieldsMap.getOrElseNull(name)
 
   lazy val innerType: __Type = Types.innerType(this)
 

--- a/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
+++ b/core/src/main/scala/caliban/schema/ObjectFieldResolver.scala
@@ -1,5 +1,6 @@
 package caliban.schema
 
+import caliban.Scala3Annotations.static
 import caliban.schema.Step.{ NullStep, ObjectStep }
 
 import scala.collection.compat._
@@ -12,15 +13,16 @@ final private class ObjectFieldResolver[R, A] private (
   import ObjectFieldResolver._
 
   private def getFieldStep(value: A): String => Step[R] =
-    fields.getOrElse(_, nullStepFn)(value)
+    fields.getOrElse(_, NullStepFn0())(value)
 
   def resolve(value: A): Step[R] = ObjectStep(name, getFieldStep(value))
 }
 
 private object ObjectFieldResolver {
+  @static private val NullStepFn: Any => Step[Any]        = _ => NullStep
+  @static private val NullStepFn0: () => Any => Step[Any] = () => NullStepFn
+
   def apply[R, A](objectName: String, fields: Iterable[(String, A => Step[R])]): ObjectFieldResolver[R, A] =
     // NOTE: mutable.HashMap is about twice as fast than immutable.HashMap for .get
     new ObjectFieldResolver(objectName, mutable.HashMap.from(fields))
-
-  private val nullStepFn: Any => Step[Any] = _ => NullStep
 }

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -350,7 +350,7 @@ object Validator extends SchemaValidator {
           )
 
           val v2 =
-            if (t.isDefined && t.get._isOneOfInput)
+            if (t.exists(_._isOneOfInput))
               Some(
                 failWhen(v.variableType.nullable)(
                   s"Variable '${v.name}' cannot be nullable.",


### PR DESCRIPTION
This PR optimizes (mostly) `Function0` allocations that originate from `map.getOrElse(key, ???)`. In Scala 2, the optimization is fairly straight-forward; we just need to store the default value in a `Function0`. Since `=> A` compiles to `() => A`, this means that invocations of the `getOrElse(key, DefaultValueFn())` don't create a `Function0`.

In Scala 3 however, it's slightly more complex. For some reason (might be a bug, I'll open an issue in Dotty about it), this works only if the val is annotated with `@static`, which compiles to a `final static` field. To avoid having to do this everywhere, I added a package-private `syntax` object with the `getOrElseNull` method.

I've also noticed some small optimizations that could be done here and there so I did them as part of this PR