### PR TITLE
Adhere to specification for schema extension

### DIFF
--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -327,7 +327,8 @@ object DocumentRenderer extends Renderer[Document] {
       definition match {
         case SchemaDefinition(directives, query, mutation, subscription, description) =>
           val hasTypes    = query.nonEmpty || mutation.nonEmpty || subscription.nonEmpty
-          val isExtension = directives.nonEmpty && query.isEmpty
+          val isExtension =
+            (!hasTypes && directives.nonEmpty) || query.isEmpty && (mutation.nonEmpty || subscription.nonEmpty)
           var first       = true
 
           def renderOp(name: String, op: Option[String]): Unit =

--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -328,7 +328,7 @@ object DocumentRenderer extends Renderer[Document] {
         case SchemaDefinition(directives, query, mutation, subscription, description) =>
           val hasTypes    = query.nonEmpty || mutation.nonEmpty || subscription.nonEmpty
           val isExtension =
-            (!hasTypes && directives.nonEmpty) || query.isEmpty && (mutation.nonEmpty || subscription.nonEmpty)
+            (!hasTypes && directives.nonEmpty) || (query.isEmpty && (mutation.nonEmpty || subscription.nonEmpty))
           var first       = true
 
           def renderOp(name: String, op: Option[String]): Unit =

--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -327,7 +327,7 @@ object DocumentRenderer extends Renderer[Document] {
       definition match {
         case SchemaDefinition(directives, query, mutation, subscription, description) =>
           val hasTypes    = query.nonEmpty || mutation.nonEmpty || subscription.nonEmpty
-          val isExtension = directives.nonEmpty && !hasTypes
+          val isExtension = directives.nonEmpty && query.isEmpty
           var first       = true
 
           def renderOp(name: String, op: Option[String]): Unit =

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -17,6 +17,7 @@ import caliban.schema.Annotations.GQLOneOfInput
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 import caliban.schema.{ ArgBuilder, Schema }
+import zio.stream.ZStream
 import zio.{ IO, ZIO }
 import zio.test.Assertion._
 import zio.test._
@@ -101,13 +102,31 @@ object RenderingSpec extends ZIOSpecDefault {
         assertTrue(graphQL(InvalidSchemas.resolverEmpty).render.trim == "")
       },
       test(
-        "it should render a schema extension with schema directives even if no queries, mutations, or subscription"
+        "it should render a schema extension with directives only"
       ) {
         val renderedType =
           graphQL(InvalidSchemas.resolverEmpty, schemaDirectives = List(SchemaDirectives.Link)).render.trim
         assertTrue(
           renderedType == """extend schema @link(url: "https://example.com", import: ["@key", {name: "@provides", as: "@self"}])"""
         )
+      },
+      test("it should render a schema extension with directives and a mutation") {
+        val resolver     = RootResolver(
+          Option.empty[Unit],
+          Some(MutationIO(_ => ZIO.unit)),
+          Option.empty[Unit]
+        )
+        val renderedType = graphQL(resolver, schemaDirectives = List(SchemaDirectives.Link)).render.trim
+        assertTrue(renderedType.startsWith("extend schema"))
+      },
+      test("it should render a schema extension with directives and a subscription") {
+        val resolver     = RootResolver(
+          Option.empty[Unit],
+          Option.empty[Unit],
+          Some(SubscriptionIO(ZStream.empty))
+        )
+        val renderedType = graphQL(resolver, schemaDirectives = List(SchemaDirectives.Link)).render.trim
+        assertTrue(renderedType.startsWith("extend schema"))
       },
       test("it should render object arguments in type directives") {
         val testType     = __Type(

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -128,6 +128,15 @@ object RenderingSpec extends ZIOSpecDefault {
         val renderedType = graphQL(resolver, schemaDirectives = List(SchemaDirectives.Link)).render.trim
         assertTrue(renderedType.startsWith("extend schema"))
       },
+      test("it should render a schema extension with a subscription and mutation but no directives") {
+        val resolver     = RootResolver(
+          Option.empty[Unit],
+          Some(MutationIO(_ => ZIO.unit)),
+          Some(SubscriptionIO(ZStream.empty))
+        )
+        val renderedType = graphQL(resolver).render.trim
+        assertTrue(renderedType.startsWith("extend schema"))
+      },
       test("it should render object arguments in type directives") {
         val testType     = __Type(
           __TypeKind.OBJECT,


### PR DESCRIPTION
Looking into the GraphQL specification, I believe that schemas for federated graphs are being rendered in a slightly incorrect way. The [specification](https://spec.graphql.org/October2021/#sec-Root-Operation-Types) states

> A schema defines the initial root operation type for each kind of operation it supports: query, mutation, and subscription; this determines the place in the type system where those operations begin.
> 
> The query root operation type must be provided and must be an Object type.

What is important is that the final federated GraphQL schema obeys ☝️. However, subgraphs need not implement the full schema specification. Subgraphs which do not meet this criteria should use the [`extend` keyword](https://spec.graphql.org/October2021/#sec-Schema-Extension)

> Schema extensions are used to represent a schema which has been extended from an original schema. For example, this might be used by a GraphQL service which adds additional operation types, or additional directives to an existing schema.

I believe that this change more closely adheres to the correct specification.