### PR TITLE
Support Client fragments

### DIFF
--- a/client/src/main/scala/caliban/client/Argument.scala
+++ b/client/src/main/scala/caliban/client/Argument.scala
@@ -23,6 +23,9 @@ case class Argument[+A](name: String, value: A, typeInfo: String)(implicit encod
           (s"$name:${value.toString}", variables)
         }
     }
+
+  def encodeRaw: __Value =
+    encoder.encode(value)
 }
 
 object Argument {

--- a/client/src/main/scala/caliban/client/Argument.scala
+++ b/client/src/main/scala/caliban/client/Argument.scala
@@ -7,23 +7,6 @@ import caliban.client.__Value.__NullValue
  * Represents an argument in a GraphQL query. Requires an encoder for the argument type.
  */
 case class Argument[+A](name: String, value: A, typeInfo: String)(implicit encoder: ArgEncoder[A]) {
-  def toGraphQL(
-    useVariables: Boolean,
-    dropNullInputValues: Boolean,
-    variables: Map[String, (__Value, String)]
-  ): (String, Map[String, (__Value, String)]) =
-    encoder.encode(value) match {
-      case `__NullValue` => ("", variables)
-      case v             =>
-        val value = if (dropNullInputValues) v.dropNullValues else v
-        if (useVariables) {
-          val variableName = Argument.generateVariableName(name, value, variables)
-          (s"$name:$$$variableName", variables.updated(variableName, (value, typeInfo)))
-        } else {
-          (s"$name:${value.toString}", variables)
-        }
-    }
-
   def encodeRaw: __Value =
     encoder.encode(value)
 }

--- a/client/src/main/scala/caliban/client/Renderer.scala
+++ b/client/src/main/scala/caliban/client/Renderer.scala
@@ -1,0 +1,57 @@
+package caliban.client
+
+import scala.annotation.tailrec
+
+trait Renderer[-A, S, -Options] { self =>
+  type State = S
+
+  final def render(a: A, state0: State, options: Options): (String, State) = {
+    val sb     = new StringBuilder()
+    val state1 = unsafeRender(a, state0, sb, options)
+    (sb.toString, state1)
+  }
+
+  def unsafeRender(
+    a: A,
+    state: State,
+    writer: StringBuilder,
+    options: Options
+  ): State
+
+  def contramap[A0](f: A0 => A): Renderer[A0, S, Options] =
+    new Renderer[A0, S, Options] {
+      override def unsafeRender(a: A0, state: State, writer: StringBuilder, options: Options): State =
+        self.unsafeRender(f(a), state, writer, options)
+    }
+
+}
+
+object Renderer {
+
+  def empty[S]: Renderer[Any, S, Any] =
+    Empty.asInstanceOf[Renderer[Any, S, Any]]
+
+  private case object Empty extends Renderer[Any, Any, Any] {
+    override def unsafeRender(a: Any, state: Any, writer: StringBuilder, options: Any): Any =
+      state
+  }
+
+  def list[A, S, O](renderer: Renderer[A, S, O], separator: Char): Renderer[List[A], S, O] =
+    new Renderer[List[A], S, O] {
+      override def unsafeRender(a: List[A], state0: S, writer: StringBuilder, options: O): S = {
+        @tailrec
+        def loop(remaining: List[A], state: S, first: Boolean): S = remaining match {
+          case Nil          => state
+          case head :: tail =>
+            if (!first) writer.append(separator)
+            val s0 = renderer.unsafeRender(head, state, writer, options)
+            loop(tail, s0, first = false)
+        }
+
+        loop(a, state0, first = true)
+      }
+    }
+
+  def set[A, S, O](renderer: Renderer[A, S, O], separator: Char): Renderer[Set[A], S, O] =
+    list(renderer, separator).contramap(_.toList)
+}

--- a/client/src/main/scala/caliban/client/Selection.scala
+++ b/client/src/main/scala/caliban/client/Selection.scala
@@ -21,38 +21,8 @@ object Selection {
     directives: List[Directive]
   ) extends Selection {
     val code: Int = hashCode()
-
-    def toGraphQL(
-      useVariables: Boolean,
-      dropNullInputValues: Boolean,
-      variables: Map[String, (__Value, String)]
-    ): (List[String], Map[String, (__Value, String)]) = {
-      val (query, inner, variables2) = SelectionBuilder.toGraphQL(
-        selectionSet,
-        useVariables,
-        dropNullInputValues,
-        variables
-      )
-
-      (
-        s"fragment ${name.getOrElse("f" + math.abs(code))} on $on{$query}" :: inner,
-        variables2
-      )
-    }
   }
 
-  case class Directive(name: String, arguments: List[Argument[_]] = Nil) {
-    def toGraphQL(
-      useVariables: Boolean,
-      dropNullInputValues: Boolean,
-      variables: Map[String, (__Value, String)]
-    ): (String, Map[String, (__Value, String)]) = {
-      val (newArgs, newVariables) = arguments.foldLeft((List.empty[String], variables)) {
-        case ((args, variables), arg) =>
-          val (arg2, variables2) = arg.toGraphQL(useVariables, dropNullInputValues, variables)
-          (arg2 :: args, variables2)
-      }
-      (s"@$name(${newArgs.reverse.mkString(",")})", newVariables)
-    }
-  }
+  case class Directive(name: String, arguments: List[Argument[_]] = Nil)
+
 }

--- a/client/src/main/scala/caliban/client/Selection.scala
+++ b/client/src/main/scala/caliban/client/Selection.scala
@@ -14,6 +14,33 @@ object Selection {
     code: Int
   ) extends Selection
 
