### PR TITLE
Advance @stream path index across chunks

### DIFF
--- a/core/src/main/scala/caliban/execution/Executor.scala
+++ b/core/src/main/scala/caliban/execution/Executor.scala
@@ -115,24 +115,27 @@ object Executor {
         })
 
       def runStream(d: DeferredStream[R]) =
-        d.step.inner.orDie.chunks.flatMap { steps =>
-          ZStream.unwrap(ZIO.foreach(steps)(runIncrementalQuery(_, cache)).map { results =>
-            val (values, errors, more) = results.unzip3
-            val resp                   = ZStream.succeed(
-              Incremental.Stream(
-                values.toList,
-                ListValue((IntValue(d.startFrom) :: d.path).reverse),
-                errors.toList.flatten,
-                d.label
+        d.step.inner.orDie.chunks
+          .filter(_.nonEmpty)
+          .mapAccum(d.startFrom)((idx, steps) => (idx + steps.size, (idx, steps)))
+          .flatMap { case (idx, steps) =>
+            ZStream.unwrap(ZIO.foreach(steps)(runIncrementalQuery(_, cache)).map { results =>
+              val (values, errors, more) = results.unzip3
+              val resp                   = ZStream.succeed(
+                Incremental.Stream(
+                  values.toList,
+                  ListValue((IntValue(idx) :: d.path).reverse),
+                  errors.toList.flatten,
+                  d.label
+                )
               )
-            )
 
-            more.toList.flatten match {
-              case Nil  => resp
-              case rest => resp ++ makeDeferStream(rest, cache)
-            }
-          })
-        }
+              more.toList.flatten match {
+                case Nil  => resp
+                case rest => resp ++ makeDeferStream(rest, cache)
+              }
+            })
+          }
 
       ZStream.mergeAllUnbounded()(defers.map {
         case d: DeferredFragment[R] => runDefer(d)

--- a/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
+++ b/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
@@ -284,6 +284,30 @@ object IncrementalDeliverySpec extends ZIOSpecDefault {
           )
         )
       },
+      test("advance the path index across stream chunks") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             counters @stream(label: "counters", initialCount: 1)
+           }
+        }
+          """)
+
+        for {
+          response <- interpreter.flatMap(_.execute(query))
+          data     <- runIncrementalResponses(response)
+          head      = data.map(_.toString)
+        } yield assertTrue(
+          data.size == 5,
+          head == Chunk(
+            """{"data":{"character":{"counters":[0]}},"hasNext":true}""",
+            """{"incremental":[{"items":[1],"path":["character","counters",1],"label":"counters"}],"hasNext":true}""",
+            """{"incremental":[{"items":[2],"path":["character","counters",2],"label":"counters"}],"hasNext":true}""",
+            """{"incremental":[{"items":[3],"path":["character","counters",3],"label":"counters"}],"hasNext":true}""",
+            """{"hasNext":false}"""
+          )
+        )
+      },
       test("validate step occurs on on lists only") {
         val query = gqldoc("""
         {

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -73,7 +73,8 @@ object TestDeferredSchema extends SchemaDerivation[CharacterService with QuoteSe
     origin: Origin,
     role: Option[Role],
     connections: ConnectionArgs => URIO[CharacterService with QuoteService, List[CharacterZIO]],
-    quotes: ZStream[CharacterService with QuoteService, Nothing, Quote] = ZStream.empty
+    quotes: ZStream[CharacterService with QuoteService, Nothing, Quote] = ZStream.empty,
+    counters: ZStream[Any, Nothing, Int] = ZStream.empty
   )
 
   case class Query(
@@ -112,7 +113,8 @@ object TestDeferredSchema extends SchemaDerivation[CharacterService with QuoteSe
           q.from,
           ZIO.succeed(character2CharacterZIO(ch))
         )
-      })
+      }),
+      counters = ZStream.fromIterable(0 to 3).rechunk(1)
     )
 
   implicit val characterArgsSchema: Schema[CharacterService with QuoteService, CharacterArgs] =
@@ -135,7 +137,8 @@ object TestDeferredSchema extends SchemaDerivation[CharacterService with QuoteSe
         field("origin")(_.origin),
         field("role")(_.role),
         fieldWithArgs("connections")(_.connections),
-        field("quotes")(_.quotes)
+        field("quotes")(_.quotes),
+        field("counters")(_.counters)
       )
     )
   implicit val querySchema: Schema[CharacterService with QuoteService, Query]                 =


### PR DESCRIPTION
## Problem

In `Executor.makeDeferStream.runStream`, each incremental `@stream` payload hard-coded its list path index to `IntValue(d.startFrom)` — the fixed initial count captured when the `DeferredStream` was created:

```scala
d.step.inner.orDie.chunks.flatMap { steps =>
  ...
  Incremental.Stream(values.toList, ListValue((IntValue(d.startFrom) :: d.path).reverse), ...)
}
```

`runStream` emits one payload per source chunk, but the index was never advanced by the number of items already streamed. So when the remaining stream delivered its items in more than one chunk (common for any `ZStream` backed by a queue, `repeatZIO`, network, etc.), every payload after the first repeated index `startFrom` instead of `startFrom + itemsAlreadySent`, and a spec-compliant incremental-delivery client would mis-place or overwrite items.

## Fix

- Carry a running index with `mapAccum(d.startFrom)`, so each chunk's payload reports the index of its first item and the accumulator advances by `steps.size`.
- Drop empty chunks (`.filter(_.nonEmpty)`) — a chunked stream (e.g. after `peel`) can yield a leading empty chunk, which previously produced a meaningless incremental payload with no `items`.

`mapAccum` is a `zio-streams` API method (verified to compile on 2.12, 2.13 and 3.3).

## Tests

Added a `counters: ZStream[Any, Nothing, Int]` field to `TestDeferredSchema` (`ZStream.fromIterable(0 to 3).rechunk(1)`) to force a genuinely multi-chunk stream, and a test *"advance the path index across stream chunks"* asserting the items `1,2,3` arrive at paths `…counters,1`, `…counters,2`, `…counters,3` (before the fix: all at index 1, plus a spurious empty payload).

`core/testOnly caliban.execution.IncrementalDeliverySpec` passes on 2.13 and Scala 3.3.