### PR TITLE
Preserve out-of-range float literals as BigDecimal

### DIFF
--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -217,7 +217,11 @@ object Value {
     def fromStringUnsafe(s: String): FloatValue =
       try {
         val double = s.toDouble
-        if (double.isInfinity) BigDecimalNumber(BigDecimal(s)) else DoubleNumber(double)
+        if (double != 0.0 && !double.isInfinity) DoubleNumber(double)
+        else {
+          val bd = BigDecimal(s)
+          if (bd.signum == 0) DoubleNumber(double) else BigDecimalNumber(bd)
+        }
       } catch { case NonFatal(_) => BigDecimalNumber(BigDecimal(s)) }
 
     final case class FloatNumber(value: Float)           extends FloatValue {

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -215,8 +215,10 @@ object Value {
 
     @throws[NumberFormatException]("if the string is not a valid representation of a float")
     def fromStringUnsafe(s: String): FloatValue =
-      try DoubleNumber(s.toDouble)
-      catch { case NonFatal(_) => BigDecimalNumber(BigDecimal(s)) }
+      try {
+        val double = s.toDouble
+        if (double.isInfinity) BigDecimalNumber(BigDecimal(s)) else DoubleNumber(double)
+      } catch { case NonFatal(_) => BigDecimalNumber(BigDecimal(s)) }
 
     final case class FloatNumber(value: Float)           extends FloatValue {
       override def toFloat: Float           = value

--- a/core/src/test/scala/caliban/ValueSpec.scala
+++ b/core/src/test/scala/caliban/ValueSpec.scala
@@ -1,6 +1,8 @@
 package caliban
 
 import caliban.Value.BooleanValue
+import caliban.Value.FloatValue
+import caliban.Value.FloatValue.{ BigDecimalNumber, DoubleNumber }
 import caliban.Value.IntValue.IntNumber
 import zio.test.{ assertCompletes, assertTrue, ZIOSpecDefault }
 
@@ -26,6 +28,19 @@ object ValueSpec extends ZIOSpecDefault {
         val x = BooleanValue(false)
         val y = BooleanValue(false)
         assertTrue(x eq y)
+      }
+    ),
+    suite("FloatValue.fromStringUnsafe")(
+      test("preserves out-of-range values as BigDecimal instead of Infinity") {
+        val v = FloatValue.fromStringUnsafe("1e400")
+        assertTrue(
+          v == BigDecimalNumber(BigDecimal("1e400")),
+          v.toBigDecimal == BigDecimal("1e400"),
+          v.toString != "Infinity"
+        )
+      },
+      test("keeps in-range values as Double") {
+        assertTrue(FloatValue.fromStringUnsafe("1.5") == DoubleNumber(1.5))
       }
     )
   )

--- a/core/src/test/scala/caliban/ValueSpec.scala
+++ b/core/src/test/scala/caliban/ValueSpec.scala
@@ -31,7 +31,7 @@ object ValueSpec extends ZIOSpecDefault {
       }
     ),
     suite("FloatValue.fromStringUnsafe")(
-      test("preserves out-of-range values as BigDecimal instead of Infinity") {
+      test("preserves overflowing values as BigDecimal instead of Infinity") {
         val v = FloatValue.fromStringUnsafe("1e400")
         assertTrue(
           v == BigDecimalNumber(BigDecimal("1e400")),
@@ -39,8 +39,18 @@ object ValueSpec extends ZIOSpecDefault {
           v.toString != "Infinity"
         )
       },
+      test("preserves underflowing values as BigDecimal instead of zero") {
+        val v = FloatValue.fromStringUnsafe("1e-400")
+        assertTrue(
+          v == BigDecimalNumber(BigDecimal("1e-400")),
+          v.toBigDecimal == BigDecimal("1e-400")
+        )
+      },
       test("keeps in-range values as Double") {
         assertTrue(FloatValue.fromStringUnsafe("1.5") == DoubleNumber(1.5))
+      },
+      test("keeps genuine zero as Double") {
+        assertTrue(FloatValue.fromStringUnsafe("0.0") == DoubleNumber(0.0))
       }
     )
   )


### PR DESCRIPTION
## Problem

`FloatValue.fromStringUnsafe` relied on `s.toDouble` throwing to trigger its BigDecimal fallback:

```scala
try DoubleNumber(s.toDouble)
catch { case NonFatal(_) => BigDecimalNumber(BigDecimal(s)) }
```

But `Double.parseDouble` (behind `String.toDouble`) does **not** throw on out-of-range magnitudes — it silently **overflows to `Infinity`** and **underflows to `0.0`**. So the fallback only ever fired on malformed input, and a parseable-but-out-of-range literal lost its value:

- `1e400` → `DoubleNumber(Infinity)` — renders as the invalid token `Infinity` and throws `NumberFormatException` from `toBigDecimal`.
- `1e-400` → `DoubleNumber(0.0)` — silently collapsed to zero, so e.g. a `BigDecimal` argument receives `0` instead of `1e-400`.

`fromStringUnsafe` is on the query-parsing hot path (every float literal goes through it), so this is reachable from any client-supplied float literal.

## Fix

Take the fast path only for finite, non-zero doubles; otherwise reparse with `BigDecimal` and keep it whenever the literal is actually non-zero (preserving genuine `0` as a `Double`):

```scala
val double = s.toDouble
if (double != 0.0 && !double.isInfinity) DoubleNumber(double)
else {
  val bd = BigDecimal(s)
  if (bd.signum == 0) DoubleNumber(double) else BigDecimalNumber(bd)
}
```

## Tests

Added a `FloatValue.fromStringUnsafe` suite in `ValueSpec`: `1e400` and `1e-400` are preserved as `BigDecimalNumber` (with matching `toBigDecimal`, and no `Infinity`), in-range values stay `DoubleNumber`, and a genuine `0.0` stays `DoubleNumber`.

`core/testOnly caliban.ValueSpec` passes (7 tests).