### PR TITLE
Support variable-width unicode escape sequences in string values

### DIFF
--- a/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
@@ -68,7 +68,15 @@ private[caliban] trait StringParsers {
 
   def hexDigit(implicit ev: P[Any]): P[Unit]         = CharIn("0-9a-fA-F")
   def escapedUnicode(implicit ev: P[Any]): P[String] =
-    (hexDigit ~~ hexDigit ~~ hexDigit ~~ hexDigit).!.map(Integer.parseInt(_, 16).toChar.toString)
+    ("{" ~~ hexDigit.repX(1).! ~~ "}").flatMap { hex =>
+      val codePoint = BigInt(hex, 16)
+      if (codePoint <= Character.MAX_CODE_POINT && !isSurrogate(codePoint.toInt))
+        ev.freshSuccess(new String(Character.toChars(codePoint.toInt)))
+      else ev.freshFailure()
+    } | (hexDigit ~~ hexDigit ~~ hexDigit ~~ hexDigit).!.map(Integer.parseInt(_, 16).toChar.toString)
+
+  private def isSurrogate(codePoint: Int): Boolean =
+    codePoint >= Character.MIN_SURROGATE && codePoint <= Character.MAX_SURROGATE
 
   def escapedCharacter(implicit ev: P[Any]): P[String] = CharIn("\"\\\\/bfnrt").!.map {
     case "b"   => "\b"

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -215,6 +215,21 @@ object ParserSpec extends ZIOSpecDefault {
       test("block string with lone carriage-return line terminators") {
         assertTrue(Parser.parseInputValue("\"\"\"a\r    b\"\"\"") == Right(StringValue("a\nb")))
       },
+      test("unicode escape sequences") {
+        val bs                 = "\\"
+        def str(inner: String) = "\"" + inner + "\""
+        val emoji              = new String(Character.toChars(0x1f600))
+        assertTrue(
+          Parser.parseInputValue(str(bs + "u0041")) == Right(StringValue("A")),
+          Parser.parseInputValue(str(bs + "u{41}")) == Right(StringValue("A")),
+          Parser.parseInputValue(str(bs + "u{1F600}")) == Right(StringValue(emoji)),
+          Parser.parseInputValue(str(bs + "u{00000041}")) == Right(StringValue("A")),
+          Parser.parseInputValue(str(bs + "uD83D" + bs + "uDE00")) == Right(StringValue(emoji)),
+          Parser.parseInputValue(str(bs + "u{110000}")).isLeft,
+          Parser.parseInputValue(str(bs + "u{D800}")).isLeft,
+          Parser.parseInputValue(str(bs + "u{DEAD}")).isLeft
+        )
+      },
       test("enum values whose names start with a keyword") {
         val cases = List(
           "trueStory" -> EnumValue("trueStory"),


### PR DESCRIPTION
## Problem

`escapedUnicode` only accepted the fixed 4-hex-digit form `\uXXXX`. The GraphQL October 2021 spec extended `EscapedUnicode` to also allow the variable-width form `\u{HexDigit+}` (e.g. `\u{1F600}`), which caliban rejected. The fixed form also cannot directly express code points above U+FFFF except via explicit surrogate-pair escapes.

```
parseInputValue("\"\u{1F600}\"")  // was: ParsingError; now: StringValue("😀")
```

## Fix

`escapedUnicode` now accepts the variable-width `{ HexDigit+ }` form: it parses the captured hex digits with `BigInt` (so digit count / leading zeros can't overflow), requires the value to be a **Unicode scalar value** (within range and **not** a surrogate, per the spec — `\u{D800}`, `\u{DEAD}` are rejected), and emits the code point via `Character.toChars` (handling supplementary characters). Out-of-range or surrogate code points fail the parse rather than throwing.

The fixed 4-digit form is left unchanged, so surrogate-pair escapes (`😀` → 😀) still combine into a single scalar.

## Tests

Added to `ParserSpec`: fixed `A` → `A`; variable `\u{41}` → `A`; supplementary `\u{1F600}` → 😀; leading-zero `\u{00000041}` → `A`; surrogate pair `😀` → 😀 (same result); out-of-range `\u{110000}` and lone surrogates `\u{D800}`/`\u{DEAD}` fail. Verified the new forms fail before the fix.