### PR TITLE
No sub-directory with client name should be created in case of split-files.

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/CalibanSourceGenerator.scala
@@ -39,9 +39,13 @@ object CalibanSourceGenerator {
         components.reduceLeft(_.resolve(_))
       }
       val interimPath  = managedRoot.toPath.resolve(relativePath)
-      val clientName   = settings.clientName.getOrElse(interimPath.getFileName.toString.stripSuffix(".graphql"))
-      val scalaName    = if (settings.splitFiles.contains(true)) clientName else clientName + ".scala"
-      interimPath.getParent.resolve(scalaName).toFile
+      if (settings.splitFiles.contains(true)) {
+        interimPath.getParent.toFile
+      } else {
+        val clientName = settings.clientName.getOrElse(interimPath.getFileName.toString.stripSuffix(".graphql"))
+        val scalaName  = clientName + ".scala"
+        interimPath.getParent.resolve(scalaName).toFile
+      }
   }
 
   def collectSettingsFor(fileSettings: Seq[CalibanFileSettings], source: File): Seq[CalibanFileSettings] = {

--- a/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/build.sbt
+++ b/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/build.sbt
@@ -10,8 +10,7 @@ lazy val root = project
     ),
     Compile / caliban / calibanSettings ++= Seq(
       calibanSetting(file("src/main/graphql/schema.graphql"))( // Explicitly constrain to disambiguate
-        _.clientName("Client")
-          .splitFiles(true)
+        _.splitFiles(true)
       )
     )
   )

--- a/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/test
+++ b/codegen-sbt/src/sbt-test/codegen/test-split-files-compile/test
@@ -1,13 +1,13 @@
 $ exec echo compiling for the first time
 > compile
 
-$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/package.scala
-$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/Character.scala
-$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/Canterbury.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/package.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Character.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Canterbury.scala
 
 $ exec echo compiling second time
 > compile
 
-$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/package.scala
-$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/Character.scala
-$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Client/Canterbury.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/package.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Character.scala
+$ exists target/scala-2.12/src_managed/main/caliban-codegen-sbt/caliban/Canterbury.scala


### PR DESCRIPTION
The client name is ignored when split-files is used.