### PR TITLE
Use local params val in `ArgBuilder` (Scala 3)

### DIFF
--- a/core/src/main/scala-3/caliban/schema/ArgBuilderInstances.scala
+++ b/core/src/main/scala-3/caliban/schema/ArgBuilderInstances.scala
@@ -86,9 +86,10 @@ private final class ProductArgBuilder[A](
       }
 
   private def fromFields(fields: Map[String, InputValue]): Either[ExecutionError, A] = {
-    var i   = 0
-    val l   = params.length
-    val arr = Array.ofDim[Any](l)
+    val params = this.params
+    var i      = 0
+    val l      = params.length
+    val arr    = Array.ofDim[Any](l)
     while (i < l) {
       val (label, default, builder) = params(i)
       val field                     = fields.getOrElseNull(label)


### PR DESCRIPTION
Small perf improvement for Scala 3 ArgBuilder by using a local val for `params` instead of fetching the class lazy val.

I also did this for Scala 2 in #2839