### PR TITLE
Fix duplicate fragment spread ignoring per-spread @skip/@include

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -140,7 +140,7 @@ object Field {
     directives: List[Directive],
     rootType: RootType
   ): Field = {
-    val memoizedFragments      = new mutable.HashMap[String, List[(Field, Option[String])]]()
+    val memoizedFragments      = new mutable.HashMap[(String, List[Directive]), List[(Field, Option[String])]]()
     val variableDefinitionsMap =
       if (variableDefinitions eq Nil) Map.empty[String, VariableDefinition]
       else variableDefinitions.map(v => v.name -> v).toMap
@@ -194,7 +194,7 @@ object Field {
           }
         case FragmentSpread(name, directives)                           =>
           val fields = memoizedFragments.getOrElseUpdate(
-            name, {
+            (name, directives), {
               val resolvedDirectives = directives.map(resolveDirectiveVariables(variableValues, variableDefinitionsMap))
               val f                  = fragments.getOrElse(name, null)
               if ((f ne null) && checkDirectives(resolvedDirectives)) {

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -207,6 +207,27 @@ object ExecutionSpec extends ZIOSpecDefault {
           assertTrue(resp == """{"data":{"test":{"field1":"1234"}}}""")
         }
       },
+      test("same fragment spread twice with different @include directives") {
+        case class TestQuery(field1: String, field2: String)
+        case class Query(test: TestQuery)
+        val api = graphQL(RootResolver(Query(TestQuery(field1 = "1234", field2 = "5421"))))
+
+        val query =
+          """
+            |query ($cond: Boolean!) {
+            | test {
+            |   ...F @include(if: false)
+            |   ...F @include(if: $cond)
+            | }
+            |}
+            |fragment F on TestQuery { field1 }
+            |""".stripMargin
+
+        api.interpreter.flatMap(_.execute(query, None, Map("cond" -> BooleanValue(true)))).map { response =>
+          val resp = writeToString(response)
+          assertTrue(resp == """{"data":{"test":{"field1":"1234"}}}""")
+        }
+      },
       test("respects variables that are not provided") {
         sealed trait ThreeState
         object ThreeState {


### PR DESCRIPTION
## Problem

In `Field.apply`, `memoizedFragments.getOrElseUpdate(name, …)` cached the **entire** per-spread computation, keyed only by the fragment name. That cached block includes:

- the `checkDirectives(resolvedDirectives)` gate, which depends on *this* spread's `@skip`/`@include`, and
- the attached `Fragment(Some(name), resolvedDirectives)` metadata.

When the same named fragment is spread more than once in a selection set with different directive outcomes, only the first spread's result is computed; every later spread reuses it — contrary to the GraphQL field-collection spec, which evaluates each spread's directives independently.

Example (with `$cond = true`):

```graphql
query Q($cond: Boolean!) {
  ...F @include(if: false)
  ...F @include(if: $cond)
}
fragment F on Query { hero { name } }
```

Expected: `hero` present (second spread includes it). Actual: the first spread's `@include(if: false)` memoized `Nil` for key `"F"`, so the second spread reused `Nil` and `hero` was omitted. The reverse ordering wrongly included it.

## Fix

Key `memoizedFragments` by `(name, directives)` instead of `name`, so spreads of the same fragment with different directives are computed independently, while identical spreads still share the cache.

## Tests

Added a regression test in `ExecutionSpec` spreading the same fragment twice with different `@include` directives. Verified it fails before the fix and passes after.