### PR TITLE
Interface error when combined with union types

### DIFF
--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
@@ -26,18 +26,17 @@ ThisBuild / crossScalaVersions := allScala
 
 // ### Dependencies ###
 
-lazy val calibanLib: Seq[ModuleID] =
-  sys.props.get("plugin.version") match {
-    case Some(x) => Seq("com.github.ghostdogpr" %% "caliban" % x)
-    case _       => sys.error("""|The system property 'plugin.version' is not defined.
-                           |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-  }
+lazy val calibanLib = Seq("com.github.ghostdogpr" %% "caliban" %  Version.pluginVersion)
 
 lazy val sttp = Seq(
   "com.softwaremill.sttp.client3" %% "core" % "3.9.8",
   "com.softwaremill.sttp.client3" %% "zio"  % "3.9.8"
 )
 
+lazy val zioTest = Seq(
+  "dev.zio" %% "zio-test" % "2.1.9" % Test,
+  "dev.zio" %% "zio-test-sbt" % "2.1.9" % Test
+)
 // ### App Modules ###
 
 /**
@@ -53,8 +52,10 @@ lazy val root =
       potatoes,
       clients,
       postsClients,
-      potatoesClients
+      potatoesClients,
+      logrocket
     )
+    .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
     .settings(
       // Additional scripted tests commands
       InputKey[Unit]("copy-file-with-options") := {
@@ -145,3 +146,9 @@ lazy val potatoesClients =
     .settings(
       Compile / ctCalibanClient / ctCalibanClientsSettings := Seq(potatoes)
     )
+
+lazy val logrocket =
+  project
+    .in(file("modules/logrocket"))
+    .settings(libraryDependencies ++= calibanLib ++ zioTest)
+    .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/logrocket/src/main/scala/poc/caliban/logrocket/GraphQLApi.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/logrocket/src/main/scala/poc/caliban/logrocket/GraphQLApi.scala
@@ -1,0 +1,68 @@
+package poc.caliban.logrocket
+
+import caliban._
+import caliban.schema._
+import caliban.schema.Schema
+import caliban.wrappers.Wrappers._
+import zio._
+import caliban.schema.Annotations.GQLInterface
+
+import scala.language.higherKinds
+
+object GraphQLApi {
+  type ZEff[A] = UIO[A]
+
+  // https://blog.logrocket.com/handling-graphql-errors-like-a-champ-with-unions-and-interfaces/
+
+  @GQLInterface
+  sealed trait Error extends scala.Product with scala.Serializable {
+    def message: String
+  }
+
+  final case class UserRegisterInput(login: String, email: String, password: String)
+  final case class MutationUserRegisterArgs(input: UserRegisterInput)
+
+  final case class User(id: String, login: String)
+
+  sealed trait UserRegisterResult extends scala.Product with scala.Serializable
+
+  final case class UserRegisterResultSuccess(user: User) extends UserRegisterResult
+  final case class UserRegisterInvalidInputError(
+    message: String,
+    loginErrorMessage: scala.Option[String],
+    emailErrorMessage: scala.Option[String],
+    passwordErrorMessage: scala.Option[String]
+  ) extends UserRegisterResult
+      with Error
+  final case class CountryBlockedError(message: String)  extends Error with UserRegisterResult
+
+  final case class Query(
+    _empty: ZEff[scala.Option[String]]
+  )
+
+  final case class Mutation(
+    userRegister: MutationUserRegisterArgs => ZEff[UserRegisterResult]
+  )
+
+  val api: GraphQL[Any] = {
+    import caliban.schema.Schema.auto._
+    import caliban.schema.ArgBuilder.auto._
+
+    graphQL[Any, Query, Mutation, Unit](
+      RootResolver(
+        Query(
+          _empty = ZIO.succeed(None)
+        ),
+        Mutation(
+          userRegister = args => LogrocketService.userRegister(args)
+        )
+      )
+    ) @@
+      maxFields(200) @@
+      maxDepth(30) @@
+      timeout(5.seconds) @@
+      printSlowQueries(500.millis) @@
+      printErrors
+  }
+
+}

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/logrocket/src/main/scala/poc/caliban/logrocket/LogrocketService.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/logrocket/src/main/scala/poc/caliban/logrocket/LogrocketService.scala
@@ -1,0 +1,10 @@
+package poc.caliban.logrocket
+
+import poc.caliban.logrocket.GraphQLApi._
+import zio.ZIO
+
+object LogrocketService {
+  def userRegister(input: MutationUserRegisterArgs): ZEff[UserRegisterResultSuccess] = ZIO.succeed {
+    UserRegisterResultSuccess(User(id = "1", login = "test"))
+  }
+}

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/logrocket/src/test/resources/logrocket.graphql
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/logrocket/src/test/resources/logrocket.graphql
@@ -1,0 +1,44 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+union UserRegisterResult = CountryBlockedError | UserRegisterInvalidInputError | UserRegisterResultSuccess
+
+interface Error {
+  message: String!
+}
+
+input UserRegisterInput {
+  login: String!
+  email: String!
+  password: String!
+}
+
+type CountryBlockedError implements Error {
+  message: String!
+}
+
+type Mutation {
+  userRegister(input: UserRegisterInput!): UserRegisterResult!
+}
+
+type Query {
+  _empty: String
+}
+
+type User {
+  id: String!
+  login: String!
+}
+
+type UserRegisterInvalidInputError implements Error {
+  message: String!
+  loginErrorMessage: String
+  emailErrorMessage: String
+  passwordErrorMessage: String
+}
+
+type UserRegisterResultSuccess {
+  user: User!
+}

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/logrocket/src/test/scala/poc/caliban/logrocket/ValidateGraphQlSpec.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/modules/logrocket/src/test/scala/poc/caliban/logrocket/ValidateGraphQlSpec.scala
@@ -1,0 +1,20 @@
+package poc.caliban.logrocket
+
+import scala.io.Source
+import zio.test.Assertion._
+import zio.test._
+
+object ValidateGraphQlSpec extends ZIOSpecDefault {
+
+  override def spec =
+    suite("Validate Logrocket graphql")(
+      test("Render logrocket as expected") {
+        val filename = "logrocket.graphql"
+        val expectedGraphQL: String = Source.fromResource(filename).getLines().mkString("\n")
+        val gqlApi = GraphQLApi.api
+        val renderContent: String = s"${gqlApi.render}"
+
+        assertTrue(expectedGraphQL == renderContent)
+      }
+    )
+}

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/project/Version.scala
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/project/Version.scala
@@ -1,0 +1,8 @@
+object Version {
+  def pluginVersion: String =
+    sys.props.get("plugin.version") match {
+      case Some(x) => x
+      case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                                   |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+    }
+}

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/test
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/test
@@ -201,3 +201,5 @@ $ exists modules/potatoes-clients/src/main/scala/poc/caliban/client/generated/po
 -$ newer modules/posts/target/ctCalibanServer/touch modules/posts/target/ctCalibanServer/touch_old
 # TODO: This should be newer, sadly I don't find how to make it work.
 -$ newer modules/posts-clients/target/scala-2.12/src_managed/main/poc/caliban/client/generated/posts/CalibanClient.scala modules/posts-clients/tmp/CalibanClient.scala.old
+
+> reload; test

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -96,6 +96,7 @@ case class __Type(
           UnionTypeDefinition(
             description,
             name.getOrElse(""),
+            interfaces().getOrElse(Nil).map(t => NamedType(t.name.getOrElse(""), nonNull = false)),
             directives.getOrElse(Nil),
             possibleTypes.getOrElse(Nil).flatMap(_.name)
           )

--- a/core/src/main/scala/caliban/parsing/adt/Definition.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Definition.scala
@@ -129,6 +129,7 @@ object Definition {
       final case class UnionTypeDefinition(
         description: Option[String],
         name: String,
+        implements: List[NamedType],
         directives: List[Directive],
         memberTypes: List[String]
       ) extends TypeDefinition {

--- a/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
@@ -117,9 +117,15 @@ object Parsers extends SelectionParsers {
     }
 
   def unionTypeDefinition(implicit ev: P[Any]): P[UnionTypeDefinition] =
-    (stringValue.? ~ "union" ~/ name ~ directives.? ~ "=" ~ ("|".? ~ namedType) ~ ("|" ~ namedType).rep).map {
-      case (description, name, directives, m, ms) =>
-        UnionTypeDefinition(description.map(_.value), name, directives.getOrElse(Nil), (m :: ms.toList).map(_.name))
+    (stringValue.? ~ "union" ~/ name ~ implements.? ~ directives.? ~ "=" ~ ("|".? ~ namedType) ~ ("|" ~ namedType).rep).map {
+      case (description, name, implements, directives, m, ms) =>
+        UnionTypeDefinition(
+          description.map(_.value),
+          name,
+          implements.getOrElse(Nil),
+          directives.getOrElse(Nil),
+          (m :: ms.toList).map(_.name)
+        )
     }
 
   def scalarTypeDefinition(implicit ev: P[Any]): P[ScalarTypeDefinition] =

--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -29,7 +29,7 @@ object DocumentRenderer extends Renderer[Document] {
 
   private implicit val typeOrdering: Ordering[TypeDefinition] = Ordering.by {
     case TypeDefinition.ScalarTypeDefinition(_, name, _)          => (0, name)
-    case TypeDefinition.UnionTypeDefinition(_, name, _, _)        => (1, name)
+    case TypeDefinition.UnionTypeDefinition(_, name, _, _, _)     => (1, name)
     case TypeDefinition.EnumTypeDefinition(_, name, _, _)         => (2, name)
     case TypeDefinition.InputObjectTypeDefinition(_, name, _, _)  => (3, name)
     case TypeDefinition.InterfaceTypeDefinition(_, name, _, _, _) => (4, name)
@@ -403,7 +403,7 @@ object DocumentRenderer extends Renderer[Document] {
 
     override def unsafeRender(value: UnionTypeDefinition, indent: Option[Int], writer: StringBuilder): Unit =
       value match {
-        case UnionTypeDefinition(description, name, directives, members) =>
+        case UnionTypeDefinition(description, name, _, directives, members) =>
           newlineOrSpace(indent, writer)
           newlineOrEmpty(indent, writer)
           descriptionRenderer.unsafeRender(description, indent, writer)

--- a/tools/src/main/scala/caliban/tools/ClientWriter.scala
+++ b/tools/src/main/scala/caliban/tools/ClientWriter.scala
@@ -47,7 +47,7 @@ object ClientWriter {
         case ObjectTypeDefinition(_, name, _, _, _)    => name
         case InputObjectTypeDefinition(_, name, _, _)  => name
         case EnumTypeDefinition(_, name, _, _)         => name
-        case UnionTypeDefinition(_, name, _, _)        => name
+        case UnionTypeDefinition(_, name, _, _, _)     => name
         case ScalarTypeDefinition(_, name, _)          => name
         case InterfaceTypeDefinition(_, name, _, _, _) => name
       },
@@ -75,7 +75,7 @@ object ClientWriter {
       case op @ ObjectTypeDefinition(_, name, _, _, _)    => name -> op
       case op @ InputObjectTypeDefinition(_, name, _, _)  => name -> op
       case op @ EnumTypeDefinition(_, name, _, _)         => name -> op
-      case op @ UnionTypeDefinition(_, name, _, _)        => name -> op
+      case op @ UnionTypeDefinition(_, name, _, _, _)     => name -> op
       case op @ ScalarTypeDefinition(_, name, _)          => name -> op
       case op @ InterfaceTypeDefinition(_, name, _, _, _) => name -> op
     }.map { case (name, op) =>
@@ -138,7 +138,7 @@ object ClientWriter {
         .getOrElse(true)
       val unionTypes                                       = typesMap
         .get(fieldType)
-        .collect { case UnionTypeDefinition(_, _, _, memberTypes) =>
+        .collect { case UnionTypeDefinition(_, _, _, _, memberTypes) =>
           memberTypes.flatMap(name => typesMap.get(safeTypeName(name)))
         }
         .getOrElse(Nil)

--- a/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
+++ b/tools/src/main/scala/caliban/tools/IntrospectionClient.scala
@@ -141,6 +141,7 @@ object IntrospectionClient {
         UnionTypeDefinition(
           description,
           name.getOrElse(""),
+          interfaces.map(_.collect { case t: NamedType => t }).getOrElse(Nil),
           Nil,
           possibleTypes.getOrElse(Nil).collect { case NamedType(name, _) =>
             name


### PR DESCRIPTION
Adds validation check for logrocket service exampled derived from
* [Handling GraphQL errors like a champ with unions and interfaces](https://blog.logrocket.com/handling-graphql-errors-like-a-champ-with-unions-and-interfaces/ )

Seems interface are not generated when combined with union types.
![image](https://github.com/user-attachments/assets/993c852c-b7ff-4e1e-af5e-5ecbb353034b)


