### PR TITLE
Fix nested lists computing item-nullability at the wrong level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -786,7 +786,9 @@ lazy val enableMimaSettingsJVM =
     mimaPreviousArtifacts  := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet,
     mimaBinaryIssueFilters := Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.*.<clinit>"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("mdg.engine.proto.reports.*.<clinit>")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("mdg.engine.proto.reports.*.<clinit>"),
+      // private internal method; extra param added to fix nested-list null propagation
+      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.execution.Executor#StepReducer.reduceStep")
     )
   )
 

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -5,6 +5,7 @@ import caliban.ResponseValue._
 import caliban.Value._
 import caliban._
 import caliban.execution.Fragment.IsDeferred
+import caliban.introspection.adt.__Type
 import caliban.parsing.adt._
 import caliban.schema.ReducedStep.DeferStep
 import caliban.schema.Step.{ PureStep => _, _ }
@@ -160,7 +161,7 @@ object Executor {
     }
 
     ZIO.suspendSucceed {
-      stepReducer.reduceStep(plan, request.field, Map.empty, Nil) match {
+      stepReducer.reduceStep(plan, request.field, Map.empty, Nil, request.field.fieldType) match {
         case PureStep(resp) => Exit.succeed(GraphQLResponse(resp, Nil))
         case reducedStep    => makeCache.flatMap(runQuery(reducedStep, _))
       }
@@ -181,7 +182,8 @@ object Executor {
       step: Step[R],
       currentField: Field,
       arguments: Map[String, InputValue],
-      path: List[PathValue]
+      path: List[PathValue],
+      fieldType: __Type
     ): ReducedStep[R] = {
 
       def reduceObjectStep(objectName: String, getFieldStep: String => Step[R]): ReducedStep[R] = {
@@ -190,7 +192,7 @@ object Executor {
           val fname       = f.name
           val field       =
             if (fname == "__typename") PureStep(StringValue(objectName))
-            else reduceStep(getFieldStep(fname), f, f.arguments, PathValue.Key(aliasedName) :: path)
+            else reduceStep(getFieldStep(fname), f, f.arguments, PathValue.Key(aliasedName) :: path, f.fieldType)
           (aliasedName, field, fieldInfo(f, aliasedName, path, f.directives))
         }
 
@@ -225,6 +227,11 @@ object Executor {
 
       def reduceListStep(steps: List[Step[R]]): ReducedStep[R] = {
 
+        // descend one list level so nested lists compute nullability at their own depth
+        val elementType      = Types.listOf(fieldType)
+        val areItemsNullable = elementType.exists(_.isNullable)
+        val itemType         = elementType.getOrElse(fieldType)
+
         def reduceToListStep(head: ReducedStep[R], remaining0: List[Step[R]]): ReducedStep[R] = {
           var i         = 1
           val nil       = Nil
@@ -233,20 +240,13 @@ object Executor {
           lb addOne head
           var remaining = remaining0
           while (remaining ne nil) {
-            val step = reduceStep(remaining.head, currentField, arguments, PathValue.Index(i) :: path)
+            val step = reduceStep(remaining.head, currentField, arguments, PathValue.Index(i) :: path, itemType)
             if (isPure && !step.isPure) isPure = false
             lb addOne step
             i += 1
             remaining = remaining.tail
           }
-          ReducedStep.ListStep(
-            lb.result(),
-            Types.listOf(currentField.fieldType) match {
-              case Some(tpe) => tpe.isNullable
-              case None      => false
-            },
-            isPure
-          )
+          ReducedStep.ListStep(lb.result(), areItemsNullable, isPure)
         }
 
         def reduceToPureStep(head: PureStep, remaining0: List[Step[R]]): ReducedStep[R] = {
@@ -256,7 +256,7 @@ object Executor {
           var remaining = remaining0
           lb addOne head.value
           while (remaining ne nil) {
-            val step = reduceStep(remaining.head, currentField, arguments, PathValue.Index(i) :: path)
+            val step = reduceStep(remaining.head, currentField, arguments, PathValue.Index(i) :: path, itemType)
             lb addOne step.asInstanceOf[PureStep].value
             i += 1
             remaining = remaining.tail
@@ -266,7 +266,7 @@ object Executor {
 
         if (steps.isEmpty) PureStep(ListValue(Nil))
         else {
-          reduceStep(steps.head, currentField, arguments, PathValue.Index(0) :: path) match {
+          reduceStep(steps.head, currentField, arguments, PathValue.Index(0) :: path, itemType) match {
             // In 99.99% of the cases, if the head is pure, all the other elements will be pure as well but we catch that error just in case
             // NOTE: Our entire test suite passes without catching the error
             case step: PureStep =>
@@ -278,7 +278,7 @@ object Executor {
       }
 
       def reduceQuery(q: ZQuery[R, Throwable, Step[R]]): ReducedStep[R] = {
-        def success(v: Step[R])       = reduceStep(v, currentField, arguments, path)
+        def success(v: Step[R])       = reduceStep(v, currentField, arguments, path, fieldType)
         def fail(e: Cause[Throwable]) = effectfulExecutionError(path, Some(currentField.locationInfo), e)
 
         q.asExitOrElse(null) match {
@@ -292,9 +292,11 @@ object Executor {
           ReducedStep.StreamStep(
             stream
               .mapErrorCause(effectfulExecutionError(path, Some(currentField.locationInfo), _))
-              .map(reduceStep(_, currentField, arguments, path))
+              .map(reduceStep(_, currentField, arguments, path, fieldType))
           )
         } else {
+          // with @stream each streamed step is an item of the list field
+          val itemType = Types.listOf(fieldType).getOrElse(fieldType)
           currentField match {
             case IsStream(label, Some(initialCount)) if initialCount > 0 && Feature.isStreamEnabled(flags) =>
               ReducedStep.QueryStep(
@@ -313,7 +315,7 @@ object Executor {
                       reduceListStep(initial.toList),
                       ReducedStep.StreamStep(
                         ZStream.acquireReleaseExitWith(ZIO.unit)((_, exit) => scope.close(exit)) *>
-                          remaining.map(reduceStep(_, currentField, arguments, path))
+                          remaining.map(reduceStep(_, currentField, arguments, path, itemType))
                       ),
                       label,
                       path,
@@ -324,11 +326,11 @@ object Executor {
               )
             case IsStream(label, _) if Feature.isStreamEnabled(flags)                                      =>
               ReducedStep.DeferStreamStep(
-                reduceStep(PureStep(ListValue(Nil)), currentField, arguments, path),
+                reduceStep(PureStep(ListValue(Nil)), currentField, arguments, path, fieldType),
                 ReducedStep.StreamStep(
                   stream
                     .mapErrorCause(effectfulExecutionError(path, Some(currentField.locationInfo), _))
-                    .map(reduceStep(_, currentField, arguments, path))
+                    .map(reduceStep(_, currentField, arguments, path, itemType))
                 ),
                 label,
                 path,
@@ -340,7 +342,8 @@ object Executor {
                 QueryStep(ZQuery.fromZIONow(stream.runCollect.map(chunk => ListStep(chunk.toList)))),
                 currentField,
                 arguments,
-                path
+                path,
+                fieldType
               )
           }
         }
@@ -353,12 +356,13 @@ object Executor {
         case s: PureStep                => s
         case s: QueryStep[R]            => reduceQuery(s.query)
         case s: ObjectStep[R]           => val t = transformer(s, currentField); reduceObjectStep(t.name, t.fields)
-        case s: FunctionStep[R]         => reduceStep(wrapFn(s.step, arguments), currentField, Map.empty, path)
-        case s: MetadataFunctionStep[R] => reduceStep(wrapFn(s.step, currentField), currentField, arguments, path)
+        case s: FunctionStep[R]         => reduceStep(wrapFn(s.step, arguments), currentField, Map.empty, path, fieldType)
+        case s: MetadataFunctionStep[R] =>
+          reduceStep(wrapFn(s.step, currentField), currentField, arguments, path, fieldType)
         case s: ListStep[R]             => reduceListStep(s.steps)
         case s: StreamStep[R]           => reduceStream(s.inner)
         case s: ExtensionStep[R]        =>
-          val inner = reduceStep(s.inner, currentField, arguments, path)
+          val inner = reduceStep(s.inner, currentField, arguments, path, fieldType)
           ReducedStep.ExtensionStep(inner, s.extensions)
       }
     }

--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -227,7 +227,6 @@ object Executor {
 
       def reduceListStep(steps: List[Step[R]]): ReducedStep[R] = {
 
-        // descend one list level so nested lists compute nullability at their own depth
         val elementType      = Types.listOf(fieldType)
         val areItemsNullable = elementType.exists(_.isNullable)
         val itemType         = elementType.getOrElse(fieldType)
@@ -295,7 +294,6 @@ object Executor {
               .map(reduceStep(_, currentField, arguments, path, fieldType))
           )
         } else {
-          // with @stream each streamed step is an item of the list field
           val itemType = Types.listOf(fieldType).getOrElse(fieldType)
           currentField match {
             case IsStream(label, Some(initialCount)) if initialCount > 0 && Feature.isStreamEnabled(flags) =>

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -912,6 +912,28 @@ object ExecutionSpec extends ZIOSpecDefault {
           assertTrue(response.data.toString == """{"test":null}""")
         }
       },
+      test("die inside a non-nullable item of a nested nullable list") {
+        // test: [[Int!]]! — a die in a non-null inner item bubbles to null the nullable inner list
+        case class Queries(test: List[Task[List[UIO[Int]]]])
+        val api         = graphQL(
+          RootResolver(
+            Queries(
+              List(
+                ZIO.succeed(List(ZIO.succeed(1), ZIO.succeed(2))),
+                ZIO.succeed(List(ZIO.succeed(3), ZIO.die(new Exception("Boom"))))
+              )
+            )
+          )
+        )
+        val interpreter = api.interpreter
+        val query       =
+          """query{
+            |  test
+            |}""".stripMargin
+        interpreter.flatMap(_.execute(query)).map { response =>
+          assertTrue(response.data.toString == """{"test":[[1,2],null]}""")
+        }
+      },
       test("fake field") {
         sealed trait A
         object A {

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -913,7 +913,6 @@ object ExecutionSpec extends ZIOSpecDefault {
         }
       },
       test("die inside a non-nullable item of a nested nullable list") {
-        // test: [[Int!]]! — a die in a non-null inner item bubbles to null the nullable inner list
         case class Queries(test: List[Task[List[UIO[Int]]]])
         val api         = graphQL(
           RootResolver(


### PR DESCRIPTION
## Problem

In `Executor`, `reduceListStep` computed `areItemsNullable` from `currentField.fieldType`, and nested `ListStep`s recursed through `reduceStep` with the **same** `currentField`. Because a `Field` carries the entire declared type (all list wrappers at once), every nesting level read the *outer* list's element-nullability.

For a field typed `[[Int!]]`, the inner list was therefore treated as having nullable items. When a non-null inner item (`Int!`) failed, the error was caught and substituted as `null` in the item slot — placing `null` in a non-null position — instead of bubbling up to null the (nullable) inner list. The symmetric `[[Int]!]` case over-propagated.

## Fix

Thread the **actual type at each position** through `reduceStep` as a new `fieldType` parameter, descending exactly one list level per nested `ListStep`:

- `reduceListStep` computes `elementType = Types.listOf(fieldType)` once, derives `areItemsNullable` from it, and reduces each item with that descended `elementType`.
- Every other call site passes the type for its position: top-level `request.field.fieldType`, object fields `f.fieldType`, `@stream` item reductions the descended item type, and query/function/metadata/extension/subscription wrappers pass it through unchanged.

Invariant: `fieldType` is always the GraphQL type of the value the step resolves to at that position.

## Tests

Added *"die inside a non-nullable item of a nested nullable list"* in `ExecutionSpec`: `test: List[Task[List[UIO[Int]]]]` (→ `[[Int!]]!`, nullable inner lists, non-null items). A die in an inner item now yields `{"test":[[1,2],null]}` (inner list nulled) rather than the buggy `{"test":[[1,2],[3,null]]}`.

`core/testOnly caliban.execution.ExecutionSpec caliban.execution.IncrementalDeliverySpec` passes (75 tests).