### PR TITLE
Fix field-merge validation missing nested argument conflicts

### DIFF
--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -16,7 +16,7 @@ object FragmentValidator {
   ): Either[ValidationError, Unit] = {
 
     val shapeCache   = mutable.HashMap.empty[List[Selection], Chunk[String]]
-    val parentsCache = mutable.HashMap.empty[Iterable[Selection], Chunk[String]]
+    val parentsCache = mutable.HashMap.empty[(Option[String], Iterable[Selection]), Chunk[String]]
     val groupsCache  = mutable.HashMap.empty[Set[SelectedField], Chunk[Set[SelectedField]]]
 
     def sameResponseShapeByName(set: List[Selection], parentType: __Type): Chunk[String] =
@@ -39,16 +39,17 @@ object FragmentValidator {
           }
         )
 
-    def sameForCommonParentsByName(set: Iterable[Selection]): Chunk[String] =
+    def sameForCommonParentsByName(parentType: __Type, set: Iterable[Selection]): Chunk[String] =
       if (set.isEmpty) Chunk.empty
       else
         parentsCache.getOrElseUpdate(
-          set, {
+          (parentType.name, set), {
             val fields = FieldMap.make(context, parentType, set)
             Chunk.fromIterable(fields.values.flatMap { fields =>
               groupByCommonParents(fields).flatMap { group =>
-                val merged = group.flatMap(_.selection.selectionSet)
-                requireSameNameAndArguments(group) ++ sameForCommonParentsByName(merged)
+                val merged    = group.flatMap(_.selection.selectionSet)
+                val fieldType = group.headOption.fold(parentType)(_.fieldDef._type.innerType)
+                requireSameNameAndArguments(group) ++ sameForCommonParentsByName(fieldType, merged)
               }
             })
           }
@@ -106,7 +107,8 @@ object FragmentValidator {
         }
       )
 
-    val conflicts = sameResponseShapeByName(selectionSet, parentType) ++ sameForCommonParentsByName(selectionSet)
+    val conflicts =
+      sameResponseShapeByName(selectionSet, parentType) ++ sameForCommonParentsByName(parentType, selectionSet)
     if (conflicts.nonEmpty) {
       Left(ValidationError(conflicts.head, ""))
     } else {

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -200,6 +200,26 @@ object FragmentSpec extends ZIOSpecDefault {
           isSome(anything)
         )
       },
+      test("nested argument conflict on plain fields when a fragment is present") {
+        case class Nested(x: Int => String)
+        case class Query(a: Nested)
+
+        val query =
+          """query{
+            |  a { x(value: 1) }
+            |  a { x(value: 2) }
+            |  ... on Query { __typename }
+            |}""".stripMargin
+
+        val gql = graphQL(RootResolver(Query(Nested(_ => "y"))))
+        for {
+          int <- gql.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(
+          res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+            .exists(_.contains("different arguments"))
+        )
+      },
       test("nested fragment selection on the same type") {
         import caliban.schema.Schema.auto._
 


### PR DESCRIPTION
## Problem

`FragmentValidator.sameForCommonParentsByName` (the implementation of the spec's `FieldsInSetCanMerge` / `requireSameNameAndArguments` rule, 5.3.2) had no `parentType` parameter and closed over the top-level `parentType` of `findConflictsWithinSelectionSet`. When it recursed into a merged sub-selection set, it still called `FieldMap.make(context, parentType, set)` with the *original root* type.

For **plain** nested fields, `FieldMap.make` resolves them via `parentType.getFieldOrNull(name)`; with the wrong parent the lookup returns `null` and the fields are silently dropped, so their arguments are never compared. Fields wrapped in inline/named fragments accidentally worked because `FieldMap` re-derives the type from the fragment's type condition — which is why existing tests passed.

Example (a fragment must be present for the validator to run at all — it only runs at the root when `context.fragments` is non-empty or the selection set contains fragments):

```graphql
{
  a { x(value: 1) }
  a { x(value: 2) }
  ... on Query { __typename }
}
```

The merged `a` selects `[x(value:1), x(value:2)]`, which were checked against the root type instead of `a`'s type, so the conflicting `x` arguments were not detected and the query was accepted.

## Fix

- Add a `parentType` parameter to `sameForCommonParentsByName`.
- On recursion, pass the group's field return type unwrapped — `group.headOption.fold(parentType)(_.fieldDef._type.innerType)` — mirroring how `sameResponseShapeByName` already threads `f1.fieldDef._type`.
- Key `parentsCache` by `(parentType.name, set)` so the same selection set under different parent types can't collide.

## Tests

Added *"nested argument conflict on plain fields when a fragment is present"* in `FragmentSpec`, asserting the `x` argument conflict is reported. Discriminating — before the fix `x` was dropped and no error was raised.

`core/testOnly caliban.execution.FragmentSpec caliban.validation.ValidationSpec` passes (66 tests).