### PR TITLE
Optimize `ArgBuilder.list` and unify implementation with `FederationHelpers`

### DIFF
--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -12,6 +12,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.Temporal
 import java.util.UUID
 import scala.annotation.implicitNotFound
+import scala.collection.mutable.ListBuffer
 import scala.util.Try
 import scala.util.control.{ NoStackTrace, NonFatal }
 
@@ -139,7 +140,10 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
   }
   implicit lazy val uuid: ArgBuilder[UUID]             = {
     case StringValue(value) =>
-      Try(UUID.fromString(value)).fold(_ => Left(InvalidInputArgument("UUID", value)), Right(_))
+      try Right(UUID.fromString(value))
+      catch {
+        case NonFatal(_) => Left(InvalidInputArgument("UUID", value))
+      }
     case other              => Left(InvalidInputArgument("UUID", other))
   }
   implicit lazy val boolean: ArgBuilder[Boolean]       = {
@@ -201,17 +205,7 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
     case value     => ev.build(value).map(Some(_))
   }
   implicit def list[A](implicit ev: ArgBuilder[A]): ArgBuilder[List[A]]     = {
-    case InputValue.ListValue(items) =>
-      items
-        .foldLeft[Either[ExecutionError, List[A]]](Right(Nil)) {
-          case (res @ Left(_), _)  => res
-          case (Right(res), value) =>
-            ev.build(value) match {
-              case Left(error)  => Left(error)
-              case Right(value) => Right(value :: res)
-            }
-        }
-        .map(_.reverse)
+    case InputValue.ListValue(items) => traverseInputList[A](items)
     case other                       => ev.build(other).map(List(_))
   }
 
@@ -223,6 +217,24 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
   implicit lazy val upload: ArgBuilder[Upload] = {
     case StringValue(v) => Right(Upload(v))
     case other          => Left(InvalidInputArgument("Upload", other))
+  }
+
+  private[caliban] def traverseInputList[A](
+    inputs: List[InputValue]
+  )(implicit ev: ArgBuilder[A]): Either[ExecutionError, List[A]] = {
+    val nil    = Nil
+    val result = ListBuffer.empty[A]
+    var rem    = inputs
+
+    while (rem ne nil) {
+      ev.build(rem.head) match {
+        case Right(value) => result addOne value
+        case l            => return l.asInstanceOf[Either[ExecutionError, List[A]]]
+      }
+      rem = rem.tail
+    }
+
+    Right(result.result())
   }
 }
 

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -4,6 +4,7 @@ import caliban.CalibanError.ExecutionError
 import caliban.InputValue
 import caliban.Value._
 import caliban.parsing.Parser
+import caliban.syntax._
 import caliban.uploads.Upload
 import zio.Chunk
 

--- a/federation/src/main/scala/caliban/federation/FederationHelpers.scala
+++ b/federation/src/main/scala/caliban/federation/FederationHelpers.scala
@@ -6,26 +6,8 @@ import caliban.Value.{ NullValue, StringValue }
 import caliban.introspection.adt.__InputValue
 import caliban.schema.{ ArgBuilder, Schema, Types }
 
