### PR TITLE
Fix float literals with both fraction and exponent being truncated

### DIFF
--- a/core/src/main/scala/caliban/parsing/parsers/NumberParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/NumberParsers.scala
@@ -18,6 +18,6 @@ private[caliban] trait NumberParsers extends StringParsers {
   def fractionalPart(implicit ev: P[Any]): P[Unit]    = "." ~~ digit.repX(1)
   def floatValue(implicit ev: P[Any]): P[FloatValue]  =
     (
-      integerPart ~~ (fractionalPart | exponentPart | (fractionalPart ~~ exponentPart))
+      integerPart ~~ ((fractionalPart ~~ exponentPart) | fractionalPart | exponentPart)
     ).!.map(FloatValue.fromStringUnsafe)
 }

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -170,6 +170,30 @@ object ParserSpec extends ZIOSpecDefault {
           )
         }
       },
+      test("float values with fraction and exponent") {
+        val cases = List(
+          "6.022e23" -> FloatValue(6.022e23),
+          "1.5E3"    -> FloatValue(1.5e3),
+          "1.5e-3"   -> FloatValue(1.5e-3),
+          "1e10"     -> FloatValue(1e10),
+          "6.022"    -> FloatValue(6.022)
+        )
+        assertTrue(cases.forall { case (raw, expected) => Parser.parseInputValue(raw) == Right(expected) })
+      },
+      test("float value with fraction and exponent in a query argument") {
+        val query = "{ f(x: 6.022e23) }"
+        Parser.parseQuery(query).map { doc =>
+          assertTrue(
+            doc ==
+              simpleQuery(
+                selectionSet = List(
+                  simpleField("f", arguments = Map("x" -> FloatValue(6.022e23)), index = 2)
+                ),
+                sourceMapper = SourceMapper(query)
+              )
+          )
+        }
+      },
       test("block strings") {
         val query = "{ sendEmail(message: \"\"\"\n  Hello,\n    World!\n\n  Yours,\n    GraphQL. \"\"\") }"
         Parser.parseQuery(query).map { doc =>


### PR DESCRIPTION
## Problem

The `floatValue` parser dropped the exponent for any float literal that had **both** a fractional and an exponent part.

The alternation was:

```scala
integerPart ~~ (fractionalPart | exponentPart | (fractionalPart ~~ exponentPart))
```

fastparse `|` is ordered (PEG) choice, so for any number containing a decimal point the first alternative `fractionalPart` matched and the parser stopped — the combined `(fractionalPart ~~ exponentPart)` third alternative was unreachable dead code and the exponent was never consumed.

Consequences:
- `Parser.parseInputValue("6.022e23")` returned `FloatValue(6.022)` — the `e23` was silently dropped (value wrong by 23 orders of magnitude).
- Inside a full document, `{ f(x: 6.022e23) }` was **rejected** with a parsing error at the leftover `e23`, even though it is a valid GraphQL float literal.

## Fix

Reorder the alternation so the combined form is tried first:

```scala
integerPart ~~ ((fractionalPart ~~ exponentPart) | fractionalPart | exponentPart)
```

fastparse `|` backtracks (no cut is crossed), so plain fractions (`6.022`) and exponent-only values (`1e10`) still parse via the later branches.

## Tests

Added regression tests in `ParserSpec` covering `6.022e23`, `1.5E3`, `1.5e-3`, `1e10`, `6.022` as input values, plus a full query argument `{ f(x: 6.022e23) }`. `core/testOnly caliban.parsing.ParserSpec` passes.