+  case class FragmentSpread(
+    name: Option[String],
+    on: String,
+    selectionSet: List[Selection],
+    directives: List[Directive]
+  ) extends Selection {
+    val code: Int = hashCode()
+
+    def toGraphQL(
+      useVariables: Boolean,
+      dropNullInputValues: Boolean,
+      variables: Map[String, (__Value, String)]
+    ): (List[String], Map[String, (__Value, String)]) = {
+      val (query, inner, variables2) = SelectionBuilder.toGraphQL(
+        selectionSet,
+        useVariables,
+        dropNullInputValues,
+        variables
+      )
+
+      (
+        s"fragment ${name.getOrElse("f" + math.abs(code))} on $on{$query}" :: inner,
+        variables2
+      )
+    }
+  }
+
   case class Directive(name: String, arguments: List[Argument[_]] = Nil) {
     def toGraphQL(
       useVariables: Boolean,

--- a/client/src/main/scala/caliban/client/SelectionBuilder.scala
+++ b/client/src/main/scala/caliban/client/SelectionBuilder.scala
@@ -104,14 +104,13 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
     queryName: Option[String] = None,
     dropNullInputValues: Boolean = false
   )(implicit ev: IsOperation[Origin1]): GraphQLRequest = {
-    val options                = SelectionRenderer.Options(
+    val options                = caliban.client.RequestOptions(
       useVariables = useVariables,
       dropNullInputValues = dropNullInputValues,
       queryName = queryName,
-      operationName = ev.operationName,
-      indent = None
+      operationName = ev.operationName
     )
-    val (operation, variables) = SelectionRenderer.requestRenderer.render(toSelectionSet, Map.empty, options)
+    val (operation, variables) = RequestRenderer.render(toSelectionSet, Map.empty, options)
     GraphQLRequest(operation, variables.map { case (k, (v, _)) => k -> v })
   }
 
@@ -440,65 +439,16 @@ object SelectionBuilder {
     useVariables: Boolean,
     dropNullInputValues: Boolean = false,
     variables: SMap[String, (__Value, String)] = SMap()
-  ): (String, List[String], SMap[String, (__Value, String)]) = {
-    def loop(
-      fields: List[Selection],
-      variables: SMap[String, (__Value, String)]
-    ): (String, List[String], SMap[String, (__Value, String)]) = {
-      val fieldNames =
-        fields.collect { case f: Selection.Field => f }.groupBy(_.name).map { case (k, v) => k -> v.size }
+  ): (String, SMap[String, (__Value, String)]) = {
+    val (query, state) = SelectionRenderer.selections.render(
+      fields,
+      SelectionRenderer.RenderState(variables, Set.empty),
+      SelectionRenderer.Options(
+        useVariables = useVariables,
+        dropNullInputValues = dropNullInputValues
+      )
+    )
 
-      val (fragments, fragmentVariables)    =
-        fields.collect { case f: Selection.FragmentSpread => f }.distinct.foldLeft((List.empty[String], variables)) {
-          case ((fragments, variables), fs @ Selection.FragmentSpread(_, _, _, _)) =>
-            val (frags, variables2) = fs.toGraphQL(useVariables, dropNullInputValues, variables)
-            (frags ++ fragments, variables2)
-        }
-      val (fields2, fragments2, variables2) = fields
-        .foldLeft((List.empty[String], fragments, variables)) {
-          case ((fields, fragments, variables), Selection.InlineFragment(onType, selection))  =>
-            val (f, frags, v) = loop(selection, variables)
-            (s"... on $onType{$f}" :: fields, frags ++ fragments, v)
-          case ((fields, fragments, variables), fs @ Selection.FragmentSpread(name, _, _, _)) =>
-            (s"...${name.getOrElse("f" + math.abs(fs.hashCode))}" :: fields, fragments, variables)
-
-          case ((fields, fragments, variables), Selection.Field(alias, name, arguments, directives, selection, code)) =>
-            // format arguments
-            val (args, variables2) = arguments
-              .foldLeft((List.empty[String], variables)) { case ((args, variables), a) =>
-                val (a2, v2) = a.toGraphQL(useVariables, dropNullInputValues, variables)
-                (a2 :: args, v2)
-              }
-            val argString          = args.filterNot(_.isEmpty).reverse.mkString(",") match {
-              case ""   => ""
-              case args => s"($args)"
-            }
-
-            // format directives
-            val (dirs, variables3) = directives
-              .foldLeft((List.empty[String], variables2)) { case ((dirs, variables), d) =>
-                val (d2, v2) = d.toGraphQL(useVariables, dropNullInputValues, variables)
-                (d2 :: dirs, v2)
-              }
-            val dirString          = dirs.reverse.mkString(" ") match {
-              case ""   => ""
-              case dirs => s" $dirs"
-            }
-
-            // format aliases
-            val aliasString = (if (fieldNames.get(alias.getOrElse(name)).exists(_ > 1))
-                                 Some(alias.getOrElse(name) + math.abs(code))
-                               else alias).fold("")(_ + ":")
-
-            // format selection
-            val (sel, frags, variables4) = loop(selection, variables3)
-            val selString                = if (sel.nonEmpty) s"{$sel}" else ""
-
-            (s"$aliasString$name$argString$dirString$selString" :: fields, frags ++ fragments, variables4)
-        }
-      (fields2.reverse.mkString(" "), fragments2, fragmentVariables ++ variables2)
-    }
-
-    loop(fields, variables)
+    (query, state.variables)
   }
 }

--- a/client/src/main/scala/caliban/client/SelectionBuilder.scala
+++ b/client/src/main/scala/caliban/client/SelectionBuilder.scala
@@ -104,15 +104,14 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
     queryName: Option[String] = None,
     dropNullInputValues: Boolean = false
   )(implicit ev: IsOperation[Origin1]): GraphQLRequest = {
-    val (fields, fragments, variables) =
-      SelectionBuilder.toGraphQL(toSelectionSet, useVariables, dropNullInputValues)
-    val variableDef                    =
-      if (variables.nonEmpty)
-        s"(${variables.map { case (name, (_, typeName)) => s"$$$name: $typeName" }.mkString(",")})"
-      else ""
-    val nameDef                        = queryName.fold("")(name => s" $name ")
-    val fragmentDef                    = fragments.distinct.reverse.mkString(" ")
-    val operation                      = s"${ev.operationName}$nameDef$variableDef{$fields}$fragmentDef"
+    val options                = SelectionRenderer.Options(
+      useVariables = useVariables,
+      dropNullInputValues = dropNullInputValues,
+      queryName = queryName,
+      operationName = ev.operationName,
+      indent = None
+    )
+    val (operation, variables) = SelectionRenderer.requestRenderer.render(toSelectionSet, Map.empty, options)
     GraphQLRequest(operation, variables.map { case (k, (v, _)) => k -> v })
   }
 
@@ -436,7 +435,7 @@ object SelectionBuilder {
       }
       .map(_.reverse)
 
