### PR TITLE
Fix client field-name collision rendering and decoding

### DIFF
--- a/client/src/main/scala/caliban/client/SelectionBuilder.scala
+++ b/client/src/main/scala/caliban/client/SelectionBuilder.scala
@@ -369,9 +369,11 @@ object SelectionBuilder {
     override def fromGraphQL(value: __Value): Either[DecodingError, A] =
       value match {
         case __ObjectValue(fields) =>
-          fields.find { case (o, _) =>
-            alias.getOrElse(name) + math.abs(self.hashCode) == o || alias.contains(o) || name == o
-          }.toRight(DecodingError(s"Missing field $name"))
+          val disambiguated = alias.getOrElse(name) + math.abs(self.hashCode)
+          fields
+            .find(_._1 == disambiguated)
+            .orElse(fields.find { case (o, _) => alias.contains(o) || name == o })
+            .toRight(DecodingError(s"Missing field $name"))
             .flatMap(v => builder.fromGraphQL(v._2))
         case _                     => Left(DecodingError(s"Invalid field type $name"))
       }

--- a/client/src/main/scala/caliban/client/SelectionRenderer.scala
+++ b/client/src/main/scala/caliban/client/SelectionRenderer.scala
@@ -87,10 +87,8 @@ private[client] object SelectionRenderer {
               } else {
                 writer.append(resolved)
                 writer.append(math.abs(f.code))
-                if (hasAlias) {
-                  writer.append(':')
-                  writer.append(f.name)
-                }
+                writer.append(':')
+                writer.append(f.name)
               }
               val bodyWriter = new StringBuilder()
               var state1     = selections.unsafeRender(f.selectionSet, state0, bodyWriter, options)

--- a/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
+++ b/client/src/test/scala/caliban/client/SelectionBuilderSpec.scala
@@ -110,6 +110,14 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
           val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
           assertTrue(s == """{amos:character(name:"Amos Burton"){name} naomi:character(name:"Naomi Nagata"){name}}""")
         },
+        test("field-name collision renders a valid alias") {
+          val query  =
+            Queries.characters() {
+              Character.name ~ Character.nicknames ~ Character.name
+            }
+          val (s, _) = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          assertTrue(s.matches("""\{characters\{name nicknames name\d+:name\}\}"""))
+        },
         test("variables") {
           val query          =
             Queries
@@ -350,6 +358,21 @@ object SelectionBuilderSpec extends ZIOSpecDefault {
               List(
                 "amos"  -> __ObjectValue(List("name" -> __StringValue("Amos Burton"))),
                 "naomi" -> __ObjectValue(List("name" -> __StringValue("Naomi Nagata")))
+              )
+            )
+          assert(query.fromGraphQL(response))(isRight(equalTo((Some("Amos Burton"), Some("Naomi Nagata")))))
+        },
+        test("colliding aliases decode to their own values") {
+          val query     =
+            Queries.character("Amos Burton")(Character.name).withAlias("x") ~
+              Queries.character("Naomi Nagata")(Character.name).withAlias("x")
+          val (s, _)    = SelectionBuilder.toGraphQL(query.toSelectionSet, useVariables = false)
+          val secondKey = "x[0-9]+".r.findFirstIn(s).getOrElse("x")
+          val response  =
+            __ObjectValue(
+              List(
+                "x"       -> __ObjectValue(List("name" -> __StringValue("Amos Burton"))),
+                secondKey -> __ObjectValue(List("name" -> __StringValue("Naomi Nagata")))
               )
             )
           assert(query.fromGraphQL(response))(isRight(equalTo((Some("Amos Burton"), Some("Naomi Nagata")))))


### PR DESCRIPTION
## Problem

When two selections in the same selection set resolve to the same response key, `caliban-client` disambiguates the later one by appending `math.abs(code)` to the key. Two defects made this incorrect:

**1. Rendering (`SelectionRenderer`)** — in the collision branch, the `:fieldName` alias suffix was only written `if (hasAlias)`. For a collision on an **un-aliased** field, it emitted a bare `name<code>` token — which is an invalid field name (the server has no such field), so the whole query is rejected.

```
(Character.name ~ Character.nicknames) ~ Character.name
// was:  {characters{name nicknames name945005608}}      <- bare invalid field
// now:  {characters{name nicknames name945005608:name}} <- valid alias
```

**2. Decoding (`SelectionBuilder.Field.fromGraphQL`)** — the value was located with a single `find`:

```scala
alias.getOrElse(name) + math.abs(self.hashCode) == o || alias.contains(o) || name == o
```

For a field that *was* disambiguated, the fallback clauses (`alias.contains(o)` / `name == o`) also match the sibling's un-suffixed key. Because decoded objects are sorted (TreeMap), the un-suffixed key is iterated first, so the second colliding field silently decoded the **first** field's value — data corruption, even in the alias-collision case which renders a perfectly valid query.

```
character("Amos")(name).withAlias("x") ~ character("Naomi")(name).withAlias("x")
// decoded to (Some("Amos"), Some("Amos"))   instead of   (Some("Amos"), Some("Naomi"))
```

## Fix

- Renderer: the disambiguated token is always an alias, so always emit `:fieldName` after it.
- Decoder: look up the disambiguated key (`name/alias + code`) first, and only fall back to the bare name/alias when it's absent.

## Tests

Added to `SelectionBuilderSpec`: a no-alias collision now renders a valid `name<code>:name` alias; two same-alias fields on different queries decode to their own distinct values (the disambiguated key is extracted from the rendered query, so no runtime hashCode is hard-coded). Both verified to fail before the fix.