### PR TITLE
Fix encoding of json keys that contain utf-8 characters

### DIFF
--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -60,7 +60,7 @@ private[caliban] object ValueJsoniter {
     val iter = m.iterator
     while (iter.hasNext) {
       val kv = iter.next()
-      out.writeNonEscapedAsciiKey(kv._1)
+      out.writeKey(kv._1)
       encodeInputValue(kv._2, out)
     }
     out.writeObjectEnd()
@@ -110,7 +110,7 @@ private[caliban] object ValueJsoniter {
     while (remaining ne Nil) {
       val kv = remaining.head
       remaining = remaining.tail
-      out.writeNonEscapedAsciiKey(kv._1)
+      out.writeKey(kv._1)
       encodeResponseValue(kv._2, out)
     }
     out.writeObjectEnd()

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
@@ -94,6 +94,10 @@ object GraphQLResponseJsoniterSpec extends ZIOSpecDefault {
             )
           )
         )
+      },
+      test("should correctly write keys containing UTF-8") {
+        val response = GraphQLResponse(ObjectValue(List("utf8〜key" -> StringValue("any"))), Nil)
+        assertTrue(writeToString(response) == """{"data":{"utf8〜key":"any"}}""")
       }
     )
 }


### PR DESCRIPTION
As discussed in discord, this PR aims to fix the case where a json key contains UTF-8 characters, which are then not correctly encoded by jsoniter, leading to invalid json in the (http) response.