### PR TITLE
Make Scala 3 lazy vals JDK26+ compatible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -770,6 +770,7 @@ lazy val commonSettings = Def.settings(
         "-Werror",
         "-explain-types",
         s"-${if (minor >= 5) "X" else "Y"}kind-projector",
+        if (minor == 3) "-Yfuture-lazy-vals" else "",
         "-no-indent"
       )
     case _                => Nil
@@ -782,7 +783,9 @@ lazy val enableMimaSettingsJVM =
   Def.settings(
     mimaFailOnProblem      := enforceMimaCompatibility,
     mimaPreviousArtifacts  := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet,
-    mimaBinaryIssueFilters := Seq()
+    mimaBinaryIssueFilters := Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.*.<clinit>")
+    )
   )
 
 lazy val enableMimaSettingsJS =

--- a/build.sbt
+++ b/build.sbt
@@ -535,7 +535,8 @@ lazy val clientNative = client.native
       "com.github.lolgab" %%% "scala-native-crypto" % "0.3.0",
       "io.github.cquiroz" %%% "scala-java-time"     % javaTimeVersion % Test
     ),
-    Test / fork := false
+    Test / fork := false,
+    scalacOptions -= "-Yfuture-lazy-vals" // Some reason SN doesn't like this, but it's only needed for JVM anyway
   )
 
 lazy val clientLaminext = crossProject(JSPlatform)
@@ -784,7 +785,8 @@ lazy val enableMimaSettingsJVM =
     mimaFailOnProblem      := enforceMimaCompatibility,
     mimaPreviousArtifacts  := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet,
     mimaBinaryIssueFilters := Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.*.<clinit>")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.*.<clinit>"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("mdg.engine.proto.reports.*.<clinit>")
     )
   )
 


### PR DESCRIPTION
Scala 3.3.x lazy vals emit warnings in JDK26, and will no longer work in upcoming JDK versions due to their usage of `sun.misc.Unsafe`.

In Scala 3.3.8 we can generate lazy vals that use `VarHandle`s instead when using the `-Yfuture-lazy-vals` flag with a `-release:{X >= 9}` (we use `-release:17` so we're OK)

Note that Mima is complaining after this change because lazy vals created a `<clinit>`, but it might not need a minor release for it (see [here](https://github.com/scala/scala3-lts/pull/637))