-  def toGraphQL(
+  private[client] def toGraphQL(
     fields: List[Selection],
     useVariables: Boolean,
     dropNullInputValues: Boolean = false,
@@ -457,7 +456,7 @@ object SelectionBuilder {
         }
       val (fields2, fragments2, variables2) = fields
         .foldLeft((List.empty[String], fragments, variables)) {
-          case ((fields, fragments, variables), Selection.InlineFragment(onType, selection))       =>
+          case ((fields, fragments, variables), Selection.InlineFragment(onType, selection))  =>
             val (f, frags, v) = loop(selection, variables)
             (s"... on $onType{$f}" :: fields, frags ++ fragments, v)
           case ((fields, fragments, variables), fs @ Selection.FragmentSpread(name, _, _, _)) =>
@@ -492,7 +491,7 @@ object SelectionBuilder {
                                else alias).fold("")(_ + ":")
 
             // format selection
-            val (sel, frags, variables4) = toGraphQL(selection, useVariables, dropNullInputValues, variables3)
+            val (sel, frags, variables4) = loop(selection, variables3)
             val selString                = if (sel.nonEmpty) s"{$sel}" else ""
 
             (s"$aliasString$name$argString$dirString$selString" :: fields, frags ++ fragments, variables4)

--- a/client/src/main/scala/caliban/client/SelectionBuilder.scala
+++ b/client/src/main/scala/caliban/client/SelectionBuilder.scala
@@ -104,14 +104,15 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
     queryName: Option[String] = None,
     dropNullInputValues: Boolean = false
   )(implicit ev: IsOperation[Origin1]): GraphQLRequest = {
-    val (fields, variables) =
+    val (fields, fragments, variables) =
       SelectionBuilder.toGraphQL(toSelectionSet, useVariables, dropNullInputValues)
-    val variableDef         =
+    val variableDef                    =
       if (variables.nonEmpty)
         s"(${variables.map { case (name, (_, typeName)) => s"$$$name: $typeName" }.mkString(",")})"
       else ""
-    val nameDef             = queryName.fold("")(name => s" $name ")
-    val operation           = s"${ev.operationName}$nameDef$variableDef{$fields}"
+    val nameDef                        = queryName.fold("")(name => s" $name ")
+    val fragmentDef                    = fragments.distinct.reverse.mkString(" ")
+    val operation                      = s"${ev.operationName}$nameDef$variableDef{$fields}$fragmentDef"
     GraphQLRequest(operation, variables.map { case (k, (v, _)) => k -> v })
   }
 
@@ -343,8 +344,15 @@ sealed trait SelectionBuilder[-Origin, +A] { self =>
 
 object SelectionBuilder {
 
-  val __typename: SelectionBuilder[Any, String] = Field("__typename", Scalar[String]())
-  def pure[A](a: A): SelectionBuilder[Any, A]   = Pure(a)
+  val __typename: SelectionBuilder[Any, String]                                                        = Field("__typename", Scalar[String]())
+  def pure[A](a: A): SelectionBuilder[Any, A]                                                          = Pure(a)
+  def fragment[Origin, A](on: String)(inner: SelectionBuilder[Origin, A]): SelectionBuilder[Origin, A] =
+    FragmentSpread(None, on, inner)
+
+  def fragment[Origin, A](name: String, on: String)(
+    inner: SelectionBuilder[Origin, A]
+  ): SelectionBuilder[Origin, A] =
+    FragmentSpread(Some(name), on, inner)
 
   case class Field[Origin, A](
     name: String,
@@ -398,6 +406,26 @@ object SelectionBuilder {
     override def withAlias(alias: String): SelectionBuilder[Any, A] = self
   }
 
+  case class FragmentSpread[Origin, A](
+    name: Option[String],
+    on: String,
+    selection: SelectionBuilder[Origin, A],
+    directives: List[Directive] = Nil
+  ) extends SelectionBuilder[Origin, A] {
+    self =>
+    override private[caliban] def toSelectionSet: List[Selection] =
+      List(Selection.FragmentSpread(name, on, selection.toSelectionSet, directives))
+
+    private[caliban] def fromGraphQL(value: __Value): Either[DecodingError, A] =
+      selection.fromGraphQL(value)
+
+    def withDirective(directive: Directive): SelectionBuilder[Origin, A] =
+      self.copy(directives = directive :: directives)
+
+    def withAlias(alias: String): SelectionBuilder[Origin, A] =
+      copy(name = Some(alias))
+  }
+
   def combineAll[Origin, A](
     head: SelectionBuilder[Origin, A],
     tail: SelectionBuilder[Origin, A]*
@@ -413,48 +441,65 @@ object SelectionBuilder {
     useVariables: Boolean,
     dropNullInputValues: Boolean = false,
     variables: SMap[String, (__Value, String)] = SMap()
-  ): (String, SMap[String, (__Value, String)]) = {
-    val fieldNames            = fields.collect { case f: Selection.Field => f }.groupBy(_.name).map { case (k, v) => k -> v.size }
-    val (fields2, variables2) = fields
-      .foldLeft((List.empty[String], variables)) {
-        case ((fields, variables), Selection.InlineFragment(onType, selection)) =>
-          val (f, v) = toGraphQL(selection, useVariables, dropNullInputValues, variables)
-          (s"... on $onType{$f}" :: fields, v)
+  ): (String, List[String], SMap[String, (__Value, String)]) = {
+    def loop(
+      fields: List[Selection],
+      variables: SMap[String, (__Value, String)]
+    ): (String, List[String], SMap[String, (__Value, String)]) = {
+      val fieldNames =
+        fields.collect { case f: Selection.Field => f }.groupBy(_.name).map { case (k, v) => k -> v.size }
 
-        case ((fields, variables), Selection.Field(alias, name, arguments, directives, selection, code)) =>
-          // format arguments
-          val (args, variables2) = arguments
-            .foldLeft((List.empty[String], variables)) { case ((args, variables), a) =>
-              val (a2, v2) = a.toGraphQL(useVariables, dropNullInputValues, variables)
-              (a2 :: args, v2)
+      val (fragments, fragmentVariables)    =
+        fields.collect { case f: Selection.FragmentSpread => f }.distinct.foldLeft((List.empty[String], variables)) {
+          case ((fragments, variables), fs @ Selection.FragmentSpread(_, _, _, _)) =>
+            val (frags, variables2) = fs.toGraphQL(useVariables, dropNullInputValues, variables)
+            (frags ++ fragments, variables2)
+        }
+      val (fields2, fragments2, variables2) = fields
+        .foldLeft((List.empty[String], fragments, variables)) {
+          case ((fields, fragments, variables), Selection.InlineFragment(onType, selection))       =>
+            val (f, frags, v) = loop(selection, variables)
+            (s"... on $onType{$f}" :: fields, frags ++ fragments, v)
+          case ((fields, fragments, variables), fs @ Selection.FragmentSpread(name, _, _, _)) =>
+            (s"...${name.getOrElse("f" + math.abs(fs.hashCode))}" :: fields, fragments, variables)
+
+          case ((fields, fragments, variables), Selection.Field(alias, name, arguments, directives, selection, code)) =>
+            // format arguments
+            val (args, variables2) = arguments
+              .foldLeft((List.empty[String], variables)) { case ((args, variables), a) =>
+                val (a2, v2) = a.toGraphQL(useVariables, dropNullInputValues, variables)
+                (a2 :: args, v2)
+              }
+            val argString          = args.filterNot(_.isEmpty).reverse.mkString(",") match {
+              case ""   => ""
+              case args => s"($args)"
             }
-          val argString          = args.filterNot(_.isEmpty).reverse.mkString(",") match {
-            case ""   => ""
-            case args => s"($args)"
-          }
 
-          // format directives
-          val (dirs, variables3) = directives
-            .foldLeft((List.empty[String], variables2)) { case ((dirs, variables), d) =>
-              val (d2, v2) = d.toGraphQL(useVariables, dropNullInputValues, variables)
-              (d2 :: dirs, v2)
+            // format directives
+            val (dirs, variables3) = directives
+              .foldLeft((List.empty[String], variables2)) { case ((dirs, variables), d) =>
+                val (d2, v2) = d.toGraphQL(useVariables, dropNullInputValues, variables)
+                (d2 :: dirs, v2)
+              }
+            val dirString          = dirs.reverse.mkString(" ") match {
+              case ""   => ""
+              case dirs => s" $dirs"
             }
-          val dirString          = dirs.reverse.mkString(" ") match {
-            case ""   => ""
-            case dirs => s" $dirs"
-          }
 
-          // format aliases
-          val aliasString = (if (fieldNames.get(alias.getOrElse(name)).exists(_ > 1))
-                               Some(alias.getOrElse(name) + math.abs(code))
-                             else alias).fold("")(_ + ":")
+            // format aliases
+            val aliasString = (if (fieldNames.get(alias.getOrElse(name)).exists(_ > 1))
+                                 Some(alias.getOrElse(name) + math.abs(code))
+                               else alias).fold("")(_ + ":")
 
-          // format selection
-          val (sel, variables4) = toGraphQL(selection, useVariables, dropNullInputValues, variables3)
-          val selString         = if (sel.nonEmpty) s"{$sel}" else ""
+            // format selection
+            val (sel, frags, variables4) = toGraphQL(selection, useVariables, dropNullInputValues, variables3)
+            val selString                = if (sel.nonEmpty) s"{$sel}" else ""
 
-          (s"$aliasString$name$argString$dirString$selString" :: fields, variables4)
-      }
-    (fields2.reverse.mkString(" "), variables2)
+            (s"$aliasString$name$argString$dirString$selString" :: fields, frags ++ fragments, variables4)
+        }
+      (fields2.reverse.mkString(" "), fragments2, fragmentVariables ++ variables2)
+    }
+
+    loop(fields, variables)
   }
 }

--- a/client/src/main/scala/caliban/client/SelectionRenderer.scala
+++ b/client/src/main/scala/caliban/client/SelectionRenderer.scala
@@ -1,0 +1,312 @@
+package caliban.client
+
+import caliban.client.Selection.Directive
+import caliban.client.__Value.__NullValue
+
+import scala.annotation.tailrec
+
+trait SelectionRenderer[-A, S] { self =>
+  type State = S
+
+  def render(a: A, state0: State, options: SelectionRenderer.Options): (String, State) = {
+    val sb     = new StringBuilder()
+    val state1 = unsafeRender(a, state0, sb, options)
+    (sb.toString, state1)
+  }
+
+  def unsafeRender(
+    a: A,
+    state: State,
+    writer: StringBuilder,
+    options: SelectionRenderer.Options
+  ): State
+
+}
+
+object SelectionRenderer {
+  case class Options(
+    useVariables: Boolean,
+    dropNullInputValues: Boolean,
+    operationName: String,
+    queryName: Option[String],
+    indent: Option[Int]
+  )
+
+  case class SelectionState(
+    variables: Map[String, (__Value, String)],
+    fragments: Set[Selection.FragmentSpread]
+  )
+
+  def empty[S]: SelectionRenderer[Any, S] =
+    Empty.asInstanceOf[SelectionRenderer[Any, S]]
+
+  private case object Empty extends SelectionRenderer[Any, Any] {
+    override def unsafeRender(a: Any, state: Any, writer: StringBuilder, options: Options): Any =
+      state
+  }
+
+  lazy val requestRenderer: SelectionRenderer[List[Selection], Map[String, (__Value, String)]] =
+    new SelectionRenderer[List[Selection], Map[String, (__Value, String)]] {
+      override def unsafeRender(a: List[Selection], state: State, writer: StringBuilder, options: Options): State = {
+        val state0 = SelectionRenderer.SelectionState(state, Set.empty)
+        val inner  = new StringBuilder()
+
+        writer.append(options.operationName)
+        options.queryName.foreach { queryName =>
+          writer.append(' ')
+          writer.append(queryName)
+          writer.append(' ')
+        }
+        val state1 = SelectionRenderer.selectionsRenderer.unsafeRender(a, state0, inner, options)
+        val state2 = SelectionRenderer.fragmentsRenderer.unsafeRender(state1.fragments, state1, inner, options)
+
+        SelectionRenderer.variablesRenderer.unsafeRender(state2.variables, (), writer, options)
+        writer.append(inner)
+        state2.variables
+      }
+    }
+
+  def list[A, S](renderer: SelectionRenderer[A, S], separator: Char): SelectionRenderer[List[A], S] =
+    new SelectionRenderer[List[A], S] {
+      override def unsafeRender(a: List[A], state0: S, writer: StringBuilder, options: Options): S = {
+        @tailrec
+        def loop(remaining: List[A], state: S, first: Boolean): S = remaining match {
+          case Nil          => state
+          case head :: tail =>
+            if (!first) writer.append(separator)
+            val s0 = renderer.unsafeRender(head, state, writer, options)
+            loop(tail, s0, first = false)
+        }
+
+        loop(a, state0, first = true)
+      }
+    }
+
+  def set[A, S](renderer: SelectionRenderer[A, S], separator: Char): SelectionRenderer[Set[A], S] =
+    new SelectionRenderer[Set[A], S] {
+      override def unsafeRender(a: Set[A], state0: S, writer: StringBuilder, options: Options): S = {
+        @tailrec
+        def loop(remaining: List[A], state: S, first: Boolean): S = remaining match {
+          case Nil          => state
+          case head :: tail =>
+            if (!first) writer.append(separator)
+            val s0 = renderer.unsafeRender(head, state, writer, options)
+            loop(tail, s0, first = false)
+        }
+
+        loop(a.toList, state0, first = true)
+      }
+    }
+
+  private lazy val variablesRenderer: SelectionRenderer[Map[String, (__Value, String)], Unit] =
+    new SelectionRenderer[Map[String, (__Value, String)], Unit] {
+      private val listRenderer: SelectionRenderer[List[(String, String)], Unit] =
+        list(variableRenderer, ',')
+      override def unsafeRender(
+        a: Map[String, (__Value, String)],
+        state: Unit,
+        writer: StringBuilder,
+        options: Options
+      ): Unit =
+        if (a.nonEmpty) {
+          writer.append('(')
+          listRenderer.unsafeRender(a.map(kv => kv._1 -> kv._2._2).toList, state, writer, options)
+          writer.append(')')
+        }
+    }
+
+  private lazy val variableRenderer: SelectionRenderer[(String, String), Unit] =
+    new SelectionRenderer[(String, String), Unit] {
+      override def unsafeRender(a: (String, String), state: Unit, writer: StringBuilder, options: Options): Unit = {
+        writer.append('$')
+        writer.append(a._1)
+        writer.append(": ")
+        writer.append(a._2)
+        ()
+      }
+    }
+
+  lazy val selectionsRenderer: SelectionRenderer[List[Selection], SelectionState] =
+    new SelectionRenderer[List[Selection], SelectionState] {
+      override def unsafeRender(
+        a: List[Selection],
+        state: State,
+        writer: StringBuilder,
+        options: Options
+      ): State = {
+        @tailrec
+        def loop(
+          selections: List[Selection],
+          state0: State,
+          names: Set[String],
+          first: Boolean = false
+        ): State =
+          selections match {
+            case Nil                                    => state0
+            case (f: Selection.Field) :: rest           =>
+              if (!first) writer.append(' ')
+              val hasAlias   = f.alias.isDefined
+              val resolved   = f.alias.getOrElse(f.name)
+              if (!names(resolved)) {
+                writer.append(resolved)
+                if (hasAlias) {
+                  writer.append(':')
+                  writer.append(f.name)
+                }
+              } else {
+                writer.append(resolved)
+                writer.append(math.abs(f.code))
+                if (hasAlias) {
+                  writer.append(':')
+                  writer.append(f.name)
+                }
+              }
+              val bodyWriter = new StringBuilder()
+              var state1     = selectionsRenderer.unsafeRender(f.selectionSet, state0, bodyWriter, options)
+              if (f.arguments.nonEmpty) {
+                writer.append('(')
+                state1 = argumentsRenderer.unsafeRender(f.arguments, state1, writer, options)
+                writer.append(')')
+              }
+              if (f.directives.nonEmpty) {
+                state1 = directivesRenderer.unsafeRender(f.directives, state1, writer, options)
+              }
+              writer.append(bodyWriter)
+              loop(rest, state1, names + resolved)
+            case (fs: Selection.FragmentSpread) :: rest =>
+              if (!first) writer.append(' ')
+
+              val withFragment = state.copy(fragments = state.fragments + fs)
+              loop(
+                rest,
+                fragmentSpreadInlineRenderer.unsafeRender(fs, withFragment, writer, options),
+                names
+              )
+            case (is: Selection.InlineFragment) :: rest =>
+              if (!first) writer.append(' ')
+              loop(
+                rest,
+                inlineFragmentRenderer.unsafeRender(is, state, writer, options),
+                names
+              )
+          }
+
+        if (a.isEmpty) state
+        else {
+          writer.append('{')
+          val state1 = loop(a, state, Set.empty, first = true)
+          writer.append('}')
+          state1
+        }
+      }
+    }
+
+  private lazy val inlineFragmentRenderer: SelectionRenderer[Selection.InlineFragment, SelectionState] =
+    new SelectionRenderer[Selection.InlineFragment, SelectionState] {
+      override def unsafeRender(
+        a: Selection.InlineFragment,
+        state: State,
+        writer: StringBuilder,
+        options: Options
+      ): State = {
+        writer.append("... on ")
+        writer.append(a.onType)
+        selectionsRenderer.unsafeRender(a.selectionSet, state, writer, options)
+      }
+    }
+
+  private lazy val fragmentsRenderer: SelectionRenderer[Set[Selection.FragmentSpread], SelectionState] =
+    set(fragmentDefinitionRenderer, ' ')
+
+  private lazy val fragmentDefinitionRenderer: SelectionRenderer[Selection.FragmentSpread, SelectionState] =
+    new SelectionRenderer[Selection.FragmentSpread, SelectionState] {
+      override def unsafeRender(
+        a: Selection.FragmentSpread,
+        state0: State,
+        writer: StringBuilder,
+        options: Options
+      ): State = {
+        writer.append("fragment")
+        writer.append(' ')
+        writer.append(a.name.getOrElse("f" + math.abs(a.code)))
+        writer.append(" on ")
+        writer.append(a.on)
+        val state1       = selectionsRenderer.unsafeRender(a.selectionSet, state0, writer, options)
+        val newFragments = state1.fragments -- state0.fragments
+        if (newFragments.nonEmpty) {
+          writer.append(' ')
+          fragmentsRenderer.unsafeRender(newFragments, state1, writer, options)
+        } else
+          state1
+      }
+    }
+
+  private lazy val fragmentSpreadInlineRenderer: SelectionRenderer[Selection.FragmentSpread, SelectionState] =
+    new SelectionRenderer[Selection.FragmentSpread, SelectionState] {
+      override def unsafeRender(
+        a: Selection.FragmentSpread,
+        state: State,
+        writer: StringBuilder,
+        options: Options
+      ): State = {
+        writer.append("...")
+        if (a.name.isDefined) writer.append(a.name.get)
+        else writer.append('f').append(math.abs(a.code))
+
+        state
+      }
+    }
+
+  private lazy val argumentsRenderer: SelectionRenderer[List[Argument[_]], SelectionState] =
+    list(argumentRenderer, ' ')
+
+  private lazy val argumentRenderer: SelectionRenderer[Argument[_], SelectionState] =
+    new SelectionRenderer[Argument[_], SelectionState] {
+      override def unsafeRender(
+        a: Argument[_],
+        state: State,
+        writer: StringBuilder,
+        options: Options
+      ): State =
+        a.encodeRaw match {
+          case `__NullValue` => state
+          case v             =>
+            val value = if (options.dropNullInputValues) v.dropNullValues else v
+            if (options.useVariables) {
+              val variableName = Argument.generateVariableName(a.name, value, state.variables)
+              writer.append(a.name)
+              writer.append(':')
+              writer.append('$')
+              writer.append(variableName)
+              state.copy(variables = state.variables.updated(variableName, (value, a.typeInfo)))
+            } else {
+              writer.append(a.name)
+              writer.append(':')
+              writer.append(value.toString)
+              state
+            }
+        }
+    }
+
+  private lazy val directivesRenderer =
+    list(directiveRenderer, ' ')
+
+  private lazy val directiveRenderer: SelectionRenderer[Directive, SelectionState] =
+    new SelectionRenderer[Directive, SelectionState] {
+      override def unsafeRender(
+        a: Directive,
+        state0: State,
+        writer: StringBuilder,
+        options: Options
+      ): State = {
+        writer.append('@')
+        writer.append(a.name)
+        if (a.arguments.nonEmpty) {
+          writer.append('(')
+          val state = argumentsRenderer.unsafeRender(a.arguments, state0, writer, options)
+          writer.append(')')
+          state
+        } else state0
+      }
+    }
+}

--- a/client/src/main/scala/caliban/client/SelectionRenderer.scala
+++ b/client/src/main/scala/caliban/client/SelectionRenderer.scala
@@ -1,133 +1,60 @@
 package caliban.client
 
+import caliban.client.Renderer.{ list, set }
 import caliban.client.Selection.Directive
+
 import caliban.client.__Value.__NullValue
 
 import scala.annotation.tailrec
 
-trait SelectionRenderer[-A, S] { self =>
-  type State = S
+private[client] case class RequestOptions(
+  useVariables: Boolean,
+  dropNullInputValues: Boolean,
+  operationName: String,
+  queryName: Option[String]
+)
 
-  def render(a: A, state0: State, options: SelectionRenderer.Options): (String, State) = {
-    val sb     = new StringBuilder()
-    val state1 = unsafeRender(a, state0, sb, options)
-    (sb.toString, state1)
+private[client] object RequestRenderer
+    extends Renderer[List[Selection], Map[String, (__Value, String)], RequestOptions] {
+  import caliban.client.SelectionRenderer.{ selections, variablesRenderer }
+  override def unsafeRender(a: List[Selection], state: State, writer: StringBuilder, options: RequestOptions): State = {
+    val state0       = SelectionRenderer.RenderState(state, Set.empty)
+    val inner        = new StringBuilder()
+    val innerOptions = SelectionRenderer.Options(
+      useVariables = options.useVariables,
+      dropNullInputValues = options.dropNullInputValues
+    )
+
+    writer.append(options.operationName)
+    options.queryName.foreach { queryName =>
+      writer.append(' ')
+      writer.append(queryName)
+      writer.append(' ')
+    }
+    val state1 = selections.unsafeRender(a, state0, inner, innerOptions)
+    val state2 = SelectionRenderer.fragments.unsafeRender(state1.fragments, state1, inner, innerOptions)
+
+    variablesRenderer.unsafeRender(state2.variables, (), writer, innerOptions)
+    writer.append(inner)
+    state2.variables
   }
-
-  def unsafeRender(
-    a: A,
-    state: State,
-    writer: StringBuilder,
-    options: SelectionRenderer.Options
-  ): State
-
 }
 
-object SelectionRenderer {
+private[client] object SelectionRenderer {
+  type SelectionRenderer[-A] = Renderer[A, RenderState, Options]
+
   case class Options(
     useVariables: Boolean,
-    dropNullInputValues: Boolean,
-    operationName: String,
-    queryName: Option[String],
-    indent: Option[Int]
+    dropNullInputValues: Boolean
   )
 
-  case class SelectionState(
+  case class RenderState(
     variables: Map[String, (__Value, String)],
     fragments: Set[Selection.FragmentSpread]
   )
 
-  def empty[S]: SelectionRenderer[Any, S] =
-    Empty.asInstanceOf[SelectionRenderer[Any, S]]
-
-  private case object Empty extends SelectionRenderer[Any, Any] {
-    override def unsafeRender(a: Any, state: Any, writer: StringBuilder, options: Options): Any =
-      state
-  }
-
-  lazy val requestRenderer: SelectionRenderer[List[Selection], Map[String, (__Value, String)]] =
-    new SelectionRenderer[List[Selection], Map[String, (__Value, String)]] {
-      override def unsafeRender(a: List[Selection], state: State, writer: StringBuilder, options: Options): State = {
-        val state0 = SelectionRenderer.SelectionState(state, Set.empty)
-        val inner  = new StringBuilder()
-
-        writer.append(options.operationName)
-        options.queryName.foreach { queryName =>
-          writer.append(' ')
-          writer.append(queryName)
-          writer.append(' ')
-        }
-        val state1 = SelectionRenderer.selectionsRenderer.unsafeRender(a, state0, inner, options)
-        val state2 = SelectionRenderer.fragmentsRenderer.unsafeRender(state1.fragments, state1, inner, options)
-
-        SelectionRenderer.variablesRenderer.unsafeRender(state2.variables, (), writer, options)
-        writer.append(inner)
-        state2.variables
-      }
-    }
-
-  def list[A, S](renderer: SelectionRenderer[A, S], separator: Char): SelectionRenderer[List[A], S] =
-    new SelectionRenderer[List[A], S] {
-      override def unsafeRender(a: List[A], state0: S, writer: StringBuilder, options: Options): S = {
-        @tailrec
-        def loop(remaining: List[A], state: S, first: Boolean): S = remaining match {
-          case Nil          => state
-          case head :: tail =>
-            if (!first) writer.append(separator)
-            val s0 = renderer.unsafeRender(head, state, writer, options)
-            loop(tail, s0, first = false)
-        }
-
-        loop(a, state0, first = true)
-      }
-    }
-
-  def set[A, S](renderer: SelectionRenderer[A, S], separator: Char): SelectionRenderer[Set[A], S] =
-    new SelectionRenderer[Set[A], S] {
-      override def unsafeRender(a: Set[A], state0: S, writer: StringBuilder, options: Options): S = {
-        @tailrec
-        def loop(remaining: List[A], state: S, first: Boolean): S = remaining match {
-          case Nil          => state
-          case head :: tail =>
-            if (!first) writer.append(separator)
-            val s0 = renderer.unsafeRender(head, state, writer, options)
-            loop(tail, s0, first = false)
-        }
-
-        loop(a.toList, state0, first = true)
-      }
-    }
-
-  private lazy val variablesRenderer: SelectionRenderer[Map[String, (__Value, String)], Unit] =
-    new SelectionRenderer[Map[String, (__Value, String)], Unit] {
-      private val listRenderer: SelectionRenderer[List[(String, String)], Unit] =
-        list(variableRenderer, ',')
-      override def unsafeRender(
-        a: Map[String, (__Value, String)],
-        state: Unit,
-        writer: StringBuilder,
-        options: Options
-      ): Unit =
-        if (a.nonEmpty) {
-          writer.append('(')
-          listRenderer.unsafeRender(a.map(kv => kv._1 -> kv._2._2).toList, state, writer, options)
-          writer.append(')')
-        }
-    }
-
-  private lazy val variableRenderer: SelectionRenderer[(String, String), Unit] =
-    new SelectionRenderer[(String, String), Unit] {
-      override def unsafeRender(a: (String, String), state: Unit, writer: StringBuilder, options: Options): Unit = {
-        writer.append('$')
-        writer.append(a._1)
-        writer.append(": ")
-        writer.append(a._2)
-        ()
-      }
-    }
-
-  lazy val selectionsRenderer: SelectionRenderer[List[Selection], SelectionState] =
-    new SelectionRenderer[List[Selection], SelectionState] {
+  lazy val selections: SelectionRenderer[List[Selection]] =
+    new SelectionRenderer[List[Selection]] {
       override def unsafeRender(
         a: List[Selection],
         state: State,
@@ -136,12 +63,12 @@ object SelectionRenderer {
       ): State = {
         @tailrec
         def loop(
-          selections: List[Selection],
+          sel: List[Selection],
           state0: State,
           names: Set[String],
           first: Boolean = false
         ): State =
-          selections match {
+          sel match {
             case Nil                                    => state0
             case (f: Selection.Field) :: rest           =>
               if (!first) writer.append(' ')
@@ -162,13 +89,12 @@ object SelectionRenderer {
                 }
               }
               val bodyWriter = new StringBuilder()
-              var state1     = selectionsRenderer.unsafeRender(f.selectionSet, state0, bodyWriter, options)
+              var state1     = selections.unsafeRender(f.selectionSet, state0, bodyWriter, options)
               if (f.arguments.nonEmpty) {
-                writer.append('(')
                 state1 = argumentsRenderer.unsafeRender(f.arguments, state1, writer, options)
-                writer.append(')')
               }
               if (f.directives.nonEmpty) {
+                writer.append(' ')
                 state1 = directivesRenderer.unsafeRender(f.directives, state1, writer, options)
               }
               writer.append(bodyWriter)
@@ -201,8 +127,39 @@ object SelectionRenderer {
       }
     }
 
-  private lazy val inlineFragmentRenderer: SelectionRenderer[Selection.InlineFragment, SelectionState] =
-    new SelectionRenderer[Selection.InlineFragment, SelectionState] {
+  lazy val fragments: SelectionRenderer[Set[Selection.FragmentSpread]] =
+    set(fragmentDefinitionRenderer, ' ')
+
+  lazy val variablesRenderer: Renderer[Map[String, (__Value, String)], Unit, Options] =
+    new Renderer[Map[String, (__Value, String)], Unit, Options] {
+      private val listRenderer: Renderer[List[(String, String)], Unit, Options] =
+        list(variableRenderer, ',')
+      override def unsafeRender(
+        a: Map[String, (__Value, String)],
+        state: Unit,
+        writer: StringBuilder,
+        options: Options
+      ): Unit =
+        if (a.nonEmpty) {
+          writer.append('(')
+          listRenderer.unsafeRender(a.map(kv => kv._1 -> kv._2._2).toList, state, writer, options)
+          writer.append(')')
+        }
+    }
+
+  private lazy val variableRenderer: Renderer[(String, String), Unit, Options] =
+    new Renderer[(String, String), Unit, Options] {
+      override def unsafeRender(a: (String, String), state: Unit, writer: StringBuilder, options: Options): Unit = {
+        writer.append('$')
+        writer.append(a._1)
+        writer.append(": ")
+        writer.append(a._2)
+        ()
+      }
+    }
+
+  private lazy val inlineFragmentRenderer: SelectionRenderer[Selection.InlineFragment] =
+    new SelectionRenderer[Selection.InlineFragment] {
       override def unsafeRender(
         a: Selection.InlineFragment,
         state: State,
@@ -211,15 +168,12 @@ object SelectionRenderer {
       ): State = {
         writer.append("... on ")
         writer.append(a.onType)
-        selectionsRenderer.unsafeRender(a.selectionSet, state, writer, options)
+        selections.unsafeRender(a.selectionSet, state, writer, options)
       }
     }
 
-  private lazy val fragmentsRenderer: SelectionRenderer[Set[Selection.FragmentSpread], SelectionState] =
-    set(fragmentDefinitionRenderer, ' ')
-
-  private lazy val fragmentDefinitionRenderer: SelectionRenderer[Selection.FragmentSpread, SelectionState] =
-    new SelectionRenderer[Selection.FragmentSpread, SelectionState] {
+  private lazy val fragmentDefinitionRenderer: SelectionRenderer[Selection.FragmentSpread] =
+    new SelectionRenderer[Selection.FragmentSpread] {
       override def unsafeRender(
         a: Selection.FragmentSpread,
         state0: State,
@@ -231,18 +185,18 @@ object SelectionRenderer {
         writer.append(a.name.getOrElse("f" + math.abs(a.code)))
         writer.append(" on ")
         writer.append(a.on)
-        val state1       = selectionsRenderer.unsafeRender(a.selectionSet, state0, writer, options)
+        val state1       = selections.unsafeRender(a.selectionSet, state0, writer, options)
         val newFragments = state1.fragments -- state0.fragments
         if (newFragments.nonEmpty) {
           writer.append(' ')
-          fragmentsRenderer.unsafeRender(newFragments, state1, writer, options)
+          fragments.unsafeRender(newFragments, state1, writer, options)
         } else
           state1
       }
     }
 
-  private lazy val fragmentSpreadInlineRenderer: SelectionRenderer[Selection.FragmentSpread, SelectionState] =
-    new SelectionRenderer[Selection.FragmentSpread, SelectionState] {
+  private lazy val fragmentSpreadInlineRenderer: SelectionRenderer[Selection.FragmentSpread] =
+    new SelectionRenderer[Selection.FragmentSpread] {
       override def unsafeRender(
         a: Selection.FragmentSpread,
         state: State,
@@ -257,42 +211,54 @@ object SelectionRenderer {
       }
     }
 
-  private lazy val argumentsRenderer: SelectionRenderer[List[Argument[_]], SelectionState] =
-    list(argumentRenderer, ' ')
-
-  private lazy val argumentRenderer: SelectionRenderer[Argument[_], SelectionState] =
-    new SelectionRenderer[Argument[_], SelectionState] {
+  private lazy val argumentsRenderer: SelectionRenderer[List[Argument[_]]] =
+    new SelectionRenderer[List[Argument[_]]] {
       override def unsafeRender(
-        a: Argument[_],
-        state: State,
+        a: List[Argument[_]],
+        state0: State,
         writer: StringBuilder,
         options: Options
-      ): State =
-        a.encodeRaw match {
-          case `__NullValue` => state
-          case v             =>
-            val value = if (options.dropNullInputValues) v.dropNullValues else v
-            if (options.useVariables) {
-              val variableName = Argument.generateVariableName(a.name, value, state.variables)
-              writer.append(a.name)
-              writer.append(':')
-              writer.append('$')
-              writer.append(variableName)
-              state.copy(variables = state.variables.updated(variableName, (value, a.typeInfo)))
-            } else {
-              writer.append(a.name)
-              writer.append(':')
-              writer.append(value.toString)
+      ): State = {
+        @tailrec
+        def loop(args: List[Argument[_]], state: State, first: Boolean): State =
+          args match {
+            case Nil       =>
+              if (first) writer.append(')')
               state
-            }
-        }
+            case a :: rest =>
+              a.encodeRaw match {
+                case `__NullValue` => loop(rest, state, first)
+                case v             =>
+                  if (first) writer.append(',')
+                  else writer.append('(')
+                  val value = if (options.dropNullInputValues) v.dropNullValues else v
+                  if (options.useVariables) {
+                    val variableName = Argument.generateVariableName(a.name, value, state.variables)
+                    writer.append(a.name)
+                    writer.append(':')
+                    writer.append('$')
+                    writer.append(variableName)
+                    val state1       = state.copy(variables = state.variables.updated(variableName, (value, a.typeInfo)))
+                    loop(rest, state1, first = true)
+                  } else {
+                    writer.append(a.name)
+                    writer.append(':')
+                    writer.append(value.toString)
+                    loop(rest, state, first = true)
+                  }
+              }
+
+          }
+
+        loop(a, state0, first = false)
+      }
     }
 
   private lazy val directivesRenderer =
     list(directiveRenderer, ' ')
 
-  private lazy val directiveRenderer: SelectionRenderer[Directive, SelectionState] =
-    new SelectionRenderer[Directive, SelectionState] {
+  private lazy val directiveRenderer: SelectionRenderer[Directive] =
+    new SelectionRenderer[Directive] {
       override def unsafeRender(
         a: Directive,
         state0: State,
@@ -302,9 +268,7 @@ object SelectionRenderer {
         writer.append('@')
         writer.append(a.name)
         if (a.arguments.nonEmpty) {
-          writer.append('(')
           val state = argumentsRenderer.unsafeRender(a.arguments, state0, writer, options)
-          writer.append(')')
           state
         } else state0
       }

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -15,51 +15,51 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
     suite("SelectionBuilderSpec")(
       suite("query generation")(
         test("simple object") {
-          val query     =
+          val query  =
             Queries.characters() {
               Character.name
             }
-          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
-          assertTrue(s == "characters{name}")
+          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          assertTrue(s == "{characters{name}}")
         },
         test("combine 2 fields") {
-          val query     =
+          val query  =
             Queries.characters() {
               Character.name ~ Character.nicknames
             }
-          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
-          assertTrue(s == "characters{name nicknames}")
+          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          assertTrue(s == "{characters{name nicknames}}")
         },
         test("union type") {
-          val query     =
+          val query  =
             Queries.characters() {
               Character.name ~
                 Character.nicknames ~
                 Character
                   .role(Role.Captain.shipName, Role.Pilot.shipName, Role.Mechanic.shipName, Role.Engineer.shipName)
             }
-          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(
-            s == "characters{name nicknames role{__typename ... on Captain{shipName} ... on Pilot{shipName} ... on Mechanic{shipName} ... on Engineer{shipName}}}"
+            s == "{characters{name nicknames role{__typename ... on Captain{shipName} ... on Pilot{shipName} ... on Mechanic{shipName} ... on Engineer{shipName}}}}"
           )
         },
         test("union type optional") {
-          val query     =
+          val query  =
             Queries.characters() {
               Character.name ~
                 Character.nicknames ~
                 Character.roleOption(onCaptain = Some(Role.Captain.shipName))
             }
-          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
-          assertTrue(s == "characters{name nicknames role{__typename ... on Captain{shipName}}}")
+          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          assertTrue(s == "{characters{name nicknames role{__typename ... on Captain{shipName}}}}")
         },
         test("argument") {
-          val query     =
+          val query  =
             Queries.characters(Some(Origin.MARS)) {
               Character.name
             }
-          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
-          assertTrue(s == """characters(origin:"MARS"){name}""")
+          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          assertTrue(s == """{characters(origin:"MARS"){name}}""")
         },
         test("union type with optional parameters") {
           case class CharacterView(name: String, nicknames: List[String], role: Option[Option[String]])
@@ -96,7 +96,7 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
           )
         },
         test("aliases") {
-          val query     =
+          val query  =
             Queries
               .character("Amos Burton") {
                 Character.name
@@ -107,11 +107,11 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
                   Character.name
                 }
                 .copy(alias = Some("naomi"))
-          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
-          assertTrue(s == """amos:character(name:"Amos Burton"){name} naomi:character(name:"Naomi Nagata"){name}""")
+          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          assertTrue(s == """{amos:character(name:"Amos Burton"){name} naomi:character(name:"Naomi Nagata"){name}}""")
         },
         test("variables") {
-          val query             =
+          val query          =
             Queries
               .character("Amos Burton") {
                 Character.name
@@ -122,32 +122,36 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
                   Character.name
                 }
                 .withAlias("naomi")
-          val (s, _, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
-          assertTrue(s == """amos:character(name:$name){name} naomi:character(name:$name1){name}""") &&
-          assertTrue(variables("name") == ((__StringValue("Amos Burton"), "String!"))) &&
-          assertTrue(variables("name1") == ((__StringValue("Naomi Nagata"), "String!")))
+          val (s, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
+          assertTrue(
+            s == """{amos:character(name:$name){name} naomi:character(name:$name1){name}}""",
+            variables("name") == ((__StringValue("Amos Burton"), "String!")),
+            variables("name1") == ((__StringValue("Naomi Nagata"), "String!"))
+          )
         },
         test("directives") {
-          val query     =
+          val query  =
             Queries
               .character("Amos Burton") {
                 Character.name
               }
               .withDirective(Directive("yo", List(Argument("value", "what's up", "String!"))))
-          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
-          assertTrue(s == """character(name:"Amos Burton") @yo(value:"what's up"){name}""")
+          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          assertTrue(s == """{character(name:"Amos Burton") @yo(value:"what's up"){name}}""")
         },
         test("directives + variables") {
-          val query             =
+          val query          =
             Queries
               .character("Amos Burton") {
                 Character.name
               }
               .withDirective(Directive("yo", List(Argument("value", "what's up", "String!"))))
-          val (s, _, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
-          assertTrue(s == """character(name:$name) @yo(value:$value){name}""") &&
-          assertTrue(variables("name") == ((__StringValue("Amos Burton"), "String!"))) &&
-          assertTrue(variables("value") == ((__StringValue("what's up"), "String!")))
+          val (s, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
+          assertTrue(
+            s == """{character(name:$name) @yo(value:$value){name}}""",
+            variables("name") == ((__StringValue("Amos Burton"), "String!")),
+            variables("value") == ((__StringValue("what's up"), "String!"))
+          )
         },
         test("query name") {
           val query = Queries.character("Amos Burton")(Character.name).toGraphQL(queryName = Some("GetCharacter"))

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -15,50 +15,50 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
     suite("SelectionBuilderSpec")(
       suite("query generation")(
         test("simple object") {
-          val query  =
+          val query     =
             Queries.characters() {
               Character.name
             }
-          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(s == "characters{name}")
         },
         test("combine 2 fields") {
-          val query  =
+          val query     =
             Queries.characters() {
               Character.name ~ Character.nicknames
             }
-          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(s == "characters{name nicknames}")
         },
         test("union type") {
-          val query  =
+          val query     =
             Queries.characters() {
               Character.name ~
                 Character.nicknames ~
                 Character
                   .role(Role.Captain.shipName, Role.Pilot.shipName, Role.Mechanic.shipName, Role.Engineer.shipName)
             }
-          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(
             s == "characters{name nicknames role{__typename ... on Captain{shipName} ... on Pilot{shipName} ... on Mechanic{shipName} ... on Engineer{shipName}}}"
           )
         },
         test("union type optional") {
-          val query  =
+          val query     =
             Queries.characters() {
               Character.name ~
                 Character.nicknames ~
                 Character.roleOption(onCaptain = Some(Role.Captain.shipName))
             }
-          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(s == "characters{name nicknames role{__typename ... on Captain{shipName}}}")
         },
         test("argument") {
-          val query  =
+          val query     =
             Queries.characters(Some(Origin.MARS)) {
               Character.name
             }
-          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(s == """characters(origin:"MARS"){name}""")
         },
         test("union type with optional parameters") {
@@ -96,7 +96,7 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
           )
         },
         test("aliases") {
-          val query  =
+          val query     =
             Queries
               .character("Amos Burton") {
                 Character.name
@@ -107,11 +107,11 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
                   Character.name
                 }
                 .copy(alias = Some("naomi"))
-          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(s == """amos:character(name:"Amos Burton"){name} naomi:character(name:"Naomi Nagata"){name}""")
         },
         test("variables") {
-          val query          =
+          val query             =
             Queries
               .character("Amos Burton") {
                 Character.name
@@ -122,29 +122,29 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
                   Character.name
                 }
                 .withAlias("naomi")
-          val (s, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
+          val (s, _, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
           assertTrue(s == """amos:character(name:$name){name} naomi:character(name:$name1){name}""") &&
           assertTrue(variables("name") == ((__StringValue("Amos Burton"), "String!"))) &&
           assertTrue(variables("name1") == ((__StringValue("Naomi Nagata"), "String!")))
         },
         test("directives") {
-          val query  =
+          val query     =
             Queries
               .character("Amos Burton") {
                 Character.name
               }
               .withDirective(Directive("yo", List(Argument("value", "what's up", "String!"))))
-          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val (s, _, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(s == """character(name:"Amos Burton") @yo(value:"what's up"){name}""")
         },
         test("directives + variables") {
-          val query          =
+          val query             =
             Queries
               .character("Amos Burton") {
                 Character.name
               }
               .withDirective(Directive("yo", List(Argument("value", "what's up", "String!"))))
-          val (s, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
+          val (s, _, variables) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = true)
           assertTrue(s == """character(name:$name) @yo(value:$value){name}""") &&
           assertTrue(variables("name") == ((__StringValue("Amos Burton"), "String!"))) &&
           assertTrue(variables("value") == ((__StringValue("what's up"), "String!")))
@@ -156,6 +156,83 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
         test("pure fields") {
           val query = Queries.character("Amos Burton")(Character.name ~ SelectionBuilder.pure("Fake")).toGraphQL()
           assertTrue(query.query == """query{character(name:"Amos Burton"){name}}""")
+        }
+      ),
+      suite("fragments")(
+        test("simple fragment") {
+          val query = Queries
+            .character("Amos Burton")(
+              SelectionBuilder.fragment("CF", "Character")(Character.name ~ Character.nicknames)
+            )
+            .toGraphQL()
+
+          assertTrue(
+            query.query == """query{character(name:"Amos Burton"){...CF}}fragment CF on Character{name nicknames}"""
+          )
+        },
+        test("fragment deduplicates") {
+          val fragment = SelectionBuilder.fragment("CF", "Character")(Character.name ~ Character.nicknames)
+          val query    = (Queries
+            .character("Amos Burton")(fragment)
+            .withAlias("amos") ~ Queries.character("Naomi Nagata")(fragment).withAlias("naomi"))
+            .toGraphQL()
+
+          assertTrue(
+            query.query == """query{amos:character(name:"Amos Burton"){...CF} naomi:character(name:"Naomi Nagata"){...CF}}fragment CF on Character{name nicknames}"""
+          )
+        },
+        test("structural equality of fragments") {
+          val fragment1 = SelectionBuilder.fragment("CF", "Character")(Character.name ~ Character.nicknames)
+          val fragment2 = SelectionBuilder.fragment("CF", "Character")(Character.name ~ Character.nicknames)
+          val query     = (Queries.character("Amos Burton")(fragment1).withAlias("amos") ~
+            Queries.character("Naomi Nagata")(fragment2).withAlias("naomi"))
+            .toGraphQL()
+          assertTrue(
+            query.query == """query{amos:character(name:"Amos Burton"){...CF} naomi:character(name:"Naomi Nagata"){...CF}}fragment CF on Character{name nicknames}"""
+          )
+        },
+        test("distinct fragments") {
+          val fragment1 = SelectionBuilder.fragment("CF1", "Character")(Character.nicknames)
+          val fragment2 = SelectionBuilder.fragment("CF2", "Character")(Character.name)
+          val query     = (Queries.character("Amos Burton")(fragment1).withAlias("amos") ~
+            Queries.character("Naomi Nagata")(fragment2).withAlias("naomi"))
+            .toGraphQL()
+          assertTrue(
+            query.query == """query{amos:character(name:"Amos Burton"){...CF1} naomi:character(name:"Naomi Nagata"){...CF2}}fragment CF1 on Character{nicknames} fragment CF2 on Character{name}"""
+          )
+        },
+        test("nested fragments") {
+          val characterFragment = SelectionBuilder.fragment("CF", "Character")(
+            Character.name ~ SelectionBuilder.fragment("Inner", "Character")(
+              Character.roleOption(
+                onCaptain = Some(SelectionBuilder.fragment("CaptainFrag", "Captain")(Role.Captain.shipName))
+              )
+            )
+          )
+
+          val query = Queries.character("Amos Burton")(characterFragment).toGraphQL()
+          assertTrue(
+            query.query == """query{character(name:"Amos Burton"){...CF}}fragment CaptainFrag on Captain{shipName} fragment Inner on Character{role{__typename ... on Captain{...CaptainFrag}}} fragment CF on Character{name ...Inner}"""
+          )
+        },
+        test("fragments with variable references") {
+          val characterFragment = SelectionBuilder.fragment("CF", "Character")(
+            Character.name ~
+              Character.roleOption(onCaptain = Some(Role.Captain.shipName))
+          )
+
+          val query = SelectionBuilder.fragment("QueryFrag", "Query")(Queries.character("Amos Burton")(characterFragment))
+            .toGraphQL(
+              queryName = Some("GetCharacter"),
+              useVariables = true
+            )
+
+          assertTrue(
+            query.query == """query GetCharacter ($name: String!){...QueryFrag}fragment CF on Character{name role{__typename ... on Captain{shipName}}} fragment QueryFrag on Query{character(name:$name){...CF}}"""
+          )
+        },
+        test("fragments with directives") {
+          assertCompletes
         }
       ),
       suite("response parsing")(

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -212,7 +212,7 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
 
           val query = Queries.character("Amos Burton")(characterFragment).toGraphQL()
           assertTrue(
-            query.query == """query{character(name:"Amos Burton"){...CF}}fragment CaptainFrag on Captain{shipName} fragment Inner on Character{role{__typename ... on Captain{...CaptainFrag}}} fragment CF on Character{name ...Inner}"""
+            query.query == """query{character(name:"Amos Burton"){...CF}}fragment CF on Character{name ...Inner} fragment Inner on Character{role{__typename ... on Captain{...CaptainFrag}}} fragment CaptainFrag on Captain{shipName}"""
           )
         },
         test("fragments with variable references") {
@@ -221,14 +221,16 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
               Character.roleOption(onCaptain = Some(Role.Captain.shipName))
           )
 
-          val query = SelectionBuilder.fragment("QueryFrag", "Query")(Queries.character("Amos Burton")(characterFragment))
+          val query = SelectionBuilder
+            .fragment("QueryFrag", "Query")(Queries.character("Amos Burton")(characterFragment))
             .toGraphQL(
               queryName = Some("GetCharacter"),
               useVariables = true
             )
 
           assertTrue(
-            query.query == """query GetCharacter ($name: String!){...QueryFrag}fragment CF on Character{name role{__typename ... on Captain{shipName}}} fragment QueryFrag on Query{character(name:$name){...CF}}"""
+            query.query == """query GetCharacter ($name: String!){...QueryFrag}fragment QueryFrag on Query{character(name:$name){...CF}} fragment CF on Character{name role{__typename ... on Captain{shipName}}}""",
+            query.variables == Map("name" -> __Value.__StringValue("Amos Burton"))
           )
         },
         test("fragments with directives") {


### PR DESCRIPTION
Adds support for client fragments when building `SelectionBuilder`. A large part of this PR includes a rewrite of the logic that renders a selection to a request. When adding the fragment logic, it became difficult to keep track of how the rendering worked, so I reimplemented it based on the `Renderer` we have in core. This implementation was more complex because it required a state value be propagated along with the renderer to track arguments