### PR TITLE
Make `Schema`, `ArgBuilder` and `Wrapper` abstract classes

### DIFF
--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -13,17 +13,17 @@ sealed trait InputValue extends Serializable { self =>
   def toInputString: String = ValueRenderer.inputValueRenderer.renderCompact(self)
 }
 object InputValue {
-  case class ListValue(values: List[InputValue])          extends InputValue {
+  final case class ListValue(values: List[InputValue])          extends InputValue {
     override def toString: String      = values.mkString("[", ",", "]")
     override def toInputString: String = ValueRenderer.inputListValueRenderer.render(this)
   }
-  case class ObjectValue(fields: Map[String, InputValue]) extends InputValue {
+  final case class ObjectValue(fields: Map[String, InputValue]) extends InputValue {
     override def toString: String =
       fields.map { case (name, value) => s""""$name":${value.toString}""" }.mkString("{", ",", "}")
 
     override def toInputString: String = ValueRenderer.inputObjectValueRenderer.render(this)
   }
-  case class VariableValue(name: String)                  extends InputValue {
+  final case class VariableValue(name: String)                  extends InputValue {
     override def toString: String = s"$$$name"
   }
 
@@ -84,10 +84,10 @@ object ResponseValue {
     loop(path, value)
   }
 
-  case class ListValue(values: List[ResponseValue])                extends ResponseValue {
+  final case class ListValue(values: List[ResponseValue])                extends ResponseValue {
     override def toString: String = ValueRenderer.responseListValueRenderer.renderCompact(this)
   }
-  case class ObjectValue(fields: List[(String, ResponseValue)])    extends ResponseValue {
+  final case class ObjectValue(fields: List[(String, ResponseValue)])    extends ResponseValue {
     override def toString: String =
       ValueRenderer.responseObjectValueRenderer.renderCompact(this)
 
@@ -98,7 +98,7 @@ object ResponseValue {
         case _              => false
       }
   }
-  case class StreamValue(stream: Stream[Throwable, ResponseValue]) extends ResponseValue {
+  final case class StreamValue(stream: Stream[Throwable, ResponseValue]) extends ResponseValue {
     override def toString: String = "<stream>"
   }
 
@@ -111,26 +111,26 @@ object ResponseValue {
 
 sealed trait Value extends InputValue with ResponseValue
 object Value {
-  case object NullValue                   extends Value                {
+  case object NullValue                         extends Value                {
     override def toString: String = "null"
   }
-  sealed trait IntValue                   extends Value                {
+  sealed trait IntValue                         extends Value                {
     def toInt: Int
     def toLong: Long
     def toBigInt: BigInt
   }
-  sealed trait FloatValue                 extends Value                {
+  sealed trait FloatValue                       extends Value                {
     def toFloat: Float
     def toDouble: Double
     def toBigDecimal: BigDecimal
   }
-  case class StringValue(value: String)   extends Value with PathValue {
+  final case class StringValue(value: String)   extends Value with PathValue {
     override def toString: String = s""""${value.replace("\"", "\\\"").replace("\n", "\\n")}""""
   }
-  case class BooleanValue(value: Boolean) extends Value                {
+  final case class BooleanValue(value: Boolean) extends Value                {
     override def toString: String = if (value) "true" else "false"
   }
-  case class EnumValue(value: String)     extends Value                {
+  final case class EnumValue(value: String)     extends Value                {
     override def toString: String      = s""""${value.replace("\"", "\\\"")}""""
     override def toInputString: String = ValueRenderer.enumInputValueRenderer.render(this)
   }

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -27,7 +27,7 @@ Derivation requires that you have a Schema for any other type nested inside ${T}
 See https://ghostdogpr.github.io/caliban/docs/schema.html for more information.
 """
 )
-trait ArgBuilder[T] { self =>
+abstract class ArgBuilder[T] { self =>
 
   /**
    * Builds a value of type `T` from an input [[caliban.InputValue]].
@@ -69,20 +69,21 @@ trait ArgBuilder[T] { self =>
    * Builds a new `ArgBuilder` of `A` from an existing `ArgBuilder` of `T` and a function from `T` to `A`.
    * @param f a function from `T` to `A`.
    */
-  def map[A](f: T => A): ArgBuilder[A] = (input: InputValue) => self.build(input).map(f)
+  final def map[A](f: T => A): ArgBuilder[A] = (input: InputValue) => self.build(input).map(f)
 
   /**
    * Builds a new `ArgBuilder` of A from an existing `ArgBuilder` of `T` and a function from `T` to `Either[ExecutionError, A]`.
    * @param f a function from `T` to Either[ExecutionError, A]
    */
-  def flatMap[A](f: T => Either[ExecutionError, A]): ArgBuilder[A] = (input: InputValue) => self.build(input).flatMap(f)
+  final def flatMap[A](f: T => Either[ExecutionError, A]): ArgBuilder[A] = (input: InputValue) =>
+    self.build(input).flatMap(f)
 
   /**
    * Builds a new `ArgBuilder` of T from two `ArgBuilders` of `T` where the second `ArgBuilder` is a fallback if the first one fails
    * In the case that both fail, the error from the second will be returned
    * @param fallback The alternative `ArgBuilder` if this one fails
    */
-  def orElse(fallback: ArgBuilder[T]): ArgBuilder[T] =
+  final def orElse(fallback: ArgBuilder[T]): ArgBuilder[T] =
     (input: InputValue) =>
       self.build(input) match {
         case Left(_) => fallback.build(input)
@@ -92,7 +93,7 @@ trait ArgBuilder[T] { self =>
   /**
    * @see [[orElse]]
    */
-  def ||(fallback: ArgBuilder[T]): ArgBuilder[T] =
+  final def ||(fallback: ArgBuilder[T]): ArgBuilder[T] =
     orElse(fallback)
 }
 


### PR DESCRIPTION
Since traits don't contain implementations of methods or lazy vals, by using traits it means they're reimplemented each time we create a new anonymous instance of these traits. Using abstract classes is much more suitable for such usecases. The downside is that a class can't extend more than 1 abstract class, but that shouldn't be an issue since none of these are meant to be mixed-in.

Also did the following while I was at it that results in a more optimized JVM code:
- Marked all methods / overrides of anonymous Schema instances as final since for some reason anonymous classes are not marked as `final` automatically by the compiler
- Made some methods on `Schema` and `ArgBuilder` (e.g., `map`, `contramap`) final as these are not meant to be overwritten
- Made some case classes extending abstract classes / traits final