### PR TITLE
Fix @stream list-field validation

### DIFF
--- a/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
+++ b/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
@@ -101,9 +101,10 @@ object IncrementalDelivery {
       validateFields(fragment.selectionSet, currentType)
 
     def validateField(field: Field, currentType: __Type): Either[CalibanError.ValidationError, Unit] = {
-      val selected = currentType.allFields.find(_.name == field.name)
+      val selected  = currentType.allFields.find(_.name == field.name)
+      val hasStream = field.directives.exists(_.name == Directives.Stream)
       Either.cond(
-        selected.isDefined && !selected.get._type.isList && field.directives.forall(_.name != Directives.Stream),
+        !hasStream || selected.forall(_._type.isList),
         (),
         CalibanError.ValidationError("Stream directive was used on a non-list field", "")
       )

--- a/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
+++ b/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
@@ -90,7 +90,7 @@ object IncrementalDelivery {
           if (dirs.exists(_.name == Directives.Stream))
             Left(CalibanError.ValidationError("Stream directive was used on an inline fragment", ""))
           else {
-            if (typeCondition.exists(_.name.contains(currentType.typeNameRepr)))
+            if (typeCondition.forall(_.name.contains(currentType.typeNameRepr)))
               validateFields(selectionSet, currentType)
             else Right(())
           }

--- a/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
+++ b/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
@@ -103,11 +103,19 @@ object IncrementalDelivery {
     def validateField(field: Field, currentType: __Type): Either[CalibanError.ValidationError, Unit] = {
       val selected  = currentType.allFields.find(_.name == field.name)
       val hasStream = field.directives.exists(_.name == Directives.Stream)
-      Either.cond(
-        !hasStream || selected.forall(_._type.isList),
-        (),
-        CalibanError.ValidationError("Stream directive was used on a non-list field", "")
-      )
+      Either
+        .cond(
+          !hasStream || selected.forall(_._type.isList),
+          (),
+          CalibanError.ValidationError("Stream directive was used on a non-list field", "")
+        )
+        .flatMap { _ =>
+          if (field.selectionSet.isEmpty) Right(())
+          else
+            selected.fold[Either[CalibanError.ValidationError, Unit]](Right(()))(s =>
+              validateFields(field.selectionSet, s._type.innerType)
+            )
+        }
     }
 
     validateAllDiscard(context.operations) { op =>

--- a/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
+++ b/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
@@ -5,6 +5,7 @@ import caliban.introspection.adt.{ __Directive, __Type }
 import caliban.parsing.adt.Definition.ExecutableDefinition.FragmentDefinition
 import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
 import caliban.parsing.adt._
+import caliban.validation.Utils
 import caliban.validation.ValidationOps.validateAllDiscard
 import caliban.validation.Validator.{ failValidation, QueryValidation }
 import caliban.wrappers.Wrapper.ValidationWrapper
@@ -89,16 +90,13 @@ object IncrementalDelivery {
         case InlineFragment(typeCondition, dirs, selectionSet) =>
           if (dirs.exists(_.name == Directives.Stream))
             Left(CalibanError.ValidationError("Stream directive was used on an inline fragment", ""))
-          else {
-            if (typeCondition.forall(_.name.contains(currentType.typeNameRepr)))
-              validateFields(selectionSet, currentType)
-            else Right(())
-          }
+          else
+            validateFields(selectionSet, Utils.getType(typeCondition, currentType, context))
 
       }
 
     def validateSpread(fragment: FragmentDefinition, currentType: __Type): Either[CalibanError.ValidationError, Unit] =
-      validateFields(fragment.selectionSet, currentType)
+      validateFields(fragment.selectionSet, Utils.getType(Some(fragment.typeCondition), currentType, context))
 
     def validateField(field: Field, currentType: __Type): Either[CalibanError.ValidationError, Unit] = {
       val selected  = currentType.allFields.find(_.name == field.name)

--- a/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
+++ b/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
@@ -393,7 +393,7 @@ object IncrementalDeliverySpec extends ZIOSpecDefault {
         {
            character(name: "James Holden") {
              role {
-               ... on Captain {
+               ... on Pilot {
                  shipName @stream
                }
              }
@@ -419,7 +419,7 @@ object IncrementalDeliverySpec extends ZIOSpecDefault {
            }
         }
 
-        fragment RoleFields on Captain {
+        fragment RoleFields on Pilot {
           shipName @stream
         }
           """)

--- a/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
+++ b/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
@@ -309,6 +309,49 @@ object IncrementalDeliverySpec extends ZIOSpecDefault {
           )
         )
       },
+      test("don't reject a root-level list field without @stream") {
+        val query = gqldoc("""
+        {
+           characters {
+             name
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+        } yield assertTrue(response.errors.isEmpty)
+      },
+      test("allow @stream on a root-level list field") {
+        val query = gqldoc("""
+        {
+           characters @stream(initialCount: 0) {
+             name
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+        } yield assertTrue(response.errors.isEmpty)
+      },
+      test("reject @stream on a non-list field") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") @stream {
+             name
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          errors    = response.errors
+        } yield assertTrue(
+          errors.size == 1,
+          errors.head.is(_.subtype[ValidationError]).msg == "Stream directive was used on a non-list field"
+        )
+      },
       test("labels must be unique") {
         val query = gqldoc("""
         {

--- a/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
+++ b/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
@@ -388,6 +388,50 @@ object IncrementalDeliverySpec extends ZIOSpecDefault {
           errors.head.is(_.subtype[ValidationError]).msg == "Stream directive was used on a non-list field"
         )
       },
+      test("reject @stream on a non-list field inside a typed inline fragment on a subtype") {
+        val query = gqldoc("""
+        {
+           character(name: "James Holden") {
+             role {
+               ... on Captain {
+                 shipName @stream
+               }
+             }
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          errors    = response.errors
+        } yield assertTrue(
+          errors.size == 1,
+          errors.head.is(_.subtype[ValidationError]).msg == "Stream directive was used on a non-list field"
+        )
+      },
+      test("reject @stream on a non-list field inside a named fragment on a subtype") {
+        val query = gqldoc("""
+        {
+           character(name: "James Holden") {
+             role {
+               ...RoleFields
+             }
+           }
+        }
+
+        fragment RoleFields on Captain {
+          shipName @stream
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          errors    = response.errors
+        } yield assertTrue(
+          errors.size == 1,
+          errors.head.is(_.subtype[ValidationError]).msg == "Stream directive was used on a non-list field"
+        )
+      },
       test("labels must be unique") {
         val query = gqldoc("""
         {

--- a/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
+++ b/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
@@ -369,6 +369,25 @@ object IncrementalDeliverySpec extends ZIOSpecDefault {
           errors.head.is(_.subtype[ValidationError]).msg == "Stream directive was used on a non-list field"
         )
       },
+      test("reject @stream on a non-list field inside an anonymous inline fragment") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             ... {
+               name @stream
+             }
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          errors    = response.errors
+        } yield assertTrue(
+          errors.size == 1,
+          errors.head.is(_.subtype[ValidationError]).msg == "Stream directive was used on a non-list field"
+        )
+      },
       test("labels must be unique") {
         val query = gqldoc("""
         {

--- a/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
+++ b/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
@@ -352,6 +352,23 @@ object IncrementalDeliverySpec extends ZIOSpecDefault {
           errors.head.is(_.subtype[ValidationError]).msg == "Stream directive was used on a non-list field"
         )
       },
+      test("reject @stream on a nested non-list field") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             name @stream
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          errors    = response.errors
+        } yield assertTrue(
+          errors.size == 1,
+          errors.head.is(_.subtype[ValidationError]).msg == "Stream directive was used on a non-list field"
+        )
+      },
       test("labels must be unique") {
         val query = gqldoc("""
         {

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -77,7 +77,8 @@ object TestDeferredSchema extends SchemaDerivation[CharacterService with QuoteSe
   )
 
   case class Query(
-    character: CharacterArgs => URIO[CharacterService with QuoteService, Option[CharacterZIO]]
+    character: CharacterArgs => URIO[CharacterService with QuoteService, Option[CharacterZIO]],
+    characters: URIO[CharacterService with QuoteService, List[CharacterZIO]]
   )
 
   def character2CharacterZIO(ch: Character): CharacterZIO =
@@ -146,7 +147,10 @@ object TestDeferredSchema extends SchemaDerivation[CharacterService with QuoteSe
         character = args =>
           ZIO
             .serviceWithZIO[CharacterService](_.characterBy(_.name == args.name))
-            .map(_.headOption.map(character2CharacterZIO))
+            .map(_.headOption.map(character2CharacterZIO)),
+        characters = ZIO
+          .serviceWithZIO[CharacterService](_.characterBy(_ => true))
+          .map(_.map(character2CharacterZIO))
       )
     )
 


### PR DESCRIPTION
## Problem

`IncrementalDelivery.appearsOnlyOnLists` — registered as a query validation whenever the `Stream` feature is enabled (`IncrementalDelivery.stream` / `IncrementalDelivery.all`) — had several defects:

**1. Inverted valid-condition.** `validateField` used:

```scala
selected.isDefined && !selected.get._type.isList && field.directives.forall(_.name != Directives.Stream)
```

For any **list** field, `!isList` is `false`, so the whole conjunction is `false` and a `ValidationError("Stream directive was used on a non-list field")` was produced — even when no `@stream` directive was present, and even for the legitimate case of `@stream` on a list. In practice, enabling the feature on a schema whose `Query` has a list field (e.g. `characters: [Character]`) rejected an ordinary query `{ characters { name } }`.

**2. No recursion into nested selection sets.** `validateFields` reached only root fields and fragments — it never descended into a field's own `selectionSet`. So `@stream` misuse nested below the first level, e.g. `character { name @stream }`, escaped validation.

**3. Anonymous inline fragments skipped.** The `InlineFragment` branch only recursed when the type condition matched the current type, so an inline fragment without a type condition was skipped.

**4. Typed fragments on subtypes skipped.** Inline and named fragments were validated against the current type or skipped, so a subtype fragment on an interface/union (e.g. `node { ... on User { name @stream } }`) bypassed the non-list check.

## Fix

- Rewrite the predicate to the intended rule (`@stream` may only appear on a list field): a field is valid unless it carries `@stream` and is not a list.
- `validateField` recurses into the field's own selection set using the selected field's `._type.innerType`.
- Fragment traversal resolves the type condition through `rootType.types` (via `validation.Utils.getType`) and recurses with the fragment type; anonymous inline fragments recurse with the current type.

## Tests

Added a root-level list field (`characters`) to `TestDeferredSchema` and tests in `IncrementalDeliverySpec` covering: root-level list without `@stream` (accepted), `@stream` on a root list (accepted), and `@stream` rejected on a non-list field — directly, nested, inside an anonymous inline fragment, inside a typed inline fragment on a subtype, and inside a named fragment on a subtype.

`core/testOnly caliban.execution.IncrementalDeliverySpec` passes (19 tests).