### PR TITLE
Fix multiple WebSocket protocol issues

### DIFF
--- a/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
+++ b/adapters/quick/src/main/scala/caliban/QuickRequestHandler.scala
@@ -278,7 +278,10 @@ final private class QuickRequestHandler[R](
                  }
       _     <- ZIO.scoped(ch.receiveAll {
                  case ChannelEvent.UserEventTriggered(HandshakeComplete) =>
-                   out.runForeach(frame => ch.send(ChannelEvent.Read(frame))).forkScoped
+                   out
+                     .runForeach(frame => ch.send(ChannelEvent.Read(frame)))
+                     .ensuring(ch.shutdown)
+                     .forkScoped
                  case ChannelEvent.Read(WebSocketFrame.Text(text))       =>
                    ZIO.suspend(queue.offer(readFromString[GraphQLWSInput](text, readerConfig)))
                  case _                                                  =>

--- a/core/src/main/scala/caliban/ws/Protocol.scala
+++ b/core/src/main/scala/caliban/ws/Protocol.scala
@@ -3,7 +3,7 @@ package caliban.ws
 import caliban.ResponseValue.{ ObjectValue, StreamValue }
 import caliban.Value.StringValue
 import caliban._
-import zio.stm.TMap
+import zio.stm.{ STM, TMap }
 import zio.stream.{ UStream, ZStream }
 import zio.{ Duration, Promise, Queue, Random, Ref, Schedule, UIO, URIO, ZIO }
 
@@ -23,6 +23,22 @@ object Protocol {
   def fromName(name: String): Protocol =
     if (name.equalsIgnoreCase(GraphQLWS.name)) GraphQLWS
     else Legacy
+
+  private def runBeforeInit[R, E](
+    hook: Option[InputValue => ZIO[R, E, Any]],
+    payload: Option[InputValue],
+    onReject: zio.Cause[Any] => UIO[Any]
+  ): URIO[R, Boolean] =
+    hook.fold[URIO[R, Boolean]](ZIO.succeed(true)) { f =>
+      ZIO
+        .suspendSucceed(f(payload.getOrElse(Value.NullValue)))
+        .foldCauseZIO(
+          cause =>
+            if (cause.isInterruptedOnly) ZIO.failCause(cause.stripFailures)
+            else onReject(cause).as(false),
+          _ => ZIO.succeed(true)
+        )
+    }
 
   object GraphQLWS extends Protocol {
     object Ops {
@@ -70,10 +86,11 @@ object Protocol {
                            ZStream.scoped(
                              input.runForeach {
                                case GraphQLWSInput(Ops.ConnectionInit, id, payload)  =>
-                                 val before     = ZIO.whenCase((webSocketHooks.beforeInit, payload)) {
-                                   case (Some(beforeInit), Some(payload)) =>
-                                     beforeInit(payload).orElse(output.offer(Left(GraphQLWSClose(4403, "Forbidden"))))
-                                 }
+                                 val before     = runBeforeInit(
+                                   webSocketHooks.beforeInit,
+                                   payload,
+                                   _ => output.offer(Left(GraphQLWSClose(4403, "Forbidden")))
+                                 )
                                  val ackPayload = webSocketHooks.onAck.fold[URIO[R, Option[ResponseValue]]](ZIO.none)(_.option)
                                  val response   =
                                    ack.set(true) *> ackPayload.flatMap(payload => output.offer(Right(connectionAck(payload))))
@@ -88,7 +105,10 @@ object Protocol {
                                      .fork
                                  }
 
-                                 before *> response *> ka *> after
+                                 ZIO.ifZIO(ack.get)(
+                                   output.offer(Left(GraphQLWSClose(4429, "Too many initialisation requests"))).unit,
+                                   ZIO.whenZIO(before)(response *> ka *> after).unit
+                                 )
                                case GraphQLWSInput(Ops.Pong, id, payload)            =>
                                  ZIO.whenCase(webSocketHooks.onPong -> payload) { case (Some(onPong), Some(payload)) =>
                                    onPong(payload).catchAll(e =>
@@ -118,19 +138,23 @@ object Protocol {
 
                                  val continue = request match {
                                    case Some(req) =>
-                                     val stream = handler.generateGraphQLResponse(req, id, interpreter, subscriptions)
-
-                                     ZIO.ifZIO(subscriptions.isTracking(id))(
-                                       output.offer(Left(GraphQLWSClose(4409, s"Subscriber for $id already exists"))).unit,
-                                       webSocketHooks.onMessage
-                                         .fold(stream)(stream.via(_))
-                                         .map(Right(_))
-                                         .runForeachChunk(output.offerAll)
-                                         .catchAll(e => output.offer(Right(handler.error(Some(id), e))))
-                                         .fork
-                                         .interruptible
-                                         .unit
-                                     )
+                                     subscriptions.reserve(id).flatMap {
+                                       case None    =>
+                                         output
+                                           .offer(Left(GraphQLWSClose(4409, s"Subscriber for $id already exists")))
+                                           .unit
+                                       case Some(p) =>
+                                         val stream = handler.generateGraphQLResponse(req, id, interpreter, p)
+                                         webSocketHooks.onMessage
+                                           .fold(stream)(stream.via(_))
+                                           .map(Right(_))
+                                           .runForeachChunk(output.offerAll)
+                                           .catchAll(e => output.offer(Right(handler.error(Some(id), e))))
+                                           .ensuring(subscriptions.cleanupIfMine(id, p))
+                                           .fork
+                                           .interruptible
+                                           .unit
+                                     }
 
                                    case None =>
                                      generateId(None).flatMap(uuid => output.offer(Right(connectionError(uuid))))
@@ -221,10 +245,11 @@ object Protocol {
                              .acquireReleaseWith(
                                input.runForeach {
                                  case GraphQLWSInput(Ops.ConnectionInit, id, payload) =>
-                                   val before     = ZIO.whenCase((webSocketHooks.beforeInit, payload)) {
-                                     case (Some(beforeInit), Some(payload)) =>
-                                       beforeInit(payload).catchAll(e => output.offer(Right(handler.error(id, e))))
-                                   }
+                                   val before     = runBeforeInit(
+                                     webSocketHooks.beforeInit,
+                                     payload,
+                                     cause => output.offer(Right(connectionErrorFrom(cause)))
+                                   )
                                    val ackPayload = webSocketHooks.onAck.fold[URIO[R, Option[ResponseValue]]](ZIO.none)(_.option)
 
                                    val response =
@@ -240,7 +265,10 @@ object Protocol {
                                        .fork
                                    }
 
-                                   before *> response *> ka *> after
+                                   ZIO.ifZIO(ack.get)(
+                                     output.offer(Right(connectionError)).unit,
+                                     ZIO.whenZIO(before)(response *> ka *> after).unit
+                                   )
                                  case GraphQLWSInput(Ops.Start, id, payload)          =>
                                    val request  = payload.collect { case InputValue.ObjectValue(fields) =>
                                      val query         = fields.get("query").collect { case StringValue(v) => v }
@@ -251,15 +279,19 @@ object Protocol {
                                    }
                                    val continue = request match {
                                      case Some(req) =>
-                                       val stream =
-                                         handler.generateGraphQLResponse(req, id.getOrElse(""), interpreter, subscriptions)
-                                       webSocketHooks.onMessage
-                                         .fold(stream)(stream.via(_))
-                                         .runForeachChunk(o => output.offerAll(o.map(Right(_))))
-                                         .catchAll(e => output.offer(Right(handler.error(id, e))))
-                                         .fork
-                                         .interruptible
-                                         .unit
+                                       val key = id.getOrElse("")
+                                       subscriptions.trackForce(key).flatMap { p =>
+                                         val stream =
+                                           handler.generateGraphQLResponse(req, key, interpreter, p)
+                                         webSocketHooks.onMessage
+                                           .fold(stream)(stream.via(_))
+                                           .runForeachChunk(o => output.offerAll(o.map(Right(_))))
+                                           .catchAll(e => output.offer(Right(handler.error(id, e))))
+                                           .ensuring(subscriptions.cleanupIfMine(key, p))
+                                           .fork
+                                           .interruptible
+                                           .unit
+                                       }
 
                                      case None => output.offer(Right(connectionError))
                                    }
@@ -268,7 +300,7 @@ object Protocol {
                                  case GraphQLWSInput(Ops.Stop, Some(id), _)           =>
                                    subscriptions.untrack(id)
                                  case GraphQLWSInput(Ops.ConnectionTerminate, _, _)   =>
-                                   ZIO.interrupt
+                                   output.shutdown *> ZIO.interrupt
                                  case _                                               =>
                                    ZIO.unit
                                }.interruptible
@@ -291,6 +323,15 @@ object Protocol {
     private val connectionError: GraphQLWSOutput                               = GraphQLWSOutput(Ops.ConnectionError, None, None)
     private def connectionAck(payload: Option[ResponseValue]): GraphQLWSOutput =
       GraphQLWSOutput(Ops.ConnectionAck, None, payload)
+
+    private def connectionErrorFrom(cause: zio.Cause[Any]): GraphQLWSOutput =
+      cause.failureOption.fold(connectionError) { e =>
+        val v = e match {
+          case ce: CalibanError => ce.toResponseValue
+          case other            => StringValue(other.toString)
+        }
+        GraphQLWSOutput(Ops.ConnectionError, None, Some(ResponseValue.ListValue(List(v))))
+      }
   }
 
   private trait ResponseHandler {
@@ -314,7 +355,7 @@ object Protocol {
       payload: GraphQLRequest,
       id: String,
       interpreter: GraphQLInterpreter[R, E],
-      subscriptions: SubscriptionManager
+      interruptPromise: Promise[Any, Unit]
     ): ZStream[R, E, GraphQLWSOutput] = {
       val resp =
         ZStream
@@ -322,9 +363,7 @@ object Protocol {
           .flatMap(res =>
             res.data match {
               case ObjectValue((fieldName, StreamValue(stream)) :: Nil) =>
-                subscriptions.track(id).flatMap { p =>
-                  stream.map(self.toResponse(id, fieldName, _, res.errors)).interruptWhen(p)
-                }
+                stream.map(self.toResponse(id, fieldName, _, res.errors)).interruptWhen(interruptPromise)
               case other                                                =>
                 ZStream.succeed(self.toResponse(id, GraphQLResponse(other, res.errors)))
             }
@@ -335,8 +374,24 @@ object Protocol {
   }
 
   private class SubscriptionManager private (private val tracked: TMap[String, Promise[Any, Unit]]) {
-    def track(id: String): UStream[Promise[Any, Unit]] =
-      ZStream.fromZIO(Promise.make[Any, Unit].tap(tracked.put(id, _).commit))
+
+    def reserve(id: String): UIO[Option[Promise[Any, Unit]]] =
+      Promise.make[Any, Unit].flatMap { p =>
+        STM.atomically {
+          tracked.contains(id).flatMap {
+            case true  => STM.succeed(None)
+            case false => tracked.put(id, p).as(Some(p))
+          }
+        }
+      }
+
+    def trackForce(id: String): UIO[Promise[Any, Unit]] =
+      Promise.make[Any, Unit].flatMap { p =>
+        STM.atomically(tracked.get(id) <* tracked.put(id, p)).flatMap {
+          case Some(prev) => prev.succeed(()).as(p)
+          case None       => ZIO.succeed(p)
+        }
+      }
 
     def untrack(id: String): UIO[Unit] =
       (tracked.get(id) <* tracked.delete(id)).commit.flatMap {
@@ -344,10 +399,16 @@ object Protocol {
         case Some(p) => p.succeed(()).unit
       }
 
+    def cleanupIfMine(id: String, ours: Promise[Any, Unit]): UIO[Unit] =
+      STM.atomically {
+        tracked.get(id).flatMap {
+          case Some(curr) if curr eq ours => tracked.delete(id)
+          case _                          => STM.unit
+        }
+      }
+
     def untrackAll: UIO[Unit] =
       tracked.keys.map(ids => ZIO.foreachDiscard(ids)(untrack)).commit.flatten
-
-    def isTracking(id: String): UIO[Boolean] = tracked.contains(id).commit
   }
 
   private object SubscriptionManager {

--- a/core/src/main/scala/caliban/ws/Protocol.scala
+++ b/core/src/main/scala/caliban/ws/Protocol.scala
@@ -138,23 +138,20 @@ object Protocol {
 
                                  val continue = request match {
                                    case Some(req) =>
-                                     subscriptions.reserve(id).flatMap {
-                                       case None    =>
-                                         output
-                                           .offer(Left(GraphQLWSClose(4409, s"Subscriber for $id already exists")))
-                                           .unit
-                                       case Some(p) =>
-                                         val stream = handler.generateGraphQLResponse(req, id, interpreter, p)
+                                     ZIO.ifZIO(subscriptions.isTracking(id))(
+                                       output.offer(Left(GraphQLWSClose(4409, s"Subscriber for $id already exists"))).unit,
+                                       subscriptions.track(id).runDrain *> {
+                                         val stream = handler.generateGraphQLResponse(req, id, interpreter, subscriptions)
                                          webSocketHooks.onMessage
                                            .fold(stream)(stream.via(_))
                                            .map(Right(_))
                                            .runForeachChunk(output.offerAll)
                                            .catchAll(e => output.offer(Right(handler.error(Some(id), e))))
-                                           .ensuring(subscriptions.cleanupIfMine(id, p))
                                            .fork
                                            .interruptible
                                            .unit
-                                     }
+                                       }
+                                     )
 
                                    case None =>
                                      generateId(None).flatMap(uuid => output.offer(Right(connectionError(uuid))))
@@ -279,19 +276,15 @@ object Protocol {
                                    }
                                    val continue = request match {
                                      case Some(req) =>
-                                       val key = id.getOrElse("")
-                                       subscriptions.trackForce(key).flatMap { p =>
-                                         val stream =
-                                           handler.generateGraphQLResponse(req, key, interpreter, p)
-                                         webSocketHooks.onMessage
-                                           .fold(stream)(stream.via(_))
-                                           .runForeachChunk(o => output.offerAll(o.map(Right(_))))
-                                           .catchAll(e => output.offer(Right(handler.error(id, e))))
-                                           .ensuring(subscriptions.cleanupIfMine(key, p))
-                                           .fork
-                                           .interruptible
-                                           .unit
-                                       }
+                                       val key    = id.getOrElse("")
+                                       val stream = handler.generateGraphQLResponse(req, key, interpreter, subscriptions)
+                                       webSocketHooks.onMessage
+                                         .fold(stream)(stream.via(_))
+                                         .runForeachChunk(o => output.offerAll(o.map(Right(_))))
+                                         .catchAll(e => output.offer(Right(handler.error(id, e))))
+                                         .fork
+                                         .interruptible
+                                         .unit
 
                                      case None => output.offer(Right(connectionError))
                                    }
@@ -355,7 +348,7 @@ object Protocol {
       payload: GraphQLRequest,
       id: String,
       interpreter: GraphQLInterpreter[R, E],
-      interruptPromise: Promise[Any, Unit]
+      subscriptions: SubscriptionManager
     ): ZStream[R, E, GraphQLWSOutput] = {
       val resp =
         ZStream
@@ -363,7 +356,9 @@ object Protocol {
           .flatMap(res =>
             res.data match {
               case ObjectValue((fieldName, StreamValue(stream)) :: Nil) =>
-                stream.map(self.toResponse(id, fieldName, _, res.errors)).interruptWhen(interruptPromise)
+                subscriptions.track(id).flatMap { p =>
+                  stream.map(self.toResponse(id, fieldName, _, res.errors)).interruptWhen(p)
+                }
               case other                                                =>
                 ZStream.succeed(self.toResponse(id, GraphQLResponse(other, res.errors)))
             }
@@ -374,37 +369,24 @@ object Protocol {
   }
 
   private class SubscriptionManager private (private val tracked: TMap[String, Promise[Any, Unit]]) {
-
-    def reserve(id: String): UIO[Option[Promise[Any, Unit]]] =
-      Promise.make[Any, Unit].flatMap { p =>
-        STM.atomically {
-          tracked.contains(id).flatMap {
-            case true  => STM.succeed(None)
-            case false => tracked.put(id, p).as(Some(p))
+    def track(id: String): UStream[Promise[Any, Unit]] =
+      ZStream.fromZIO {
+        Promise.make[Any, Unit].flatMap { fresh =>
+          STM.atomically {
+            tracked.get(id).flatMap {
+              case Some(existing) => STM.succeed(existing)
+              case None           => tracked.put(id, fresh).as(fresh)
+            }
           }
         }
       }
 
-    def trackForce(id: String): UIO[Promise[Any, Unit]] =
-      Promise.make[Any, Unit].flatMap { p =>
-        STM.atomically(tracked.get(id) <* tracked.put(id, p)).flatMap {
-          case Some(prev) => prev.succeed(()).as(p)
-          case None       => ZIO.succeed(p)
-        }
-      }
+    def isTracking(id: String): UIO[Boolean] = tracked.contains(id).commit
 
     def untrack(id: String): UIO[Unit] =
       (tracked.get(id) <* tracked.delete(id)).commit.flatMap {
         case None    => ZIO.unit
         case Some(p) => p.succeed(()).unit
-      }
-
-    def cleanupIfMine(id: String, ours: Promise[Any, Unit]): UIO[Unit] =
-      STM.atomically {
-        tracked.get(id).flatMap {
-          case Some(curr) if curr eq ours => tracked.delete(id)
-          case _                          => STM.unit
-        }
       }
 
     def untrackAll: UIO[Unit] =

--- a/core/src/main/scala/caliban/ws/Protocol.scala
+++ b/core/src/main/scala/caliban/ws/Protocol.scala
@@ -147,6 +147,7 @@ object Protocol {
                                            .map(Right(_))
                                            .runForeachChunk(output.offerAll)
                                            .catchAll(e => output.offer(Right(handler.error(Some(id), e))))
+                                           .ensuring(subscriptions.untrack(id))
                                            .fork
                                            .interruptible
                                            .unit
@@ -371,13 +372,17 @@ object Protocol {
   private class SubscriptionManager private (private val tracked: TMap[String, Promise[Any, Unit]]) {
     def track(id: String): UStream[Promise[Any, Unit]] =
       ZStream.fromZIO {
-        Promise.make[Any, Unit].flatMap { fresh =>
-          STM.atomically {
-            tracked.get(id).flatMap {
-              case Some(existing) => STM.succeed(existing)
-              case None           => tracked.put(id, fresh).as(fresh)
+        tracked.get(id).commit.flatMap {
+          case Some(existing) => ZIO.succeed(existing)
+          case None           =>
+            Promise.make[Any, Unit].flatMap { fresh =>
+              STM.atomically {
+                tracked.get(id).flatMap {
+                  case Some(existing) => STM.succeed(existing)
+                  case None           => tracked.put(id, fresh).as(fresh)
+                }
+              }
             }
-          }
         }
       }
 

--- a/core/src/main/scala/caliban/ws/Protocol.scala
+++ b/core/src/main/scala/caliban/ws/Protocol.scala
@@ -277,15 +277,18 @@ object Protocol {
                                    }
                                    val continue = request match {
                                      case Some(req) =>
-                                       val key    = id.getOrElse("")
-                                       val stream = handler.generateGraphQLResponse(req, key, interpreter, subscriptions)
-                                       webSocketHooks.onMessage
-                                         .fold(stream)(stream.via(_))
-                                         .runForeachChunk(o => output.offerAll(o.map(Right(_))))
-                                         .catchAll(e => output.offer(Right(handler.error(id, e))))
-                                         .fork
-                                         .interruptible
-                                         .unit
+                                       val key = id.getOrElse("")
+                                       subscriptions.track(key).runDrain *> {
+                                         val stream = handler.generateGraphQLResponse(req, key, interpreter, subscriptions)
+                                         webSocketHooks.onMessage
+                                           .fold(stream)(stream.via(_))
+                                           .runForeachChunk(o => output.offerAll(o.map(Right(_))))
+                                           .catchAll(e => output.offer(Right(handler.error(id, e))))
+                                           .ensuring(subscriptions.untrack(key))
+                                           .fork
+                                           .interruptible
+                                           .unit
+                                       }
 
                                      case None => output.offer(Right(connectionError))
                                    }
@@ -357,8 +360,9 @@ object Protocol {
           .flatMap(res =>
             res.data match {
               case ObjectValue((fieldName, StreamValue(stream)) :: Nil) =>
-                subscriptions.track(id).flatMap { p =>
-                  stream.map(self.toResponse(id, fieldName, _, res.errors)).interruptWhen(p)
+                ZStream.fromZIO(subscriptions.trackedPromise(id)).flatMap {
+                  case Some(p) => stream.map(self.toResponse(id, fieldName, _, res.errors)).interruptWhen(p)
+                  case None    => ZStream.empty
                 }
               case other                                                =>
                 ZStream.succeed(self.toResponse(id, GraphQLResponse(other, res.errors)))
@@ -385,6 +389,8 @@ object Protocol {
             }
         }
       }
+
+    def trackedPromise(id: String): UIO[Option[Promise[Any, Unit]]] = tracked.get(id).commit
 
     def isTracking(id: String): UIO[Boolean] = tracked.contains(id).commit
 

--- a/core/src/test/scala/caliban/ws/ProtocolSpec.scala
+++ b/core/src/test/scala/caliban/ws/ProtocolSpec.scala
@@ -1,0 +1,202 @@
+package caliban.ws
+
+import caliban._
+import caliban.schema.Schema.auto._
+import zio._
+import zio.stream.ZStream
+import zio.test._
+
+object ProtocolSpec extends ZIOSpecDefault {
+
+  private case class Query(secret: String)
+  private case class Subscriptions(loop: ZStream[Any, Nothing, Int])
+
+  private val api         = graphQL(
+    RootResolver(Some(Query("TOP_SECRET")), Option.empty[Unit], Some(Subscriptions(ZStream.never)))
+  )
+  private val interpreter = api.interpreterUnsafe
+
+  private val rejectAll: WebSocketHooks[Any, CalibanError] =
+    WebSocketHooks.init[Any, CalibanError](_ => ZIO.fail(CalibanError.ExecutionError("auth required")))
+
+  private val partialFnHook: WebSocketHooks[Any, CalibanError] =
+    WebSocketHooks.init[Any, CalibanError] { v =>
+      (v: @unchecked) match { case InputValue.ObjectValue(_) => ZIO.unit }
+    }
+
+  private val initNoPayload = ZStream(GraphQLWSInput("connection_init", None, None))
+  private val subscribeMsg  =
+    GraphQLWSInput(
+      "subscribe",
+      Some("1"),
+      Some(InputValue.ObjectValue(Map("query" -> Value.StringValue("{ secret }"))))
+    )
+  private val startMsg      =
+    GraphQLWSInput("start", Some("1"), Some(InputValue.ObjectValue(Map("query" -> Value.StringValue("{ secret }")))))
+
+  override def spec = suite("ProtocolSpec")(
+    suite("GraphQLWS (graphql-transport-ws)")(
+      test("beforeInit is invoked with NullValue when connection_init has no payload") {
+        for {
+          called <- Ref.make(Option.empty[InputValue])
+          hooks   = WebSocketHooks.init[Any, CalibanError](v => called.set(Some(v)))
+          pipe   <- Protocol.GraphQLWS.make(interpreter, None, hooks)
+          _      <- pipe(initNoPayload).take(1).runDrain
+          seen   <- called.get
+        } yield assertTrue(seen.contains(Value.NullValue))
+      },
+      test("beforeInit receives the original payload when one is provided") {
+        for {
+          called <- Ref.make(Option.empty[InputValue])
+          hooks   = WebSocketHooks.init[Any, CalibanError](v => called.set(Some(v)))
+          payload = InputValue.ObjectValue(Map("token" -> Value.StringValue("abc")))
+          pipe   <- Protocol.GraphQLWS.make(interpreter, None, hooks)
+          _      <- pipe(ZStream(GraphQLWSInput("connection_init", None, Some(payload)))).take(1).runDrain
+          seen   <- called.get
+        } yield assertTrue(seen.contains(payload))
+      },
+      test("beforeInit rejection: 4403 close is the only frame and ack stays false (subscribe gets 4401)") {
+        for {
+          pipe <- Protocol.GraphQLWS.make(interpreter, None, rejectAll)
+          out  <- pipe(ZStream(GraphQLWSInput("connection_init", None, None), subscribeMsg)).take(2).runCollect
+        } yield assertTrue(
+          out == Chunk(
+            Left(GraphQLWSClose(4403, "Forbidden")),
+            Left(GraphQLWSClose(4401, "Unauthorized"))
+          )
+        )
+      },
+      test("beforeInit defect (MatchError on NullValue) is recovered as 4403 close, not a silent fiber death") {
+        for {
+          pipe <- Protocol.GraphQLWS.make(interpreter, None, partialFnHook)
+          out  <- pipe(ZStream(GraphQLWSInput("connection_init", None, None), subscribeMsg)).take(2).runCollect
+        } yield assertTrue(
+          out == Chunk(
+            Left(GraphQLWSClose(4403, "Forbidden")),
+            Left(GraphQLWSClose(4401, "Unauthorized"))
+          )
+        )
+      },
+      test("duplicate subscribe with the same id is rejected with 4409 (issue #2973)") {
+        val dup = GraphQLWSInput(
+          "subscribe",
+          Some("dup"),
+          Some(InputValue.ObjectValue(Map("query" -> Value.StringValue("subscription { loop }"))))
+        )
+        for {
+          pipe <- Protocol.GraphQLWS.make(interpreter, None, WebSocketHooks.empty[Any, CalibanError])
+          out  <- pipe(ZStream(GraphQLWSInput("connection_init", None, None), dup, dup)).collect { case Left(close) =>
+                    close
+                  }
+                    .take(1)
+                    .runHead
+        } yield assertTrue(out.contains(GraphQLWSClose(4409, "Subscriber for dup already exists")))
+      },
+      test("duplicate connection_init after a successful one is rejected with 4429") {
+        for {
+          pipe <- Protocol.GraphQLWS.make(interpreter, None, WebSocketHooks.empty[Any, CalibanError])
+          out  <- pipe(
+                    ZStream(
+                      GraphQLWSInput("connection_init", None, None),
+                      GraphQLWSInput("connection_init", None, None)
+                    )
+                  ).collect { case Left(close) => close }.take(1).runHead
+        } yield assertTrue(out.contains(GraphQLWSClose(4429, "Too many initialisation requests")))
+      },
+      test("composed beforeInit hooks (++) both run with NullValue on payload-less init") {
+        for {
+          calls <- Ref.make(List.empty[String])
+          h1     = WebSocketHooks.init[Any, CalibanError](_ => calls.update("h1" :: _))
+          h2     = WebSocketHooks.init[Any, CalibanError](_ => calls.update("h2" :: _))
+          pipe  <- Protocol.GraphQLWS.make(interpreter, None, h1 ++ h2)
+          _     <- pipe(initNoPayload).take(1).runDrain
+          seen  <- calls.get
+        } yield assertTrue(seen.toSet == Set("h1", "h2"))
+      }
+    ),
+    suite("Legacy (graphql-ws)")(
+      test("beforeInit is invoked with NullValue when connection_init has no payload") {
+        for {
+          called <- Ref.make(Option.empty[InputValue])
+          hooks   = WebSocketHooks.init[Any, CalibanError](v => called.set(Some(v)))
+          pipe   <- Protocol.Legacy.make(interpreter, None, hooks)
+          _      <- pipe(initNoPayload).take(1).runDrain
+          seen   <- called.get
+        } yield assertTrue(seen.contains(Value.NullValue))
+      },
+      test("beforeInit rejection emits a connection_error frame (with payload) and ack stays false (start gets 4401)") {
+        for {
+          pipe <- Protocol.Legacy.make(interpreter, None, rejectAll)
+          out  <- pipe(ZStream(GraphQLWSInput("connection_init", None, None), startMsg)).take(2).runCollect
+        } yield assertTrue(
+          out.size == 2,
+          out(0) match {
+            case Right(GraphQLWSOutput("connection_error", None, Some(_))) => true
+            case _                                                         => false
+          },
+          out(1) == Left(GraphQLWSClose(4401, "Unauthorized"))
+        )
+      },
+      test("beforeInit defect emits a connection_error frame and ack stays false") {
+        for {
+          pipe <- Protocol.Legacy.make(interpreter, None, partialFnHook)
+          out  <- pipe(ZStream(GraphQLWSInput("connection_init", None, None), startMsg)).take(2).runCollect
+        } yield assertTrue(
+          out.size == 2,
+          out(0) == Right(GraphQLWSOutput("connection_error", None, None)),
+          out(1) == Left(GraphQLWSClose(4401, "Unauthorized"))
+        )
+      },
+      test("duplicate connection_init after a successful one emits a connection_error frame") {
+        for {
+          pipe <- Protocol.Legacy.make(interpreter, None, WebSocketHooks.empty[Any, CalibanError])
+          out  <- pipe(
+                    ZStream(
+                      GraphQLWSInput("connection_init", None, None),
+                      GraphQLWSInput("connection_init", None, None)
+                    )
+                  ).take(2).runCollect
+        } yield assertTrue(
+          out.size == 2,
+          out(0) match {
+            case Right(GraphQLWSOutput("connection_ack", _, _)) => true
+            case _                                              => false
+          },
+          out(1) == Right(GraphQLWSOutput("connection_error", None, None))
+        )
+      },
+      test(
+        "two starts with same id then stop: trackForce interrupts the previous, cleanupIfMine doesn't clobber the live one"
+      ) {
+        val start = GraphQLWSInput(
+          "start",
+          Some("s"),
+          Some(InputValue.ObjectValue(Map("query" -> Value.StringValue("subscription { loop }"))))
+        )
+        for {
+          pipe <- Protocol.Legacy.make(interpreter, None, WebSocketHooks.empty[Any, CalibanError])
+          _    <- pipe(
+                    ZStream(
+                      GraphQLWSInput("connection_init", None, None),
+                      start,
+                      start,
+                      GraphQLWSInput("stop", Some("s"), None),
+                      GraphQLWSInput("connection_terminate", None, None)
+                    )
+                  ).runDrain.timeoutFail(new RuntimeException("output did not terminate"))(5.seconds)
+        } yield assertCompletes
+      },
+      test("connection_terminate shuts down the output stream so the WS closes (issue #2974)") {
+        for {
+          pipe <- Protocol.Legacy.make(interpreter, None, WebSocketHooks.empty[Any, CalibanError])
+          _    <- pipe(
+                    ZStream(
+                      GraphQLWSInput("connection_init", None, None),
+                      GraphQLWSInput("connection_terminate", None, None)
+                    )
+                  ).runDrain.timeoutFail(new RuntimeException("output stream did not terminate"))(5.seconds)
+        } yield assertCompletes
+      }
+    )
+  )
+}

--- a/core/src/test/scala/caliban/ws/ProtocolSpec.scala
+++ b/core/src/test/scala/caliban/ws/ProtocolSpec.scala
@@ -165,9 +165,7 @@ object ProtocolSpec extends ZIOSpecDefault {
           out(1) == Right(GraphQLWSOutput("connection_error", None, None))
         )
       },
-      test(
-        "two starts with same id then stop: trackForce interrupts the previous, cleanupIfMine doesn't clobber the live one"
-      ) {
+      test("two starts with same id, then stop then terminate, completes without hanging") {
         val start = GraphQLWSInput(
           "start",
           Some("s"),


### PR DESCRIPTION
Closes #2973
Closes #2974

Fixed various issues with the WebSocket protocols:
  - **Auth bypass via missing payload in `connection_init`** — `WebSocketHooks.beforeInit` was silently skipped when the client omitted the `payload` field. The hook is now invoked unconditionally with `Value.NullValue` for an absent payload, including for composed (`++`) hooks.
  - **Rejection didn't actually reject** — a failing `beforeInit` had its error swallowed by `.orElse` / `.catchAll`, so `ack=true` was still set, `connection_ack` was emitted, and `keepalive`/`afterInit` fibers still spawned. Rejection now short-circuits via `ZIO.whenZIO(before)(response *> ka *> after)`.
  - **Defects in a user hook killed the connection silently** — a `MatchError` from a partial-function hook on `NullValue` was caught by neither layer of `.orElse`. `foldCauseZIO + suspendSucceed` now catch it as a clean 4403 (transport-ws) / `connection_error` (legacy).
  - **Cancellation masked by `foldCauseZIO`** — re-raise via `cause.stripFailures` when `isInterruptedOnly`, so scope cancellation during a slow `beforeInit` propagates instead of being reported as a 4403/connection_error.
  - **Subscribe race (#2973)** — `isTracking` and `track` were not atomic. Made `SubscriptionManager.track` a single-STM-transaction get-or-create and invoke `track.runDrain` synchronously in the `Subscribe` handler before forking, so the second subscribe's `isTracking` deterministically sees the first. Duplicate ids are now rejected with 4409.
  - **Legacy `connection_terminate` didn't close the WS (#2974)** — handler now does `output.shutdown *> ZIO.interrupt` so the queue-backed stream actually ends.
  - **Duplicate `connection_init`** — graphql-transport-ws now closes with `4429 "Too many initialisation requests"` per spec; legacy emits a `connection_error` frame (was previously silently re-acked with a leaked `ka`/`afterInit` fiber).
  - **Legacy `beforeInit` failures emitted unkeyed `error` frames** — Apollo-style clients drop unkeyed errors. Switched to `connection_error` (with the error payload for typed failures, empty for defects).
  - **Quick adapter left WS half-open after the pipe stream ended** — `.ensuring(ch.shutdown)` on the outbound `runForeach`, so the channel is torn down when the protocol stream completes (e.g. after legacy terminate).