### PR TITLE
don't add .scala suffix to sources directory when using splitFiles

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
@@ -40,7 +40,7 @@ object CalibanSourceGenerator {
       }
       val interimPath  = managedRoot.toPath.resolve(relativePath)
       val clientName   = settings.clientName.getOrElse(interimPath.getFileName.toString.stripSuffix(".graphql"))
-      val scalaName    = clientName + ".scala"
+      val scalaName    = if (settings.splitFiles.contains(true)) clientName else clientName + ".scala"
       interimPath.getParent.resolve(scalaName).toFile
   }
 

--- a/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/build.sbt
@@ -1,0 +1,17 @@
+import _root_.caliban.tools.Codegen
+
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(CalibanPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.ghostdogpr" %% "caliban"        % Version.pluginVersion,
+      "com.github.ghostdogpr" %% "caliban-client" % Version.pluginVersion
+    ),
+    Compile / caliban / calibanSettings ++= Seq(
+      calibanSetting(file("src/main/graphql/schema.graphql"))( // Explicitly constrain to disambiguate
+        _.clientName("Client")
+          .splitFiles(true)
+      )
+    )
+  )

--- a/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/project/Version.scala
+++ b/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/project/Version.scala
@@ -1,0 +1,8 @@
+object Version {
+  def pluginVersion: String =
+    sys.props.get("plugin.version") match {
+      case Some(x) => x
+      case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                             |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+    }
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/project/plugins.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.ghostdogpr" % "caliban-codegen-sbt" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/src/main/graphql/schema.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/src/main/graphql/schema.graphql
@@ -1,0 +1,136 @@
+directive @lazy on FIELD_DEFINITION
+directive @oneOf on INPUT_OBJECT
+
+# Schema
+schema {
+    query: Q
+}
+
+# Query
+type Q {
+    # nested object type
+    characters: [Character!]!
+    # nested object type with argument
+    character(name: String!): Character
+    # oneOf input object
+    character2(oneOfThese: CharacterOneOfInput!): Character
+
+    # default arguments for optional and list arguments
+    characters2(
+        first: Int!
+        last: Int
+        origins: [String]!
+    ): String
+
+    testJson: Json!
+
+    # test for scala.Option / Option conflicts
+    defaultOptionForProductId(id: String!): Option
+    availableOptionsForProductId(id: String!): [Option!]
+
+    # nested @lazy fields
+    cant: Canterbury!
+}
+
+# Input object
+input CharacterInput {
+    name: String!
+    nicknames: [String!]!
+    nicknames2: [String]!
+    nicknames3: [String!]
+    nicknames4: [String]
+
+    # reserved name
+    wait: String!
+}
+
+# Input object
+input CharacterOneOfInput @oneOf {
+    name: String
+    nickname: String
+    origin: Origin
+
+    # reserved name
+    wait: String
+}
+
+# Object
+type Character {
+    name: String!
+    nicknames: [String!]!
+
+    # reserved name
+    type: String!
+
+    # enum
+    origin: Origin
+
+    # union
+    role: Role
+
+    # Deprecated field + comment
+    oldName: String! @deprecated(reason: "blah")
+    oldNicknames: [String!]! @deprecated
+    # Deprecated field + comment newline
+    oldName2: String! @deprecated(reason: "foo\nbar")
+    # Deprecated field + comment with double quotes and newlines
+    """a deprecated field"""
+    oldName3: String!
+    @deprecated(reason: """
+    This field is deprecated for the following reasons:
+    1. "Outdated data model": The field relies on an outdated data model.
+    2. "Performance issues": Queries using this field have performance issues.
+    Please use `name` instead.
+    """)
+}
+
+# Enum
+enum Origin {
+    EARTH
+    MARS
+    BELT
+}
+
+# Regression test for a conflict with SelectionBuilder.Field (#917)
+enum Field {
+    name
+    nicknames
+    origin
+}
+
+# Union
+union Role = Captain | Pilot
+type Captain {
+    shipName: String!
+}
+type Pilot {
+    shipName: String!
+}
+
+# Json
+scalar Json
+
+# A type that could conflict with scala.Option
+type Option {
+    defaultColor: String!
+}
+type Product {
+    id: String
+    defaultOption: Option!
+    configuredOption: Option
+    availableOptions: [Option!]!
+    specialOrderOption: [Option]
+}
+
+type Canterbury {
+    officer: Officer!
+}
+
+type Officer {
+    dossier: Dossier! @lazy
+}
+
+type Dossier {
+    homeWorld: String!
+    faction: String! @lazy
+}

--- a/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/test
+++ b/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/test
@@ -1,0 +1,13 @@
+$ exec echo compiling for the first time
+> compile
+
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/package.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/Character.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/Canterbury.scala
+
+$ exec echo compiling second time
+> compile
+
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/package.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/Character.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/Canterbury.scala

--- a/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/verify.sh
+++ b/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if grep -q "$1" "$2"; then
+  echo "$1 exists in $2"
+  exit 0
+else
+  echo "$1 is missing in $2"
+  exit 1
+fi


### PR DESCRIPTION
`sbt` seems to try to pick up the directory as a source and compile it, which breaks compilation; I receive a stack trace like the following:

```
[error] ## Exception when compiling 2728 sources to C:\Users\redacted\libs\shopify-admin-api\target\scala-3.6.3\classes
[error] java.nio.file.AccessDeniedException: C:\Users\redacted\libs\shopify-admin-api\target\scala-3.6.3\src_managed\main\caliban-codegen-sbt\com\redacted\libs\shopify\admin\client\ShopifyAdminClient.scala
[error] java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:89)
[error] java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
[error] java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
[error] java.base/sun.nio.fs.WindowsFileSystemProvider.newByteChannel(WindowsFileSystemProvider.java:234)
[error] java.base/java.nio.file.Files.newByteChannel(Files.java:380)
[error] java.base/java.nio.file.Files.newByteChannel(Files.java:432)
[error] java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
[error] java.base/java.nio.file.Files.newInputStream(Files.java:160)
[error] dotty.tools.io.File.inputStream(File.scala:51)
[error] dotty.tools.io.PlainFile.input(PlainFile.scala:69)
[error] dotty.tools.io.AbstractFile.toByteArray(AbstractFile.scala:173)
[error] dotty.tools.dotc.util.SourceFile$.apply(SourceFile.scala:281)
[error] dotty.tools.dotc.core.Contexts$.dotty$tools$dotc$core$Contexts$Context$$_$getSource$$anonfun$1(Contexts.scala:257)
```

I had to include the following code in my `build.sbt` to get it to work: 
```
    Compile / managedSources := {
      val ms = (Compile / managedSources).value.get()
      ms.filterNot(_.isDirectory)
    },
```

however, this seems like a workaround, and it was still interfering with other things (like IntelliJ which for some reason wasn't respecting that setting).

Removing the `.scala` suffix on the directory appears to resolve the issue for me when testing locally.