### PR TITLE
Reject unknown input-object fields in lists and oneOf inputs

### DIFF
--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -79,29 +79,31 @@ private object ValueValidator {
 
           case INPUT_OBJECT =>
             argValue match {
-              case obj: ObjectValue if inputType._isOneOfInput =>
-                Validator.validateOneOfInputValue(obj, errorContext)
-              case ObjectValue(fields)                         =>
-                validateAllDiscard(fields) { (k, _) =>
+              case obj: ObjectValue =>
+                validateAllDiscard(obj.fields) { (k, _) =>
                   when(!inputType.allInputFields.exists(_.name == k))(
                     failValidation(
                       s"Input field '$k' is not defined on type '${inputType.name.getOrElse("?")}'.",
                       "Every input field provided in an input object value must be defined in the set of possible fields of that input object’s expected type."
                     )
                   )
-                } *> validateAllDiscard(inputType.allInputFields) { f =>
-                  fields.collectFirst { case (name, fieldValue) if name == f.name => fieldValue } match {
-                    case Some(value)                    =>
-                      validateType(f._type, value, context, s"Field ${f.name} in $errorContext")
-                    case None if f.defaultValue.isEmpty =>
-                      validateType(f._type, NullValue, context, s"Field ${f.name} in $errorContext")
-                    case _                              =>
-                      unit
-                  }
+                } *> {
+                  if (inputType._isOneOfInput) Validator.validateOneOfInputValue(obj, errorContext)
+                  else
+                    validateAllDiscard(inputType.allInputFields) { f =>
+                      obj.fields.collectFirst { case (name, fieldValue) if name == f.name => fieldValue } match {
+                        case Some(value)                    =>
+                          validateType(f._type, value, context, s"Field ${f.name} in $errorContext")
+                        case None if f.defaultValue.isEmpty =>
+                          validateType(f._type, NullValue, context, s"Field ${f.name} in $errorContext")
+                        case _                              =>
+                          unit
+                      }
+                    }
                 }
-              case NullValue                                   =>
+              case NullValue        =>
                 unit
-              case _                                           =>
+              case _                =>
                 failValidation(
                   s"$errorContext has invalid type: $argValue",
                   "Input field was supposed to be an input object."

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -82,7 +82,14 @@ private object ValueValidator {
               case obj: ObjectValue if inputType._isOneOfInput =>
                 Validator.validateOneOfInputValue(obj, errorContext)
               case ObjectValue(fields)                         =>
-                validateAllDiscard(inputType.allInputFields) { f =>
+                validateAllDiscard(fields) { (k, _) =>
+                  when(!inputType.allInputFields.exists(_.name == k))(
+                    failValidation(
+                      s"Input field '$k' is not defined on type '${inputType.name.getOrElse("?")}'.",
+                      "Every input field provided in an input object value must be defined in the set of possible fields of that input object’s expected type."
+                    )
+                  )
+                } *> validateAllDiscard(inputType.allInputFields) { f =>
                   fields.collectFirst { case (name, fieldValue) if name == f.name => fieldValue } match {
                     case Some(value)                    =>
                       validateType(f._type, value, context, s"Field ${f.name} in $errorContext")

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -1687,6 +1687,24 @@ object ExecutionSpec extends ZIOSpecDefault {
             )
         }
       },
+      test("reject an unknown field in a oneOf input inside a list") {
+        case class AddPets(pets: List[Pet.Wrapper])
+        case class Queries(addPets: AddPets => List[Pet])
+
+        val api: GraphQL[Any] = graphQL(RootResolver(Queries(_.pets.map(_.pet))))
+        val query             = gqldoc("""{
+          addPets(pets: [{ bogus: { name: "a" } }]) {
+            __typename
+          }
+        }""")
+
+        api.interpreter.flatMap(_.execute(query)).map { response =>
+          assertTrue(
+            response.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+              .exists(_.contains("Input field 'bogus' is not defined"))
+          )
+        }
+      },
       test("add extensions from a resolver") {
         case class UserArgs(id: Int)
         case class User(test: UserArgs => String)

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -306,6 +306,24 @@ object ValidationSpec extends ZIOSpecDefault {
              }""")
         check(query, "Required field 'nicknames' on object 'CharacterInput' was not provided.")
       },
+      test("reject unknown input field inside a list argument") {
+        import caliban.schema.Schema.auto._
+        import caliban.schema.ArgBuilder.auto._
+
+        case class MyInput(a: Int)
+        case class Args(items: List[MyInput])
+        case class Query(field: Args => Int)
+
+        val gql   = graphQL(RootResolver(Query(_.items.size)))
+        val query = gqldoc("""query { field(items: [{ a: 1, bogus: 2 }]) }""")
+        for {
+          int <- gql.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(
+          res.errors.collectFirst { case e: ValidationError => e.msg }
+            .exists(_.contains("Input field 'bogus' is not defined"))
+        )
+      },
       test("directive used in wrong location") {
         val query = gqldoc("""
              query @skip(if: true) {


### PR DESCRIPTION
## Problem

Unknown-input-field detection (spec 5.6.2) was only enforced for a **top-level** input-object argument, in `Validator.validateInputValues`. For an argument whose type is a **list** of input objects, `argValue` is a `ListValue`, which misses that branch and delegates to `ValueValidator.validateType`. Its `INPUT_OBJECT` branch only iterated `inputType.allInputFields` and validated their values — it never scanned the *provided* object's keys for undefined ones, so extra fields passed unchecked inside lists.

Additionally, the `INPUT_OBJECT` branch short-circuited to `validateOneOfInputValue` for **oneOf** inputs, which only checks the "exactly one non-null key" rule — so a oneOf input (in a list or otherwise) with a single *unknown* key also slipped through.

Examples — given `items: [MyInput!]` where `MyInput` defines only `a: Int`, and a oneOf `Pet` input:

```graphql
field(items: [{ a: 1, bogus: 2 }])       # accepted (unknown `bogus`)
addPets(pets: [{ bogus: { name: "a" } }]) # accepted (unknown `bogus` as the sole oneOf key)
```

whereas the same error in a non-list, non-oneOf argument was correctly rejected.

## Fix

In `ValueValidator`'s `INPUT_OBJECT` branch, scan the provided fields and reject any key not defined on the type — for **all** input objects, running before the oneOf-specific cardinality check. Uses the same message as the direct-argument path.

## Tests

- `ValidationSpec`: `field(items: [{ a: 1, bogus: 2 }])` is rejected with `Input field 'bogus' is not defined …`.
- `ExecutionSpec`: an unknown key in a oneOf input inside a list is rejected too.

`core/testOnly caliban.validation.ValidationSpec caliban.execution.ExecutionSpec` passes.