### PR TITLE
Cache commonly used `IntNumber`s

### DIFF
--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -7,8 +7,9 @@ import caliban.rendering.ValueRenderer
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import zio.stream.Stream
 
-import scala.collection.mutable
 import scala.collection.compat._
+import scala.collection.mutable
+import scala.runtime.AbstractFunction1
 import scala.util.control.NonFatal
 import scala.util.hashing.MurmurHash3
 
@@ -169,7 +170,7 @@ object Value {
         case NonFatal(_) => BigIntNumber(BigInt(s)) // Should never happen, but we leave it as a fallback
       }
 
-    object IntNumber {
+    object IntNumber extends AbstractFunction1[Int, IntNumber] {
       private final val MaxCachedInt = 1024
 
       private val cache = {

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -169,17 +169,35 @@ object Value {
         case NonFatal(_) => BigIntNumber(BigInt(s)) // Should never happen, but we leave it as a fallback
       }
 
+    object IntNumber {
+      private final val MaxCachedInt = 1024
+
+      private val cache = {
+        val arr = new Array[IntNumber](MaxCachedInt)
+        var i   = 0
+        while (i < MaxCachedInt) {
+          arr(i) = new IntNumber(i)
+          i += 1
+        }
+        arr
+      }
+
+      def apply(value: Int): IntNumber =
+        if (value >= 0 && value < MaxCachedInt) cache(value)
+        else new IntNumber(value)
+    }
+
     final case class IntNumber(value: Int)       extends IntValue with PathValue {
       override def toInt: Int       = value
       override def toLong: Long     = value.toLong
       override def toBigInt: BigInt = BigInt(value)
-      override def toString: String = value.toString
+      override def toString: String = String.valueOf(value)
     }
     final case class LongNumber(value: Long)     extends IntValue                {
       override def toInt: Int       = value.toInt
       override def toLong: Long     = value
       override def toBigInt: BigInt = BigInt(value)
-      override def toString: String = value.toString
+      override def toString: String = String.valueOf(value)
     }
     final case class BigIntNumber(value: BigInt) extends IntValue                {
       override def toInt: Int       = value.toInt
@@ -203,13 +221,13 @@ object Value {
       override def toFloat: Float           = value
       override def toDouble: Double         = value.toDouble
       override def toBigDecimal: BigDecimal = BigDecimal.decimal(value)
-      override def toString: String         = value.toString
+      override def toString: String         = String.valueOf(value)
     }
     final case class DoubleNumber(value: Double)         extends FloatValue {
       override def toFloat: Float           = value.toFloat
       override def toDouble: Double         = value
       override def toBigDecimal: BigDecimal = BigDecimal(value)
-      override def toString: String         = value.toString
+      override def toString: String         = String.valueOf(value)
     }
     final case class BigDecimalNumber(value: BigDecimal) extends FloatValue {
       override def toFloat: Float           = value.toFloat

--- a/core/src/test/scala/caliban/ValueSpec.scala
+++ b/core/src/test/scala/caliban/ValueSpec.scala
@@ -1,0 +1,32 @@
+package caliban
+
+import caliban.Value.BooleanValue
+import caliban.Value.IntValue.IntNumber
+import zio.test.{ assertCompletes, assertTrue, ZIOSpecDefault }
+
+object ValueSpec extends ZIOSpecDefault {
+
+  val spec = suite("ValueSpec")(
+    suite("IntNumber")(
+      test("uses cached instances for ints in the 0 <= x <= 1023 range") {
+        (0 to 1023).map { i =>
+          val x = IntNumber(i)
+          val y = IntNumber(i)
+          assertTrue(x eq y)
+        }.foldLeft(assertCompletes)(_ && _)
+      }
+    ),
+    suite("BooleaValue")(
+      test("uses cached instance for true") {
+        val x = BooleanValue(true)
+        val y = BooleanValue(true)
+        assertTrue(x eq y)
+      },
+      test("uses cached instance for false") {
+        val x = BooleanValue(false)
+        val y = BooleanValue(false)
+        assertTrue(x eq y)
+      }
+    )
+  )
+}


### PR DESCRIPTION
This is a trick used both for `java.lang.Integer` and `scala.math.BigInt`. For commonly used ints, we cache them so we reduce allocations during runtime.

While users might not use many `int`s in their schemas, the reason we want to do this is because `IntNumber` is created very frequently due to `PathValue` which is created for each array in the executor. Some other implementations (such as `java.lang.Integer` cache both negative and positive ints in that range, but I don't think it's necessary for us to do it since negative values are not as common (as they don't exist in the path)