### PR TITLE
Reject out-of-range Int and Long argument literals instead of wrapping

### DIFF
--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -110,14 +110,18 @@ object ArgBuilder extends ArgBuilderInstances {
 trait ArgBuilderInstances extends ArgBuilderDerivation {
   implicit lazy val unit: ArgBuilder[Unit]             = _ => Right(())
   implicit lazy val int: ArgBuilder[Int]               = {
-    case value: IntValue => Right(value.toInt)
-    case other           => Left(InvalidInputArgument("Int", other))
+    case IntValue.IntNumber(value)                        => Right(value)
+    case IntValue.LongNumber(value) if value.isValidInt   => Right(value.toInt)
+    case IntValue.BigIntNumber(value) if value.isValidInt => Right(value.toInt)
+    case other                                            => Left(InvalidInputArgument("Int", other))
   }
   implicit lazy val long: ArgBuilder[Long]             = {
-    case value: IntValue    => Right(value.toLong)
-    case StringValue(value) =>
+    case IntValue.IntNumber(value)                         => Right(value.toLong)
+    case IntValue.LongNumber(value)                        => Right(value)
+    case IntValue.BigIntNumber(value) if value.isValidLong => Right(value.toLong)
+    case StringValue(value)                                =>
       Try(value.toLong).fold(_ => Left(InvalidInputArgument("Long", value)), Right(_))
-    case other              => Left(InvalidInputArgument("Long", other))
+    case other                                             => Left(InvalidInputArgument("Long", other))
   }
   implicit lazy val bigInt: ArgBuilder[BigInt]         = {
     case value: IntValue => Right(value.toBigInt)

--- a/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
+++ b/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
@@ -24,6 +24,23 @@ object ArgBuilderSpec extends ZIOSpecDefault {
         )
       )
     ),
+    suite("int")(
+      test("Int within range")(
+        assert(ArgBuilder.int.build(IntValue.LongNumber(Int.MaxValue.toLong)))(
+          isRight(equalTo(Int.MaxValue))
+        )
+      ),
+      test("Int above range fails instead of wrapping")(
+        assert(ArgBuilder.int.build(IntValue.LongNumber(Int.MaxValue.toLong + 1)))(
+          isLeft(anything)
+        )
+      ),
+      test("Int from out-of-range BigInt fails")(
+        assert(ArgBuilder.int.build(IntValue.BigIntNumber(BigInt(Int.MaxValue) + 1)))(
+          isLeft(anything)
+        )
+      )
+    ),
     suite("long")(
       test("Long from string")(
         check(Gen.long) { value =>
@@ -31,6 +48,16 @@ object ArgBuilderSpec extends ZIOSpecDefault {
             isRight(equalTo(value))
           )
         }
+      ),
+      test("Long within range")(
+        assert(ArgBuilder.long.build(IntValue.BigIntNumber(BigInt(Long.MaxValue))))(
+          isRight(equalTo(Long.MaxValue))
+        )
+      ),
+      test("Long above range fails instead of wrapping")(
+        assert(ArgBuilder.long.build(IntValue.BigIntNumber(BigInt(Long.MaxValue) + 1)))(
+          isLeft(anything)
+        )
       )
     ),
     suite("java.time")(


### PR DESCRIPTION
## Problem

`ArgBuilder.int` coerced any `IntValue` via `value.toInt`, and `ArgBuilder.long` via `value.toLong`. For a `LongNumber`/`BigIntNumber` outside the target range these are silent JVM narrowing conversions, so out-of-range literals wrapped instead of erroring:

- `field(intArg: 2147483648)` → resolver received `-2147483648` (should be a coercion error).
- Variable `{"intArg": 5000000000}` → `705032704`.
- `field(longArg: 9223372036854775808)` (2^63) → `Long.MinValue`.

Nothing upstream caught this: the `Int` validator only checks that the value is *some* `IntValue` (no range check), and `Long` is treated as a custom scalar and passed through unchecked.

## Fix

Match the `IntValue` subtypes and range-check:

- `int`: `IntNumber` is always valid; `LongNumber`/`BigIntNumber` are accepted only when `isValidInt`, otherwise fall through to `InvalidInputArgument`.
- `long`: `IntNumber`/`LongNumber` are always valid; `BigIntNumber` is accepted only when `isValidLong`, otherwise error.

The common `IntNumber` path stays allocation-free (no `BigInt` conversion).

## Tests

Added to `ArgBuilderSpec`: in-range `Int`/`Long` succeed; above-range `Int` (`LongNumber`), out-of-range `Int` (`BigInt`), and above-range `Long` (`BigInt`) all fail instead of wrapping. Verified they fail before the fix.