### PR TITLE
Fix field-merge validation using queryType as parent for all operations

### DIFF
--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -494,7 +494,7 @@ object Validator {
   ): Either[ValidationError, Unit] = {
     val v1 = validateFields(context, selectionSet, currentType)(mutable.HashSet.empty)
     if (!context.fragments.isEmpty || containsFragments(selectionSet))
-      v1 *> FragmentValidator.findConflictsWithinSelectionSet(context, context.rootType.queryType, selectionSet)
+      v1 *> FragmentValidator.findConflictsWithinSelectionSet(context, currentType, selectionSet)
     else v1
   }
 

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -220,6 +220,27 @@ object FragmentSpec extends ZIOSpecDefault {
             .exists(_.contains("different arguments"))
         )
       },
+      test("field-merge conflict is detected on a mutation operation") {
+        case class Nested(x: Int => String)
+        case class Query(a: Nested)
+        case class Mutation(update: Int => Nested)
+
+        val query =
+          """mutation{
+            |  a: update(value: 1) { x(value: 1) }
+            |  a: update(value: 2) { x(value: 1) }
+            |  ... on Mutation { __typename }
+            |}""".stripMargin
+
+        val gql = graphQL(RootResolver(Query(Nested(_ => "y")), Mutation(_ => Nested(_ => "y"))))
+        for {
+          int <- gql.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(
+          res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+            .exists(_.contains("different arguments"))
+        )
+      },
       test("nested fragment selection on the same type") {
         import caliban.schema.Schema.auto._
 


### PR DESCRIPTION
## Problem

`validateSelectionSet` receives the operation's actual root type in `currentType`, but hardcoded `context.rootType.queryType` when invoking `FragmentValidator.findConflictsWithinSelectionSet`.

For `mutation` and `subscription` operations, top-level fields were therefore resolved against the **Query** type inside `FieldMap.make`. Since those fields don't exist on Query, `addField` skipped them (`getFieldOrNull` returned null), so they never entered the field map and their merge conflicts were never detected.

Example (previously passed validation, should be rejected):

```graphql
mutation {
  a: update(value: 1) { x(value: 1) }
  a: update(value: 2) { x(value: 1) }
  ... on Mutation { __typename }
}
```

The inline fragment makes the conflict check run, but the two `a: update` selections were resolved against Query, dropped, and the `a`/`a` alias collision with different arguments was not reported.

## Fix

Pass `currentType` (the operation's real root type) instead of `context.rootType.queryType` to `findConflictsWithinSelectionSet`.

## Tests

Added a regression test in `FragmentSpec` exercising a field-merge conflict on a `mutation` operation. Verified it fails before the fix and passes after.