### PR TITLE
Adding ability to partially mutate objects

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSettings.scala
@@ -30,6 +30,7 @@ sealed trait CalibanSettings {
   final def addDerives(value: Boolean): Self                      = withSettings(_.addDerives(value))
   final def envForDerives(value: String): Self                    = withSettings(_.envForDerives(value))
   final def excludeDeprecated(value: Boolean): Self               = withSettings(_.excludeDeprecated(value))
+  final def partialMutations(value: Boolean): Self                = withSettings(_.partialMutations(value))
 }
 
 final case class CalibanFileSettings(file: File, settings: CalibanCommonSettings) extends CalibanSettings {

--- a/codegen-sbt/src/main/scala/caliban/codegen/OptionsParser.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/OptionsParser.scala
@@ -24,7 +24,8 @@ object OptionsParser {
     addDerives: Option[Boolean],
     envForDerives: Option[String],
     excludeDeprecated: Option[Boolean],
-    supportDeprecatedArgs: Option[Boolean]
+    supportDeprecatedArgs: Option[Boolean],
+    partialMutations: Option[Boolean]
   )
 
   private object RawOptions {
@@ -73,7 +74,8 @@ object OptionsParser {
                   rawOpts.addDerives,
                   rawOpts.envForDerives,
                   rawOpts.excludeDeprecated,
-                  rawOpts.supportDeprecatedArgs
+                  rawOpts.supportDeprecatedArgs,
+                  rawOpts.partialMutations
                 )
               }
               .option

--- a/codegen-sbt/src/test/scala/caliban/codegen/OptionsParserSpec.scala
+++ b/codegen-sbt/src/test/scala/caliban/codegen/OptionsParserSpec.scala
@@ -32,6 +32,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -63,6 +64,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 None,
                 None,
                 None,
+                None,
                 None
               )
             )
@@ -78,6 +80,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                 Options(
                   "schema",
                   "output",
+                  None,
                   None,
                   None,
                   None,
@@ -145,6 +148,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -164,6 +168,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some("GraphqlClient.scala"),
+                  None,
                   None,
                   None,
                   None,
@@ -209,6 +214,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -229,6 +235,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(true),
+                  None,
                   None,
                   None,
                   None,
@@ -273,6 +280,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -295,6 +303,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(Map("Long" -> "scala.Long")),
+                  None,
                   None,
                   None,
                   None,
@@ -337,6 +346,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -361,6 +371,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(true),
+                  None,
                   None,
                   None,
                   None,
@@ -401,6 +412,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
+                  None,
                   None
                 )
               )
@@ -418,6 +430,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   "output",
                   Some("fmtPath"),
                   Some(List(Header("aaa", "bbb:ccc"))),
+                  None,
                   None,
                   None,
                   None,
@@ -465,6 +478,7 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   Some(true),
+                  None,
                   None
                 )
               )
