### PR TITLE
Fix laziness issue with derived ArgBuilder class initialization

### DIFF
--- a/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderDerivation.scala
@@ -68,11 +68,17 @@ trait CommonArgBuilderDerivation {
           )
 
       case m: Mirror.ProductOf[A] =>
-        makeProductArgBuilder(
-          recurseProduct[A, m.MirroredElemLabels, m.MirroredElemTypes](),
-          MagnoliaMacro.paramAnns[A].toMap,
-          DerivationUtils.isValueType[A, m.MirroredElemLabels]
-        )(m.fromProduct)
+        inline if (
+          !DerivationUtils.hasSingleField[m.MirroredElemTypes]
+          && DerivationUtils.isValueType[A, m.MirroredElemLabels]
+        ) {
+          scala.compiletime.error("value classes must have exactly one field")
+        } else
+          makeProductArgBuilder(
+            recurseProduct[A, m.MirroredElemLabels, m.MirroredElemTypes](),
+            MagnoliaMacro.paramAnns[A].toMap,
+            DerivationUtils.isValueType[A, m.MirroredElemLabels]
+          )(m.fromProduct)
     }
 
   private def makeSumArgBuilder[A](
@@ -106,7 +112,7 @@ trait CommonArgBuilderDerivation {
     traitLabel: String
   ): ArgBuilder[A] = new ArgBuilder[A] {
 
-    override val partial: PartialFunction[InputValue, Either[ExecutionError, A]] = {
+    override lazy val partial: PartialFunction[InputValue, Either[ExecutionError, A]] = {
       val xs = _subTypes.map(_._3).asInstanceOf[List[ArgBuilder[A]]]
 
       val checkSize: PartialFunction[InputValue, Either[ExecutionError, A]] = {
@@ -135,8 +141,6 @@ trait CommonArgBuilderDerivation {
       val finalLabel = labelList.flatMap(_.collectFirst { case GQLName(name) => name }).getOrElse(label)
       (finalLabel, default, builder)
     })
-
-    assert(!isValueType || params.length == 1, "value classes must have exactly one field")
 
     private lazy val required = params.collect { case (label, default, _) if default.isLeft => label }
 

--- a/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
+++ b/core/src/main/scala-3/caliban/schema/DerivationUtils.scala
@@ -47,10 +47,16 @@ private object DerivationUtils {
   def getDeprecatedReason(annotations: Seq[Any]): Option[String] =
     annotations.collectFirst { case GQLDeprecated(reason) => reason }
 
-  transparent inline def isValueType[A, Labels]: Boolean =
+  transparent inline def isValueType[A, Labels <: Tuple]: Boolean =
     inline erasedValue[Labels] match {
       case _: EmptyTuple => false
       case _             => MagnoliaMacro.isValueClass[A] || Macros.hasAnnotation[A, GQLValueType]
+    }
+
+  transparent inline def hasSingleField[Labels <: Tuple]: Boolean =
+    inline erasedValue[Labels] match {
+      case _: (_ *: EmptyTuple) => true
+      case _                    => false
     }
 
   def mkEnum(annotations: List[Any], info: TypeInfo, subTypes: List[(String, __Type, List[Any])]): __Type =

--- a/core/src/test/scala-3/caliban/schema/DerivationUtilsSpec.scala
+++ b/core/src/test/scala-3/caliban/schema/DerivationUtilsSpec.scala
@@ -1,0 +1,15 @@
+package caliban.schema
+
+import zio.test.*
+
+object DerivationUtilsSpec extends ZIOSpecDefault {
+  override def spec = suite("DerivationUtilsSpec")(
+    test("hasSingleField") {
+      val n0 = DerivationUtils.hasSingleField[EmptyTuple]
+      val n1 = DerivationUtils.hasSingleField[Tuple1[String]]
+      val n2 = DerivationUtils.hasSingleField[(String, Int)]
+
+      assertTrue(!n0, n1, !n2)
+    }
+  )
+}


### PR DESCRIPTION
I noticed a potential initialization issue with the ArgBuilder derived classes while reviewing another PR.

TLDR; in some cases we're triggering the computation of the lazy `_subTypes: => List[(String, List[Any], ArgBuilder[Any])]` too early.

This _should_ have been throwing runtime errors, and I suspect that the only reason that it hasn't happened has to do with the order of operations when the derived class is initialized. Anyways, it's better not to play with fire and avoid triggering the computation of `_subTypes` when we initialize the classes.