### PR TITLE
Heartbeating for SSE based subscriptions

### DIFF
--- a/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
@@ -85,6 +85,8 @@ final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R]) {
   def configureWebSocket[R1](config: quick.WebSocketConfig[R1]): QuickAdapter[R & R1] =
     new QuickAdapter(requestHandler.configureWebSocket(config))
 
+  def configureSse(config: quick.SseConfig): QuickAdapter[R] =
+    new QuickAdapter(requestHandler.configureSse(config))
 }
 
 object QuickAdapter {

--- a/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickAdapter.scala
@@ -6,6 +6,7 @@ import zio.http._
 import zio.http.netty.NettyConfig
 import zio.http.netty.NettyConfig.LeakDetectionLevel
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.stream.ZStream
 
 final class QuickAdapter[R] private (requestHandler: QuickRequestHandler[R]) {
 
@@ -90,7 +91,7 @@ object QuickAdapter {
   type Configurator[-R] = URIO[R & Scope, Unit]
 
   def apply[R](interpreter: GraphQLInterpreter[R, Any]): QuickAdapter[R] =
-    new QuickAdapter(new QuickRequestHandler(interpreter, quick.WebSocketConfig.default))
+    new QuickAdapter(new QuickRequestHandler(interpreter, quick.WebSocketConfig.default, quick.SseConfig.default))
 
   def handlers[R](implicit tag: Tag[R], trace: Trace): URIO[QuickAdapter[R], QuickHandlers[R]] =
     ZIO.serviceWith(_.handlers)

--- a/adapters/quick/src/main/scala/caliban/quick/SseConfig.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/SseConfig.scala
@@ -1,0 +1,14 @@
+package caliban.quick
+
+import zio._
+
+case class SseConfig(
+  heartbeatInterval: Option[Duration]
+) {
+  def withHeartbeatInterval(time: Duration): SseConfig =
+    copy(heartbeatInterval = Some(time))
+}
+
+object SseConfig {
+  def default: SseConfig = SseConfig(Some(10.seconds))
+}

--- a/adapters/quick/src/main/scala/caliban/quick/SseConfig.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/SseConfig.scala
@@ -2,6 +2,17 @@ package caliban.quick
 
 import zio._
 
+/**
+ * Configuration settings for Server-Sent Events (SSE) connections.
+ *
+ * This configuration controls parameters like the frequency of heartbeat messages
+ * sent to keep the connection alive.
+ *
+ * @param heartbeatInterval The interval at which a 'heartbeat' (a comment line)
+ * should be sent to the client to prevent connection
+ * timeouts. [[scala.None]] means no automatic heartbeats
+ * will be sent by the server.
+ */
 case class SseConfig(
   heartbeatInterval: Option[Duration]
 ) {

--- a/adapters/quick/src/main/scala/caliban/quick/SseConfig.scala
+++ b/adapters/quick/src/main/scala/caliban/quick/SseConfig.scala
@@ -10,5 +10,5 @@ case class SseConfig(
 }
 
 object SseConfig {
-  def default: SseConfig = SseConfig(Some(10.seconds))
+  def default: SseConfig = SseConfig(None)
 }

--- a/adapters/quick/src/test/scala/caliban/QuickAdapterSpec.scala
+++ b/adapters/quick/src/test/scala/caliban/QuickAdapterSpec.scala
@@ -23,10 +23,13 @@ object QuickAdapterSpec extends ZIOSpecDefault {
 
   private val apiLayer = envLayer >>> ZLayer.fromZIO {
     for {
-      _       <- TestApi.api
-                   .routes("/api/graphql", uploadPath = Some("/upload/graphql"), webSocketPath = Some("/ws/graphql"))
-                   .map(_ @@ auth)
-                   .flatMap(_.serve[TestService & Uploads].forkScoped)
+      adapter <- TestApi.api.interpreter.map { interpreter =>
+                   QuickAdapter(interpreter).configureSse(SseConfig(Some(1.second)))
+                 }
+      routes   =
+        (adapter
+          .routes("/api/graphql", uploadPath = Some("/upload/graphql"), webSocketPath = Some("/ws/graphql")) @@ auth)
+      _       <- Server.serve(routes).forkScoped
       _       <- Live.live(Clock.sleep(3 seconds))
       service <- ZIO.service[TestService]
     } yield service

--- a/core/src/main/scala/caliban/HttpUtils.scala
+++ b/core/src/main/scala/caliban/HttpUtils.scala
@@ -50,7 +50,7 @@ private[caliban] object HttpUtils {
       resp: GraphQLResponse[Any],
       toSse: ResponseValue => Sse,
       done: Sse,
-      heartbeater: Option[ZStream[Any, Nothing, Sse]]
+      heartbeater: Option[ZStream[Any, Nothing, Sse]] = None
     )(implicit trace: Trace): UStream[Sse] =
       (resp.data match {
         case ObjectValue((fieldName, StreamValue(stream)) :: Nil) =>

--- a/examples/src/main/scala/example/quick/ExampleApp.scala
+++ b/examples/src/main/scala/example/quick/ExampleApp.scala
@@ -14,20 +14,23 @@ object ExampleApp extends ZIOAppDefault {
       Console.printLine("Press RETURN to stop...") *>
       Console.readLine.unit
 
-  private val serve =
-    ZIO
-      .serviceWithZIO[GraphQL[Any]] {
-        _.runServer(
-          port = 8090,
-          apiPath = "/api/graphql",
-          graphiqlPath = Some("/graphiql"),
-          webSocketPath = Some("/ws/graphql")
-        )
-      }
-      .provide(
-        ExampleService.make(sampleCharacters),
-        ExampleApi.layer
-      )
+  private val serve = (for {
+    gql <- ZIO.service[GraphQL[Any]]
+    _   <- gql.interpreter.flatMap { interpreter =>
+             QuickAdapter(interpreter)
+               .configureSse(SseConfig(Some(5.seconds)))
+               .runServer(
+                 port = 8090,
+                 apiPath = "/api/graphql",
+                 graphiqlPath = Some("/graphiql"),
+                 webSocketPath = Some("/ws/graphql")
+               )
+           }
+  } yield ())
+    .provide(
+      ExampleService.make(sampleCharacters),
+      ExampleApi.layer
+    )
 
   override def run: ZIO[Any, Throwable, Unit] = serve race cliShutdownSignal
 

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -184,8 +184,7 @@ object TapirAdapter {
     val response = HttpUtils.ServerSentEvents.transformResponse(
       resp,
       v => ServerSentEvent(Some(responseCodec.encode(v)), Some("next")),
-      ServerSentEvent(None, Some("complete")),
-      None
+      ServerSentEvent(None, Some("complete"))
     )
     Right(streamConstructor(ZioServerSentEvents.serialiseSSEToBytes(response)))
   }

--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -184,7 +184,8 @@ object TapirAdapter {
     val response = HttpUtils.ServerSentEvents.transformResponse(
       resp,
       v => ServerSentEvent(Some(responseCodec.encode(v)), Some("next")),
-      ServerSentEvent(None, Some("complete"))
+      ServerSentEvent(None, Some("complete")),
+      None
     )
     Right(streamConstructor(ZioServerSentEvents.serialiseSSEToBytes(response)))
   }

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/TapirAdapterSpec.scala
@@ -300,11 +300,40 @@ object TapirAdapterSpec {
                          method = Method.POST.method,
                          query = """mutation{ deleteCharacter(name: "Amos Burton") }"""
                        )
-              event <- res.runHead
+              event <-
+                res
+                  .filter(_.data.isDefined)
+                  .takeUntil(e =>
+                    e == ServerSentEvent(Some("""{"data":{"characterDeleted":"Amos Burton"}}"""), Some("next"))
+                  )
+                  .runHead
             } yield assertTrue(
-              event.isDefined && event.get == ServerSentEvent(
-                Some("""{"data":{"characterDeleted":"Amos Burton"}}"""),
-                Some("next")
+              event.isDefined && event.contains(
+                ServerSentEvent(
+                  Some("""{"data":{"characterDeleted":"Amos Burton"}}"""),
+                  Some("next")
+                )
+              )
+            )
+          } @@ TestAspect.timeout(10.seconds) @@ TestAspect.ignore,
+          test("heartbeating") {
+            for {
+              res   <- runSSERequest(
+                         acceptTextEventStream,
+                         "subscription { characterDeleted }"
+                       )
+              event <-
+                res
+                  .filterNot(_.data.isDefined)
+                  .runHead
+            } yield assertTrue(
+              event.isDefined && event.contains(
+                ServerSentEvent(
+                  None,
+                  None,
+                  None,
+                  None
+                )
               )
             )
           } @@ TestAspect.timeout(10.seconds) @@ TestAspect.ignore

--- a/vuepress/docs/docs/adapters.md
+++ b/vuepress/docs/docs/adapters.md
@@ -126,6 +126,7 @@ for {
 The `QuickAdapter` exposes the following methods that allow you to customize the server or apply middleware to the routes:
 
 - `configure` which takes a `Configurator[R]` [similar to the tapir-based adapters](adapters.md#built-in-tapir-adapters)
+- `configureSse` which takes an `SseConfig` where you can configure if and how often SSE based subscriptions should heartbeat.
 - `handlers` which returns a `QuickHandlers[R]` which contains individual handlers to manually construct routes.
   Note that this handler is only for the api routes. To construct the graphiql handler use `caliban.GraphiQLHandler.handler`.
 


### PR DESCRIPTION
This adds heartbeating for SSE subscriptions. With the new zio-http version these heartbeats are now sent as SSE comments (ignored by the client but keeps the connection up) making sure we don't close the connection if no messages are passed within the default timeouts