### PR TITLE
add a built-in `ArgBuilder` for enums

### DIFF
--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -153,6 +153,10 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
     case BooleanValue(value) => Right(value)
     case other               => Left(InvalidInputArgument("Boolean", other))
   }
+  lazy val enum: ArgBuilder[String]                    = {
+    case EnumValue(value) => Right(value)
+    case other            => Left(InvalidInputArgument("Enum", other))
+  }
 
   private abstract class TemporalDecoder[A](name: String) extends ArgBuilder[A] {
     protected[this] def parseUnsafe(input: String): A

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -153,7 +153,7 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
     case BooleanValue(value) => Right(value)
     case other               => Left(InvalidInputArgument("Boolean", other))
   }
-  lazy val enum: ArgBuilder[String]                    = {
+  lazy val `enum`: ArgBuilder[String]                  = {
     case EnumValue(value) => Right(value)
     case other            => Left(InvalidInputArgument("Enum", other))
   }

--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -15,6 +15,7 @@ import scala.annotation.implicitNotFound
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+import scala.reflect.ClassTag
 import scala.util.Try
 import scala.util.control.{ NoStackTrace, NonFatal }
 
@@ -153,9 +154,24 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
     case BooleanValue(value) => Right(value)
     case other               => Left(InvalidInputArgument("Boolean", other))
   }
-  lazy val `enum`: ArgBuilder[String]                  = {
+  private lazy val enumBuilder: ArgBuilder[String]     = {
     case EnumValue(value) => Right(value)
     case other            => Left(InvalidInputArgument("Enum", other))
+  }
+
+  def enumString[A](f: String => A)(implicit d: DummyImplicit): ArgBuilder[A] = enumBuilder.map(f)
+  def enumString[A](f: String => Either[ExecutionError, A]): ArgBuilder[A]    = enumBuilder.flatMap(f)
+  def enumJava[T <: Enum[T]](implicit ct: ClassTag[T]): ArgBuilder[T]         = enumString { value =>
+    val cls = ct.runtimeClass.asInstanceOf[Class[T]]
+    Try {
+      Enum.valueOf[T](cls, value)
+    }.toEither.left.map { t =>
+      val validValues = cls.getEnumConstants.map(_.name()).mkString(", ")
+      ExecutionError(
+        s"'$value' is not a valid value of ${cls.getSimpleName}. Valid values are: [$validValues]",
+        innerThrowable = Some(t)
+      )
+    }
   }
 
   private abstract class TemporalDecoder[A](name: String) extends ArgBuilder[A] {

--- a/core/src/test/java/caliban/schema/Color.java
+++ b/core/src/test/java/caliban/schema/Color.java
@@ -1,0 +1,5 @@
+package caliban.schema;
+
+public enum Color {
+    Red, Green, Blue
+}

--- a/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
+++ b/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
@@ -4,7 +4,7 @@ import caliban.CalibanError.ExecutionError
 import caliban.InputValue
 import caliban.InputValue.{ ListValue, ObjectValue }
 import caliban.schema.ArgBuilder.auto._
-import caliban.Value.{ IntValue, NullValue, StringValue }
+import caliban.Value.{ EnumValue, IntValue, NullValue, StringValue }
 import caliban.schema.Annotations.{ GQLOneOfInput, GQLValueType }
 import zio.test.Assertion._
 import zio.test._
@@ -221,6 +221,24 @@ object ArgBuilderSpec extends ZIOSpecDefault {
               Map("map" -> ListValue(List(ObjectValue(Map("key" -> StringValue("bar"), "value" -> IntValue(1))))))
             )
           ).isLeft
+        )
+      }
+    ),
+    suite("Enums")(
+      test("should support Java enums") {
+        assert(ArgBuilder.enumJava[Color].build(EnumValue("Red")))(
+          isRight(equalTo(Color.Red))
+        )
+      },
+      test("should fail for invalid enum value") {
+        assert(ArgBuilder.enumJava[Color].build(EnumValue("Purple")))(
+          isLeft(
+            hasField(
+              "msg",
+              _.msg,
+              equalTo("'Purple' is not a valid value of Color. Valid values are: [Red, Green, Blue]")
+            )
+          )
         )
       }
     )


### PR DESCRIPTION
- adds two new `enumString` methods on `ArgBuilder` to that accept `map`/`flatMap`-like functions and apply them to a graphql enum value
- adds a new `enumJava` method on `ArgBuilder` meant to automatically construct an `ArgBuilder[T]` for some `java.lang.Enum[T]`