### PR TITLE
Upgrade zio-opentelemetry to 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val zioConfigVersion          = "4.0.2"
 val zqueryVersion             = "0.7.6"
 val zioJsonVersion            = "0.7.3"
 val zioHttpVersion            = "3.0.1"
-val zioOpenTelemetryVersion   = "3.0.0-RC21"
+val zioOpenTelemetryVersion   = "3.0.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 

--- a/tracing/src/test/scala/caliban/tracing/MockTracer.scala
+++ b/tracing/src/test/scala/caliban/tracing/MockTracer.scala
@@ -5,6 +5,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
 import zio._
+import zio.telemetry.opentelemetry.OpenTelemetry
 import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.tracing.Tracing
 
@@ -22,10 +23,10 @@ object TracingMock {
   val inMemoryTracerLayer: ULayer[InMemorySpanExporter with Tracer with ContextStorage] =
     ZLayer.fromZIOEnvironment(inMemoryTracer.map { case (inMemorySpanExporter, tracer) =>
       ZEnvironment(inMemorySpanExporter).add(tracer)
-    }) ++ ContextStorage.fiberRef
+    }) ++ OpenTelemetry.contextZIO
 
   val layer: ULayer[Tracing with InMemorySpanExporter with Tracer] =
-    inMemoryTracerLayer >>> (Tracing.live ++ inMemoryTracerLayer)
+    inMemoryTracerLayer >>> (Tracing.live() ++ inMemoryTracerLayer)
 
   def getFinishedSpans =
     ZIO


### PR DESCRIPTION
`ContextStorage.fiberRef` is now private so we need to use `OpenTelemetry.contextZIO`