### PR TITLE
Reject explicit null for non-null variables and non-null list items

### DIFF
--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -129,8 +129,8 @@ object VariablesCoercer {
       case None      => Right(value)
     }
 
-  private def resolveType(rootType: RootType, `type`: Type): Option[__Type] =
-    `type` match {
+  private def resolveType(rootType: RootType, `type`: Type): Option[__Type] = {
+    val resolved = `type` match {
       case NamedType(name, _)  => rootType.types.get(name)
       case ListType(ofType, _) =>
         Some(
@@ -140,6 +140,9 @@ object VariablesCoercer {
           )
         )
     }
+    if (`type`.nonNull) resolved.map(t => __Type(kind = __TypeKind.NON_NULL, ofType = Some(t)))
+    else resolved
+  }
 
   private val coercionDescription = "Variable values need to follow GraphQL's coercion rules."
 

--- a/core/src/test/scala/caliban/validation/InputArgumentSpec.scala
+++ b/core/src/test/scala/caliban/validation/InputArgumentSpec.scala
@@ -922,12 +922,10 @@ object InputArgumentSpec extends ZIOSpecDefault {
           for {
             res <- execute(query, vars)
           } yield assertTrue(
-            // Variable value validation now happens at coercion/execution time, not validation time.
-            // Per spec note on "Values of Correct Type": variable values are checked during coercion.
             res.errors.exists {
-              case CalibanError.ExecutionError(msg, _, _, _, _) =>
-                msg == "Can't build an instance of 'Int' from 'null'"
-              case _                                            => false
+              case CalibanError.ValidationError(msg, _, _, _) =>
+                msg == "Variable 'var' null is null, should be Int!"
+              case _                                          => false
             }
           )
         },

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -306,6 +306,29 @@ object ValidationSpec extends ZIOSpecDefault {
           assertTrue(errors.isEmpty)
         }
       },
+      test("explicit null is rejected for a non-null variable") {
+        val query = gqldoc("""
+             query($o: Origin!) {
+               characters(origin: $o) {
+                 name
+               }
+              }""")
+        execute(query, Map("o" -> NullValue)).map { errors =>
+          assertTrue(errors.exists(_.msg.contains("is null")))
+        }
+      },
+      test("explicit null list item is rejected for a non-null item type") {
+        val query = gqldoc("""
+             query($names: [String!]!) {
+               charactersIn(names: $names) {
+                 name
+               }
+              }""")
+        execute(query, Map("names" -> InputValue.ListValue(List(StringValue("Amos Burton"), NullValue)))).map {
+          errors =>
+            assertTrue(errors.exists(_.msg.contains("is null")))
+        }
+      },
       test("variable used only in an operation directive is not flagged as unused") {
         val logDirective = __Directive(
           name = "log",


### PR DESCRIPTION
## Problem

`VariablesCoercer.resolveType` discarded the `nonNull` flag of a variable's declared type:

- for a `NamedType` it returned the bare scalar/enum/input `__Type` (kind `SCALAR`/`ENUM`/`INPUT_OBJECT`, never `NON_NULL`);
- for a `ListType` it built a `__Type(LIST, ofType = …)` with no `NON_NULL` wrapper on the item type.

As a result, the `NON_NULL` enforcement branch in `coerceValues` was unreachable for a variable's own top-level type and for list-item types (it only fired for input-object fields, whose `__Type` carries `NON_NULL` from introspection). An explicitly-provided `null` therefore passed coercion:

```graphql
query Q($b: Boolean!) { bool(input: $b) }   # variables { "b": null }  -> accepted (should error)
query Q($xs: [Int!])  { ... }               # variables { "xs": [null] } -> accepted (should error)
```

The dedicated top-level null check only ran when the variable was **absent**, not when it was present as `null`.

## Fix

`resolveType` now wraps the resolved `__Type` in a `NON_NULL` when the declared `Type.nonNull` is set, so the existing null-rejection branch in `coerceValues` fires for the variable's own type and its list-item types.

## Tests

- `ValidationSpec`: explicit `null` is rejected for `$o: Origin!`, and an explicit `null` list item is rejected for `[String!]!`. Both verified to fail before the fix.
- `InputArgumentSpec`: the existing `{ b: $var } + { var: null }` test asserted the old downstream error (`Can't build an instance of 'Int' from 'null'`); updated to expect the correct coercion-time `ValidationError` (`Variable 'var' ... is null, should be Int!`).

Full `core/test` suite passes.