### PR TITLE
Fix Field.resolveVariables dropping missing variables inside list literals

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -275,7 +275,7 @@ object Field {
             value      <- variableValues.get(name).orElse(definition.defaultValue)
           } yield value
         case InputValue.ListValue(values)   =>
-          Some(InputValue.ListValue(values.flatMap(resolveVariable)))
+          Some(InputValue.ListValue(values.map(v => resolveVariable(v).getOrElse(Value.NullValue))))
         case InputValue.ObjectValue(fields) =>
           Some(InputValue.ObjectValue(fields.flatMap { case (k, v) => resolveVariable(v).map(k -> _) }))
         case value: Value                   =>

--- a/core/src/test/scala/caliban/execution/FieldArgsSpec.scala
+++ b/core/src/test/scala/caliban/execution/FieldArgsSpec.scala
@@ -215,6 +215,34 @@ object FieldArgsSpec extends ZIOSpecDefault {
                          )
                        )
       } yield assertTrue(res.data.toString == "{\"query\":\"BLUE\"}")
+    },
+    test("missing nullable variable inside a list is coerced to null, not dropped") {
+      case class QueryInput(tags: List[Option[String]])
+      case class Query(query: Field => QueryInput => UIO[String])
+      val query =
+        """query MyQuery($x: String) {
+          |  query(tags: ["fixed", $x, "important"])
+          |}""".stripMargin
+
+      for {
+        ref         <- Ref.make[Option[Field]](None)
+        api          = graphQL(
+                         RootResolver(
+                           Query(
+                             query = info => _ => ref.set(Option(info)).as("ok")
+                           )
+                         )
+                       )
+        interpreter <- api.interpreter
+        _           <- interpreter.executeRequest(
+                         request = GraphQLRequest(query = Some(query), variables = Some(Map.empty))
+                       )
+        res         <- ref.get
+      } yield assertTrue(
+        res.get.arguments("tags") == InputValue.ListValue(
+          List(Value.StringValue("fixed"), Value.NullValue, Value.StringValue("important"))
+        )
+      )
     }
   )
 }


### PR DESCRIPTION
Closes #2946 (list case).

Inside a list literal, a variable with no provided value and no default was being elided from the list (shortening it) instead of being coerced to `null`. Switch the `ListValue` branch of `resolveVariable` from `flatMap` to `map` + `getOrElse(NullValue)` so the slot is preserved as `null`, matching `graphql-js`.

The issue's proposed changes for the top-level argument and `ObjectValue` branches are intentionally skipped — `graphql-js` and the spec (`CoerceArgumentValues`) treat unset nullable variables there as *absent*, which is what caliban already does.