### PR TITLE
Collect variables used in operation-level directives

### DIFF
--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -155,7 +155,11 @@ object Validator {
       case (t, _)                                            => t
     }
 
-  private def collectVariablesUsed(context: Context, selectionSet: List[Selection]): mutable.Set[String] = {
+  private def collectVariablesUsed(
+    context: Context,
+    selectionSet: List[Selection],
+    operationDirectives: List[Directive]
+  ): mutable.Set[String] = {
     val allValues = ListBuffer.empty[InputValue]
     val variables = mutable.Set.empty[String]
     val seen      = mutable.HashSet.empty[String]
@@ -201,6 +205,7 @@ object Validator {
       }
 
     collectValues(selectionSet)
+    operationDirectives.foreachOne(d => if (!d.arguments.isEmpty) allValues.addAll(d.arguments.values))
     if (!allValues.isEmpty) collectVariableValues(allValues)
     variables
   }
@@ -363,7 +368,7 @@ object Validator {
   def validateVariables(context: Context): Either[ValidationError, Unit] =
     validateAllDiscard(context.operations) { op =>
       val variableDefinitions = op.variableDefinitions
-      val variableUsages      = collectVariablesUsed(context, op.selectionSet)
+      val variableUsages      = collectVariablesUsed(context, op.selectionSet, op.directives)
       if (variableDefinitions.isEmpty && variableUsages.isEmpty) unit
       else
         validateAllDiscard(op.variableDefinitions.groupBy(_.name)) { (name, variables) =>

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -6,8 +6,9 @@ import caliban.InputValue.ObjectValue
 import caliban.Macros.gqldoc
 import caliban.TestUtils._
 import caliban.Value.{ BooleanValue, IntValue, NullValue, StringValue }
+import caliban.introspection.adt.{ __Directive, __DirectiveLocation, __InputValue }
 import caliban.schema.Annotations.{ GQLDefault, GQLOneOfInput }
-import caliban.schema.{ ArgBuilder, Schema }
+import caliban.schema.{ ArgBuilder, Schema, Types }
 import zio.{ IO, UIO, ZIO }
 import zio.test.Assertion._
 import zio.test._
@@ -303,6 +304,25 @@ object ValidationSpec extends ZIOSpecDefault {
               }""")
         execute(query, Map("x" -> StringValue("y"))).map { errors =>
           assertTrue(errors.isEmpty)
+        }
+      },
+      test("variable used only in an operation directive is not flagged as unused") {
+        val logDirective = __Directive(
+          name = "log",
+          description = None,
+          locations = Set(__DirectiveLocation.QUERY),
+          args = _ => List(__InputValue("level", None, () => Types.string, None)),
+          isRepeatable = false
+        )
+        val interpreter  = graphQL(resolver, List(logDirective)).interpreter
+        val query        = gqldoc("""
+             query Q($lvl: String!) @log(level: $lvl) {
+               characters {
+                 name
+               }
+              }""")
+        interpreter.flatMap(_.execute(query, variables = Map("lvl" -> StringValue("info")))).map { response =>
+          assertTrue(response.errors.isEmpty)
         }
       },
       test("invalid input field") {


### PR DESCRIPTION
## Problem

`collectVariablesUsed` only traversed the operation's selection set (and directives on fields, fragment spreads, fragment definitions, and inline fragments) — it never inspected the operation's own directives. As a result, a variable referenced *only* in an operation directive was not counted as used, and the "All Variables Used" check reported it as unused with a spurious `ValidationError`.

Example (custom `directive @log(level: String) on QUERY`):

```graphql
query Q($lvl: String!) @log(level: $lvl) {
  characters { name }
}
```

`$lvl` is used only in the operation directive, so validation failed with `Variable 'lvl' is not used.`

## Fix

Thread the operation's own directives into `collectVariablesUsed` and include their argument values when gathering variable usages.

## Tests

Added a regression test in `ValidationSpec`: an operation with a custom QUERY-location directive whose argument is a variable used nowhere else. Asserts validation passes. Verified it fails before the fix.