### PR TITLE
Added option for forwarding upload request

### DIFF
--- a/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
@@ -7,7 +7,7 @@ import zio.http.netty.NettyConfig
 import zio.http.netty.NettyConfig.LeakDetectionLevel
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R]) {
+final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R], forwardUploadRequest: Boolean) {
 
   private implicit val trace: Trace = Trace.empty
 
@@ -15,14 +15,14 @@ final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R]) {
    * Converts this adapter to a [[QuickHandlers]] which contains [[zio.http.RequestHandler]]s for manually constructing zio-http routes
    */
   val handlers: QuickHandlers[R] = QuickHandlers(
-    api = Handler.fromFunctionZIO[Request](requestHandler.handleHttpRequest),
+    api = Handler.fromFunctionZIO[Request](requestHandler.handleHttpRequest(forwardUploadRequest)),
     upload = Handler.fromFunctionZIO[Request](requestHandler.handleUploadRequest),
     webSocket = Handler.fromFunctionZIO[Request](requestHandler.handleWebSocketRequest)
   )
 
   @deprecated("Use `handlers` instead", "2.5.0")
   lazy val handler: RequestHandler[R, Nothing] =
-    Handler.fromFunctionZIO[Request](requestHandler.handleHttpRequest)
+    Handler.fromFunctionZIO[Request](requestHandler.handleHttpRequest(forwardUploadRequest))
 
   /**
    * Converts this adapter to a `Routes` serving the GraphQL API at the specified path.
@@ -80,21 +80,21 @@ final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R]) {
       )
 
   def configure(config: ExecutionConfiguration)(implicit trace: Trace): QuickAdapter[R] =
-    new QuickAdapter(requestHandler.configure(config))
+    new QuickAdapter(requestHandler.configure(config), forwardUploadRequest)
 
   def configure[R1](configurator: QuickAdapter.Configurator[R1])(implicit trace: Trace): QuickAdapter[R & R1] =
-    new QuickAdapter(requestHandler.configure[R1](configurator))
+    new QuickAdapter(requestHandler.configure[R1](configurator), forwardUploadRequest)
 
   def configureWebSocket[R1](config: quick.WebSocketConfig[R1]): QuickAdapter[R & R1] =
-    new QuickAdapter(requestHandler.configureWebSocket(config))
+    new QuickAdapter(requestHandler.configureWebSocket(config), forwardUploadRequest)
 
 }
 
 object QuickAdapter {
   type Configurator[-R] = URIO[R & Scope, Unit]
 
-  def apply[R](interpreter: GraphQLInterpreter[R, Any]): QuickAdapter[R] =
-    new QuickAdapter(new QuickRequestHandler(interpreter, quick.WebSocketConfig.default))
+  def apply[R](interpreter: GraphQLInterpreter[R, Any], forwardUploadRequest: Boolean = false): QuickAdapter[R] =
+    new QuickAdapter(new QuickRequestHandler(interpreter, quick.WebSocketConfig.default), forwardUploadRequest)
 
   def handlers[R](implicit tag: Tag[R], trace: Trace): URIO[QuickAdapter[R], QuickHandlers[R]] =
     ZIO.serviceWith(_.handlers)

--- a/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
@@ -7,7 +7,7 @@ import zio.http.netty.NettyConfig
 import zio.http.netty.NettyConfig.LeakDetectionLevel
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R], forwardUploadRequest: Boolean) {
+final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R]) {
 
   private implicit val trace: Trace = Trace.empty
 
@@ -15,14 +15,14 @@ final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R], for
    * Converts this adapter to a [[QuickHandlers]] which contains [[zio.http.RequestHandler]]s for manually constructing zio-http routes
    */
   val handlers: QuickHandlers[R] = QuickHandlers(
-    api = Handler.fromFunctionZIO[Request](requestHandler.handleHttpRequest(forwardUploadRequest)),
+    api = Handler.fromFunctionZIO[Request](requestHandler.handleHttpRequest),
     upload = Handler.fromFunctionZIO[Request](requestHandler.handleUploadRequest),
     webSocket = Handler.fromFunctionZIO[Request](requestHandler.handleWebSocketRequest)
   )
 
   @deprecated("Use `handlers` instead", "2.5.0")
   lazy val handler: RequestHandler[R, Nothing] =
-    Handler.fromFunctionZIO[Request](requestHandler.handleHttpRequest(forwardUploadRequest))
+    Handler.fromFunctionZIO[Request](requestHandler.handleHttpRequest)
 
   /**
    * Converts this adapter to a `Routes` serving the GraphQL API at the specified path.
@@ -80,21 +80,21 @@ final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R], for
       )
 
   def configure(config: ExecutionConfiguration)(implicit trace: Trace): QuickAdapter[R] =
-    new QuickAdapter(requestHandler.configure(config), forwardUploadRequest)
+    new QuickAdapter(requestHandler.configure(config))
 
   def configure[R1](configurator: QuickAdapter.Configurator[R1])(implicit trace: Trace): QuickAdapter[R & R1] =
-    new QuickAdapter(requestHandler.configure[R1](configurator), forwardUploadRequest)
+    new QuickAdapter(requestHandler.configure[R1](configurator))
 
   def configureWebSocket[R1](config: quick.WebSocketConfig[R1]): QuickAdapter[R & R1] =
-    new QuickAdapter(requestHandler.configureWebSocket(config), forwardUploadRequest)
+    new QuickAdapter(requestHandler.configureWebSocket(config))
 
 }
 
 object QuickAdapter {
   type Configurator[-R] = URIO[R & Scope, Unit]
 
-  def apply[R](interpreter: GraphQLInterpreter[R, Any], forwardUploadRequest: Boolean = false): QuickAdapter[R] =
-    new QuickAdapter(new QuickRequestHandler(interpreter, quick.WebSocketConfig.default), forwardUploadRequest)
+  def apply[R](interpreter: GraphQLInterpreter[R, Any]): QuickAdapter[R] =
+    new QuickAdapter(new QuickRequestHandler(interpreter, quick.WebSocketConfig.default))
 
   def handlers[R](implicit tag: Tag[R], trace: Trace): URIO[QuickAdapter[R], QuickHandlers[R]] =
     ZIO.serviceWith(_.handlers)

--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -42,14 +42,25 @@ final private class QuickRequestHandler[R](
   def configureWebSocket[R1](config: quick.WebSocketConfig[R1]): QuickRequestHandler[R & R1] =
     new QuickRequestHandler[R & R1](interpreter, config)
 
-  def handleHttpRequest(request: Request)(implicit trace: Trace): URIO[R, Response] = ZIO.suspendSucceed {
-    transformHttpRequest(request)
-      .flatMap(executeRequest(request.method, _))
-      .foldZIO(
-        Exit.succeed,
-        resp => Exit.succeed(transformResponse(request, resp))
+  def handleHttpRequest(forwardUploadRequests: Boolean = false)(request: Request)(implicit
+    trace: Trace
+  ): URIO[R, Response] =
+    if (
+      forwardUploadRequests && request.headers.exists(
+        _.renderedValue.contains(MediaType.multipart.`form-data`.fullType)
       )
-  }
+    ) {
+      handleUploadRequest(request)
+    } else {
+      ZIO.suspendSucceed {
+        transformHttpRequest(request)
+          .flatMap(executeRequest(request.method, _))
+          .foldZIO(
+            Exit.succeed,
+            resp => Exit.succeed(transformResponse(request, resp))
+          )
+      }
+    }
 
   def handleUploadRequest(request: Request)(implicit trace: Trace): URIO[R, Response] = ZIO.suspendSucceed {
     transformUploadRequest(request).flatMap { case (req, fileHandle) =>

--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -46,9 +46,8 @@ final private class QuickRequestHandler[R](
     trace: Trace
   ): URIO[R, Response] =
     if (
-      forwardUploadRequests && request.headers.exists(
-        _.renderedValue.contains(MediaType.multipart.`form-data`.fullType)
-      )
+      forwardUploadRequests &&
+      request.body.mediaType.exists(MediaType.multipart.`form-data`.matches(_, ignoreParameters = true))
     ) {
       handleUploadRequest(request)
     } else {

--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -42,13 +42,10 @@ final private class QuickRequestHandler[R](
   def configureWebSocket[R1](config: quick.WebSocketConfig[R1]): QuickRequestHandler[R & R1] =
     new QuickRequestHandler[R & R1](interpreter, config)
 
-  def handleHttpRequest(forwardUploadRequests: Boolean = false)(request: Request)(implicit
+  def handleHttpRequest(request: Request)(implicit
     trace: Trace
   ): URIO[R, Response] =
-    if (
-      forwardUploadRequests &&
-      request.body.mediaType.exists(MediaType.multipart.`form-data`.matches(_, ignoreParameters = true))
-    ) {
+    if (request.body.mediaType.exists(MediaType.multipart.`form-data`.matches(_, ignoreParameters = true))) {
       handleUploadRequest(request)
     } else {
       ZIO.suspendSucceed {


### PR DESCRIPTION
Proposal to extend the `QuickAdapter` with a boolean `forwardUploadRequests` which can be set true
in order to forward upload request/multipart form-data to the upload handler.

In this way clients do not have to change endpoints for upload requests.

@ghostdogpr what do you think?