### PR TITLE
Validate directives on variable definitions and required directive arguments

### DIFF
--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -336,7 +336,17 @@ object Validator {
                             failWhen(!directive.locations.contains(location))(
                               s"Directive '${d.name}' is used in invalid location '$location'.",
                               "GraphQL servers define what directives they support and where they support them. For each usage of a directive, the directive must be used in a location that the server has declared support for."
-                            )
+                            ) *>
+                            validateAllDiscard(directive.allArgs) { arg =>
+                              failWhen(
+                                arg._type.kind == __TypeKind.NON_NULL &&
+                                  arg.defaultValue.isEmpty &&
+                                  d.arguments.getOrElse(arg.name, NullValue) == NullValue
+                              )(
+                                s"Required argument '${arg.name}' is null or missing on directive '${d.name}' ($location).",
+                                "Arguments can be required. An argument is required if the argument type is non‐null and does not have a default value. Otherwise, the argument is optional."
+                              )
+                            }
                       }
                     }
     } yield ()

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -246,6 +246,10 @@ object Validator {
           }
           dirs.foreachOne(v => all.addOne((v, location)))
         }
+        op.variableDefinitions.foreachOne { vd =>
+          val vdDirs = vd.directives
+          if (vdDirs ne Nil) vdDirs.foreachOne(v => all.addOne((v, __DirectiveLocation.VARIABLE_DEFINITION)))
+        }
       }
       fragmentDirs.foreachOne(_.foreachOne(v => all.addOne((v, __DirectiveLocation.FRAGMENT_DEFINITION))))
       if (selectionDirectives ne Nil) all.addAll(selectionDirectives)

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -228,6 +228,11 @@ object Validator {
     val ops                  = context.operations
     for {
       _                   <- validateAllDiscard(ops)(op => checkDirectivesUniqueness(op.directives, directiveDefinitions))
+      _                   <- validateAllDiscard(ops)(op =>
+                               validateAllDiscard(op.variableDefinitions)(vd =>
+                                 checkDirectivesUniqueness(vd.directives, directiveDefinitions)
+                               )
+                             )
       fragmentDirs         = {
         val fr = context.fragments
         if (fr.isEmpty) Nil else fr.values.toList.map(_.directives)

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -236,6 +236,19 @@ object ValidationSpec extends ZIOSpecDefault {
               }""")
         check(query, "Directive 'yolo' is not supported.")
       },
+      test("directive missing required argument") {
+        val query = gqldoc("""
+             query {
+               characters {
+                 name @include
+               }
+              }""")
+        execute(query).map(e =>
+          assertTrue(
+            e.exists(_.msg.contains("Required argument 'if' is null or missing on directive 'include'"))
+          )
+        )
+      },
       test("variable defined twice") {
         val query = gqldoc("""
              query($name: String, $name: String) {

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -337,6 +337,15 @@ object ValidationSpec extends ZIOSpecDefault {
              }""")
         check(query, "Directive 'skip' is used in invalid location 'VARIABLE_DEFINITION'.")
       },
+      test("directive used twice on a variable definition") {
+        val query = gqldoc("""
+             query($x: String @skip(if: true) @skip(if: true)) {
+               characters {
+                 name
+               }
+             }""")
+        check(query, "Directive 'skip' is defined more than once.")
+      },
       test("directive used twice") {
         val query = gqldoc("""
              query {

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -328,6 +328,15 @@ object ValidationSpec extends ZIOSpecDefault {
              }""")
         check(query, "Directive 'skip' is used in invalid location 'QUERY'.")
       },
+      test("directive on a variable definition is validated") {
+        val query = gqldoc("""
+             query($x: String @skip(if: true)) {
+               characters {
+                 name
+               }
+             }""")
+        check(query, "Directive 'skip' is used in invalid location 'VARIABLE_DEFINITION'.")
+      },
       test("directive used twice") {
         val query = gqldoc("""
              query {


### PR DESCRIPTION
## Problem

Directive validation had gaps around directives on **variable definitions** and around **required directive arguments**:

1. `validateDirectives` validated only the arguments actually *provided* plus the directive location. It never checked that non-null directive arguments without a default were present (spec 5.4.2.1) — the directive analogue of the `fieldArgsNonNull` check for field arguments. So `@include`/`@skip` (`if: Boolean!`, no default) passed with `if` omitted (`{ field @include }`) and were silently defaulted at execution.

2. `collectAllDirectives` gathered operation, fragment, field, fragment-spread and inline-fragment directives, but **not variable-definition directives**. So a directive on `query($x: T @foo)` bypassed directive validation entirely (support, location, arguments, required arguments).

3. `checkDirectivesUniqueness` likewise never ran on variable-definition directives, so a non-repeatable directive could be repeated there (`query($x: String @foo @foo)`).

## Fix

- Add a required-argument check over `directive.allArgs` (fail when a non-null, no-default argument is missing or null), mirroring the input-object required-field pattern.
- Collect variable-definition directives in `collectAllDirectives` with the `VARIABLE_DEFINITION` location so they go through the full support/location/argument checks.
- Run `checkDirectivesUniqueness` per variable definition as well.

## Tests

In `ValidationSpec`:
- `name @include` (missing required `if`) → `Required argument 'if' is null or missing on directive 'include' …`.
- `query($x: String @skip(if: true))` → rejected as invalid location `VARIABLE_DEFINITION` (proves VD directives are now validated).
- `query($x: String @skip(if: true) @skip(if: true))` → `Directive 'skip' is defined more than once.`

Verified no false positives on directive-heavy specs (`ValidationSpec` 46, `ExecutionSpec` 63).