### PR TITLE
Feat: GraphQL schema visualization

### DIFF
--- a/core/src/main/scala/caliban/parsing/adt/Document.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Document.scala
@@ -6,6 +6,7 @@ import caliban.parsing.adt.Definition.ExecutableDefinition.{ FragmentDefinition,
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
 import caliban.parsing.adt.Definition.TypeSystemDefinition.{ DirectiveDefinition, SchemaDefinition, TypeDefinition }
 import caliban.parsing.adt.OperationType.{ Mutation, Query, Subscription }
+import caliban.parsing.adt.Definition.TypeSystemDefinition.AggregationTypeDefinition
 
 case class Document(definitions: List[Definition], sourceMapper: SourceMapper) {
 
@@ -39,9 +40,10 @@ case class Document(definitions: List[Definition], sourceMapper: SourceMapper) {
     definitions.collect { case od: OperationDefinition if od.operationType == Mutation => od }
   @transient lazy val subscriptionDefinitions: List[OperationDefinition]          =
     definitions.collect { case od: OperationDefinition if od.operationType == Subscription => od }
-
-  def objectTypeDefinition(name: String): Option[ObjectTypeDefinition]       =
+  @transient lazy val aggregationTypeDefinitions: List[AggregationTypeDefinition] =
+    definitions.collect { case agg: AggregationTypeDefinition => agg }
+  def objectTypeDefinition(name: String): Option[ObjectTypeDefinition]            =
     objectTypeDefinitions.find(t => t.name == name)
-  def interfaceTypeDefinition(name: String): Option[InterfaceTypeDefinition] =
+  def interfaceTypeDefinition(name: String): Option[InterfaceTypeDefinition]      =
     interfaceTypeDefinitions.find(t => t.name == name)
 }

--- a/core/src/main/scala/caliban/parsing/adt/Type.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Type.scala
@@ -31,8 +31,9 @@ object Type {
   case class ListType(ofType: Type, nonNull: Boolean)  extends Type
 
   /**
-   * Returns the inner type of a type. For example, the inner type of `[[User]]` is `User`.
-   * For another example, the inner type of `User!` is `User`.
+   * Returns the inner type name of a type. It recursively goes down outer type
+   * until it finds a named type. For example, the inner type of `[User]` is `"User"`.
+   * For another example, the inner type of `User!` is `"User"`.
    */
   @tailrec
   def innerType(t: Type): String = t match {

--- a/core/src/main/scala/caliban/parsing/adt/Type.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Type.scala
@@ -30,6 +30,10 @@ object Type {
   case class NamedType(name: String, nonNull: Boolean) extends Type
   case class ListType(ofType: Type, nonNull: Boolean)  extends Type
 
+  /**
+   * Returns the inner type of a type. For example, the inner type of `[[User]]` is `User`.
+   * For another example, the inner type of `User!` is `User`.
+   */
   @tailrec
   def innerType(t: Type): String = t match {
     case NamedType(name, _)  => name

--- a/tools/src/main/scala/caliban/tools/viz/Dot.scala
+++ b/tools/src/main/scala/caliban/tools/viz/Dot.scala
@@ -1,0 +1,241 @@
+package caliban.tools.viz
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
+import caliban.parsing.adt.Definition.TypeSystemDefinition.{ AggregationTypeDefinition, TypeDefinition }
+import caliban.parsing.adt.{ Definition, Directive, Directives, Document, Type }
+
+sealed trait DotEdge {
+  def toDot(): String
+}
+object DotEdge       {
+  sealed trait FieldRelation extends DotEdge
+  sealed trait TypeRelation  extends DotEdge
+  sealed trait InputRelation extends DotEdge
+  object FieldRelation {
+    private case class FieldRelationImpl(fromType: String, fromField: String, toType: String) extends FieldRelation {
+      def toDot(): String = s""""${fromType}":${fromField}port -> "${toType}";"""
+    }
+    def apply(fromType: String, fromField: String, toType: String): FieldRelation =
+      FieldRelationImpl(fromType, fromField, toType)
+    def unapply(relation: DotEdge): Option[(String, String, String)] = relation match {
+      case FieldRelationImpl(fromType, fromField, toType) => Some((fromType, fromField, toType))
+      case _                                              => None
+    }
+  }
+  object TypeRelation  {
+    private case class TypeRelationImpl(fromType: String, toType: String, label: Option[String] = None)
+        extends TypeRelation {
+      def toDot(): String = s""""${fromType}":__title -> "${toType}":__title;"""
+    }
+    def apply(fromType: String, toType: String, label: Option[String] = None): TypeRelation =
+      TypeRelationImpl(fromType, toType, label)
+    def unapply(relation: DotEdge): Option[(String, String, Option[String])] = relation match {
+      case TypeRelationImpl(fromType, toType, label) => Some((fromType, toType, label))
+      case _                                         => None
+    }
+  }
+  object InputRelation {
+    private case class InputRelationImpl(fromType: String, toType: String, toField: String) extends InputRelation {
+      def toDot(): String = s""""${fromType}" -> "${toType}":${toField}port;"""
+    }
+    def apply(fromType: String, toType: String, toField: String): InputRelation =
+      InputRelationImpl(fromType, toType, toField)
+    def unapply(relation: DotEdge): Option[(String, String, String)] = relation match {
+      case InputRelationImpl(fromType, toType, toField) => Some((fromType, toType, toField))
+      case _                                            => None
+    }
+  }
+}
+
+object Relations {
+  def fromTypes(types: List[TypeDefinition]): List[DotEdge] = {
+    val knownTypeNames = types.map(_.name).toSet
+    types.flatMap {
+      case obj: ObjectTypeDefinition  =>
+        val implRels  = obj.implements.flatMap { impl =>
+          val tpe = impl.name
+          if (knownTypeNames.contains(tpe))
+            DotEdge.TypeRelation(obj.name, impl.name) :: Nil
+          else Nil
+        }
+        val fieldRels = obj.fields.flatMap { field =>
+          val tpe                         = Type.innerType(field.ofType)
+          val fieldTypeRel                =
+            if (knownTypeNames.contains(tpe))
+              DotEdge.FieldRelation(obj.name, field.name, tpe) :: Nil
+            else Nil
+          val fieldArgRels: List[DotEdge] = field.args.flatMap { arg =>
+            val argTpe = Type.innerType(arg.ofType)
+            if (knownTypeNames.contains(argTpe))
+              DotEdge.InputRelation(argTpe, obj.name, field.name) :: Nil
+            else Nil
+          }
+          fieldTypeRel ::: fieldArgRels
+        }
+        fieldRels ::: implRels
+      case union: UnionTypeDefinition =>
+        union.memberTypes.flatMap { name =>
+          if (knownTypeNames.contains(name))
+            Some(DotEdge.TypeRelation(union.name, name))
+          else
+            None
+        }
+      case _                          => Nil
+    }
+  }
+}
+
+trait DotNode[T <: TypeDefinition] {
+  def toDot(t: T)(theme: Theme = Theme.default): String
+  def stereotype: Option[String]
+  protected def groupLabel: String
+  protected def stereotypeLabel: String = stereotype match {
+    case Some(name) if name.nonEmpty => s"&laquo;$name&raquo;<BR/>"
+    case _                           => ""
+  }
+
+  protected def tableHead(t: T)(theme: Theme) =
+    s"""
+       |<TR>
+       |  <TD PORT="__title"><FONT COLOR="${theme.color}">$stereotypeLabel<B>${t.name}</B></FONT></TD>
+       |</TR>
+       |""".stripMargin.trim()
+}
+
+trait AggDotNode[T <: AggregationTypeDefinition] extends DotNode[T] {
+  override def toDot(t: T)(theme: Theme = Theme.default): String =
+    s"""
+       |"${t.name}" [
+       |  label=<
+       |    <TABLE
+       |      COLOR="${theme.color}"
+       |      BORDER="0"
+       |      CELLBORDER="1"
+       |      CELLSPACING="0"
+       |    >
+       |${Rendering.withIndent(4)(tableHead(t)(theme))}
+       |${Rendering.withIndent(4)(t.fields.map(Fields.field(_)(theme)).mkString("\n"))}
+       |    </TABLE>
+       |  >
+       |]""".stripMargin.trim()
+}
+
+object DotNode {
+  implicit val enumToDot: DotNode[EnumTypeDefinition]               = new DotNode[EnumTypeDefinition] {
+    def stereotype: Option[String]                                         = Some("enumeration")
+    def groupLabel: String                                                 = "Enum Types"
+    def toDot(t: EnumTypeDefinition)(theme: Theme = Theme.default): String =
+      s"""
+         |"${t.name}" [
+         |  label=<
+         |    <TABLE
+         |      COLOR="${theme.color}"
+         |      BORDER="0"
+         |      CELLBORDER="1"
+         |      CELLSPACING="0"
+         |    >
+         |${Rendering.withIndent(4)(tableHead(t)(theme))}
+         |${Rendering.withIndent(4)(t.enumValuesDefinition.map(Fields.field(_)(theme)).mkString("\n"))}
+         |    </TABLE>
+         |  >
+         |]""".stripMargin.trim()
+  }
+  implicit val inputObjectToDot: DotNode[InputObjectTypeDefinition] = new DotNode[InputObjectTypeDefinition] {
+    def stereotype: Option[String]                                                = Some("input")
+    def groupLabel: String                                                        = "Input Types"
+    def toDot(t: InputObjectTypeDefinition)(theme: Theme = Theme.default): String =
+      s"""
+         |"${t.name}" [
+         |  label=<
+         |    <TABLE
+         |      COLOR="${theme.color}"
+         |      BORDER="0"
+         |      CELLBORDER="1"
+         |      CELLSPACING="0"
+         |    >
+         |${Rendering.withIndent(4)(tableHead(t)(theme))}
+         |${Rendering.withIndent(4)(t.fields.map(Fields.field(_)(theme)).mkString("\n"))}
+         |    </TABLE>
+         |  >
+         |]""".stripMargin.trim()
+  }
+  implicit val objToDot: DotNode[ObjectTypeDefinition]              = new AggDotNode[ObjectTypeDefinition] {
+    def stereotype: Option[String] = None
+    def groupLabel: String         = "Types"
+  }
+  implicit val interfaceToDot: DotNode[InterfaceTypeDefinition]     = new AggDotNode[InterfaceTypeDefinition] {
+    def stereotype: Option[String] = Some("interface")
+    def groupLabel: String         = "Interface Types"
+  }
+}
+
+private[viz] object Fields {
+  def field(f: EnumValueDefinition)(theme: Theme): String  =
+    field(f.enumValue, fieldLabel(f)(theme), theme)
+  def field(f: InputValueDefinition)(theme: Theme): String =
+    field(f.name, fieldLabel(f)(theme), theme)
+
+  def field(f: FieldDefinition)(theme: Theme): String =
+    field(f.name, fieldLabel(f)(theme), theme)
+
+  def field(name: String, label: String, theme: Theme): String =
+    s"""
+       |<TR>
+       |  <TD ALIGN="${theme.align}" PORT="${name}port"><FONT COLOR="${theme.color}">$label</FONT></TD>
+       |</TR>
+       |""".stripMargin.trim()
+
+  def fieldLabel(f: EnumValueDefinition)(theme: Theme): String  = Fields.notes(f.directives) match {
+    case None        => f.enumValue
+    case Some(notes) => s"""${f.enumValue} $notes"""
+  }
+  def fieldLabel(f: InputValueDefinition)(theme: Theme): String = {
+    val name  = f.name
+    val tpe   = f.ofType.toString()
+    val notes = Fields.notes(f.directives)
+    val field = s"${name}: ${tpe}"
+    notes match {
+      case Some(notes) => s"$field $notes"
+      case None        => field
+    }
+  }
+  def fieldLabel(f: FieldDefinition)(theme: Theme): String      = {
+    val name  = f.name
+    val args  = Fields.args(f.args)
+    val tpe   = f.ofType.toString()
+    val notes = Fields.notes(f.directives)
+    val field = s"${name}${args}: ${tpe}"
+    notes match {
+      case Some(notes) => s"$field $notes"
+      case None        => field
+    }
+  }
+  def args(args: List[InputValueDefinition]): String            = args match {
+    case Nil  => ""
+    case args => args.map(arg => s"""${arg.name}: ${arg.ofType.toString()}""").mkString("(", ", ", ")")
+  }
+
+  def notes(directives: List[Directive]): Option[String] = {
+    val deprecation = (Directives.isDeprecated(directives), Directives.deprecationReason(directives)) match {
+      case (true, Some(reason)) => Some(reason)
+      case (true, None)         => Some("Deprecated")
+      case _                    => None
+    }
+    deprecation match {
+      case None       => None
+      case Some(text) => Some(s"""<FONT COLOR="RED">$text</FONT>""")
+    }
+  }
+}
+
+private[viz] trait DotInstanceSyntax {
+  implicit class DotOps[T <: TypeDefinition](t: T)(implicit dot: DotNode[T]) {
+    def toDot(theme: Theme = Theme.default): String = dot.toDot(t)(theme)
+  }
+}
+
+private[viz] object Rendering {
+  def withIndent(level: Int)(lines: String): String = {
+    val indent = " " * level * 2
+    lines.split("\n").map(indent + _).mkString("\n")
+  }
+}

--- a/tools/src/main/scala/caliban/tools/viz/GraphQLToDot.scala
+++ b/tools/src/main/scala/caliban/tools/viz/GraphQLToDot.scala
@@ -21,7 +21,9 @@ object GraphQLToDot extends DotInstanceSyntax {
     val relations  = Relations.fromTypes(document.typeDefinitions).map(_.toDot())
     val dotfile    = s"""
                      |digraph erd {
-                     |  rankdir = "LR";
+                     |  graph [
+                     |    rankdir = "LR";
+                     |  ];
                      |  node [
                      |    fontsize = "16"
                      |    shape = "plaintext"

--- a/tools/src/main/scala/caliban/tools/viz/GraphQLToDot.scala
+++ b/tools/src/main/scala/caliban/tools/viz/GraphQLToDot.scala
@@ -1,0 +1,40 @@
+package caliban.tools.viz
+
+import caliban.parsing.Parser
+import caliban.parsing.adt.Definition.ExecutableDefinition.{ FragmentDefinition, OperationDefinition }
+import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
+import caliban.parsing.adt.Definition.TypeSystemExtension.SchemaExtension
+import caliban.parsing.adt.Definition.TypeSystemExtension.TypeExtension._
+import caliban.parsing.adt.{ Definition, Directive, Directives, Document }
+import caliban.schema.Schema
+import caliban.tools.SchemaLoader
+import zio.{ Task, ZIO }
+
+object GraphQLToDot extends DotInstanceSyntax {
+
+  def generate(document: Document): String = {
+    val objects    = document.objectTypeDefinitions.map(_.toDot())
+    val interfaces = document.interfaceTypeDefinitions.map(_.toDot())
+    val inputs     = document.inputObjectTypeDefinitions.map(_.toDot())
+    val enums      = document.enumTypeDefinitions.map(_.toDot())
+    val unions     = document.unionTypeDefinitions
+    val relations  = Relations.fromTypes(document.typeDefinitions).map(_.toDot())
+    val dotfile    = s"""
+                     |digraph erd {
+                     |  rankdir = "LR";
+                     |  node [
+                     |    fontsize = "16"
+                     |    shape = "plaintext"
+                     |  ];
+                     |  edge [
+                     |  ];
+                     |${Rendering.withIndent(2)(objects.mkString("\n"))}
+                     |${Rendering.withIndent(2)(interfaces.mkString("\n"))}
+                     |${Rendering.withIndent(2)(inputs.mkString("\n"))}
+                     |${Rendering.withIndent(2)(enums.mkString("\n"))}
+                     |${Rendering.withIndent(2)(relations.mkString("\n"))}
+                     |}
+                     |""".stripMargin.trim()
+    dotfile + "\n\n"
+  }
+}

--- a/tools/src/main/scala/caliban/tools/viz/Theme.scala
+++ b/tools/src/main/scala/caliban/tools/viz/Theme.scala
@@ -1,0 +1,10 @@
+package caliban.tools.viz
+
+case class Theme(
+  color: String,
+  align: String
+)
+
+object Theme {
+  def default = Theme(color = "black", align = "LEFT")
+}

--- a/tools/src/test/resources/snapshots/GraphQLToDotSpec/simple-schema.dot
+++ b/tools/src/test/resources/snapshots/GraphQLToDotSpec/simple-schema.dot
@@ -1,5 +1,7 @@
 digraph erd {
-  rankdir = "LR";
+  graph [
+    rankdir = "LR";
+  ];
   node [
     fontsize = "16"
     shape = "plaintext"

--- a/tools/src/test/resources/snapshots/GraphQLToDotSpec/simple-schema.dot
+++ b/tools/src/test/resources/snapshots/GraphQLToDotSpec/simple-schema.dot
@@ -69,23 +69,6 @@ digraph erd {
         </TABLE>
       >
     ]
-    "Statusable" [
-      label=<
-        <TABLE
-          COLOR="black"
-          BORDER="0"
-          CELLBORDER="1"
-          CELLSPACING="0"
-        >
-            <TR>
-              <TD PORT="__title"><FONT COLOR="black">&laquo;interface&raquo;<BR/><B>Statusable</B></FONT></TD>
-            </TR>
-            <TR>
-              <TD ALIGN="LEFT" PORT="statusport"><FONT COLOR="black">status: Status!</FONT></TD>
-            </TR>
-        </TABLE>
-      >
-    ]
     "SearchInput" [
       label=<
         <TABLE

--- a/tools/src/test/resources/snapshots/GraphQLToDotSpec/simple-schema.dot
+++ b/tools/src/test/resources/snapshots/GraphQLToDotSpec/simple-schema.dot
@@ -1,0 +1,133 @@
+digraph erd {
+  rankdir = "LR";
+  node [
+    fontsize = "16"
+    shape = "plaintext"
+  ];
+  edge [
+  ];
+    "Root" [
+      label=<
+        <TABLE
+          COLOR="black"
+          BORDER="0"
+          CELLBORDER="1"
+          CELLSPACING="0"
+        >
+            <TR>
+              <TD PORT="__title"><FONT COLOR="black"><B>Root</B></FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="accountport"><FONT COLOR="black">account(id: String!): Account</FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="allAccountsport"><FONT COLOR="black">allAccounts: [Account!]!</FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="searchport"><FONT COLOR="black">search(input: SearchInput!): [Account!]!</FONT></TD>
+            </TR>
+        </TABLE>
+      >
+    ]
+    "Account" [
+      label=<
+        <TABLE
+          COLOR="black"
+          BORDER="0"
+          CELLBORDER="1"
+          CELLSPACING="0"
+        >
+            <TR>
+              <TD PORT="__title"><FONT COLOR="black"><B>Account</B></FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="idport"><FONT COLOR="black">id: String!</FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="emailport"><FONT COLOR="black">email: String</FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="statusport"><FONT COLOR="black">status: Status!</FONT></TD>
+            </TR>
+        </TABLE>
+      >
+    ]
+    "Node" [
+      label=<
+        <TABLE
+          COLOR="black"
+          BORDER="0"
+          CELLBORDER="1"
+          CELLSPACING="0"
+        >
+            <TR>
+              <TD PORT="__title"><FONT COLOR="black">&laquo;interface&raquo;<BR/><B>Node</B></FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="idport"><FONT COLOR="black">id: String!</FONT></TD>
+            </TR>
+        </TABLE>
+      >
+    ]
+    "Statusable" [
+      label=<
+        <TABLE
+          COLOR="black"
+          BORDER="0"
+          CELLBORDER="1"
+          CELLSPACING="0"
+        >
+            <TR>
+              <TD PORT="__title"><FONT COLOR="black">&laquo;interface&raquo;<BR/><B>Statusable</B></FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="statusport"><FONT COLOR="black">status: Status!</FONT></TD>
+            </TR>
+        </TABLE>
+      >
+    ]
+    "SearchInput" [
+      label=<
+        <TABLE
+          COLOR="black"
+          BORDER="0"
+          CELLBORDER="1"
+          CELLSPACING="0"
+        >
+            <TR>
+              <TD PORT="__title"><FONT COLOR="black">&laquo;input&raquo;<BR/><B>SearchInput</B></FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="textport"><FONT COLOR="black">text: String!</FONT></TD>
+            </TR>
+        </TABLE>
+      >
+    ]
+    "Status" [
+      label=<
+        <TABLE
+          COLOR="black"
+          BORDER="0"
+          CELLBORDER="1"
+          CELLSPACING="0"
+        >
+            <TR>
+              <TD PORT="__title"><FONT COLOR="black">&laquo;enumeration&raquo;<BR/><B>Status</B></FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="ACTIVEport"><FONT COLOR="black">ACTIVE</FONT></TD>
+            </TR>
+            <TR>
+              <TD ALIGN="LEFT" PORT="INACTIVEport"><FONT COLOR="black">INACTIVE</FONT></TD>
+            </TR>
+        </TABLE>
+      >
+    ]
+    "Root":accountport -> "Account";
+    "Root":allAccountsport -> "Account";
+    "Root":searchport -> "Account";
+    "SearchInput" -> "Root":searchport;
+    "Account":statusport -> "Status";
+    "Account":__title -> "Node":__title;
+}
+

--- a/tools/src/test/scala/caliban/tools/SnapshotTest.scala
+++ b/tools/src/test/scala/caliban/tools/SnapshotTest.scala
@@ -12,13 +12,15 @@ trait SnapshotTest extends ZIOSpecDefault {
   def testName: String
 
   def snapshotTest(
-    label0: String
+    label0: String,
+    fileExtension: String = ".scala"
   )(str: Task[String])(implicit sourceLocation: SourceLocation, trace: Trace): Spec[Any, Throwable] = {
     val label = label0.replace('/', '_').replace("'", "")
     zio.test.test[Task[TestResult]](label) {
       str.map { str =>
         val isCi = SnapshotTest.isCi
-        val path = SnapshotTest.projectRoot.resolve(s"tools/src/test/resources/snapshots/$testName/${label + ".scala"}")
+        val path =
+          SnapshotTest.projectRoot.resolve(s"tools/src/test/resources/snapshots/$testName/${label + fileExtension}")
 
         def write(): TestResult = {
           Files.createDirectories(path.getParent)

--- a/tools/src/test/scala/caliban/tools/viz/GraphQLToDotSpec.scala
+++ b/tools/src/test/scala/caliban/tools/viz/GraphQLToDotSpec.scala
@@ -17,9 +17,6 @@ object GraphQLToDotSpec extends SnapshotTest {
             interface Node {
               id: String!
             }
-            interface Statusable {
-              status: Status!
-            }
 
             enum Status {
               ACTIVE

--- a/tools/src/test/scala/caliban/tools/viz/GraphQLToDotSpec.scala
+++ b/tools/src/test/scala/caliban/tools/viz/GraphQLToDotSpec.scala
@@ -1,0 +1,44 @@
+package caliban.tools
+package viz
+import zio.ZIO
+import zio.test._
+import caliban.parsing.Parser
+
+object GraphQLToDotSpec extends SnapshotTest {
+  override val testName: String = "GraphQLToDotSpec"
+  val assertions                = List(snapshotTest("simple-schema", ".dot") {
+    val simpleSchema = """
+            type Root {
+               account(id: String!): Account
+               allAccounts: [Account!]!
+               search(input: SearchInput!): [Account!]!
+            }
+
+            interface Node {
+              id: String!
+            }
+            interface Statusable {
+              status: Status!
+            }
+
+            enum Status {
+              ACTIVE
+              INACTIVE
+            }
+
+            input SearchInput {
+              text: String!
+            }
+
+            type Account implements & Node {
+              id: String!
+              email: String
+              status: Status!
+            }
+            """
+    ZIO.fromEither(Parser.parseQuery(simpleSchema)).map { doc =>
+      GraphQLToDot.generate(doc)
+    }
+  })
+  def spec                      = suite("GraphQLToDotSpec")(assertions: _*)
+}


### PR DESCRIPTION
Hello, maintainers. Thank you for the great GraphQL library.
To make developer experience slightly better,  I write a draft for GraphQL schema visualizer(Caliban Document type to `.dot` language converter). For now, It can transform the following schema into the figure below.

If you think it is useful and you are happy with adding this feature to caliban tools module, I will continue implementing the remaining part of visualization such as union type, mutation operation and subscription operation. Otherwise, let me know. I will withdraw this PR.

```graphql
type Root {
    account(id: String!): Account
    allAccounts: [Account!]!
    search(input: SearchInput!): [Account!]!
}

interface Node {
  id: String!
}
interface Statusable {
  status: Status!
}

enum Status {
  ACTIVE
  INACTIVE
}

input SearchInput {
  text: String!
}

type Account implements & Node {
  id: String!
  email: String
  status: Status!
}
```


<img width="494" alt="image" src="https://github.com/user-attachments/assets/5dbf5642-c55d-4ef4-9784-21846ed2a01e" />
