### PR TITLE
Fix compact block-string description ending in backslash-quote

### DIFF
--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -103,16 +103,10 @@ object DocumentRenderer extends Renderer[Document] {
             def valueEscaped(): Unit = unsafeFastEscapeQuote(value, writer)
 
             writer append tripleQuote
-            // check if it ends in quote but it is already escaped
-            if (value.endsWith("\\\"")) {
-              newlineOrEmpty(indent, writer)
-              valueEscaped()
-              newlineOrEmpty(indent, writer)
-            } else if (value.last == '"') {
+            if (value.last == '"') {
               newlineOrEmpty(indent, writer)
               valueEscaped()
               newlineOrSpace(indent, writer)
-              // check if it ends in quote. We need to break the sequence of 4 or more '"'
             } else {
               // ok. No quotes at the end of value
               newlineOrEmpty(indent, writer)

--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -103,16 +103,9 @@ object DocumentRenderer extends Renderer[Document] {
             def valueEscaped(): Unit = unsafeFastEscapeQuote(value, writer)
 
             writer append tripleQuote
-            if (value.last == '"') {
-              newlineOrEmpty(indent, writer)
-              valueEscaped()
-              newlineOrSpace(indent, writer)
-            } else {
-              // ok. No quotes at the end of value
-              newlineOrEmpty(indent, writer)
-              valueEscaped()
-              newlineOrEmpty(indent, writer)
-            }
+            newlineOrEmpty(indent, writer)
+            valueEscaped()
+            if (value.last == '"') writer append '\n' else newlineOrEmpty(indent, writer)
             writer append tripleQuote
             newlineOrSpace(indent, writer)
           case value                         =>

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -202,6 +202,15 @@ object RenderingSpec extends ZIOSpecDefault {
           renderedType == "\n\"\"\"\nA multiline \"TestType\" description\ngiven inside \\\"\"\"-quotes\n\n\"\"\"\ntype TestType\n"
         )
       },
+      test("it should render a compact block-string description ending in backslash-quote as parseable SDL") {
+        val testType = __Type(
+          __TypeKind.SCALAR,
+          name = Some("TestType"),
+          description = Some("A multiline description\nending in \\\"")
+        )
+        val rendered = DocumentRenderer.typesRenderer.renderCompact(List(testType))
+        assertTrue(Parser.parseQuery(rendered).isRight)
+      },
       test("it should render single line descriptions") {
         val api = graphQL(resolver)
         checkApi(api)

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -202,14 +202,19 @@ object RenderingSpec extends ZIOSpecDefault {
           renderedType == "\n\"\"\"\nA multiline \"TestType\" description\ngiven inside \\\"\"\"-quotes\n\n\"\"\"\ntype TestType\n"
         )
       },
-      test("it should render a compact block-string description ending in backslash-quote as parseable SDL") {
-        val testType = __Type(
+      test("it should round-trip a compact block-string description ending in backslash-quote") {
+        val description       = "A multiline description\nending in \\\""
+        val testType          = __Type(
           __TypeKind.SCALAR,
           name = Some("TestType"),
-          description = Some("A multiline description\nending in \\\"")
+          description = Some(description)
         )
-        val rendered = DocumentRenderer.typesRenderer.renderCompact(List(testType))
-        assertTrue(Parser.parseQuery(rendered).isRight)
+        val rendered          = DocumentRenderer.typesRenderer.renderCompact(List(testType))
+        val parsedDescription = Parser
+          .parseQuery(rendered)
+          .toOption
+          .flatMap(_.definitions.collectFirst { case d: TypeDefinition.ScalarTypeDefinition => d.description }.flatten)
+        assertTrue(parsedDescription.contains(description))
       },
       test("it should render single line descriptions") {
         val api = graphQL(resolver)


### PR DESCRIPTION
## Problem

In `DocumentRenderer.descriptionRenderer`, the block-string branch special-cased values ending in `\"` and closed with no separator, so in compact mode (`indent = None`) a description ending in `\"` was emitted immediately followed by the closing `"""`, producing a `\` followed by four `"` (`\""""`). On re-parse `\"""` is consumed as an *escaped* triple-quote — swallowing the closing delimiter and leaving the block string unterminated.

The branch's premise ("it ends in quote but it is already escaped") is wrong for block strings: `\` is not an escape character there (only `\"""` is special), so a value ending in `\"` still ends in a `"` that collides with the closing `"""`.

## Fix

A value ending in `"` (including `\"`) needs a separator before the closing `"""`. Use a **newline** for that separator, even in compact mode: the block-string dedenting logic (`blockStringValue`) trims a trailing blank line, so the description round-trips **exactly** — whereas a space would be appended to the parsed value (semantic drift). Values not ending in a quote are unchanged.

## Tests

Added a test that renders a `SCALAR` type (valid SDL without a body) with a multiline description ending in `\"` via `renderCompact`, re-parses it, and asserts the parsed description **equals the original** (not merely that it parses).

`core/testOnly caliban.RenderingSpec` passes (28 tests).