### PR TITLE
Fix FragmentValidator cache and optimize FieldMap

### DIFF
--- a/benchmarks/src/main/scala/caliban/validation/FragmentValidatorBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/validation/FragmentValidatorBenchmark.scala
@@ -1,0 +1,164 @@
+package caliban.validation
+
+import caliban._
+import caliban.parsing.Parser
+import caliban.schema.RootType
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+class FragmentValidatorBenchmark {
+  import FragmentValidatorBenchmark._
+
+  @Benchmark
+  def fragmentConflicts(): Any =
+    run(Validator.validateAll(parsedQuery, rootType))
+}
+
+object FragmentValidatorBenchmark {
+  import caliban.schema.Schema.auto._
+  import caliban.schema.ArgBuilder.auto._
+
+  def run[A](either: Either[Throwable, A]): A = either.fold(throw _, identity)
+
+  case class Owner(name: String, age: Int, address: String)
+
+  sealed trait Pet
+
+  sealed trait DogCommand
+  case object DOG_SIT  extends DogCommand
+  case object DOG_DOWN extends DogCommand
+  case object DOG_HEEL extends DogCommand
+
+  sealed trait CatCommand
+  case object CAT_JUMP extends CatCommand
+  case object CAT_PURR extends CatCommand
+
+  case class Dog(
+    name: String,
+    nickname: Option[String],
+    barkVolume: Int,
+    doesKnowCommand: DogCommand => Boolean,
+    owner: Option[Owner]
+  ) extends Pet
+
+  case class Cat(
+    name: String,
+    nickname: Option[String],
+    meowVolume: Int,
+    doesKnowCommand: CatCommand => Boolean,
+    owner: Option[Owner]
+  ) extends Pet
+
+  case class Bird(
+    name: String,
+    nickname: Option[String],
+    wingspan: Int,
+    owner: Option[Owner]
+  ) extends Pet
+
+  case class Fish(
+    name: String,
+    nickname: Option[String],
+    waterType: String,
+    owner: Option[Owner]
+  ) extends Pet
+
+  case class Query(pet: Pet, pets: List[Pet])
+
+  val api: GraphQL[Any] =
+    graphQL(RootResolver(Query(Dog("Rex", Some("Rexie"), 5, _ => true, None), Nil)))
+
+  val rootType: RootType =
+    run(api.validateRootSchema.map { schema =>
+      RootType(
+        schema.query.opType,
+        schema.mutation.map(_.opType),
+        schema.subscription.map(_.opType)
+      )
+    })
+
+  // Query designed to stress the shape/parents/groups caches inside
+  // FragmentValidator.findConflictsWithinSelectionSet:
+  //  - Many inline fragments on a union type (Pet) drive groupByCommonParents
+  //    and produce repeated `Set[SelectedField]` shapes (groupsCache hits).
+  //  - The same named fragments are spread at multiple nesting levels, so the
+  //    same selection-set hashes recur (shapeCache + parentsCache hits).
+  //  - Several spreads of the same fragment in a single selection multiply the
+  //    number of recursive calls without introducing new selection shapes.
+  val query: String = {
+    val petSpreads = ("...PetDetails\n" + "...PetOwner\n") * 4
+    s"""
+       |fragment OwnerDetails on Owner {
+       |  name
+       |  age
+       |  address
+       |}
+       |
+       |fragment PetDetails on Pet {
+       |  ... on Dog {
+       |    name
+       |    nickname
+       |    barkVolume
+       |    doesKnowCommand(value: DOG_SIT)
+       |    owner { ...OwnerDetails }
+       |  }
+       |  ... on Cat {
+       |    name
+       |    nickname
+       |    meowVolume
+       |    doesKnowCommand(value: CAT_JUMP)
+       |    owner { ...OwnerDetails }
+       |  }
+       |  ... on Bird {
+       |    name
+       |    nickname
+       |    wingspan
+       |    owner { ...OwnerDetails }
+       |  }
+       |  ... on Fish {
+       |    name
+       |    nickname
+       |    waterType
+       |    owner { ...OwnerDetails }
+       |  }
+       |}
+       |
+       |fragment PetOwner on Pet {
+       |  ... on Dog {
+       |    name
+       |    owner { ...OwnerDetails }
+       |  }
+       |  ... on Cat {
+       |    name
+       |    owner { ...OwnerDetails }
+       |  }
+       |  ... on Bird {
+       |    name
+       |    owner { ...OwnerDetails }
+       |  }
+       |  ... on Fish {
+       |    name
+       |    owner { ...OwnerDetails }
+       |  }
+       |}
+       |
+       |query {
+       |  pet {
+       |    $petSpreads
+       |  }
+       |  pets {
+       |    $petSpreads
+       |  }
+       |}
+       |""".stripMargin
+  }
+
+  val parsedQuery = run(Parser.parseQuery(query))
+}

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -3,11 +3,17 @@ package caliban.validation
 import caliban.introspection.adt._
 import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
 import caliban.parsing.adt._
-import Utils._
+import caliban.syntax._
+import caliban.validation.Utils._
 
