### PR TITLE
Optimize `Field#allFieldsUniqueNameAndCondition`

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -48,9 +48,9 @@ case class Field(
 
   // TODO: Change the name to `allConditionsUnique` in the next minor version
   private[caliban] def allFieldsUniqueNameAndCondition: Boolean =
-    fields.isEmpty || fields.tail.isEmpty || allConditionsUniqueLzy
+    fields.isEmpty || fields.tail.isEmpty || allConditionsUniqueLazy
 
-  private lazy val allConditionsUniqueLzy: Boolean = {
+  private lazy val allConditionsUniqueLazy: Boolean = {
     val headCondition = fields.head._condition
     var rem           = fields.tail
     var res           = true

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -46,25 +46,21 @@ case class Field(
   private[caliban] val aliasedName: String =
     if (alias.isEmpty) name else alias.get
 
-  private[caliban] lazy val allFieldsUniqueNameAndCondition: Boolean = {
-    def inner(fields: List[Field]): Boolean = {
-      val headCondition = fields.head._condition
+  // TODO: Change the name to `allConditionsUnique` in the next minor version
+  private[caliban] def allFieldsUniqueNameAndCondition: Boolean =
+    fields.isEmpty || fields.tail.isEmpty || allConditionsUniqueLzy
 
-      val seen = new mutable.HashSet[String]
-      seen.add(fields.head.aliasedName)
-
-      var rem = fields.tail
-      while (rem ne Nil) {
-        val f        = rem.head
-        val continue = seen.add(f.aliasedName) && f._condition == headCondition
-        if (!continue) return false
+  private lazy val allConditionsUniqueLzy: Boolean = {
+    val headCondition = fields.head._condition
+    var rem           = fields.tail
+    var res           = true
+    while ((rem ne Nil) && res) {
+      val f = rem.head
+      if (f._condition == headCondition)
         rem = rem.tail
-      }
-      true
+      else res = false
     }
-
-    val fields0 = fields
-    fields0.isEmpty || fields0.tail.isEmpty || inner(fields0)
+    res
   }
 
   def combine(other: Field): Field =

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -54,7 +54,8 @@ case class Field(
     val headCondition = fields.head._condition
     var rem           = fields.tail
     var res           = true
-    while ((rem ne Nil) && res) {
+    val nil           = Nil
+    while ((rem ne nil) && res) {
       val f = rem.head
       if (f._condition == headCondition)
         rem = rem.tail


### PR DESCRIPTION
This method exists in the _very_ hot path of execution, so even micro-optimizations to it are quite nice.

Basically this PR does the following:
1. Avoids initializing the `lazy val` when we can check if the conditions are unique without iterating through the fields
2. Removes the unique check on the `aliasedName`, which also removes the need for allocating a HashSet. It just occurred to me that we if the conditions are all the same, then the names are guaranteed to be unique because otherwise we would have deduplicated them when we create the Field