### PR TITLE
Escape control characters when rendering GraphQL string values

### DIFF
--- a/core/src/main/scala/caliban/rendering/Renderer.scala
+++ b/core/src/main/scala/caliban/rendering/Renderer.scala
@@ -153,7 +153,12 @@ object Renderer {
           case '\r' => writer.append("\\r")
           case '\t' => writer.append("\\t")
           case '"'  => writer.append("\\\"")
-          case c    => writer.append(c)
+          case c    =>
+            if (c < ' ') {
+              writer.append("\\u00")
+              writer.append(Character.forDigit((c >> 4) & 0xf, 16))
+              writer.append(Character.forDigit(c & 0xf, 16))
+            } else writer.append(c)
         }
         i += 1
       }

--- a/core/src/test/scala/caliban/ValueSpec.scala
+++ b/core/src/test/scala/caliban/ValueSpec.scala
@@ -4,6 +4,8 @@ import caliban.Value.BooleanValue
 import caliban.Value.FloatValue
 import caliban.Value.FloatValue.{ BigDecimalNumber, DoubleNumber }
 import caliban.Value.IntValue.IntNumber
+import caliban.Value.StringValue
+import caliban.parsing.Parser
 import zio.test.{ assertCompletes, assertTrue, ZIOSpecDefault }
 
 object ValueSpec extends ZIOSpecDefault {
@@ -51,6 +53,17 @@ object ValueSpec extends ZIOSpecDefault {
       },
       test("keeps genuine zero as Double") {
         assertTrue(FloatValue.fromStringUnsafe("0.0") == DoubleNumber(0.0))
+      }
+    ),
+    suite("StringValue.toInputString")(
+      test("escapes control characters so the output round-trips") {
+        val bs       = "\\"
+        val value    = StringValue(s"a${0x07.toChar}b${0x00.toChar}c${0x1f.toChar}d")
+        val rendered = value.toInputString
+        assertTrue(
+          rendered == "\"a" + bs + "u0007b" + bs + "u0000c" + bs + "u001fd\"",
+          Parser.parseInputValue(rendered) == Right(value)
+        )
       }
     )
   )


### PR DESCRIPTION
## Problem

`Renderer.escapedString` — used for all double-quoted, non-block GraphQL string values (via `ValueRenderer`'s `StringValue` case) and for the single-line description fallback — only special-cased `\\`, `\b`, `\f`, `\n`, `\r`, `\t`, `\"`. Every other character fell through to `case c => writer.append(c)` and was emitted **raw**, including control characters U+0000–U+0007, U+000B, U+000E–U+001F.

The parser's `stringCharacter` rule only accepts `sourceCharacter` (U+0009, U+000A, U+000D, U+0020–U+FFFF) plus escape sequences, so those raw control characters cannot be re-parsed. Any SDL string value carrying such a character — an input/argument default value, a `@deprecated(reason: …)`, a `specifiedBy(url: …)` — produced invalid SDL that failed the render → parse round-trip.

## Fix

In the default branch of the escaper, escape characters below `0x20` as `\u00XX` (built manually, so the common path stays allocation-free and the `@switch` remains intact). All other characters render as before.

## Tests

Added to `ValueSpec`: a `StringValue` containing U+0007/U+0000/U+001F renders to `"abcd"` and round-trips through `Parser.parseInputValue`. Verified it fails before the fix (the raw control characters are rejected by the parser).
