### PR TITLE
Fix block-string line terminators and control-character rendering

### DIFF
--- a/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
@@ -92,7 +92,7 @@ private[caliban] trait StringParsers {
     ).map(v => StringValue(v))
 
   def blockStringValue(rawValue: String): String = {
-    val l1           = rawValue.split("\r?\n").toList
+    val l1           = rawValue.split("\r\n|\r|\n").toList
     val commonIndent = l1 match {
       case Nil       => None
       case _ :: tail =>

--- a/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
+++ b/core/src/main/scala/caliban/rendering/DocumentRenderer.scala
@@ -98,8 +98,8 @@ object DocumentRenderer extends Renderer[Document] {
 
       override def unsafeRender(description: Option[String], indent: Option[Int], writer: StringBuilder): Unit =
         description.foreach {
-          case value if value.isBlank        => ()
-          case value if value.contains('\n') =>
+          case value if value.isBlank                                           => ()
+          case value if value.contains('\n') && value.forall(isBlockStringChar) =>
             def valueEscaped(): Unit = unsafeFastEscapeQuote(value, writer)
 
             writer append tripleQuote
@@ -108,7 +108,7 @@ object DocumentRenderer extends Renderer[Document] {
             if (value.last == '"') writer append '\n' else newlineOrEmpty(indent, writer)
             writer append tripleQuote
             newlineOrSpace(indent, writer)
-          case value                         =>
+          case value                                                            =>
             pad(indent, writer)
             writer append '"'
             Renderer.escapedString.unsafeRender(value, indent, writer)
@@ -929,6 +929,9 @@ object DocumentRenderer extends Renderer[Document] {
 
   private def spaceOrEmpty(indentation: Option[Int], writer: StringBuilder): Unit =
     if (indentation.isDefined) writer append ' '
+
+  private def isBlockStringChar(c: Char): Boolean =
+    c >= ' ' || c == '\t' || c == '\n' || c == '\r'
 
   private def newlineOrEmpty(indent: Option[Int], writer: StringBuilder): Unit =
     if (indent.isDefined) writer append '\n'

--- a/core/src/test/scala/caliban/RenderingSpec.scala
+++ b/core/src/test/scala/caliban/RenderingSpec.scala
@@ -216,6 +216,20 @@ object RenderingSpec extends ZIOSpecDefault {
           .flatMap(_.definitions.collectFirst { case d: TypeDefinition.ScalarTypeDefinition => d.description }.flatten)
         assertTrue(parsedDescription.contains(description))
       },
+      test("it should round-trip a multiline description containing control characters") {
+        val description       = "line1\nvalue\f"
+        val testType          = __Type(
+          __TypeKind.SCALAR,
+          name = Some("TestType"),
+          description = Some(description)
+        )
+        val rendered          = DocumentRenderer.typesRenderer.renderCompact(List(testType))
+        val parsedDescription = Parser
+          .parseQuery(rendered)
+          .toOption
+          .flatMap(_.definitions.collectFirst { case d: TypeDefinition.ScalarTypeDefinition => d.description }.flatten)
+        assertTrue(parsedDescription.contains(description))
+      },
       test("it should render single line descriptions") {
         val api = graphQL(resolver)
         checkApi(api)

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -212,6 +212,9 @@ object ParserSpec extends ZIOSpecDefault {
           )
         }
       },
+      test("block string with lone carriage-return line terminators") {
+        assertTrue(Parser.parseInputValue("\"\"\"a\r    b\"\"\"") == Right(StringValue("a\nb")))
+      },
       test("variables") {
         val query = """query getZuckProfile($devicePicSize: Int = 60) {
                       |  user(id: 4) {


### PR DESCRIPTION
Two related block-string edge cases (parsing + rendering).

## Parsing — lone carriage return not treated as a line terminator

`blockStringValue` dedented lines using `rawValue.split("\r?\n")`, which only recognizes LF and CRLF. Per the spec, a lone CR is also a `LineTerminator`, and the block-string lexer captures raw CR characters. So a block string authored with classic-Mac (CR-only) newlines was not split into lines, no indentation was removed, and the literal `\r` was retained.

Fixed by splitting on all three line terminators: `split("\r\n|\r|\n")`.

Example: `"""a\r    b"""` now parses to `"a\nb"` (dedented) instead of `"a\r    b"`.

## Rendering — control characters emitted raw into block strings

`descriptionRenderer` chose block-string rendering whenever the description contained a newline. But a block string can only escape `\"""`; other characters are literal, and control characters such as backspace (`\b`) or form-feed (`\f`) are not valid GraphQL source characters. So a multiline description containing `\f` was emitted raw and produced unparseable SDL, while the same value without a newline was correctly escaped by the single-line branch.

Fixed by only using block-string rendering when every character is representable in one (`value.forall(isBlockStringChar)` — tab/LF/CR or `>= 0x20`); otherwise the value falls through to the single-line escaped form, which already escapes `\n`, `\b`, `\f`, etc.

## Tests

- `ParserSpec`: `parseInputValue("\"\"\"a\r    b\"\"\"")` yields `StringValue("a\nb")`.
- `RenderingSpec`: a `"line1\nvalue\f"` description round-trips through `renderCompact` → parse (previously unparseable).

`core/testOnly caliban.parsing.ParserSpec caliban.RenderingSpec` passes (80 tests).