### PR TITLE
Update `safeName` to not use `$` as suffix

### DIFF
--- a/codegen/src/main/scala/caliban/codegen/package.scala
+++ b/codegen/src/main/scala/caliban/codegen/package.scala
@@ -67,8 +67,8 @@ package object codegen {
   val doubleQuotes = "\""
 
   def safeName(name: String): String =
-    if (name == "_") "_$" // scala 3 does not allow a name of `_`
+    if (name == "_") "`__`" // scala 3 does not allow a name of `_`
     else if (reservedKeywords.contains(name) || name.endsWith("_")) s"`$name`"
-    else if (caseClassReservedFields.contains(name)) s"$name$$"
+    else if (caseClassReservedFields.contains(name)) s"${name}_"
     else name
 }

--- a/codegen/src/test/resources/snapshots/ClientWriterSpec/input object with reserved name.scala
+++ b/codegen/src/test/resources/snapshots/ClientWriterSpec/input object with reserved name.scala
@@ -3,11 +3,11 @@ import caliban.client.__Value._
 
 object Client {
 
-  final case class CharacterInput(wait$ : String)
+  final case class CharacterInput(wait_ : String)
   object CharacterInput {
     implicit val encoder: ArgEncoder[CharacterInput] = new ArgEncoder[CharacterInput] {
       override def encode(value: CharacterInput): __Value =
-        __ObjectValue(List("wait" -> implicitly[ArgEncoder[String]].encode(value.wait$)))
+        __ObjectValue(List("wait" -> implicitly[ArgEncoder[String]].encode(value.wait_)))
     }
   }
 

--- a/codegen/src/test/resources/snapshots/ClientWriterSpec/safe names with underscores.scala
+++ b/codegen/src/test/resources/snapshots/ClientWriterSpec/safe names with underscores.scala
@@ -5,7 +5,7 @@ object Client {
 
   type Character
   object Character {
-    def _$ : SelectionBuilder[Character, scala.Option[Boolean]]      =
+    def `__` : SelectionBuilder[Character, scala.Option[Boolean]]    =
       _root_.caliban.client.SelectionBuilder.Field("_", OptionOf(Scalar()))
     def `_name_` : SelectionBuilder[Character, scala.Option[String]] =
       _root_.caliban.client.SelectionBuilder.Field("_name_", OptionOf(Scalar()))

--- a/codegen/src/test/resources/snapshots/SchemaWriterSpec/final case class reserved field name used.scala
+++ b/codegen/src/test/resources/snapshots/SchemaWriterSpec/final case class reserved field name used.scala
@@ -1,5 +1,5 @@
 object Types {
 
-  final case class Character(wait$ : String)
+  final case class Character(wait_ : String)
 
 }


### PR DESCRIPTION
Fixes #2988 

Updates `def safeName` to not use `$` as a suffix when it encounters a reserved keyword.