-import scala.collection.mutable.ListBuffer
-
 private[federation] object FederationHelpers {
   import caliban.syntax._
-
-  private def buildInputsAsAny(list: List[InputValue]): Either[ExecutionError, List[_Any]] = {
-    val nil    = Nil
-    val result = ListBuffer.empty[_Any]
-    var rem    = list
-
-    while (rem ne nil) {
-      anyArgBuilder.build(rem.head) match {
-        case Right(value) => result addOne value
-        case l            => return l.asInstanceOf[Either[ExecutionError, List[_Any]]]
-      }
-      rem = rem.tail
-    }
-
-    Right(result.result())
-  }
 
   private[federation] val _FieldSet = __InputValue(
     "fields",
@@ -36,40 +18,47 @@ private[federation] object FederationHelpers {
 
   case class _Any(__typename: String, fields: InputValue)
 
-  implicit val anySchema: Schema[Any, _Any] =
-    Schema.scalarSchema("_Any", None, None, None, _ => NullValue)
+  object _Any {
+    implicit val schema: Schema[Any, _Any] =
+      Schema.scalarSchema("_Any", None, None, None, _ => NullValue)
 
-  val anyArgBuilder: ArgBuilder[_Any] = {
-    case v @ InputValue.ObjectValue(fields) =>
-      fields.getOrElseNull("__typename") match {
-        case StringValue(__typename) => Right(_Any(__typename, v))
-        case _                       => Left(ExecutionError("_Any must contain a __typename value"))
-      }
-    case other                              => Left(ExecutionError(s"Can't build a _Any from input $other"))
+    implicit val argBuilder: ArgBuilder[_Any] = {
+      case v @ InputValue.ObjectValue(fields) =>
+        fields.getOrElseNull("__typename") match {
+          case StringValue(__typename) => Right(_Any(__typename, v))
+          case _                       => Left(ExecutionError("_Any must contain a __typename value"))
+        }
+      case other                              => Left(ExecutionError(s"Can't build a _Any from input $other"))
+    }
   }
 
   case class RepresentationsArgs(representations: List[_Any])
 
-  implicit val representationsArgBuilder: ArgBuilder[RepresentationsArgs] = {
-    case InputValue.ObjectValue(fields) =>
-      fields.getOrElseNull("representations") match {
-        case InputValue.ListValue(values) => buildInputsAsAny(values).map(RepresentationsArgs.apply)
-        case null                         => Left(ExecutionError("RepresentationsArgs must contain a representations value"))
-        case other                        => Left(ExecutionError(s"Can't build a representations from input $other"))
-      }
-    case other                          => Left(ExecutionError(s"Can't build a representations from input $other"))
+  object RepresentationsArgs {
+    implicit val argBuilder: ArgBuilder[RepresentationsArgs] = {
+      case InputValue.ObjectValue(fields) =>
+        fields.getOrElseNull("representations") match {
+          case InputValue.ListValue(values) => ArgBuilder.traverseInputList[_Any](values).map(RepresentationsArgs.apply)
+          case null                         => Left(ExecutionError("RepresentationsArgs must contain a representations value"))
+          case other                        => Left(ExecutionError(s"Can't build a representations from input $other"))
+        }
+      case other                          => Left(ExecutionError(s"Can't build a representations from input $other"))
+    }
   }
 
   case class _Entity(__typename: String, value: InputValue)
 
-  case class FieldSet(fields: String)
   case class _Service(sdl: String)
 
-  implicit val fieldSetSchema: Schema[Any, FieldSet] = Schema.scalarSchema[FieldSet](
-    "_FieldSet",
-    None,
-    None,
-    None,
-    (fs: FieldSet) => StringValue(fs.fields)
-  )
+  case class FieldSet(fields: String)
+
+  object FieldSet {
+    implicit val schema: Schema[Any, FieldSet] = Schema.scalarSchema[FieldSet](
+      "_FieldSet",
+      None,
+      None,
+      None,
+      (fs: FieldSet) => StringValue(fs.fields)
+    )
+  }
 }

--- a/federation/src/main/scala/caliban/federation/FederationSupport.scala
+++ b/federation/src/main/scala/caliban/federation/FederationSupport.scala
@@ -16,7 +16,7 @@ abstract class FederationSupport(
   // This is a bit of a hack to determine if we are using the v1 version of the federation spec
   // All of the v2 directives come through schema directives while the v1 is through the supported directives field instead
   private val isV1       = supportedDirectives.nonEmpty && schemaDirectives.isEmpty
-  private val extraTypes = if (isV1) List(fieldSetSchema.toType_()) else Nil
+  private val extraTypes = if (isV1) List(FieldSet.schema.toType_()) else Nil
 
   /**
    * Accepts a GraphQL and returns a GraphQL with the minimum settings to support federation. This variant does not


### PR DESCRIPTION
I noticed that the implementation of `ArgBuilder.list` was a bit suboptimal (requiring a fold and traversing the whole list even on failures). I also realised that this should be the same implementation as the one used in `FederationHelpers` that I did in a previous PR

In this PR we:
- use a single implementation of traversing through a list of inputs
- placed the implicit schemas / argbuilders in the companion object of case classes defined in `FederationHelpers` to avoid potential issues with imports
- (Bonus) Slightly optimized happy path in `ArgBuilder.uuid` to use `try { ... }` instead of `Try(...).fold`