### PR TITLE
Use `@threadUnsafe` for cached hash codes in Scala 3

### DIFF
--- a/core/src/main/scala-2/caliban/Scala3Annotations.scala
+++ b/core/src/main/scala-2/caliban/Scala3Annotations.scala
@@ -6,5 +6,6 @@ import scala.annotation.StaticAnnotation
  * Stubs for annotations that exist in Scala 3 but not in Scala 2
  */
 private[caliban] object Scala3Annotations {
-  final class static extends StaticAnnotation
+  final class static       extends StaticAnnotation
+  final class threadUnsafe extends StaticAnnotation
 }

--- a/core/src/main/scala-3/caliban/Scala3Annotations.scala
+++ b/core/src/main/scala-3/caliban/Scala3Annotations.scala
@@ -6,5 +6,6 @@ import scala.annotation
  * Proxies for annotations that exist in Scala 3 but not in Scala 2
  */
 private[caliban] object Scala3Annotations {
-  type static = annotation.static
+  type static       = annotation.static
+  type threadUnsafe = annotation.threadUnsafe
 }

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -1,5 +1,6 @@
 package caliban
 
+import caliban.Scala3Annotations.threadUnsafe
 import caliban.Value.StringValue
 import caliban.interop.tapir.IsTapirSchema
 import caliban.rendering.ValueRenderer
@@ -91,8 +92,10 @@ object ResponseValue {
     override def toString: String =
       ValueRenderer.responseObjectValueRenderer.renderCompact(this)
 
-    @transient override lazy val hashCode: Int = MurmurHash3.unorderedHash(fields)
-    override def equals(other: Any): Boolean   =
+    @transient @threadUnsafe
+    override lazy val hashCode: Int = MurmurHash3.unorderedHash(fields)
+
+    override def equals(other: Any): Boolean =
       other match {
         case o: ObjectValue => o.hashCode == hashCode
         case _              => false

--- a/core/src/main/scala/caliban/introspection/adt/__Field.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Field.scala
@@ -1,5 +1,6 @@
 package caliban.introspection.adt
 
+import caliban.Scala3Annotations.threadUnsafe
 import caliban.Value.StringValue
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition.{ FieldDefinition, InputValueDefinition }
 import caliban.parsing.adt.Directive
@@ -16,6 +17,7 @@ case class __Field(
   deprecationReason: Option[String] = None,
   @GQLExcluded directives: Option[List[Directive]] = None
 ) {
+  @transient @threadUnsafe
   final override lazy val hashCode: Int = MurmurHash3.productHash(this)
 
   def toFieldDefinition: FieldDefinition = {

--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -1,5 +1,6 @@
 package caliban.introspection.adt
 
+import caliban.Scala3Annotations.threadUnsafe
 import caliban.Value.StringValue
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition
 import caliban.parsing.adt.Definition.TypeSystemDefinition.TypeDefinition._
@@ -28,7 +29,8 @@ case class __Type(
 ) { self =>
   import caliban.syntax._
 
-  @transient final override lazy val hashCode: Int = MurmurHash3.productHash(self)
+  @transient @threadUnsafe
+  final override lazy val hashCode: Int = MurmurHash3.productHash(self)
 
   private[caliban] lazy val typeNameRepr: String = DocumentRenderer.renderTypeName(this)
 

--- a/core/src/main/scala/caliban/parsing/adt/Selection.scala
+++ b/core/src/main/scala/caliban/parsing/adt/Selection.scala
@@ -1,13 +1,15 @@
 package caliban.parsing.adt
 
 import caliban.InputValue
+import caliban.Scala3Annotations.threadUnsafe
 import caliban.parsing.adt.Type.NamedType
 
 import scala.util.hashing.MurmurHash3
 
-sealed trait Selection extends Serializable {
-  // TODO: Kept for binary compatibility
-  @transient override lazy val hashCode: Int = super.hashCode()
+sealed trait Selection extends Product with Serializable {
+
+  @transient @threadUnsafe
+  override final lazy val hashCode: Int = MurmurHash3.productHash(this)
 }
 
 object Selection {
@@ -19,20 +21,14 @@ object Selection {
     directives: List[Directive],
     selectionSet: List[Selection],
     index: Int
-  ) extends Selection {
-    @transient final override lazy val hashCode: Int = MurmurHash3.productHash(this)
-  }
+  ) extends Selection
 
-  case class FragmentSpread(name: String, directives: List[Directive]) extends Selection {
-    @transient final override lazy val hashCode: Int = MurmurHash3.productHash(this)
-  }
+  case class FragmentSpread(name: String, directives: List[Directive]) extends Selection
 
   case class InlineFragment(
     typeCondition: Option[NamedType],
     dirs: List[Directive],
     selectionSet: List[Selection]
-  ) extends Selection {
-    @transient final override lazy val hashCode: Int = MurmurHash3.productHash(this)
-  }
+  ) extends Selection
 
 }

--- a/core/src/main/scala/caliban/validation/package.scala
+++ b/core/src/main/scala/caliban/validation/package.scala
@@ -1,5 +1,6 @@
 package caliban
 
+import caliban.Scala3Annotations.threadUnsafe
 import caliban.parsing.adt.Definition.ExecutableDefinition.{ FragmentDefinition, OperationDefinition }
 import caliban.introspection.adt.{ __Field, __Type }
 import caliban.parsing.SourceMapper
@@ -15,7 +16,8 @@ package object validation {
     selection: Field,
     fieldDef: __Field
   ) {
-    @transient final override lazy val hashCode: Int = MurmurHash3.productHash(this)
+    @transient @threadUnsafe
+    final override lazy val hashCode: Int = MurmurHash3.productHash(this)
   }
 
   type FieldMap = Map[String, Set[SelectedField]]


### PR DESCRIPTION
`lazy val` is quite heavyweight in different ways because it needs to guarantee "exactly once" semantics when called. In almost all of our lazy val definitions we don't care about exactly once as we use them for caching.

In Scala 3 we can use a much more lightweight implementation using `@threadUnsafe` that doesn't guarantee "exactly once" semantics. The downside of course is that concurrent thread access to the same lazy val might be computed more than once, but since the computation of `hashCode` is pure it doesn't really matter. Also, we mostly dedup these objects during validation, which is not done in parallel. 

This way our objects have a smaller memory footprint and access to `hashCode` doesn't require a volatile read / write plus unboxing of the `Int` (yeah, "normal" lazy vals box primitives......)

Note that we have a lot more lazy vals that can be treated this way, but I thought to keep it simple for the time being as this change is binary compatible so we can add this annotation to lazy vals as needed