### PR TITLE
Honor covariant narrowing of interface fields per spec

### DIFF
--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -220,23 +220,25 @@ object Types {
       }
 
   /**
-   * Finds the closest common interface (or interface chain ancestor) shared by `t1` and `t2`,
-   * by walking each type's `interfaces()` lists transitively.
+   * Finds the closest type reachable from both `t1` and `t2` via their `interfaces()` chain
+   * (including each type itself, so that a direct implementer/interface pair returns the
+   * interface). BFS order is used so the closest match wins; a `visited` set guards against
+   * cyclic interface graphs.
    *
    * Used by [[unify]] as a fallback when two types differ but covariantly narrow a shared interface
    * field (per https://spec.graphql.org/October2021/#IsValidImplementationFieldType()).
    */
   private def commonInterface(t1: __Type, t2: __Type): Option[__Type] = {
-    def ancestors(t: __Type): List[__Type] = {
-      val direct = t.interfaces().toList.flatten
-      direct ::: direct.flatMap(ancestors)
+    @tailrec
+    def selfAndAncestors(queue: List[__Type], acc: List[__Type]): List[__Type] = queue match {
+      case Nil       => acc.reverse
+      case h :: rest =>
+        if (acc.exists(same(_, h))) selfAndAncestors(rest, acc)
+        else selfAndAncestors(rest ::: h.interfaces().toList.flatten, h :: acc)
     }
-    val a1                                 = ancestors(t1)
-    if (a1.isEmpty) None
-    else {
-      val a2 = ancestors(t2)
-      a1.find(i1 => a2.exists(i2 => same(i1, i2)))
-    }
+    val a1                                                                     = selfAndAncestors(List(t1), Nil)
+    val a2                                                                     = selfAndAncestors(List(t2), Nil)
+    a1.find(i1 => a2.exists(i2 => same(i1, i2)))
   }
 
   def extractCommonDescription(l: List[__Field]): Option[String] =

--- a/core/src/main/scala/caliban/schema/Types.scala
+++ b/core/src/main/scala/caliban/schema/Types.scala
@@ -208,10 +208,36 @@ object Types {
     if (same(t1, t2)) Option(t1)
     else
       (t1.kind, t2.kind) match {
-        case (__TypeKind.NON_NULL, _) => t1.ofType.flatMap(unify(_, t2))
-        case (_, __TypeKind.NON_NULL) => t2.ofType.flatMap(unify(_, t1))
-        case _                        => None
+        case (__TypeKind.NON_NULL, __TypeKind.NON_NULL) =>
+          for {
+            a <- t1.ofType
+            b <- t2.ofType
+            u <- unify(a, b)
+          } yield u.nonNull
+        case (__TypeKind.NON_NULL, _)                   => t1.ofType.flatMap(unify(_, t2))
+        case (_, __TypeKind.NON_NULL)                   => t2.ofType.flatMap(unify(_, t1))
+        case _                                          => commonInterface(t1, t2)
       }
+
+  /**
+   * Finds the closest common interface (or interface chain ancestor) shared by `t1` and `t2`,
+   * by walking each type's `interfaces()` lists transitively.
+   *
+   * Used by [[unify]] as a fallback when two types differ but covariantly narrow a shared interface
+   * field (per https://spec.graphql.org/October2021/#IsValidImplementationFieldType()).
+   */
+  private def commonInterface(t1: __Type, t2: __Type): Option[__Type] = {
+    def ancestors(t: __Type): List[__Type] = {
+      val direct = t.interfaces().toList.flatten
+      direct ::: direct.flatMap(ancestors)
+    }
+    val a1                                 = ancestors(t1)
+    if (a1.isEmpty) None
+    else {
+      val a2 = ancestors(t2)
+      a1.find(i1 => a2.exists(i2 => same(i1, i2)))
+    }
+  }
 
   def extractCommonDescription(l: List[__Field]): Option[String] =
     l.map(_.description).distinct match {

--- a/core/src/main/scala/caliban/validation/SchemaValidator.scala
+++ b/core/src/main/scala/caliban/validation/SchemaValidator.scala
@@ -262,8 +262,15 @@ private[caliban] object SchemaValidator {
         }
 
         def implementsTransitively(t: __Type, ancestor: __Type): Boolean = {
-          val direct = t.interfaces().toList.flatten
-          direct.exists(d => Types.same(d, ancestor) || implementsTransitively(d, ancestor))
+          @scala.annotation.tailrec
+          def loop(queue: List[__Type], visited: List[__Type]): Boolean = queue match {
+            case Nil       => false
+            case h :: rest =>
+              if (visited.exists(Types.same(_, h))) loop(rest, visited)
+              else if (Types.same(h, ancestor)) true
+              else loop(rest ::: h.interfaces().toList.flatten, h :: visited)
+          }
+          loop(t.interfaces().toList.flatten, List(t))
         }
 
         validateAllDiscard(objectFields) { objField =>

--- a/core/src/main/scala/caliban/validation/SchemaValidator.scala
+++ b/core/src/main/scala/caliban/validation/SchemaValidator.scala
@@ -230,20 +230,40 @@ private[caliban] object SchemaValidator {
         val objectFields    = obj.allFields
         val supertypeFields = supertype.flatMap(_.allFields)
 
-        def isNonNullableSubtype(supertypeFieldType: __Type, objectFieldType: __Type) = {
+        // https://spec.graphql.org/October2021/#IsValidImplementationFieldType()
+        def isValidSubtype(supertypeFieldType: __Type, objectFieldType: __Type): Boolean = {
           import __TypeKind._
-          objectFieldType.kind match {
-            case NON_NULL => objectFieldType.ofType.exists(Types.same(supertypeFieldType, _))
-            case _        => false
-          }
+          if (objectFieldType.kind == NON_NULL) {
+            // Non-Null is a valid sub-type of either Non-Null or its nullable variant.
+            val unwrappedObj = objectFieldType.ofType.getOrElse(objectFieldType)
+            val unwrappedSup =
+              if (supertypeFieldType.kind == NON_NULL) supertypeFieldType.ofType.getOrElse(supertypeFieldType)
+              else supertypeFieldType
+            isValidSubtype(unwrappedSup, unwrappedObj)
+          } else if (supertypeFieldType.kind == NON_NULL) {
+            // A nullable object field cannot implement a non-nullable interface field.
+            false
+          } else if (supertypeFieldType.kind == LIST && objectFieldType.kind == LIST) {
+            (for {
+              s <- supertypeFieldType.ofType
+              o <- objectFieldType.ofType
+            } yield isValidSubtype(s, o)).getOrElse(false)
+          } else if (Types.same(supertypeFieldType, objectFieldType)) {
+            true
+          } else
+            (supertypeFieldType.kind, objectFieldType.kind) match {
+              case (UNION, OBJECT)                              =>
+                supertypeFieldType.possibleTypes.toList.flatten.exists(Types.same(_, objectFieldType))
+              case (INTERFACE, OBJECT) | (INTERFACE, INTERFACE) =>
+                supertypeFieldType.possibleTypes.toList.flatten.exists(Types.same(_, objectFieldType)) ||
+                implementsTransitively(objectFieldType, supertypeFieldType)
+              case _                                            => false
+            }
         }
 
-        def isValidSubtype(supertypeFieldType: __Type, objectFieldType: __Type) = {
-          val supertypePossibleTypes = supertypeFieldType.possibleTypes.toList.flatten
-
-          Types.same(supertypeFieldType, objectFieldType) ||
-          supertypePossibleTypes.exists(Types.same(_, objectFieldType)) ||
-          isNonNullableSubtype(supertypeFieldType, objectFieldType)
+        def implementsTransitively(t: __Type, ancestor: __Type): Boolean = {
+          val direct = t.interfaces().toList.flatten
+          direct.exists(d => Types.same(d, ancestor) || implementsTransitively(d, ancestor))
         }
 
         validateAllDiscard(objectFields) { objField =>

--- a/core/src/test/scala/caliban/TestUtils.scala
+++ b/core/src/test/scala/caliban/TestUtils.scala
@@ -552,6 +552,40 @@ object TestUtils {
           ),
         subTypes = List(nullableExtraArgsObject)
       )
+
+      // Covariantly narrowed sub-type field per https://spec.graphql.org/October2021/#IsValidImplementationFieldType()
+      // The interface field is `species: Species!` (Species is itself an interface implemented by Mammalia/Aves),
+      // and the object field narrows it to `species: Mammalia!`.
+      lazy val speciesInterface: __Type = Types.makeInterface(
+        name = Some("Species"),
+        description = None,
+        fields = () => List(__Field("name", None, _ => Nil, () => Types.string.nonNull)),
+        subTypes = List(mammaliaObject, avesObject)
+      )
+      lazy val mammaliaObject: __Type   = __Type(
+        kind = __TypeKind.OBJECT,
+        name = Some("Mammalia"),
+        interfaces = () => Some(List(speciesInterface)),
+        fields = _ => Some(List(__Field("name", None, _ => Nil, () => Types.string.nonNull)))
+      )
+      lazy val avesObject: __Type       = __Type(
+        kind = __TypeKind.OBJECT,
+        name = Some("Aves"),
+        interfaces = () => Some(List(speciesInterface)),
+        fields = _ => Some(List(__Field("name", None, _ => Nil, () => Types.string.nonNull)))
+      )
+      lazy val animalInterface: __Type  = Types.makeInterface(
+        name = Some("Animal"),
+        description = None,
+        fields = () => List(__Field("species", None, _ => Nil, () => speciesInterface.nonNull)),
+        subTypes = List(narrowedMammalObject)
+      )
+      lazy val narrowedMammalObject     = __Type(
+        kind = __TypeKind.OBJECT,
+        name = Some("NarrowedMammal"),
+        interfaces = () => Some(List(animalInterface)),
+        fields = _ => Some(List(__Field("species", None, _ => Nil, () => mammaliaObject.nonNull)))
+      )
     }
 
     @GQLDirective(Directive("__name"))

--- a/core/src/test/scala/caliban/schema/TypesSpec.scala
+++ b/core/src/test/scala/caliban/schema/TypesSpec.scala
@@ -1,0 +1,61 @@
+package caliban.schema
+
+import caliban.introspection.adt.{ __Field, __Type, __TypeKind }
+import zio.test._
+
+object TypesSpec extends ZIOSpecDefault {
+
+  private val species: __Type = Types.makeInterface(
+    name = Some("Species"),
+    description = None,
+    fields = () => List(__Field("name", None, _ => Nil, () => Types.string.nonNull)),
+    subTypes = Nil
+  )
+
+  private val mammalia: __Type = __Type(
+    kind = __TypeKind.OBJECT,
+    name = Some("Mammalia"),
+    interfaces = () => Some(List(species)),
+    fields = _ => Some(List(__Field("name", None, _ => Nil, () => Types.string.nonNull)))
+  )
+
+  private val aves: __Type = __Type(
+    kind = __TypeKind.OBJECT,
+    name = Some("Aves"),
+    interfaces = () => Some(List(species)),
+    fields = _ => Some(List(__Field("name", None, _ => Nil, () => Types.string.nonNull)))
+  )
+
+  override def spec = suite("TypesSpec")(
+    suite("unify")(
+      test("returns the type when both arguments are the same") {
+        assertTrue(Types.unify(Types.string, Types.string).contains(Types.string))
+      },
+      test("preserves NON_NULL when both arguments are the same NON_NULL type") {
+        val t = Types.string.nonNull
+        assertTrue(Types.unify(t, t).map(_.kind).contains(__TypeKind.NON_NULL))
+      },
+      test("strips NON_NULL when one argument is nullable") {
+        assertTrue(Types.unify(Types.string.nonNull, Types.string).contains(Types.string))
+      },
+      test("falls back to the closest common interface for distinct sub-types") {
+        // Per https://spec.graphql.org/October2021/#IsValidImplementationFieldType() interface fields
+        // may be covariantly narrowed by their implementations. unify should yield the shared interface.
+        assertTrue(Types.unify(mammalia, aves).flatMap(_.name).contains("Species"))
+      },
+      test("preserves NON_NULL when both sub-types share an interface") {
+        val unified = Types.unify(mammalia.nonNull, aves.nonNull)
+        assertTrue(unified.map(_.kind).contains(__TypeKind.NON_NULL)) &&
+        assertTrue(unified.flatMap(_.ofType).flatMap(_.name).contains("Species"))
+      },
+      test("returns None when no common interface exists") {
+        val unrelated = __Type(
+          kind = __TypeKind.OBJECT,
+          name = Some("Unrelated"),
+          interfaces = () => Some(Nil)
+        )
+        assertTrue(Types.unify(mammalia, unrelated).isEmpty)
+      }
+    )
+  )
+}

--- a/core/src/test/scala/caliban/schema/TypesSpec.scala
+++ b/core/src/test/scala/caliban/schema/TypesSpec.scala
@@ -55,6 +55,32 @@ object TypesSpec extends ZIOSpecDefault {
           interfaces = () => Some(Nil)
         )
         assertTrue(Types.unify(mammalia, unrelated).isEmpty)
+      },
+      test("returns the interface when one type directly implements the other") {
+        // unify(Mammalia, Species) should return Species since Mammalia implements Species.
+        assertTrue(Types.unify(mammalia, species).flatMap(_.name).contains("Species")) &&
+        assertTrue(Types.unify(species, mammalia).flatMap(_.name).contains("Species"))
+      },
+      test("terminates on a cyclic interfaces() graph") {
+        // Defensively guard against malformed schemas: two interfaces that each list the other
+        // as an interface should not cause infinite recursion.
+        lazy val a: __Type = Types
+          .makeInterface(
+            name = Some("CycleA"),
+            description = None,
+            fields = () => Nil,
+            subTypes = Nil
+          )
+          .copy(interfaces = () => Some(List(b)))
+        lazy val b: __Type = Types
+          .makeInterface(
+            name = Some("CycleB"),
+            description = None,
+            fields = () => Nil,
+            subTypes = Nil
+          )
+          .copy(interfaces = () => Some(List(a)))
+        assertTrue(Types.unify(a, b).flatMap(_.name).contains("CycleA"))
       }
     )
   )

--- a/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
@@ -294,6 +294,13 @@ object ValidationSchemaSpec extends ZIOSpecDefault {
           test("field type that is a Non-Null variant of a valid interface field type is valid") {
             graphQL(resolverNonNullableSubtype).interpreter.exit.map(assert(_)(succeeds(anything)))
           },
+          test(
+            "non-null object field is a valid sub-type of a non-null interface field that the object's type implements"
+          ) {
+            // Covariantly narrowed sub-type: interface field `species: Species!` and object field `species: Mammalia!`
+            // where Mammalia implements Species. See https://spec.graphql.org/October2021/#IsValidImplementationFieldType()
+            assert(SchemaValidator.validateType(narrowedMammalObject))(isRight)
+          },
           test("fields including arguments of the same name and type defined in an interface are valid") {
             graphQL(resolverFieldWithArg).interpreter.exit.map(assert(_)(succeeds(anything)))
           },

--- a/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSchemaSpec.scala
@@ -301,6 +301,42 @@ object ValidationSchemaSpec extends ZIOSpecDefault {
             // where Mammalia implements Species. See https://spec.graphql.org/October2021/#IsValidImplementationFieldType()
             assert(SchemaValidator.validateType(narrowedMammalObject))(isRight)
           },
+          test("subtype check terminates when the implementer's interfaces() graph is cyclic") {
+            // Defensive: a malformed schema where two interfaces list each other should not hang validation.
+            lazy val cycleA: __Type        =
+              Types.makeInterface(Some("CycleA"), None, () => Nil, Nil).copy(interfaces = () => Some(List(cycleB)))
+            lazy val cycleB: __Type        =
+              Types.makeInterface(Some("CycleB"), None, () => Nil, Nil).copy(interfaces = () => Some(List(cycleA)))
+            val unrelatedInterface: __Type = Types.makeInterface(
+              Some("Unrelated"),
+              None,
+              () => List(__Field("f", None, _ => Nil, () => Types.makeInterface(Some("Other"), None, () => Nil, Nil))),
+              Nil
+            )
+            val cyclicObject: __Type       = __Type(
+              kind = __TypeKind.OBJECT,
+              name = Some("CyclicObject"),
+              interfaces = () => Some(List(unrelatedInterface)),
+              fields = _ =>
+                Some(
+                  List(
+                    __Field(
+                      "f",
+                      None,
+                      _ => Nil,
+                      () =>
+                        __Type(
+                          kind = __TypeKind.OBJECT,
+                          name = Some("Impl"),
+                          interfaces = () => Some(List(cycleA)),
+                          fields = _ => Some(Nil)
+                        )
+                    )
+                  )
+                )
+            )
+            assert(SchemaValidator.validateType(cyclicObject))(isLeft)
+          },
           test("fields including arguments of the same name and type defined in an interface are valid") {
             graphQL(resolverFieldWithArg).interpreter.exit.map(assert(_)(succeeds(anything)))
           },


### PR DESCRIPTION
## Summary

Fixes the two interacting bugs described in #2931 around covariant narrowing of interface fields, per [spec §IsValidImplementationFieldType()](https://spec.graphql.org/October2021/#IsValidImplementationFieldType()).

### `Types.unify` — preserve narrowed-but-related interface fields

When two sub-type field types differ but transitively share a common interface, `unify` now returns that interface instead of `None`. NON_NULL wrapping is preserved when both sides agree. This keeps the field on the parent interface (using the shared interface as the abstract type) rather than dropping it from the rendered schema entirely.

### `SchemaValidator.isValidSubtype` — spec-compliant sub-type check

Previously, an interface field of `Foo!` could not be implemented by `Bar!` even when `Bar implements Foo`, because the `possibleTypes` lookup happened on the NON_NULL wrapper (whose `possibleTypes` is `None`) and the implementer's `interfaces` list was never consulted.

The check is reworked to follow the spec algorithm:

- Strip NON_NULL on both sides (allowing the implementing field to be non-null when the interface field is nullable, but not the reverse).
- Recurse into LIST item types.
- For an interface supertype field, accept any object/interface that is in `possibleTypes` *or* transitively implements the supertype via `interfaces()`.

## Test plan

- [x] `core/testOnly caliban.validation.ValidationSchemaSpec caliban.schema.TypesSpec` — new tests cover the unify fallback (with and without NON_NULL) and the validator accepting a non-null narrowed sub-type field.
- [x] Full `core/test` on Scala 2.13 — all 548 tests pass, no regressions.
- [x] Full `core/test` on Scala 3.3.7 — all 597 tests pass, no regressions.
- [x] `sbt fmt` clean.

Closes #2931