### PR TITLE
Update zio-http to 3.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ val zioInteropReactiveVersion = "2.0.2"
 val zioConfigVersion          = "4.0.6"
 val zqueryVersion             = "0.7.7"
 val zioJsonVersion            = "0.7.45"
-val zioHttpVersion            = "3.4.0"
+val zioHttpVersion            = "3.6.0"
 val zioOpenTelemetryVersion   = "3.1.12"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges


### PR DESCRIPTION
Updating zio-http to handle [heartbeating](https://github.com/zio/zio-http/pull/3703) in SSE based subscriptions with SSE comments instead. PR coming that's using this as well