### PR TITLE
Coerce out-of-Long-range integer literals to Float/Double via BigInt

### DIFF
--- a/core/src/main/scala/caliban/schema/ArgBuilder.scala
+++ b/core/src/main/scala/caliban/schema/ArgBuilder.scala
@@ -128,12 +128,12 @@ trait ArgBuilderInstances extends ArgBuilderDerivation {
     case other           => Left(InvalidInputArgument("BigInt", other))
   }
   implicit lazy val float: ArgBuilder[Float]           = {
-    case value: IntValue   => Right(value.toLong.toFloat)
+    case value: IntValue   => Right(value.toBigInt.toFloat)
     case value: FloatValue => Right(value.toFloat)
     case other             => Left(InvalidInputArgument("Float", other))
   }
   implicit lazy val double: ArgBuilder[Double]         = {
-    case value: IntValue   => Right(value.toLong.toDouble)
+    case value: IntValue   => Right(value.toBigInt.toDouble)
     case value: FloatValue => Right(value.toDouble)
     case other             => Left(InvalidInputArgument("Double", other))
   }

--- a/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
+++ b/core/src/test/scala/caliban/schema/ArgBuilderSpec.scala
@@ -60,6 +60,16 @@ object ArgBuilderSpec extends ZIOSpecDefault {
         )
       )
     ),
+    suite("float/double")(
+      test("Double from an out-of-Long-range integer literal is not truncated") {
+        val big = BigInt("99999999999999999999")
+        assert(ArgBuilder.double.build(IntValue.BigIntNumber(big)))(isRight(equalTo(big.toDouble)))
+      },
+      test("Float from an out-of-Long-range integer literal is not truncated") {
+        val big = BigInt("99999999999999999999")
+        assert(ArgBuilder.float.build(IntValue.BigIntNumber(big)))(isRight(equalTo(big.toFloat)))
+      }
+    ),
     suite("java.time")(
       test("Instant from epoch")(
         assert(ArgBuilder.instantEpoch.build(IntValue.LongNumber(100)))(


### PR DESCRIPTION
## Problem

`ArgBuilder.float` and `.double` coerced integer literals with `value.toLong.toFloat` / `value.toLong.toDouble`. For an `IntValue.BigIntNumber` beyond the signed 64-bit range, `toLong` performs a silent JVM narrowing (low 64 bits), so out-of-range integer literals were corrupted before the float/double conversion:

- `f(x: 18446744073709551616)` (2^64) → `0.0` (expected ≈ 1.8e19)
- `f(x: 99999999999999999999)` (~1e20) → ≈ 7.77e18 (off by ~13×)

Nothing upstream range-checks integer literals for the `Float`/`Double` scalars (literal arguments bypass `VariablesCoercer`, whose Float branch already uses `BigDecimal`).

## Fix

Convert integer literals through `value.toBigInt` (exact) before the `.toFloat` / `.toDouble` conversion. No range rejection is needed — an integer literal is a valid `Float` input per the spec, and `Float`/`Double` legitimately represent large magnitudes (with the inherent precision loss). This is the Float/Double sibling of the Int/Long overflow fix (#3029), which deliberately left float/double untouched.

## Tests

Added to `ArgBuilderSpec`: `Double`/`Float` built from `BigInt("99999999999999999999")` equal `big.toDouble` / `big.toFloat` instead of the truncated value. Verified both fail before the fix.