### PR TITLE
Update Scala 3 to 3.3.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 
 val scala212 = "2.12.20"
 val scala213 = "2.13.15"
-val scala3   = "3.3.3"
+val scala3   = "3.3.4"
 val allScala = Seq(scala212, scala213, scala3)
 
 val akkaVersion               = "2.6.20"

--- a/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/compiletime-codegen/test-compile/build.sbt
@@ -3,7 +3,7 @@ import sbt.librarymanagement.Resolver
 
 val scala212 = "2.12.20"
 val scala213 = "2.13.15"
-val scala3   = "3.3.3"
+val scala3   = "3.3.4"
 val allScala = Seq(scala212, scala213, scala3)
 
 def scalaDefaultVersion: String =

--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -7,6 +7,7 @@ import caliban.schema.macros.Macros
 import caliban.{ CalibanError, InputValue }
 import magnolia1.Macro as MagnoliaMacro
 
+import scala.annotation.nowarn
 import scala.compiletime.*
 import scala.deriving.Mirror
 import scala.util.NotGiven
@@ -183,6 +184,7 @@ trait ArgBuilderDerivation extends CommonArgBuilderDerivation {
   }
 
   object Auto {
+    @nowarn("msg=anonymous class")
     inline def derived[A]: Auto[A] = new {
       private val impl = ArgBuilder.derived[A]
       export impl.*

--- a/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SchemaDerivation.scala
@@ -5,6 +5,7 @@ import caliban.schema.Annotations.*
 import caliban.schema.macros.Macros
 import magnolia1.Macro as MagnoliaMacro
 
+import scala.annotation.nowarn
 import scala.compiletime.*
 import scala.deriving.Mirror
 import scala.reflect.ClassTag
@@ -157,6 +158,7 @@ trait SchemaDerivation[R] extends CommonSchemaDerivation {
   }
 
   object Auto {
+    @nowarn("msg=anonymous class")
     inline def derived[A]: Auto[A] = new {
       private val impl = Schema.derived[R, A]
       export impl.*

--- a/core/src/main/scala-3/caliban/schema/SubscriptionSchemaDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/SubscriptionSchemaDerivation.scala
@@ -16,8 +16,10 @@ trait SubscriptionSchemaDerivation {
     inline summonInline[Mirror.ProductOf[A]] match {
       case m: Mirror.ProductOf[A] =>
         checkParams[m.MirroredElemTypes]
-        new SubscriptionSchema[A] {}
+        new ProductSubscriptionSchema[A]
     }
 
   inline given gen[A]: SubscriptionSchema[A] = derived
 }
+
+private final class ProductSubscriptionSchema[A] extends SubscriptionSchema[A]


### PR DESCRIPTION
In Scala 3.3.4, a warning is raised when we create a new anonymous class within an `inline` method. In the cases of `Schema.Auto` and `ArgBuilder.Auto` we can't do much about it since the automatic derivation only works by creating a new anonymous class so we just suppress the warning. In the case of `SubscriptionSchema` though we can fix it by creating a final class and then creating new instances of it.

Note that we could also do this, but since `SubscriptionSchema`s are not that common, I think it's better to just keep the code cleaner:

```scala
inline def derived[A]: SubscriptionSchema[A] =
  inline summonInline[Mirror.ProductOf[A]] match {
    case m: Mirror.ProductOf[A] =>
      checkParams[m.MirroredElemTypes]
      ProductSubscriptionSchema.asInstanceOf[SubscriptionSchema[A]]
  }

private object ProductSubscriptionSchema extends SubscriptionSchema[?]
```