### PR TITLE
Update ZIO Http

### DIFF
--- a/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
@@ -54,15 +54,6 @@ final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R]) {
     Routes.fromIterable(apiRoutes ::: graphiqlRoute ::: uploadRoute ::: wsRoute)
   }
 
-  @deprecated("Use `routes` instead", "2.6.1")
-  def toApp(
-    apiPath: String,
-    graphiqlPath: Option[String] = None,
-    uploadPath: Option[String] = None,
-    webSocketPath: Option[String] = None
-  ): HttpApp[R] =
-    HttpApp(routes(apiPath, graphiqlPath, uploadPath, webSocketPath))
-
   /**
    * Runs the server using the default zio-http server configuration on the specified port.
    * This is meant as a convenience method for getting started quickly

--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -236,7 +236,9 @@ final private class QuickRequestHandler[R](
       .mapConcatChunk(Chunk.fromArray)
   }
 
-  private def encodeTextEventStream(resp: GraphQLResponse[Any])(implicit trace: Trace): UStream[ServerSentEvent] =
+  private def encodeTextEventStream(
+    resp: GraphQLResponse[Any]
+  )(implicit trace: Trace): UStream[ServerSentEvent[String]] =
     ServerSentEvents.transformResponse(
       resp,
       v => ServerSentEvent(writeToString(v), Some("next")),

--- a/adapters/quick/src/main/scala/caliban/quick/package.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/package.scala
@@ -62,22 +62,6 @@ package object quick {
         )
       )
 
-    @deprecated("use `routes` instead", "2.6.1")
-    def toApp(
-      apiPath: String,
-      graphiqlPath: Option[String] = None,
-      uploadPath: Option[String] = None,
-      webSocketPath: Option[String] = None
-    )(implicit trace: Trace): IO[CalibanError.ValidationError, HttpApp[R]] =
-      gql.interpreter.map(
-        QuickAdapter(_).toApp(
-          apiPath = apiPath,
-          graphiqlPath = graphiqlPath,
-          uploadPath = uploadPath,
-          webSocketPath = webSocketPath
-        )
-      )
-
     /**
      * Creates a zio-http handler for the GraphQL API
      *

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val zioInteropReactiveVersion = "2.0.2"
 val zioConfigVersion          = "3.0.7"
 val zqueryVersion             = "0.7.5"
 val zioJsonVersion            = "0.7.3"
-val zioHttpVersion            = "3.0.0-RC10"
+val zioHttpVersion            = "3.0.0"
 val zioOpenTelemetryVersion   = "3.0.0-RC21"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/build.sbt
+++ b/build.sbt
@@ -746,7 +746,10 @@ lazy val enableMimaSettingsJVM =
   Def.settings(
     mimaFailOnProblem      := enforceMimaCompatibility,
     mimaPreviousArtifacts  := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet,
-    mimaBinaryIssueFilters := Seq()
+    mimaBinaryIssueFilters := Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.quick.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.QuickAdapter.*")
+    )
   )
 
 lazy val enableMimaSettingsJS =

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val zioInteropReactiveVersion = "2.0.2"
 val zioConfigVersion          = "3.0.7"
 val zqueryVersion             = "0.7.5"
 val zioJsonVersion            = "0.7.3"
-val zioHttpVersion            = "3.0.0-RC9"
+val zioHttpVersion            = "3.0.0-RC10"
 val zioOpenTelemetryVersion   = "3.0.0-RC21"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges


### PR DESCRIPTION
Due to the removal of deprecated methods in ZIO Http, we have to remove the deprecated methods. The issue now is that if we want to strictly follow the versioning scheme we have to bump the version to 2.9.0.

Note that users can't update to ZIO Http RC10 until we release a new version