### PR TITLE
Fix RenameType renaming enum values that collide with a type name

### DIFF
--- a/core/src/main/scala/caliban/transformers/Transformer.scala
+++ b/core/src/main/scala/caliban/transformers/Transformer.scala
@@ -69,16 +69,10 @@ object Transformer {
 
   final private class RenameType(map: Map[String, String]) extends Transformer[Any] {
 
-    val typeVisitor: TypeVisitor = {
-      val renameType = { (t: __Type) =>
+    val typeVisitor: TypeVisitor =
+      TypeVisitor.modify { (t: __Type) =>
         t.name.flatMap(map.get).fold(t)(newName => t.copy(name = Some(newName)))
       }
-      val renameEnum = { (t: __EnumValue) =>
-        map.get(t.name).fold(t)(newName => t.copy(name = newName))
-      }
-
-      TypeVisitor.modify(renameType) |+| TypeVisitor.enumValues.modify(renameEnum)
-    }
 
     protected val typeNames: Set[String] = map.keySet
 

--- a/core/src/test/scala/caliban/transformers/TransformerSpec.scala
+++ b/core/src/test/scala/caliban/transformers/TransformerSpec.scala
@@ -40,6 +40,27 @@ object TransformerSpec extends ZIOSpecDefault {
                         |""".stripMargin
         )
       },
+      test("rename type does not rename colliding enum values") {
+        sealed trait Color
+        object Color {
+          case object Red   extends Color
+          case object Green extends Color
+        }
+        case class Green(x: String)
+        case class Q(color: Color, green: Green)
+
+        val localApi    = graphQL(RootResolver(Q(Color.Green, Green("hi"))))
+        val transformed = localApi.transform(Transformer.RenameType("Green" -> "RenamedType"))
+        val rendered    = transformed.render
+        for {
+          interpreter <- transformed.interpreter
+          result      <- interpreter.execute("{ color green { x } }").map(_.data.toString)
+        } yield assertTrue(
+          result == """{"color":"Green","green":{"x":"hi"}}""",
+          rendered.contains("enum Color {\n  Green\n  Red\n}"),
+          rendered.contains("green: RenamedType!")
+        )
+      },
       test("rename field") {
         val transformed: GraphQL[Any] = api.transform(Transformer.RenameField("InnerObject" -> "b" -> "c"))
         val rendered                  = transformed.render


### PR DESCRIPTION
## Problem

`RenameType`'s type visitor was:

```scala
TypeVisitor.modify(renameType) |+| TypeVisitor.enumValues.modify(renameEnum)
```

where `renameEnum` looked up each enum **value** name in the same `oldTypeName -> newTypeName` map used for types. Since `TypeVisitor.enumValues.modify` runs over every enum value of every enum in the schema, any enum value whose name happens to equal a type being renamed was silently renamed too.

Worse, this only affected the advertised SDL/introspection: `transformStep` only rewrites `ObjectStep` names at runtime and never touches enum values, so the resolver kept emitting the original value — advertising an enum value that no longer existed in responses.

Example: object type `Foo` and an unrelated enum `Category { Foo, Bar }`. `RenameType("Foo" -> "Baz")` (intending to rename only the object type) also renamed the enum value: introspection showed `enum Category { Baz Bar }`, while `{ category }` still returned `"Foo"` at runtime.

This has been present since the transformers feature was introduced (#2218).

## Fix

Drop the `enumValues.modify(renameEnum)` branch so `RenameType` only renames types. Enum values are a separate namespace and must not be affected.

Renaming an enum **type** still works, because enum types are `__Type` values handled by `renameType` (verified: `RenameType("Color" -> "Colour")` renames the enum type and all references, runtime unaffected). There was no working way to rename enum **values** on purpose — the removed code only triggered on accidental name collisions and never updated the runtime.

## Tests

Added a regression test in `TransformerSpec`: object type `Green` + enum `Color { Red, Green }`, renamed via `RenameType("Green" -> "RenamedType")`. Asserts the enum still renders `Green`, the field becomes `green: RenamedType!`, and the runtime value stays `"Green"`. Verified it fails before the fix.