-object FieldMap {
+import scala.collection.compat._
+import scala.collection.mutable
+
+private[caliban] object FieldMap {
+  @deprecated("Kept for bin-compatibility only", "3.1.3")
   val empty: FieldMap = Map.empty
 
+  @deprecated("Kept for bin-compatibility only", "3.1.3")
   implicit class FieldMapOps(val self: FieldMap) extends AnyVal {
     def |+|(that: FieldMap): FieldMap = {
       val mb = Map.newBuilder[String, Set[SelectedField]]
@@ -46,22 +52,58 @@ object FieldMap {
     }
   }
 
+  private type FM = mutable.HashMap[String, Set[SelectedField]]
+
+  @deprecated("Kept for bin-compatibility only", "3.1.3")
   def apply(context: Context, parentType: __Type, selectionSet: Iterable[Selection]): FieldMap =
-    selectionSet.foldLeft(FieldMap.empty) { case (fields, selection) =>
-      selection match {
-        case FragmentSpread(name, _)                        =>
-          context.fragments
-            .get(name)
-            .map { definition =>
-              val typ = getType(Some(definition.typeCondition), parentType, context)
-              apply(context, typ, definition.selectionSet) |+| fields
-            }
-            .getOrElse(fields)
+    make(context, parentType, selectionSet).toMap
+
+  def make(
+    context: Context,
+    parentType: __Type,
+    selectionSet: Iterable[Selection]
+  ): collection.Map[String, Set[SelectedField]] = {
+    val fields: FM = mutable.HashMap.empty
+    loop(context, parentType, selectionSet)(fields)
+    fields
+  }
+
+  private def loop(
+    context: Context,
+    parentType: __Type,
+    selectionSet: Iterable[Selection]
+  )(implicit fields: FM): Unit = {
+    val it = selectionSet.iterator
+    while (it.hasNext)
+      it.next() match {
         case f: Field                                       =>
-          fields.addField(f, parentType, f)
+          addField(f, parentType)
+        case FragmentSpread(name, _)                        =>
+          context.fragments.getOrElseNull(name) match {
+            case null       => ()
+            case definition =>
+              val typ = getType(Some(definition.typeCondition), parentType, context)
+              loop(context, typ, definition.selectionSet)
+          }
         case InlineFragment(typeCondition, _, selectionSet) =>
           val typ = getType(typeCondition, parentType, context)
-          apply(context, typ, selectionSet) |+| fields
+          loop(context, typ, selectionSet)
       }
+  }
+
+  private def addField(
+    f: Field,
+    parentType: __Type
+  )(implicit self: FM): Unit =
+    parentType.getFieldOrNull(f.name) match {
+      case null => ()
+      case f1   =>
+        val responseName = f.alias.getOrElse(f.name)
+        val sf           = SelectedField(parentType, f, f1)
+        self.updateWith(responseName) {
+          case Some(s) => Some(s + sf)
+          case _       => Some(Set.empty + sf)
+        }
     }
+
 }

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -28,7 +28,7 @@ object FragmentValidator {
             Chunk.fromIterable(fields.flatMap { case (name, values) =>
               cross(values, includeIdentity = true).flatMap { case (f1, f2) =>
                 if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type)) {
-                  Chunk(
+                  Chunk.single(
                     s"$name has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
                         .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
                   )
@@ -86,9 +86,7 @@ object FragmentValidator {
     def groupByCommonParents(fields: Set[SelectedField]): Chunk[Set[SelectedField]] =
       groupsCache.getOrElseUpdate(
         fields, {
-          val abstractGroup = fields.collect {
-            case field if !isConcrete(field.parentType) => field
-          }
+          val abstractGroup = fields.filter(field => isAbstract(field.parentType))
 
           val concreteGroups =
             mutable.HashMap.empty[String, mutable.Builder[SelectedField, Set[SelectedField]]]
@@ -103,7 +101,7 @@ object FragmentValidator {
             case _ => ()
           }
 
-          if (concreteGroups.isEmpty) Chunk(fields)
+          if (concreteGroups.isEmpty) Chunk.single(fields)
           else Chunk.fromIterable(concreteGroups.values.map(_.result()))
         }
       )

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -7,7 +7,6 @@ import caliban.validation.Utils._
 import zio.Chunk
 
 import scala.collection.mutable
-import scala.util.hashing.MurmurHash3
 
 object FragmentValidator {
   def findConflictsWithinSelectionSet(
@@ -16,49 +15,44 @@ object FragmentValidator {
     selectionSet: List[Selection]
   ): Either[ValidationError, Unit] = {
 
-    // NOTE: We use the `hashCode()` as the key since it's much more performant
-    val shapeCache   = mutable.Map.empty[Int, Chunk[String]]
-    val parentsCache = mutable.Map.empty[Int, Chunk[String]]
-    val groupsCache  = mutable.Map.empty[Int, Chunk[Set[SelectedField]]]
+    val shapeCache   = mutable.HashMap.empty[List[Selection], Chunk[String]]
+    val parentsCache = mutable.HashMap.empty[Iterable[Selection], Chunk[String]]
+    val groupsCache  = mutable.HashMap.empty[Set[SelectedField], Chunk[Set[SelectedField]]]
 
-    def sameResponseShapeByName(set: Iterable[Selection], parentType: __Type): Chunk[String] = {
-      val keyHash = MurmurHash3.unorderedHash(set)
-      shapeCache.get(keyHash) match {
-        case Some(value) => value
-        case None        =>
-          val fields = FieldMap(context, parentType, set)
-          val res    = Chunk.fromIterable(fields.flatMap { case (name, values) =>
-            cross(values, includeIdentity = true).flatMap { case (f1, f2) =>
-              if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type)) {
-                Chunk(
-                  s"$name has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
-                      .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
-                )
-              } else
-                sameResponseShapeByName(f1.selection.selectionSet ::: f2.selection.selectionSet, f1.fieldDef._type)
-            }
-          })
-          shapeCache.update(keyHash, res)
-          res
-      }
-    }
+    def sameResponseShapeByName(set: List[Selection], parentType: __Type): Chunk[String] =
+      if (set.isEmpty) Chunk.empty
+      else
+        shapeCache.getOrElseUpdate(
+          set, {
+            val fields = FieldMap.make(context, parentType, set)
+            Chunk.fromIterable(fields.flatMap { case (name, values) =>
+              cross(values, includeIdentity = true).flatMap { case (f1, f2) =>
+                if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type)) {
+                  Chunk(
+                    s"$name has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
+                        .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
+                  )
+                } else
+                  sameResponseShapeByName(f1.selection.selectionSet ::: f2.selection.selectionSet, f1.fieldDef._type)
+              }
+            })
+          }
+        )
 
-    def sameForCommonParentsByName(set: Iterable[Selection]): Chunk[String] = {
-      val keyHash = MurmurHash3.unorderedHash(set)
-      parentsCache.get(keyHash) match {
-        case Some(value) => value
-        case None        =>
-          val fields = FieldMap(context, parentType, set)
-          val res    = Chunk.fromIterable(fields.flatMap { case (_, fields) =>
-            groupByCommonParents(fields).flatMap { group =>
-              val merged = group.flatMap(_.selection.selectionSet)
-              requireSameNameAndArguments(group) ++ sameForCommonParentsByName(merged)
-            }
-          })
-          parentsCache.update(keyHash, res)
-          res
-      }
-    }
+    def sameForCommonParentsByName(set: Iterable[Selection]): Chunk[String] =
+      if (set.isEmpty) Chunk.empty
+      else
+        parentsCache.getOrElseUpdate(
+          set, {
+            val fields = FieldMap.make(context, parentType, set)
+            Chunk.fromIterable(fields.values.flatMap { fields =>
+              groupByCommonParents(fields).flatMap { group =>
+                val merged = group.flatMap(_.selection.selectionSet)
+                requireSameNameAndArguments(group) ++ sameForCommonParentsByName(merged)
+              }
+            })
+          }
+        )
 
     def doTypesConflict(t1: __Type, t2: __Type): Boolean =
       if (isNonNull(t1))
@@ -89,17 +83,15 @@ object FragmentValidator {
         else None
       }
 
-    def groupByCommonParents(fields: Set[SelectedField]): Chunk[Set[SelectedField]] = {
-      val keyHash = fields.hashCode()
-      groupsCache.get(keyHash) match {
-        case Some(value) => value
-        case None        =>
+    def groupByCommonParents(fields: Set[SelectedField]): Chunk[Set[SelectedField]] =
+      groupsCache.getOrElseUpdate(
+        fields, {
           val abstractGroup = fields.collect {
             case field if !isConcrete(field.parentType) => field
           }
 
           val concreteGroups =
-            mutable.Map.empty[String, mutable.Builder[SelectedField, Set[SelectedField]]]
+            mutable.HashMap.empty[String, mutable.Builder[SelectedField, Set[SelectedField]]]
 
           fields.foreach {
             case field @ SelectedField(
@@ -111,14 +103,10 @@ object FragmentValidator {
             case _ => ()
           }
 
-          val res =
-            if (concreteGroups.isEmpty) Chunk(fields)
-            else Chunk.fromIterable(concreteGroups.values.map(_.result()))
-
-          groupsCache.update(keyHash, res)
-          res
-      }
-    }
+          if (concreteGroups.isEmpty) Chunk(fields)
+          else Chunk.fromIterable(concreteGroups.values.map(_.result()))
+        }
+      )
 
     val conflicts = sameResponseShapeByName(selectionSet, parentType) ++ sameForCommonParentsByName(selectionSet)
     if (conflicts.nonEmpty) {


### PR DESCRIPTION
/fixes #2948

Also added a benchmark for this because our current benchmarks didn't stress the fragment validation cache at all. After adding the benchmark I realised that the `FieldMap` was extremely slow, primarily due to unnecessarily concatting sets. 

Since `FieldMap` was only being used internally (there's no need for users to call those methods) I deprecated all the public methods on it and made the object package-private (which is bin-compat). Whenever we're happy with breaking binary compatibility, we can remove all the deprecated methods.

With the new methods on `FieldMap` and some other minor optimization, fragment validation is ~4-5x faster based on the benchmark that I added