### PR TITLE
Added test for fragment on root query

### DIFF
--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -32,6 +32,24 @@ object FragmentSpec extends ZIOSpecDefault {
           res <- int.execute(query)
         } yield assertTrue(res.data.toString == """{"amos":{"name":"Amos Burton"}}""")
       },
+      test("fragment on root query") {
+        val interpreter = graphQL(resolver).interpreter
+        val query       = gqldoc("""
+          {
+            ...amos
+          }
+
+          fragment amos on Query {
+            amos: character(name: "Amos Burton") {
+              name
+            }
+          }
+          """)
+        for {
+          int <- interpreter
+          res <- int.execute(query)
+        } yield assertTrue(res.data.toString == """{"amos":{"name":"Amos Burton"}}""")
+      },
       test("fragment on union") {
         val query = gqldoc("""
                    {


### PR DESCRIPTION
We had some problem with fragment in root query in our environment where fragments where not included in output.
So added this minor test for it, but it worked fine. So decided to add it.

What do you think, could it be in that in a more complex scenario with ZQuery this does not work as expected.
