### PR TITLE
Parse VARIABLE_DEFINITION directive location

### DIFF
--- a/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/Parsers.scala
@@ -285,7 +285,8 @@ object Parsers extends SelectionParsers {
         "ENUM",
         "ENUM_VALUE",
         "INPUT_OBJECT",
-        "INPUT_FIELD_DEFINITION"
+        "INPUT_FIELD_DEFINITION",
+        "VARIABLE_DEFINITION"
       ).!
     ).map {
       case "QUERY"                  => ExecutableDirectiveLocation.QUERY

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -1245,6 +1245,27 @@ object ParserSpec extends ZIOSpecDefault {
           )
         }
       },
+      test("parse directive on VARIABLE_DEFINITION") {
+        val gqlInputExtension = "directive @test on VARIABLE_DEFINITION"
+        Parser.parseQuery(gqlInputExtension).map { doc =>
+          assertTrue(
+            doc == Document(
+              List(
+                DirectiveDefinition(
+                  None,
+                  "test",
+                  List.empty,
+                  isRepeatable = false,
+                  Set(
+                    TypeSystemDefinition.DirectiveLocation.TypeSystemDirectiveLocation.VARIABLE_DEFINITION
+                  )
+                )
+              ),
+              sourceMapper = SourceMapper.apply(gqlInputExtension)
+            )
+          )
+        }
+      },
       test("parse repeatable directives") {
         val gqlInputExtension = "directive @test repeatable on FIELD_DEFINITION"
         Parser.parseQuery(gqlInputExtension).map { doc =>


### PR DESCRIPTION
## Problem

`directiveLocation`'s `StringIn(...)` set omitted `"VARIABLE_DEFINITION"`, even though the `.map` immediately below already had a `case "VARIABLE_DEFINITION" => TypeSystemDirectiveLocation.VARIABLE_DEFINITION` (unreachable dead code). So `directive @foo on VARIABLE_DEFINITION` failed to parse:

```
directive @test on VARIABLE_DEFINITION
```

`VARIABLE_DEFINITION` is otherwise fully supported by caliban (parsing ADT, introspection ADT, and rendering), so caliban could *render* that location but not re-parse its own output — a broken round-trip and rejection of spec-valid SDL.

## Fix

Add `"VARIABLE_DEFINITION"` to the `StringIn` set so the existing mapping is reachable.

The categorization is left as-is: caliban's ADT defines `VARIABLE_DEFINITION extends TypeSystemDirectiveLocation` consistently across the parsing ADT, introspection mapping and renderer. (The spec groups it under *executable* locations, but re-categorizing would be a larger, binary-incompatible change and is out of scope here.)

## Tests

Added *"parse directive on VARIABLE_DEFINITION"* in `ParserSpec`, asserting the definition parses to `TypeSystemDirectiveLocation.VARIABLE_DEFINITION`. Discriminating — before the fix it was a parse error.

`core/testOnly caliban.parsing.ParserSpec` passes (50 tests).