### PR TITLE
Accept integer literals for ID arguments

### DIFF
--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -149,8 +149,8 @@ private object ValueValidator {
         }
       case "ID"      =>
         argValue match {
-          case _: StringValue | NullValue => unit
-          case t                          => failValidation(s"$errorContext has invalid type $t", "Expected 'ID'")
+          case _: StringValue | _: Value.IntValue | NullValue => unit
+          case t                                              => failValidation(s"$errorContext has invalid type $t", "Expected 'ID'")
         }
       case "Int"     =>
         argValue match {

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -306,6 +306,28 @@ object ValidationSpec extends ZIOSpecDefault {
              }""")
         check(query, "Required field 'nicknames' on object 'CharacterInput' was not provided.")
       },
+      test("integer literal is accepted for an ID argument") {
+        import caliban.schema.Schema.auto._
+        import caliban.schema.ArgBuilder.auto._
+
+        case class Id(value: String)
+        implicit val idSchema: Schema[Any, Id]    =
+          Schema.scalarSchema("ID", None, None, None, (id: Id) => StringValue(id.value))
+        implicit val idArgBuilder: ArgBuilder[Id] = {
+          case StringValue(v) => Right(Id(v))
+          case i: IntValue    => Right(Id(i.toInt.toString))
+          case other          => Left(ExecutionError(s"Can't build an Id from $other"))
+        }
+        case class Args(id: Id)
+        case class Query(node: Args => String)
+
+        val api   = graphQL(RootResolver(Query(_.id.value)))
+        val query = gqldoc("""query { node(id: 4) }""")
+        for {
+          int <- api.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(res.errors.isEmpty, res.data.toString == """{"node":"4"}""")
+      },
       test("directive used in wrong location") {
         val query = gqldoc("""
              query @skip(if: true) {


### PR DESCRIPTION
## Problem

`ValueValidator.validateScalar` accepted only `StringValue`/`NullValue` for the built-in `ID` scalar and rejected everything else:

```scala
case "ID" =>
  argValue match {
    case _: StringValue | NullValue => unit
    case t => failValidation(s"$errorContext has invalid type $t", "Expected 'ID'")
  }
```

Per the GraphQL spec, the `ID` scalar's input coercion accepts **both String and Int** literals (e.g. graphql-js `GraphQLID.parseLiteral` accepts `IntValueNode` and `StringValueNode`). So a valid query like `{ node(id: 4) }` was rejected at validation with `Expected 'ID'`.

This also created an inconsistency: the variables path (`VariablesCoercer`) has no special `ID` case and passes the value through untouched, so the same integer supplied via a variable was accepted while the inline literal was rejected.

## Fix

Accept `IntValue` for `ID` as well:

```scala
case "ID" =>
  argValue match {
    case _: StringValue | _: Value.IntValue | NullValue => unit
    case t => failValidation(s"$errorContext has invalid type $t", "Expected 'ID'")
  }
```

## Tests

Added *"integer literal is accepted for an ID argument"* in `ValidationSpec`, using a custom `ID`-named scalar whose `ArgBuilder` accepts both String and Int, then executing `{ node(id: 4) }` and asserting no errors and `{"node":"4"}`. Discriminating — before the fix, validation rejected it with `Expected 'ID'`.

`core/testOnly caliban.validation.ValidationSpec` passes (44 tests).