### PR TITLE
Fix enum values whose names start with true/false/null being mis-parsed

### DIFF
--- a/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
@@ -64,6 +64,7 @@ private[caliban] trait StringParsers {
       else ev.freshSuccess(s)
     }
   def nameOnly(implicit ev: P[Any]): P[String]                           = Start ~ name ~ End
+  def nameContinue(implicit ev: P[Any]): P[Unit]                         = CharIn("_0-9A-Za-z")
 
   def hexDigit(implicit ev: P[Any]): P[Unit]         = CharIn("0-9a-fA-F")
   def escapedUnicode(implicit ev: P[Any]): P[String] =

--- a/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/ValueParsers.scala
@@ -10,9 +10,9 @@ import scala.annotation.nowarn
 @nowarn("msg=NoWhitespace") // False positive warning in Scala 2.12.x
 private[caliban] trait ValueParsers extends NumberParsers {
   def booleanValue(implicit ev: P[Any]): P[BooleanValue] =
-    StringIn("true", "false").!.map(v => BooleanValue(v.toBoolean))
+    (StringIn("true", "false").! ~~ !nameContinue).map(v => BooleanValue(v.toBoolean))
 
-  def nullValue(implicit ev: P[Any]): P[InputValue] = LiteralStr("null").map(_ => NullValue)
+  def nullValue(implicit ev: P[Any]): P[InputValue] = (LiteralStr("null") ~~ !nameContinue).map(_ => NullValue)
   def enumValue(implicit ev: P[Any]): P[InputValue] = name.map(EnumValue.apply)
   def listValue(implicit ev: P[Any]): P[ListValue]  = ("[" ~/ value.rep ~ "]").map(values => ListValue(values.toList))
 

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -215,6 +215,31 @@ object ParserSpec extends ZIOSpecDefault {
       test("block string with lone carriage-return line terminators") {
         assertTrue(Parser.parseInputValue("\"\"\"a\r    b\"\"\"") == Right(StringValue("a\nb")))
       },
+      test("enum values whose names start with a keyword") {
+        val cases = List(
+          "trueStory" -> EnumValue("trueStory"),
+          "falseFlag" -> EnumValue("falseFlag"),
+          "nullable"  -> EnumValue("nullable"),
+          "true"      -> BooleanValue(true),
+          "false"     -> BooleanValue(false),
+          "null"      -> NullValue
+        )
+        assertTrue(cases.forall { case (raw, expected) => Parser.parseInputValue(raw) == Right(expected) })
+      },
+      test("enum value starting with a keyword in a query argument") {
+        val query = "{ f(x: nullable) }"
+        Parser.parseQuery(query).map { doc =>
+          assertTrue(
+            doc ==
+              simpleQuery(
+                selectionSet = List(
+                  simpleField("f", arguments = Map("x" -> EnumValue("nullable")), index = 2)
+                ),
+                sourceMapper = SourceMapper(query)
+              )
+          )
+        }
+      },
       test("variables") {
         val query = """query getZuckProfile($devicePicSize: Int = 60) {
                       |  user(id: 4) {


### PR DESCRIPTION
## Problem

The input-value parser tries `booleanValue` and `nullValue` before `enumValue`, and the `true`/`false`/`null` keyword literals had no trailing name-boundary lookahead. Per the GraphQL spec, `EnumValue` is any `Name` except exactly `true`/`false`/`null`, so identifiers like `trueStory`, `falseFlag`, `nullable` are valid enum values.

Because of the missing boundary:

- `parseInputValue("trueStory")` returned `Right(BooleanValue(true))` instead of `EnumValue("trueStory")`.
- `parseInputValue("nullable")` returned `Right(NullValue)`.
- `{ f(x: trueStory) }` failed to parse entirely (the `true` prefix matched, leaving `Story) }` unconsumed).

## Fix

- Add `nameContinue = CharIn("_0-9A-Za-z")` (the GraphQL `Name` continuation character class) in `StringParsers`.
- `booleanValue` and `nullValue` now require `~~ !nameContinue` after the keyword, so `true`/`false`/`null` only match when not immediately followed by a name character.

## Tests

Added regression tests in `ParserSpec`:
- `trueStory`/`falseFlag`/`nullable` parse to `EnumValue`, while plain `true`/`false`/`null` still parse to their literal values.
- `{ f(x: nullable) }` parses with argument `x -> EnumValue("nullable")`.