### PR TITLE
Fix a code sample in the oneof input documentation

### DIFF
--- a/vuepress/docs/docs/schema.md
+++ b/vuepress/docs/docs/schema.md
@@ -402,8 +402,8 @@ case class Name(firstName: String, lastName: String)
 @GQLOneOfInput
 sealed trait AuthorInput
 object AuthorInput {
-  case class ById(id: String)
-  case class ByName(name: Name)
+  case class ById(id: String) extends AuthorInput
+  case class ByName(name: Name) extends AuthorInput
 }
 
 case class AuthorArgs(lookup: AuthorInput)


### PR DESCRIPTION
`ById` and `ByName` are intended to be cases of the `AuthorInput` ADT, see the Scala 3 example below.