### PR TITLE
No @oneOf variable validation on lists

### DIFF
--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -363,8 +363,12 @@ object Validator {
             "Variables can only be input types. Objects, unions, and interfaces cannot be used as inputs."
           )
 
-          val v2 =
-            if (t.exists(_._isOneOfInput))
+          val isObjField = v.variableType match {
+            case _: Type.NamedType => true
+            case _: Type.ListType  => false
+          }
+          val v2         =
+            if (isObjField && t.exists(_._isOneOfInput))
               Some(
                 failWhen(v.variableType.nullable)(
                   s"Variable '${v.name}' cannot be nullable.",


### PR DESCRIPTION
If a variable is a list of @oneOf input objects then the validation required by a @oneOf input object variable does not apply.