### PR TITLE
Fix compile-time client codegen on sbt 2 (use fgRunMain)

### DIFF
--- a/codegen-sbt/src/main/scala/caliban/codegen/sbt/CompileTimeCalibanPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/sbt/CompileTimeCalibanPlugin.scala
@@ -301,7 +301,6 @@ object CompileTimeCalibanClientPlugin extends AutoPlugin with CompileTimeCaliban
                                   Def
                                     .task[Set[File]](listGeneratedClientsFiles)
                                     .flatMapTask { beforeGenDirFiles =>
-                                      // `fgRunMain` (not `runMain`) so the generator runs synchronously: sbt 2's `runMain` returns before the forked run finishes, leaving the after-snapshot empty.
                                       (serverProject / fgRunMain)
                                         .toTask(s" $generatorRef $baseDirValue")
                                         .maybeTaskValue

--- a/codegen-sbt/src/main/scala/caliban/codegen/sbt/CompileTimeCalibanPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/sbt/CompileTimeCalibanPlugin.scala
@@ -301,14 +301,7 @@ object CompileTimeCalibanClientPlugin extends AutoPlugin with CompileTimeCaliban
                                   Def
                                     .task[Set[File]](listGeneratedClientsFiles)
                                     .flatMapTask { beforeGenDirFiles =>
-                                      // We use `fgRunMain` (foreground) rather than `runMain` on purpose. In sbt 1
-                                      // `runMain` blocks until the run completes, but in sbt 2 it was rewritten to be
-                                      // client-side/background-aware: under the server/client execution model it
-                                      // dispatches the run and returns before the forked generator has written its
-                                      // files, so the `afterGenDirFiles` snapshot below would run against an empty
-                                      // directory and the freshly generated client would be missing from the current
-                                      // compilation pass. `fgRunMain` runs the generator synchronously on both sbt
-                                      // versions.
+                                      // `fgRunMain` (not `runMain`) so the generator runs synchronously: sbt 2's `runMain` returns before the forked run finishes, leaving the after-snapshot empty.
                                       (serverProject / fgRunMain)
                                         .toTask(s" $generatorRef $baseDirValue")
                                         .maybeTaskValue

--- a/codegen-sbt/src/main/scala/caliban/codegen/sbt/CompileTimeCalibanPlugin.scala
+++ b/codegen-sbt/src/main/scala/caliban/codegen/sbt/CompileTimeCalibanPlugin.scala
@@ -301,7 +301,15 @@ object CompileTimeCalibanClientPlugin extends AutoPlugin with CompileTimeCaliban
                                   Def
                                     .task[Set[File]](listGeneratedClientsFiles)
                                     .flatMapTask { beforeGenDirFiles =>
-                                      (serverProject / runMain)
+                                      // We use `fgRunMain` (foreground) rather than `runMain` on purpose. In sbt 1
+                                      // `runMain` blocks until the run completes, but in sbt 2 it was rewritten to be
+                                      // client-side/background-aware: under the server/client execution model it
+                                      // dispatches the run and returns before the forked generator has written its
+                                      // files, so the `afterGenDirFiles` snapshot below would run against an empty
+                                      // directory and the freshly generated client would be missing from the current
+                                      // compilation pass. `fgRunMain` runs the generator synchronously on both sbt
+                                      // versions.
+                                      (serverProject / fgRunMain)
                                         .toTask(s" $generatorRef $baseDirValue")
                                         .maybeTaskValue
                                         .map { _ =>


### PR DESCRIPTION
## Problem

Under sbt 2, a cold `client/compile` fails on the first run with e.g. `value graphql is not a member of example`, even though the generated client is written to disk; a second run succeeds. Reproducer: https://github.com/civilizeddev/caliban-sbt2-repro

## Root cause

`CompileTimeCalibanClientPlugin` generates the client by running the generator via `serverProject / runMain`, then diffing the output directory before/after to collect the generated sources.

`runMain` changed behavior between sbt versions:

- **sbt 1** — `runMain` (`foregroundRunMainTask`) starts a background job and then **waits** for it (`service.waitForTry(handle).get`), so it is synchronous in effect.
- **sbt 2** — `runMain` (`defaultRunMainTask(..., clientSide)`) is client-side/background-aware: under the server/client execution model it dispatches the run and returns **without waiting**.

So under sbt 2's server/client model (what the `sbt`/`sbtn` command uses), the generator runs asynchronously and the after-snapshot executes against a still-empty directory. The before/after diff is empty and the freshly generated client is missing from the current compilation pass. On the next run the file already exists on disk and is picked up, which is why the second compile succeeds.

Captured from an instrumented failing run (sbt 2 server mode):

```
before-snapshot: Set()
running (fork) caliban.generator.CalibanClientGenerator_0 ...
after-snapshot: Set()     <- empty: forked generator hasn't written yet
diff: Set()               <- nothing handed to the compile pass
```

## Fix

Use `fgRunMain` instead of `runMain`. `fgRunMain` is the direct synchronous `runMainTask` in both sbt 1 and sbt 2, so it is behavior-preserving on sbt 1 and corrective on sbt 2.

## Why the scripted tests don't catch it

Scripted runs in batch / `LauncherBased` mode, where the run is synchronous regardless of the JDK or `fork` setting — the after-snapshot correctly sees the generated file, so it passes. The bug only manifests in the server-based execution used by the real `sbt`/`sbtn` command, which scripted cannot exercise. (Verified by mirroring the reproducer as a scripted test: it passed even with `fork := true`.)

## Verification

- Reproducer: cold `client/compile` now succeeds on the first run (sbt 2.0.1, server mode).
- Compiles for both `++2.12` (sbt 1) and the sbt 2 cross-build.
- Existing `compiletime-codegen/test-compile` scripted test passes for both `++2.12` and the sbt 2 cross-build.