### PR TITLE
Fix fragment validation when a field is both in a fragment and outside a fragment

### DIFF
--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -21,7 +21,7 @@ object FragmentValidator {
     val parentsCache = mutable.Map.empty[Int, Chunk[String]]
     val groupsCache  = mutable.Map.empty[Int, Chunk[Set[SelectedField]]]
 
-    def sameResponseShapeByName(set: Iterable[Selection]): Chunk[String] = {
+    def sameResponseShapeByName(set: Iterable[Selection], parentType: __Type): Chunk[String] = {
       val keyHash = MurmurHash3.unorderedHash(set)
       shapeCache.get(keyHash) match {
         case Some(value) => value
@@ -35,7 +35,7 @@ object FragmentValidator {
                       .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
                 )
               } else
-                sameResponseShapeByName(f1.selection.selectionSet ::: f2.selection.selectionSet)
+                sameResponseShapeByName(f1.selection.selectionSet ::: f2.selection.selectionSet, f1.fieldDef._type)
             }
           })
           shapeCache.update(keyHash, res)
@@ -120,7 +120,7 @@ object FragmentValidator {
       }
     }
 
-    val conflicts = sameResponseShapeByName(selectionSet) ++ sameForCommonParentsByName(selectionSet)
+    val conflicts = sameResponseShapeByName(selectionSet, parentType) ++ sameForCommonParentsByName(selectionSet)
     if (conflicts.nonEmpty) {
       Left(ValidationError(conflicts.head, ""))
     } else {

--- a/core/src/test/scala/caliban/FragmentSchema.scala
+++ b/core/src/test/scala/caliban/FragmentSchema.scala
@@ -1,0 +1,32 @@
+package caliban
+
+import caliban.schema.Annotations._
+
+object FragmentSchema {
+
+  @GQLDescription("Queries")
+  case class Query(
+    bar: Option[Bar],
+    foo: List[Foo]
+  )
+
+  case class Foo(
+    id: String
+  )
+  case class Bar(
+    id: String,
+    baz: Option[Baz]
+  )
+
+  case class Baz(
+    id: String,
+    foo: Option[Foo]
+  )
+
+  val resolverFooBar: RootResolver[Query, Unit, Unit] = RootResolver(
+    Query(
+      bar = Some(Bar("1", Some(Baz("2", Some(Foo("3")))))),
+      foo = List(Foo("1"), Foo("2"))
+    )
+  )
+}

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -50,6 +50,33 @@ object FragmentSpec extends ZIOSpecDefault {
           res <- int.execute(query)
         } yield assertTrue(res.data.toString == """{"amos":{"name":"Amos Burton"}}""")
       },
+      test("fragment with inner and outer") {
+        val interpreter = graphQL(caliban.FragmentSchema.resolverFooBar).interpreter
+        val query       = gqldoc("""
+           query {
+             bar {
+               ...Outer
+             }
+           }
+           fragment Outer on Bar {
+             baz {
+               foo {
+                id
+               }
+               ...Inner
+             }
+           }
+           fragment Inner on Baz {
+             foo {
+               id
+            }
+           }
+           """)
+        for {
+          int <- interpreter
+          res <- int.execute(query)
+        } yield assertTrue(res.errors.isEmpty)
+      },
       test("fragment on union") {
         val query = gqldoc("""
                    {

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -8,6 +8,7 @@ import caliban.Value.StringValue
 import caliban.schema.Annotations.GQLDefault
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
+import caliban.schema.Schema
 import zio.test.Assertion._
 import zio.test._
 
@@ -51,7 +52,9 @@ object FragmentSpec extends ZIOSpecDefault {
         } yield assertTrue(res.data.toString == """{"amos":{"name":"Amos Burton"}}""")
       },
       test("fragment with inner and outer") {
-        val interpreter = graphQL(caliban.FragmentSchema.resolverFooBar).interpreter
+        implicit lazy val bazSchema: Schema[Any, FragmentSchema.Baz] = Schema.gen
+
+        val interpreter = graphQL(FragmentSchema.resolverFooBar).interpreter
         val query       = gqldoc("""
            query {
              bar {


### PR DESCRIPTION
Fixes https://github.com/ghostdogpr/caliban/pull/2486

`parentType` was always equal to the top parent, even in nested calls, and it was being compared with the fragment's type, which caused a mismatch. I used `f1` because at that point we know that f1 and f2 are compatible.