### PR TITLE
Manually extract tuple params in CPU-hotpath code

### DIFF
--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -59,9 +59,9 @@ private[caliban] object ValueJsoniter {
     out.writeObjectStart()
     val iter = m.iterator
     while (iter.hasNext) {
-      val (k, v) = iter.next()
-      out.writeNonEscapedAsciiKey(k)
-      encodeInputValue(v, out)
+      val kv = iter.next()
+      out.writeNonEscapedAsciiKey(kv._1)
+      encodeInputValue(kv._2, out)
     }
     out.writeObjectEnd()
   }
@@ -108,10 +108,10 @@ private[caliban] object ValueJsoniter {
     out.writeObjectStart()
     var remaining = l
     while (remaining ne Nil) {
-      val (k, v) = remaining.head
+      val kv = remaining.head
       remaining = remaining.tail
-      out.writeNonEscapedAsciiKey(k)
-      encodeResponseValue(v, out)
+      out.writeNonEscapedAsciiKey(kv._1)
+      encodeResponseValue(kv._2, out)
     }
     out.writeObjectEnd()
   }


### PR DESCRIPTION
_Many thanks to @plokhotnyuk for pointing this out to me_

The Scala compiler is a bit overly cautious when we extract tuple params via `val (a, b) = tuple2` or `case (a, b) => ???`. Before invoking the `_1` and `_2` methods on the tuple, it will do a non-null check on the tuple. e.g., the following methods:

```scala
  def foo = {
    val t      = ("a", "b")
    val (a, b) = t
    a + b
  }

  def bar = {
    val t = ("a", "b")
    val a = t._1
    val b = t._2
    a + b
  }
```

Decompile to:

```java
    public String foo() {
        Tuple2 t = .MODULE$.apply("a", "b");
        if (t != null) {
            String a = (String)t._1();
            String b = (String)t._2();
            Tuple2 var2 = .MODULE$.apply(a, b);
            String a = (String)var2._1();
            String b = (String)var2._2();
            return (new StringBuilder(0)).append(a).append(b).toString();
        } else {
            throw new MatchError(t);
        }
    }

    public String bar() {
        Tuple2 t = .MODULE$.apply("a", "b");
        String a = (String)t._1();
        String b = (String)t._2();
        return (new StringBuilder(0)).append(a).append(b).toString();
    }
```

While this is not an issue in most cases it does make it more difficult for the JVM to JIT optimize methods / loops. As such, it's better to extract tuple params manually in hotpath code (such as the json encoder and Executor) to make it easier on the JVM to optimize these methods.