### PR TITLE
[Bug] Nested fragments don't work as expected

### DIFF
--- a/core/src/test/scala/caliban/FragmentSchema.scala
+++ b/core/src/test/scala/caliban/FragmentSchema.scala
@@ -1,0 +1,32 @@
+package caliban
+
+import caliban.schema.Annotations._
+
+object FragmentSchema {
+
+  @GQLDescription("Queries")
+  case class Query(
+    bar: Option[Bar],
+    foo: List[Foo]
+  )
+
+  case class Foo(
+    id: String
+  )
+  case class Bar(
+    id: String,
+    baz: Option[Baz]
+  )
+
+  case class Baz(
+    id: String,
+    foo: Option[Foo]
+  )
+
+  val resolverFooBar: RootResolver[Query, Unit, Unit] = RootResolver(
+    Query(
+      bar = Some(Bar("1", Some(Baz("2", Some(Foo("3")))))),
+      foo = List(Foo("1"), Foo("2"))
+    )
+  )
+}

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -50,6 +50,35 @@ object FragmentSpec extends ZIOSpecDefault {
           res <- int.execute(query)
         } yield assertTrue(res.data.toString == """{"amos":{"name":"Amos Burton"}}""")
       },
+      test("fragment with inner and outer") {
+        val interpreter = graphQL(caliban.FragmentSchema.resolverFooBar).interpreter
+        val query       = gqldoc("""
+           query {
+             bar {
+               ...Outer
+             }
+           }
+
+           fragment Outer on Bar {
+             baz {
+               foo {
+                id
+               }
+               ...Inner
+             }
+           }
+
+           fragment Inner on Baz {
+             foo {
+               id
+            }
+           }
+           """)
+        for {
+          int <- interpreter
+          res <- int.execute(query)
+        } yield assertTrue(res.errors.isEmpty)
+      },
       test("fragment on union") {
         val query = gqldoc("""
                    {


### PR DESCRIPTION
Fragment validation fails for the following nested fragment with the `ValidationError` `"foo has conflicting types: Baz.foo and Query.foo. Try using an alias."`. Notice that `Query.foo` is not part of the actual query.

```graphql
query {
  bar {
    ...Outer
  }
}

fragment Outer on Bar {
  baz {
    foo {
      id
    }
    ...Inner
  }
}

fragment Inner on Baz {
  foo {
    id
  }
}
```

The underlying schema is:

```graphql
case class Query(
  bar: Option[Bar],
  foo: List[Foo]
)

case class Foo(
  id: String
)
case class Bar(
  id: String,
  baz: Option[Baz]
)

case class Baz(
  id: String,
  foo: Option[Foo]
)
```

Notice that there is _no_ error if either

1. we remove `Query.foo`, or
2. we remove the `foo { id }` from the `Outer` fragment.

We (me and @develeon) believe this is a bug with Caliban and specifically within [FragmentValidator.scala](https://github.com/lervag/caliban/blob/series/2.x/core/src/main/scala/caliban/validation/FragmentValidator.scala), but we have not been able to figure out exactly where it goes wrong. We notice that @frekw have worked on this file, so he is probably relevant for this discussion.

This PR includes a test for this bug that will fail. Do you want us to create an issue as well?