### PR TITLE
add test that generates code that doesn't compile

### DIFF
--- a/codegen-sbt/src/sbt-test/codegen/gen-client-task/project/duplicate-scalar-implicit.graphql
+++ b/codegen-sbt/src/sbt-test/codegen/gen-client-task/project/duplicate-scalar-implicit.graphql
@@ -1,0 +1,5 @@
+type PriceRuleCustomerSelection {
+  customers(after: String, savedSearchId: ID): String
+}
+
+scalar ID

--- a/codegen-sbt/src/sbt-test/codegen/gen-client-task/test
+++ b/codegen-sbt/src/sbt-test/codegen/gen-client-task/test
@@ -38,3 +38,7 @@ $ exists src/main/scala/genview/client/Project.scala
 $ exec sh verify.sh ProjectView ./src/main/scala/genview/client/Project.scala
 $ exec sh verify.sh ProjectViewArgs ./src/main/scala/genview/client/Project.scala
 $ exec sh verify.sh ProjectViewSelectionArgs ./src/main/scala/genview/client/Project.scala
+
+> calibanGenClient project/duplicate-scalar-implicit.graphql src/main/scala/client/DuplicateScalarImplicit.scala --packageName client
+$ exists src/main/scala/client/DuplicateScalarImplicit.scala
+> compile

--- a/tools/src/test/resources/snapshots/ClientWriterSpec/implicit encoders for String and scalar.scala
+++ b/tools/src/test/resources/snapshots/ClientWriterSpec/implicit encoders for String and scalar.scala
@@ -1,0 +1,19 @@
+import caliban.client.FieldBuilder._
+import caliban.client._
+
+object Client {
+
+  type PriceRuleCustomerSelection
+  object PriceRuleCustomerSelection {
+    def customers(after: scala.Option[String] = None, savedSearchId: scala.Option[String] = None)(implicit
+      encoder0: ArgEncoder[scala.Option[String]],
+      encoder1: ArgEncoder[scala.Option[String]]
+    ): SelectionBuilder[PriceRuleCustomerSelection, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field(
+        "customers",
+        OptionOf(Scalar()),
+        arguments = List(Argument("after", after, "String"), Argument("savedSearchId", savedSearchId, "ID"))
+      )
+  }
+
+}

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -112,6 +112,16 @@ object ClientWriterSpec extends SnapshotTest {
              }
             """)
       },
+      snapshotTest("implicit encoders for String and scalar") {
+        gen(
+          """
+             type PriceRuleCustomerSelection {
+               customers(after: String, savedSearchId: ID): String
+             }
+
+             scalar ID
+            """)
+      },
       snapshotTest("schema") {
         gen("""
              schema {

--- a/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
+++ b/tools/src/test/scala/caliban/tools/ClientWriterSpec.scala
@@ -113,8 +113,7 @@ object ClientWriterSpec extends SnapshotTest {
             """)
       },
       snapshotTest("implicit encoders for String and scalar") {
-        gen(
-          """
+        gen("""
              type PriceRuleCustomerSelection {
                customers(after: String, savedSearchId: ID): String
              }


### PR DESCRIPTION
In https://github.com/ghostdogpr/caliban/pull/2701, explicit uses of implicits were removed for Scala 3.7 compatibility. However, this appears to break when the graphql schema contains scalars.

One possible solution might be to revert to the old code, and explicitly add in `using`

[this guard](https://github.com/ghostdogpr/caliban/pull/2701/files#r2191378588) doesn't work for custom graphql scalar types