### PR TITLE
Fix ArgBuilder derivation for case classes containing only optional fields

### DIFF
--- a/core/src/main/scala-2/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-2/caliban/schema/DerivationUtils.scala
@@ -1,0 +1,11 @@
+package caliban.schema
+
+import caliban.schema.Annotations.GQLValueType
+import magnolia1.ReadOnlyCaseClass
+
+private object DerivationUtils {
+
+  def isValueType[F[_]](ctx: ReadOnlyCaseClass[F, ?]): Boolean =
+    (ctx.isValueClass || ctx.annotations.exists(_.isInstanceOf[GQLValueType])) && ctx.parameters.nonEmpty
+
+}

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -38,12 +38,6 @@ trait CommonSchemaDerivation[R] {
 
   type Typeclass[T] = Schema[R, T]
 
-  def isValueType[T](ctx: ReadOnlyCaseClass[Typeclass, T]): Boolean =
-    ctx.annotations.exists {
-      case GQLValueType(_) => true
-      case _               => false
-    }
-
   def isScalarValueType[T](ctx: ReadOnlyCaseClass[Typeclass, T]): Boolean =
     ctx.annotations.exists {
       case GQLValueType(true) => true
@@ -59,7 +53,7 @@ trait CommonSchemaDerivation[R] {
         }
       )
 
-    private lazy val _isValueType = (ctx.isValueClass || isValueType(ctx)) && ctx.parameters.nonEmpty
+    private lazy val _isValueType = DerivationUtils.isValueType(ctx)
 
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
       val _ = objectResolver // Initializes lazy val

--- a/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-2/caliban/schema/SchemaDerivation.scala
@@ -1,6 +1,5 @@
 package caliban.schema
 
-import caliban.CalibanError.ValidationError
 import caliban.Value._
 import caliban.introspection.adt._
 import caliban.parsing.adt.{ Directive, Directives }
@@ -37,6 +36,12 @@ trait CommonSchemaDerivation[R] {
     if (name.endsWith("Input")) name else s"${name}Input"
 
   type Typeclass[T] = Schema[R, T]
+
+  def isValueType[T](ctx: ReadOnlyCaseClass[Typeclass, T]): Boolean =
+    ctx.annotations.exists {
+      case GQLValueType(_) => true
+      case _               => false
+    }
 
   def isScalarValueType[T](ctx: ReadOnlyCaseClass[Typeclass, T]): Boolean =
     ctx.annotations.exists {

--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -71,11 +71,11 @@ trait CommonArgBuilderDerivation {
         makeProductArgBuilder(
           recurseProduct[A, m.MirroredElemLabels, m.MirroredElemTypes](),
           MagnoliaMacro.paramAnns[A].toMap,
-          isValueClass[A, m.MirroredElemLabels]
+          isValueType[A, m.MirroredElemLabels]
         )(m.fromProduct)
     }
 
-  transparent inline private def isValueClass[A, Labels]: Boolean =
+  transparent inline private def isValueType[A, Labels]: Boolean =
     inline if (MagnoliaMacro.isValueClass[A]) true
     else
       inline erasedValue[Labels] match {

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -4,7 +4,10 @@ import caliban.introspection.adt.*
 import caliban.parsing.adt.{ Directive, Directives }
 import caliban.schema.Annotations.*
 import caliban.schema.Types.*
-import magnolia1.TypeInfo
+import caliban.schema.macros.Macros
+import magnolia1.{ Macro as MagnoliaMacro, TypeInfo }
+
+import scala.compiletime.erasedValue
 
 private object DerivationUtils {
 
@@ -43,6 +46,14 @@ private object DerivationUtils {
 
   def getDeprecatedReason(annotations: Seq[Any]): Option[String] =
     annotations.collectFirst { case GQLDeprecated(reason) => reason }
+
+  transparent inline def isValueType[A, Labels]: Boolean =
+    inline if (MagnoliaMacro.isValueClass[A]) true
+    else
+      inline erasedValue[Labels] match {
+        case _: EmptyTuple => false
+        case _             => Macros.hasAnnotation[A, GQLValueType]
+      }
 
   def mkEnum(annotations: List[Any], info: TypeInfo, subTypes: List[(String, __Type, List[Any])]): __Type =
     makeEnum(

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -48,12 +48,10 @@ private object DerivationUtils {
     annotations.collectFirst { case GQLDeprecated(reason) => reason }
 
   transparent inline def isValueType[A, Labels]: Boolean =
-    inline if (MagnoliaMacro.isValueClass[A]) true
-    else
-      inline erasedValue[Labels] match {
-        case _: EmptyTuple => false
-        case _             => Macros.hasAnnotation[A, GQLValueType]
-      }
+    inline erasedValue[Labels] match {
+      case _: EmptyTuple => false
+      case _             => MagnoliaMacro.isValueClass[A] || Macros.hasAnnotation[A, GQLValueType]
+    }
 
   def mkEnum(annotations: List[Any], info: TypeInfo, subTypes: List[(String, __Type, List[Any])]): __Type =
     makeEnum(

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -106,20 +106,20 @@ trait CommonSchemaDerivation {
 
       case m: Mirror.ProductOf[A] =>
         inline erasedValue[m.MirroredElemLabels] match {
-          case _: EmptyTuple if !Macros.hasFieldsFromMethods[A] =>
+          case _: EmptyTuple if !Macros.hasFieldsFromMethods[A]          =>
             new EnumValueSchema[R, A](
               MagnoliaMacro.typeInfo[A],
               // Workaround until we figure out why the macro uses the parent's annotations when the leaf is a Scala 3 enum
               inline if (!MagnoliaMacro.isEnum[A]) MagnoliaMacro.anns[A] else Nil,
               config.enableSemanticNonNull
             )
-          case _ if Macros.hasAnnotation[A, GQLValueType]       =>
+          case _ if DerivationUtils.isValueType[A, m.MirroredElemLabels] =>
             new ValueTypeSchema[R, A](
               valueTypeSchema[R, m.MirroredElemLabels, m.MirroredElemTypes],
               MagnoliaMacro.typeInfo[A],
               MagnoliaMacro.anns[A]
             )
-          case _                                                =>
+          case _                                                         =>
             new ObjectSchema[R, A](
               recurseProduct[R, A, m.MirroredElemLabels, m.MirroredElemTypes]()(),
               Macros.fieldsFromMethods[R, A],

--- a/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
+++ b/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
@@ -71,6 +71,16 @@ object ArgBuilderSpec extends ZIOSpecDefault {
         )
       )
     ),
+    suite("derived build")(
+      test("should fail when null is provided for case class with optional fields") {
+        case class Foo(value: Option[String])
+        val ab = ArgBuilder.gen[Foo]
+        assertTrue(
+          ab.build(NullValue).isLeft,
+          ab.build(ObjectValue(Map())).isRight
+        )
+      }
+    ),
     suite("buildMissing")(
       test("works with derived case class ArgBuilders") {
         sealed abstract class Nullable[+T]


### PR DESCRIPTION
/fixes #2407

Issue was that we were treating all case classes as potential value types. Fix is to determine during compile-time whether the case class is a value type (either using annotations or checking if the case class extends `AnyVal`)

@guymers I also added the tests that were in #2403 to ensure that `oneOf` input derivation is working as expected now.

