### PR TITLE
Fix defer/stream label uniqueness check aborting in single-feature mode

### DIFF
--- a/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
+++ b/core/src/main/scala/caliban/wrappers/IncrementalDelivery.scala
@@ -149,19 +149,19 @@ object IncrementalDelivery {
 
       @tailrec
       def allLabelsUnique(selections: List[Selection]): Boolean = selections match {
-        case Selection.Field(_, _, _, directives, children, _) :: rest if Feature.isStreamEnabled(flags)    =>
-          val label = extractLabel(directives, Directives.Stream)
+        case Selection.Field(_, _, _, directives, children, _) :: rest     =>
+          val label = if (Feature.isStreamEnabled(flags)) extractLabel(directives, Directives.Stream) else None
 
           isLabelUnique(label) && allLabelsUnique(rest ++ children)
-        case Selection.InlineFragment(_, directives, selectionSet) :: rest if Feature.isDeferEnabled(flags) =>
-          val label = extractLabel(directives, Directives.Defer)
+        case Selection.InlineFragment(_, directives, selectionSet) :: rest =>
+          val label = if (Feature.isDeferEnabled(flags)) extractLabel(directives, Directives.Defer) else None
 
           isLabelUnique(label) && allLabelsUnique(rest ++ selectionSet)
-        case Selection.FragmentSpread(name, directives) :: rest if Feature.isDeferEnabled(flags)            =>
-          val label = extractLabel(directives, Directives.Defer)
+        case Selection.FragmentSpread(name, directives) :: rest            =>
+          val label = if (Feature.isDeferEnabled(flags)) extractLabel(directives, Directives.Defer) else None
 
           isLabelUnique(label) && allLabelsUnique(rest ++ context.fragments(name).selectionSet)
-        case _                                                                                              => true
+        case _                                                             => true
       }
 
       if (!allLabelsUnique(context.operations.flatMap(_.selectionSet))) {

--- a/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
+++ b/core/src/test/scala/caliban/execution/IncrementalDeliverySpec.scala
@@ -478,6 +478,24 @@ object IncrementalDeliverySpec extends ZIOSpecDefault {
           errors.size == 1,
           errors.head.is(_.subtype[ValidationError]).msg == "Stream and defer directive labels must be unique"
         )
+      },
+      test("duplicate defer labels are detected in defer-only mode") {
+        val query = gqldoc("""
+        {
+           character(name: "Roberta Draper") {
+             ... @defer(label: "dup") { n1: nicknames }
+             ... @defer(label: "dup") { n2: nicknames }
+           }
+        }
+          """)
+
+        for {
+          response <- deferOnlyInterpreter.flatMap(_.execute(query))
+          errors    = response.errors
+        } yield assertTrue(
+          errors.size == 1,
+          errors.head.is(_.subtype[ValidationError]).msg == "Stream and defer directive labels must be unique"
+        )
       }
     )
   ).provide(CharacterService.test, QuoteService.test)

--- a/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
+++ b/core/src/test/scala/caliban/execution/TestDeferredSchema.scala
@@ -157,7 +157,8 @@ object TestDeferredSchema extends SchemaDerivation[CharacterService with QuoteSe
       )
     )
 
-  val interpreter = (graphQL(resolver) @@ IncrementalDelivery.all).interpreter
+  val interpreter          = (graphQL(resolver) @@ IncrementalDelivery.all).interpreter
+  val deferOnlyInterpreter = (graphQL(resolver) @@ IncrementalDelivery.defer).interpreter
 }
 
 object TestDatasourceDeferredSchema extends GenericSchema[Any] {


### PR DESCRIPTION
## Problem

In `IncrementalDelivery.uniqueLabels`, the recursive `allLabelsUnique` traversal coupled *recursion into a field's children* to the `isStreamEnabled` guard, and recursion into fragments to the `isDeferEnabled` guard:

```scala
case Selection.Field(_, _, _, directives, children, _) :: rest if Feature.isStreamEnabled(flags)    => ...
case Selection.InlineFragment(_, directives, selectionSet) :: rest if Feature.isDeferEnabled(flags) => ...
case Selection.FragmentSpread(name, directives) :: rest if Feature.isDeferEnabled(flags)            => ...
case _                                                                                              => true
```

When only `@defer` is enabled (`IncrementalDelivery.defer`, a public API), `isStreamEnabled` is false, so a `Field` at the head of a selection list matched no guarded case and fell through to `case _ => true` — aborting the traversal before descending into the field's `children`, where `@defer` fragments actually live. Duplicate `@defer` labels were therefore never detected. The symmetric problem existed in stream-only mode when a fragment led the list.

The existing "labels must be unique" test only passed because it uses `IncrementalDelivery.all` (both features enabled), where the `Field` case matches via `isStreamEnabled`.

## Fix

Decouple traversal from the feature-specific label check: always recurse into children and selection sets, and gate only the *label extraction* on the relevant feature flag (`Stream` label when stream is enabled, `Defer` label when defer is enabled).

## Tests

- `TestDeferredSchema`: added a `deferOnlyInterpreter` (`@@ IncrementalDelivery.defer`).
- `IncrementalDeliverySpec`: duplicate `@defer` labels inside a field's children now produce the uniqueness `ValidationError` in defer-only mode. Verified it fails before the fix.