### PR TITLE
Avoid interface method dispatches for iterables in `Validator`

### DIFF
--- a/core/src/main/scala-2/caliban/syntax.scala
+++ b/core/src/main/scala-2/caliban/syntax.scala
@@ -12,4 +12,13 @@ private[caliban] object syntax {
   implicit class EnrichedHashMapOps[K, V <: AnyRef](private val self: mutable.HashMap[K, V]) extends AnyVal {
     def getOrElseNull(key: K): V = self.getOrElse(key, NullFn()).asInstanceOf[V]
   }
+
+  implicit class EnrichedListOps[A](private val self: List[A]) extends AnyVal {
+
+    /**
+     * In Scala 3, foreach is not inlined which can lead to performance issues when used in hot paths.
+     * In Scala 2 this method simply points to foreach, but in Scala 3 it is inlined to a while loop.
+     */
+    @inline def foreachOne(f: A => Unit): Unit = self.foreach(f)
+  }
 }

--- a/core/src/main/scala-3/caliban/syntax.scala
+++ b/core/src/main/scala-3/caliban/syntax.scala
@@ -14,6 +14,21 @@ private[caliban] object syntax {
   extension [K, V <: AnyRef](inline map: mutable.HashMap[K, V]) {
     transparent inline def getOrElseNull(key: K): V = map.getOrElse(key, NullFn()).asInstanceOf[V]
   }
+
+  extension [A](inline list: List[A]) {
+
+    /**
+     * In Scala 3, foreach is not inlined which can lead to performance issues when used in hot paths.
+     * In Scala 2 this method simply points to foreach, but in Scala 3 it is inlined to a while loop.
+     */
+    inline def foreachOne(inline f: A => Any): Unit = {
+      var rem = list
+      while (rem ne Nil) {
+        f(rem.head)
+        rem = rem.tail
+      }
+    }
+  }
 }
 
 // Required for @static fields

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -138,7 +138,9 @@ object Field {
     rootType: RootType
   ): Field = {
     val memoizedFragments      = new mutable.HashMap[String, List[(Field, Option[String])]]()
-    val variableDefinitionsMap = variableDefinitions.map(v => v.name -> v).toMap
+    val variableDefinitionsMap =
+      if (variableDefinitions eq Nil) Map.empty[String, VariableDefinition]
+      else variableDefinitions.map(v => v.name -> v).toMap
 
     def loop(
       selectionSet: List[Selection],


### PR DESCRIPTION
While looking at some profiles, I noticed a lot of `itable stub`s in Caliban's `Validator`. Most of those came from methods such as `nonEmpty` and `toList` on classes that don't override them. In addition, in Scala 3 there was a fair bit of overhead when using `foreach` because it is not inlined (unlike Scala 2).

In this PR, we:
- substitute calls to `nonEmpty` with either `v ne Nil` for Lists and `!v.isEmpty` for other iterables, and in some cases avoid method calls altogether when we know the iterable is empty.
- Add a package-private `foreachOne` method as a substitute of `foreach` for lists (which we heavily use in `Validator`). In Scala 3 this is an inlined while loop, whereas in Scala 2 we simply proxy to `foreach` (which the compiler inlines)
- Avoid invocation of `unapply` methods wherever possible especially in cases that we are not using all of the arguments of a case class

This results in a rather noticeably performance improvement (for Scala 3, haven't tested for Scala 2) especially when validating small queries (up to 50% improvement)

series/2.x:
```
[info] Benchmark                                        Mode  Cnt        Score        Error  Units
[info] ValidationBenchmark.deep                        thrpt   10  1767580.000 ±   8513.908  ops/s
[info] ValidationBenchmark.introspection               thrpt   10   161401.839 ±  11599.050  ops/s
[info] ValidationBenchmark.multifield                  thrpt   10  2143755.893 ±  35898.045  ops/s
[info] ValidationBenchmark.simple                      thrpt   10  4089052.472 ±  60659.943  ops/s
```
PR:
```
[info] Benchmark                                        Mode  Cnt        Score        Error  Units
[info] ValidationBenchmark.deep                        thrpt   10  2578415.376 ±  34212.116  ops/s
[info] ValidationBenchmark.introspection               thrpt   10   168605.760 ±   3666.029  ops/s
[info] ValidationBenchmark.multifield                  thrpt   10  2888155.836 ±  12638.780  ops/s
[info] ValidationBenchmark.simple                      thrpt   10  6226946.771 ±  88354.757  ops/s
```