@@ -497,7 +511,41 @@ object OptionsParserSpec extends ZIOSpecDefault {
                   None,
                   None,
                   None,
-                  Some(false)
+                  Some(false),
+                  None
+                )
+              )
+          )
+        }
+      },
+      test("provide partialMutations") {
+        val input = List("schema", "output", "--partialMutations", "true")
+        OptionsParser.fromArgs(input).map { result =>
+          assertTrue(
+            result ==
+              Some(
+                Options(
+                  "schema",
+                  "output",
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  Some(true)
                 )
               )
           )

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -13,6 +13,9 @@ sealed trait InputValue extends Serializable { self =>
   def toInputString: String = ValueRenderer.inputValueRenderer.renderCompact(self)
 }
 object InputValue {
+  case object UndefinedValue                              extends InputValue {
+    override def toString: String = "undefined"
+  }
   case class ListValue(values: List[InputValue])          extends InputValue {
     override def toString: String      = values.mkString("[", ",", "]")
     override def toInputString: String = ValueRenderer.inputListValueRenderer.render(this)

--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -269,6 +269,7 @@ object Field {
   ): Map[String, InputValue] = {
     def resolveVariable(value: InputValue): Option[InputValue] =
       value match {
+        case InputValue.UndefinedValue      => None
         case InputValue.VariableValue(name) =>
           for {
             definition <- variableDefinitions.get(name)

--- a/core/src/main/scala/caliban/interop/circe/circe.scala
+++ b/core/src/main/scala/caliban/interop/circe/circe.scala
@@ -17,20 +17,20 @@ object json {
 
   private val inputValueEncoder: Encoder[InputValue]         = Encoder
     .instance[InputValue] {
-      case NullValue                          => Json.Null
-      case IntValue.IntNumber(value)          => Json.fromInt(value)
-      case IntValue.LongNumber(value)         => Json.fromLong(value)
-      case IntValue.BigIntNumber(value)       => Json.fromBigInt(value)
-      case FloatValue.FloatNumber(value)      => Json.fromFloatOrNull(value)
-      case FloatValue.DoubleNumber(value)     => Json.fromDoubleOrNull(value)
-      case FloatValue.BigDecimalNumber(value) => Json.fromBigDecimal(value)
-      case StringValue(value)                 => Json.fromString(value)
-      case BooleanValue(value)                => Json.fromBoolean(value)
-      case EnumValue(value)                   => Json.fromString(value)
-      case InputValue.ListValue(values)       => Json.arr(values.map(inputValueEncoder.apply): _*)
-      case InputValue.ObjectValue(fields)     =>
+      case NullValue | InputValue.UndefinedValue => Json.Null
+      case IntValue.IntNumber(value)             => Json.fromInt(value)
+      case IntValue.LongNumber(value)            => Json.fromLong(value)
+      case IntValue.BigIntNumber(value)          => Json.fromBigInt(value)
+      case FloatValue.FloatNumber(value)         => Json.fromFloatOrNull(value)
+      case FloatValue.DoubleNumber(value)        => Json.fromDoubleOrNull(value)
+      case FloatValue.BigDecimalNumber(value)    => Json.fromBigDecimal(value)
+      case StringValue(value)                    => Json.fromString(value)
+      case BooleanValue(value)                   => Json.fromBoolean(value)
+      case EnumValue(value)                      => Json.fromString(value)
+      case InputValue.ListValue(values)          => Json.arr(values.map(inputValueEncoder.apply): _*)
+      case InputValue.ObjectValue(fields)        =>
         Json.obj(fields.map { case (k, v) => k -> inputValueEncoder.apply(v) }.toList: _*)
-      case InputValue.VariableValue(name)     => Json.fromString(name)
+      case InputValue.VariableValue(name)        => Json.fromString(name)
     }
   private def jsonToResponseValue(json: Json): ResponseValue =
     json.fold(

--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -33,6 +33,7 @@ private[caliban] object ValueJsoniter {
     case v: BooleanValue                => out.writeVal(v.value)
     case v: IntValue.IntNumber          => out.writeVal(v.value)
     case NullValue                      => out.writeNull()
+    case InputValue.UndefinedValue      => ()
     case v: EnumValue                   => out.writeVal(v.value)
     case v: InputValue.ObjectValue      => writeInputObject(v.fields, out)
     case v: InputValue.ListValue        => writeInputArray(v.values, out)
@@ -60,8 +61,13 @@ private[caliban] object ValueJsoniter {
     val iter = m.iterator
     while (iter.hasNext) {
       val kv = iter.next()
-      out.writeKey(kv._1)
-      encodeInputValue(kv._2, out)
+      kv._2 match {
+        case InputValue.UndefinedValue =>
+        // Ignore undefined values
+        case _                         =>
+          out.writeKey(kv._1)
+          encodeInputValue(kv._2, out)
+      }
     }
     out.writeObjectEnd()
   }

--- a/core/src/main/scala/caliban/interop/play/play.scala
+++ b/core/src/main/scala/caliban/interop/play/play.scala
@@ -52,8 +52,14 @@ object json {
     case value: Value                   => valueWrites.writes(value)
     case InputValue.ListValue(values)   => JsArray(values.map(inputValueWrites.writes))
     case InputValue.ObjectValue(fields) =>
-      JsObject(fields.map { case (k, v) => k -> inputValueWrites.writes(v) })
+      JsObject(fields.filter {
+        case (_, InputValue.UndefinedValue) => false
+        case _                              => true
+      }.map { case (k, v) =>
+        k -> inputValueWrites.writes(v)
+      })
     case InputValue.VariableValue(name) => JsString(name)
+    case InputValue.UndefinedValue      => JsNull
   }
 
   private def jsonToResponseValue(json: JsValue): ResponseValue =

--- a/core/src/main/scala/caliban/interop/zio/zio.scala
+++ b/core/src/main/scala/caliban/interop/zio/zio.scala
@@ -20,17 +20,20 @@ object json {
 
   private def fromInputValue(input: InputValue): Json =
     input match {
-      case InputValue.ListValue(values)   =>
+      case InputValue.ListValue(values)                =>
         Json.Arr(Chunk.fromIterable(values.map(fromInputValue)))
-      case InputValue.ObjectValue(fields) =>
-        Json.Obj(Chunk.fromIterable(fields.map { case (k, v) => k -> fromInputValue(v) }))
-      case InputValue.VariableValue(name) => Json.Str(name)
-      case EnumValue(value)               => Json.Str(value)
-      case BooleanValue(value)            => Json.Bool(value)
-      case StringValue(value)             => Json.Str(value)
-      case x: IntValue                    => Json.Num(BigDecimal(x.toBigInt))
-      case x: FloatValue                  => Json.Num(x.toBigDecimal)
-      case Value.NullValue                => Json.Null
+      case InputValue.ObjectValue(fields)              =>
+        Json.Obj(Chunk.fromIterable(fields.filter {
+          case (_, InputValue.UndefinedValue) => false
+          case _                              => true
+        }.map { case (k, v) => k -> fromInputValue(v) }))
+      case InputValue.VariableValue(name)              => Json.Str(name)
+      case EnumValue(value)                            => Json.Str(value)
+      case BooleanValue(value)                         => Json.Bool(value)
+      case StringValue(value)                          => Json.Str(value)
+      case x: IntValue                                 => Json.Num(BigDecimal(x.toBigInt))
+      case x: FloatValue                               => Json.Num(x.toBigDecimal)
+      case Value.NullValue | InputValue.UndefinedValue => Json.Null
     }
 
   private def toResponseValue(input: Json): ResponseValue =

--- a/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
@@ -12,6 +12,8 @@ private[caliban] trait ValueParsers extends NumberParsers {
   def booleanValue(implicit ev: P[Any]): P[BooleanValue] =
     StringIn("true", "false").!.map(v => BooleanValue(v.toBoolean))
 
+  def undefinedValue(implicit ev: P[Any]): P[InputValue] = LiteralStr("undefined").map(_ => UndefinedValue)
+
   def nullValue(implicit ev: P[Any]): P[InputValue] = LiteralStr("null").map(_ => NullValue)
   def enumValue(implicit ev: P[Any]): P[InputValue] = name.map(EnumValue.apply)
   def listValue(implicit ev: P[Any]): P[ListValue]  = ("[" ~/ value.rep ~ "]").map(values => ListValue(values.toList))
@@ -23,6 +25,6 @@ private[caliban] trait ValueParsers extends NumberParsers {
   def variableValue(implicit ev: P[Any]): P[VariableValue] = ("$" ~/ name).map(VariableValue.apply)
 
   def value(implicit ev: P[Any]): P[InputValue] =
-    floatValue | intValue | booleanValue | stringValue | nullValue | enumValue | listValue | objectValue | variableValue
+    floatValue | intValue | booleanValue | stringValue | nullValue | undefinedValue | enumValue | listValue | objectValue | variableValue
 
 }

--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -638,11 +638,13 @@ object DocumentRenderer extends Renderer[Document] {
 
   private lazy val defaultValueRenderer: Renderer[Option[InputValue]] = new Renderer[Option[InputValue]] {
     override def unsafeRender(value: Option[InputValue], indent: Option[Int], writer: StringBuilder): Unit =
-      value.foreach { value =>
-        spaceOrEmpty(indent, writer)
-        writer append '='
-        spaceOrEmpty(indent, writer)
-        ValueRenderer.inputValueRenderer.unsafeRender(value, indent, writer)
+      value.foreach {
+        case InputValue.UndefinedValue => ()
+        case value                     =>
+          spaceOrEmpty(indent, writer)
+          writer append '='
+          spaceOrEmpty(indent, writer)
+          ValueRenderer.inputValueRenderer.unsafeRender(value, indent, writer)
       }
   }
 

--- a/core/src/main/scala/caliban/rendering/ValueRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/ValueRenderer.scala
@@ -24,6 +24,7 @@ object ValueRenderer {
         case Value.EnumValue(value)         => Renderer.escapedString.unsafeRender(value, indent, write)
         case Value.BooleanValue(value)      => write append value
         case Value.NullValue                => write ++= "null"
+        case InputValue.UndefinedValue      => ()
         case IntNumber(value)               => write append value
         case LongNumber(value)              => write append value
         case BigIntNumber(value)            => write append value
@@ -41,12 +42,18 @@ object ValueRenderer {
         Renderer.char(',') ++ Renderer.spaceOrEmpty,
         Renderer.char(':') ++ Renderer.spaceOrEmpty
       )
-      .contramap[InputValue.ObjectValue](_.fields) ++ Renderer.char('}')
+      .contramap[InputValue.ObjectValue](_.fields.filter {
+        case (_, InputValue.UndefinedValue) => false
+        case _                              => true
+      }) ++ Renderer.char('}')
 
   lazy val inputListValueRenderer: Renderer[InputValue.ListValue] =
     Renderer.char('[') ++ inputValueRenderer
       .list(Renderer.char(',') ++ Renderer.spaceOrEmpty)
-      .contramap[InputValue.ListValue](_.values) ++ Renderer.char(']')
+      .contramap[InputValue.ListValue](_.values.filter {
+        case InputValue.UndefinedValue => false
+        case _                         => true
+      }) ++ Renderer.char(']')
 
   lazy val enumInputValueRenderer: Renderer[Value.EnumValue] = new Renderer[Value.EnumValue] {
     override protected[caliban] def unsafeRender(

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -196,11 +196,11 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
   implicit lazy val zonedDateTime: ArgBuilder[ZonedDateTime]   = TemporalDecoder("ZonedDateTime")(ZonedDateTime.parse)
   implicit lazy val offsetDateTime: ArgBuilder[OffsetDateTime] = TemporalDecoder("OffsetDateTime")(OffsetDateTime.parse)
 
-  implicit def option[A](implicit ev: ArgBuilder[A]): ArgBuilder[Option[A]] = {
+  implicit def option[A](implicit ev: ArgBuilder[A]): ArgBuilder[Option[A]]       = {
     case NullValue => Right(None)
     case value     => ev.build(value).map(Some(_))
   }
-  implicit def list[A](implicit ev: ArgBuilder[A]): ArgBuilder[List[A]]     = {
+  implicit def list[A](implicit ev: ArgBuilder[A]): ArgBuilder[List[A]]           = {
     case InputValue.ListValue(items) =>
       items
         .foldLeft[Either[ExecutionError, List[A]]](Right(Nil)) {
@@ -213,6 +213,10 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
         }
         .map(_.reverse)
     case other                       => ev.build(other).map(List(_))
+  }
+  implicit def either[A](implicit ev: ArgBuilder[A]): ArgBuilder[Either[Unit, A]] = {
+    case InputValue.UndefinedValue => Right(Left(()))
+    case value                     => ev.build(value).map(Right(_))
   }
 
   implicit def seq[A](implicit ev: ArgBuilder[A]): ArgBuilder[Seq[A]]       = list[A].map(_.toSeq)

--- a/core/src/main/scala/caliban/schema/Schema.scala
+++ b/core/src/main/scala/caliban/schema/Schema.scala
@@ -355,7 +355,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
   implicit val base64CursorSchema: Schema[Any, Base64Cursor] =
     Schema.stringSchema.contramap(Cursor[Base64Cursor].encode)
 
-  implicit def optionSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Option[A]]                                  = new Schema[R0, Option[A]] {
+  implicit def optionSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Option[A]]               = new Schema[R0, Option[A]] {
     override def nullable: Boolean                                         = true
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
 
@@ -365,7 +365,7 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
         case None        => NullStep
       }
   }
-  implicit def listSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, List[A]]                                      = new Schema[R0, List[A]] {
+  implicit def listSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, List[A]]                   = new Schema[R0, List[A]] {
     override def toType(isInput: Boolean, isSubscription: Boolean): __Type = {
       val t = ev.toType_(isInput, isSubscription)
       (if (ev.nullable || ev.canFail) t else t.nonNull).list
@@ -373,28 +373,35 @@ trait GenericSchema[R] extends SchemaDerivation[R] with TemporalSchema {
 
     override def resolve(value: List[A]): Step[R0] = ListStep(value.map(ev.resolve))
   }
-  implicit def setSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Set[A]]                                        = listSchema[R0, A].contramap(_.toList)
-  implicit def seqSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Seq[A]]                                        = listSchema[R0, A].contramap(_.toList)
-  implicit def vectorSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Vector[A]]                                  =
+  implicit def setSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Set[A]]                     = listSchema[R0, A].contramap(_.toList)
+  implicit def seqSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Seq[A]]                     = listSchema[R0, A].contramap(_.toList)
+  implicit def vectorSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Vector[A]]               =
     listSchema[R0, A].contramap(_.toList)
-  implicit def chunkSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Chunk[A]]                                    =
+  implicit def chunkSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Chunk[A]]                 =
     listSchema[R0, A].contramap(_.toList)
-  implicit def nonEmptyChunkSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, NonEmptyChunk[A]]                    =
+  implicit def nonEmptyChunkSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, NonEmptyChunk[A]] =
     chunkSchema[R0, A].contramap(_.toChunk)
-  implicit def functionUnitSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, () => A]                              =
+  implicit def functionUnitSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, () => A]           =
     new Schema[R0, () => A] {
       override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = ev.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: () => A): Step[R0]                         = FunctionStep(_ => ev.resolve(value()))
     }
-  implicit def metadataFunctionSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Field => A]                       =
+  implicit def metadataFunctionSchema[R0, A](implicit ev: Schema[R0, A]): Schema[R0, Field => A]    =
     new Schema[R0, Field => A] {
       override def arguments: List[__InputValue]                             = ev.arguments
       override def nullable: Boolean                                         = ev.nullable
       override def canFail: Boolean                                          = ev.canFail
       override def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
       override def resolve(value: Field => A): Step[R0]                      = MetadataFunctionStep(field => ev.resolve(value(field)))
+    }
+
+  implicit def undefinedSchema[R, A](implicit ev: Schema[R, A]): Schema[R, Either[Unit, A]]                            =
+    new Schema[R, Either[Unit, A]] {
+      def toType(isInput: Boolean, isSubscription: Boolean): __Type = ev.toType_(isInput, isSubscription)
+
+      def resolve(value: Either[Unit, A]): Step[R] = value.fold(_ => Step.NullStep, ev.resolve)
     }
 
   implicit def eitherSchema[RA, RB, A, B](implicit

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -65,20 +65,20 @@ private object ValueValidator {
             }
           case LIST     =>
             argValue match {
-              case ListValue(values) =>
+              case ListValue(values)          =>
                 validateAllDiscard(values)(v =>
                   validateType(inputType.ofType.getOrElse(inputType), v, context, s"List item in $errorContext")
                 )
-              case NullValue         =>
+              case NullValue | UndefinedValue =>
                 unit
-              case other             =>
+              case other                      =>
                 // handle item as the first item in the list
                 validateType(inputType.ofType.getOrElse(inputType), other, context, s"List item in $errorContext")
             }
 
           case INPUT_OBJECT =>
             argValue match {
-              case ObjectValue(fields) =>
+              case ObjectValue(fields)        =>
                 validateAllDiscard(inputType.allInputFields) { f =>
                   fields.collectFirst { case (name, fieldValue) if name == f.name => fieldValue } match {
                     case Some(value)                    =>
@@ -89,9 +89,9 @@ private object ValueValidator {
                       unit
                   }
                 }
-              case NullValue           =>
+              case NullValue | UndefinedValue =>
                 unit
-              case _                   =>
+              case _                          =>
                 failValidation(
                   s"$errorContext has invalid type: $argValue",
                   "Input field was supposed to be an input object."
@@ -99,11 +99,11 @@ private object ValueValidator {
             }
           case ENUM         =>
             argValue match {
-              case EnumValue(value) =>
+              case EnumValue(value)           =>
                 validateEnum(value, inputType, errorContext)
-              case NullValue        =>
+              case NullValue | UndefinedValue =>
                 unit
-              case _                =>
+              case _                          =>
                 failValidation(
                   s"$errorContext has invalid type: $argValue",
                   "Input field was supposed to be an enum value."
@@ -141,28 +141,28 @@ private object ValueValidator {
     inputType.name.getOrElse("") match {
       case "String"  =>
         argValue match {
-          case _: StringValue | NullValue => unit
-          case t                          => failValidation(s"$errorContext has invalid type $t", "Expected 'String'")
+          case _: StringValue | NullValue | UndefinedValue => unit
+          case t                                           => failValidation(s"$errorContext has invalid type $t", "Expected 'String'")
         }
       case "ID"      =>
         argValue match {
-          case _: StringValue | NullValue => unit
-          case t                          => failValidation(s"$errorContext has invalid type $t", "Expected 'ID'")
+          case _: StringValue | NullValue | UndefinedValue => unit
+          case t                                           => failValidation(s"$errorContext has invalid type $t", "Expected 'ID'")
         }
       case "Int"     =>
         argValue match {
-          case _: Value.IntValue | NullValue => unit
-          case t                             => failValidation(s"$errorContext has invalid type $t", "Expected 'Int'")
+          case _: Value.IntValue | NullValue | UndefinedValue => unit
+          case t                                              => failValidation(s"$errorContext has invalid type $t", "Expected 'Int'")
         }
       case "Float"   =>
         argValue match {
-          case _: Value.FloatValue | _: Value.IntValue | NullValue => unit
-          case t                                                   => failValidation(s"$errorContext has invalid type $t", "Expected 'Float'")
+          case _: Value.FloatValue | _: Value.IntValue | NullValue | UndefinedValue => unit
+          case t                                                                    => failValidation(s"$errorContext has invalid type $t", "Expected 'Float'")
         }
       case "Boolean" =>
         argValue match {
-          case _: BooleanValue | NullValue => unit
-          case t                           => failValidation(s"$errorContext has invalid type $t", "Expected 'Boolean'")
+          case _: BooleanValue | NullValue | UndefinedValue => unit
+          case t                                            => failValidation(s"$errorContext has invalid type $t", "Expected 'Boolean'")
         }
       // We can't really validate custom scalars here (since we can't summon a correct ArgBuilder instance), so just pass them along
       case _         => unit

--- a/core/src/test/scala/caliban/execution/DefaultValueSpec.scala
+++ b/core/src/test/scala/caliban/execution/DefaultValueSpec.scala
@@ -3,7 +3,7 @@ package caliban.execution
 import caliban._
 import caliban.Macros.gqldoc
 import caliban.RootResolver
-import caliban.schema.Annotations.GQLDefault
+import caliban.schema.Annotations.{ GQLDefault, GQLInputName }
 import caliban.schema.Schema.auto._
 import caliban.schema.ArgBuilder.auto._
 import zio.test.Assertion._
@@ -48,6 +48,13 @@ object DefaultValueSpec extends ZIOSpecDefault {
           case class TestInput(@GQLDefault("1") b: Boolean)
           case class Query(test: TestInput => Boolean)
           val gql = graphQL(RootResolver(Query(i => i.b)))
+          gql.interpreter.exit.map(e => assert(e)(fails(isSubtype[CalibanError.ValidationError](anything))))
+        },
+        test("invalid undefined validation") {
+          case class TestInput(@GQLDefault("undefined") c: Boolean)
+          case class Query()
+          case class Mutations(test: TestInput => Boolean)
+          val gql = graphQL(RootResolver(Query(), Mutations(i => i.c)))
           gql.interpreter.exit.map(e => assert(e)(fails(isSubtype[CalibanError.ValidationError](anything))))
         },
         test("valid enum validation") {
@@ -111,6 +118,14 @@ object DefaultValueSpec extends ZIOSpecDefault {
           case class Query(test: TestInput => String)
           val gql = graphQL(RootResolver(Query(v => v.nested.field)))
           gql.interpreter.map(i => assert(i)(anything))
+        },
+        test("valid non-mandatory field validation") {
+          case class TestInput(@GQLDefault("undefined") c: Either[Unit, COLOR])
+          case class TestQuery(c: COLOR)
+          case class Query(test: TestQuery => COLOR)
+          case class Mutations(test: TestInput => Boolean)
+          val gql = graphQL(RootResolver(Query(_.c), Mutations(i => i.c.fold(_ => false, _ => true))))
+          gql.interpreter.map(i => assert(i)(anything))
         }
       ),
       test("field default values") {
@@ -165,6 +180,58 @@ object DefaultValueSpec extends ZIOSpecDefault {
           res <- int.execute(query)
         } yield assert(res.errors.headOption)(
           isSome(isSubtype[CalibanError.ValidationError](anything))
+        )
+      },
+      test("not passing non-mandatory field for mutation is valid") {
+        case class TestInput(@GQLDefault("undefined") string: Either[Unit, String], mandatory: Boolean)
+        case class Mutation(test: TestInput => String)
+        case class Query(test: TestInput => String)
+        val qgl   = graphQL(RootResolver(Query(_ => "foo"), Mutation(_.string.fold(_ => "bar", identity))))
+        val query =
+          """mutation {
+            |  test(mandatory: true)
+            |}""".stripMargin
+        for {
+          int <- qgl.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(res.errors.isEmpty && res.data.toString == """{"test":"bar"}""")
+      },
+      test("passing non-mandatory field for mutation is valid") {
+        case class TestInput(@GQLDefault("undefined") string: Either[Unit, String], mandatory: Boolean)
+        case class Mutation(test: TestInput => String)
+        case class Query(test: TestInput => String)
+        val qgl   = graphQL(RootResolver(Query(_ => "foo"), Mutation(_.string.fold(_ => "bar", identity))))
+        val query =
+          """mutation {
+            |  test(mandatory: true, string: "foo")
+            |}""".stripMargin
+        for {
+          int <- qgl.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(res.errors.isEmpty && res.data.toString == """{"test":"foo"}""")
+      },
+      test("it should render non-mandatory fields in the SDL") {
+        case class MutationInput(@GQLDefault("undefined") string: Either[Unit, String], mandatory: Boolean)
+        case class Mutation(test: MutationInput => String)
+        case class QueryInput(intValue: Int)
+        case class Query(test: QueryInput => Int)
+        val rendered =
+          graphQL(RootResolver(Query(_.intValue), Mutation(_.string.fold(_ => "bar", identity)))).render.trim
+
+        assertTrue(
+          rendered ==
+            """|schema {
+               |  query: Query
+               |  mutation: Mutation
+               |}
+               |
+               |type Mutation {
+               |  test(string: String!, mandatory: Boolean!): String!
+               |}
+               |
+               |type Query {
+               |  test(intValue: Int!): Int!
+               |}""".stripMargin.trim
         )
       },
       test("it should render default values in the SDL") {

--- a/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
+++ b/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
@@ -5,9 +5,10 @@ import caliban.InputValue
 import caliban.InputValue.ObjectValue
 import caliban.schema.ArgBuilder.auto._
 import caliban.Value.{ IntValue, NullValue, StringValue }
-import caliban.schema.Annotations.{ GQLOneOfInput, GQLValueType }
+import caliban.schema.Annotations.{ GQLDefault, GQLOneOfInput, GQLValueType }
 import zio.test.Assertion._
 import zio.test._
+
 import java.time._
 
 object ArgBuilderSpec extends ZIOSpecDefault {
@@ -128,10 +129,14 @@ object ArgBuilderSpec extends ZIOSpecDefault {
 
       object Foo {
         case class Arg1(stringValue: String) extends Foo
-        case class Arg2(fooString2: String)  extends Foo
-        case class Arg3(intValue: Foo1)      extends Foo
-        case class Arg4(fooInt2: Foo2)       extends Foo
-        case class Arg5(altString: String)   extends Foo
+
+        case class Arg2(fooString2: String) extends Foo
+
+        case class Arg3(intValue: Foo1) extends Foo
+
+        case class Arg4(fooInt2: Foo2) extends Foo
+
+        case class Arg5(altString: String) extends Foo
 
       }
 
@@ -195,6 +200,16 @@ object ArgBuilderSpec extends ZIOSpecDefault {
         )
         implicit lazy val argBuilder: ArgBuilder[RecursionTest] = ArgBuilder.gen
         assert(argBuilder)(Assertion.anything)
+      }
+    ),
+    suite("Either")(
+      test("should support non-mandatory fields") {
+        case class Foo(@GQLDefault("undefined") value: Either[Unit, Int])
+        val ab = ArgBuilder.gen[Foo]
+        assertTrue(
+          ab.build(ObjectValue(Map())) == Right(Foo(Left(()))),
+          ab.build(ObjectValue(Map("value" -> IntValue(42)))) == Right(Foo(Right(42)))
+        )
       }
     )
   )

--- a/tools/src/main/scala/caliban/tools/CalibanCommonSettings.scala
+++ b/tools/src/main/scala/caliban/tools/CalibanCommonSettings.scala
@@ -21,7 +21,8 @@ final case class CalibanCommonSettings(
   addDerives: Option[Boolean],
   envForDerives: Option[String],
   excludeDeprecated: Option[Boolean],
-  supportDeprecatedArgs: Option[Boolean]
+  supportDeprecatedArgs: Option[Boolean],
+  partialMutations: Option[Boolean]
 ) {
 
   private[caliban] def toOptions(schemaPath: String, toPath: String): Options =
@@ -45,7 +46,8 @@ final case class CalibanCommonSettings(
       addDerives = addDerives,
       envForDerives = envForDerives,
       excludeDeprecated = excludeDeprecated,
-      supportDeprecatedArgs = supportDeprecatedArgs
+      supportDeprecatedArgs = supportDeprecatedArgs,
+      partialMutations = partialMutations
     )
 
   private[caliban] def combine(r: => CalibanCommonSettings): CalibanCommonSettings =
@@ -68,7 +70,8 @@ final case class CalibanCommonSettings(
       addDerives = r.addDerives.orElse(this.addDerives),
       envForDerives = r.envForDerives.orElse(this.envForDerives),
       excludeDeprecated = r.excludeDeprecated.orElse(this.excludeDeprecated),
-      supportDeprecatedArgs = r.supportDeprecatedArgs.orElse(this.supportDeprecatedArgs)
+      supportDeprecatedArgs = r.supportDeprecatedArgs.orElse(this.supportDeprecatedArgs),
+      partialMutations = r.partialMutations.orElse(this.partialMutations)
     )
 
   def clientName(value: String): CalibanCommonSettings                         = this.copy(clientName = Some(value))
@@ -95,6 +98,7 @@ final case class CalibanCommonSettings(
   def excludeDeprecated(value: Boolean): CalibanCommonSettings                 = this.copy(excludeDeprecated = Some(value))
   def supportDeprecatedArgs(value: Boolean): CalibanCommonSettings             =
     this.copy(supportDeprecatedArgs = Some(value))
+  def partialMutations(value: Boolean): CalibanCommonSettings                  = this.copy(partialMutations = Some(value))
 }
 
 object CalibanCommonSettings {
@@ -118,6 +122,7 @@ object CalibanCommonSettings {
       addDerives = None,
       envForDerives = None,
       excludeDeprecated = None,
-      supportDeprecatedArgs = None
+      supportDeprecatedArgs = None,
+      partialMutations = None
     )
 }

--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -35,6 +35,7 @@ object Codegen {
       enableFmt                 = arguments.enableFmt.getOrElse(true)
       extensibleEnums           = arguments.extensibleEnums.getOrElse(false)
       excludeDeprecated         = arguments.excludeDeprecated.getOrElse(false)
+      partialMutations          = arguments.partialMutations.getOrElse(false)
       code                      = genType match {
                                     case GenType.Schema =>
                                       List(
@@ -47,7 +48,8 @@ object Codegen {
                                           abstractEffectType,
                                           preserveInputNames,
                                           addDerives,
-                                          envForDerives
+                                          envForDerives,
+                                          partialMutations
                                         )
                                       )
                                     case GenType.Client =>

--- a/tools/src/main/scala/caliban/tools/Options.scala
+++ b/tools/src/main/scala/caliban/tools/Options.scala
@@ -20,7 +20,8 @@ final case class Options(
   addDerives: Option[Boolean],
   envForDerives: Option[String],
   excludeDeprecated: Option[Boolean],
-  supportDeprecatedArgs: Option[Boolean]
+  supportDeprecatedArgs: Option[Boolean],
+  partialMutations: Option[Boolean]
 )
 
 object Options {

--- a/tools/src/main/scala/caliban/tools/SchemaWriter.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaWriter.scala
@@ -21,7 +21,8 @@ object SchemaWriter {
     isEffectTypeAbstract: Boolean = false,
     preserveInputNames: Boolean = false,
     addDerives: Boolean = false,
-    envForDerives: Option[String] = None
+    envForDerives: Option[String] = None,
+    partialMutations: Boolean = false
   ): String = {
 
     val (derivesSchema, derivesSchemaAndArgBuilder, envSchemaDerivation, derivesEnvSchema) =
@@ -261,11 +262,15 @@ object SchemaWriter {
     def writeInputValue(value: InputValueDefinition): String = {
       val GQLNewTypeInputDirective = writeGQLNewTypeDirective(value.directives)
 
-      val inputDef = resolveNewTypeInputDef(value).getOrElse(value)
+      val inputDef    = resolveNewTypeInputDef(value).getOrElse(value)
+      val missing     = if (partialMutations) escapeAndWrap("undefined", "GQLDefault") else ""
+      val writtenType =
+        if (partialMutations) s"scala.Either[Unit, ${writeType(inputDef.ofType)}]"
+        else writeType(inputDef.ofType)
 
-      s"""$GQLNewTypeInputDirective${writeInputAnnotations(inputDef)}${safeName(inputDef.name)} : ${writeType(
-          inputDef.ofType
-        )}"""
+      s"""$GQLNewTypeInputDirective${writeInputAnnotations(inputDef)}$missing${safeName(
+          inputDef.name
+        )} : $writtenType"""
     }
 
     def writeArguments(field: FieldDefinition, of: TypeDefinition): String = {

--- a/tools/src/main/scala/caliban/tools/compiletime/Config.scala
+++ b/tools/src/main/scala/caliban/tools/compiletime/Config.scala
@@ -38,7 +38,8 @@ trait Config {
         addDerives = None,
         envForDerives = None,
         excludeDeprecated = Some(excludeDeprecated),
-        supportDeprecatedArgs = Some(supportDeprecatedArgs)
+        supportDeprecatedArgs = Some(supportDeprecatedArgs),
+        partialMutations = None
       )
 
     private[caliban] def asScalaCode: String = {

--- a/tools/src/test/scala/caliban/tools/CodegenSpec.scala
+++ b/tools/src/test/scala/caliban/tools/CodegenSpec.scala
@@ -69,7 +69,8 @@ object CodegenSpec extends ZIOSpecDefault {
       addDerives = None,
       envForDerives = None,
       excludeDeprecated = None,
-      supportDeprecatedArgs = None
+      supportDeprecatedArgs = None,
+      partialMutations = None
     )
 
     getPackageAndObjectName(arguments)

--- a/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
+++ b/tools/src/test/scala/caliban/tools/compiletime/ConfigSpec.scala
@@ -47,7 +47,8 @@ object ConfigSpec extends ZIOSpecDefault {
               addDerives = None,
               envForDerives = None,
               excludeDeprecated = Some(true),
-              supportDeprecatedArgs = Some(true)
+              supportDeprecatedArgs = Some(true),
+              partialMutations = None
             )
         )
       )

--- a/vuepress/docs/docs/server-codegen.md
+++ b/vuepress/docs/docs/server-codegen.md
@@ -50,6 +50,7 @@ calibanGenSchema project/schema.graphql src/main/MyAPI.scala --addDerives true
 - `preserveInputNames`: Disables the default behavior of appending `Input` to the type name of input types in the derived schema.
 - `addDerives`: Adds `derives` clauses for type class instance derivation in Scala 3.
 - `envForDerives`: Specifies the type alias for your ZIO Environment when using `derives` and a ZIO Environment other than `Any`.
+- `partialMutations`: All fields of input types for mutations are not mandatory. Each field has type `scala.Either[Unit, T]`, where `Left(())` means the field is missing and not intended to be updated. This allows to distinguish the cases when the field is not passed and when the field is passed with `null` value (`None` in scala).
 
 ## Lazy evaluation
 


### PR DESCRIPTION
Added flag `partialMutations` for server code-generation. With this flag, the server will generate all fields of input types as `Either[Unit, T]`, where `Left(())` means that the field is missing. This allows to distinguish the case when the field is set explicitly to `null` from the case when the field is not passed to mutation and it's value should not change.