### PR TITLE
Fix codegen ClientWriter enum encoder, enum .value, and doc-comment escaping

### DIFF
--- a/codegen/src/main/scala/caliban/codegen/ClientWriter.scala
+++ b/codegen/src/main/scala/caliban/codegen/ClientWriter.scala
@@ -134,7 +134,9 @@ object ClientWriter {
       commonInterface: Boolean
     ): FieldInfo = {
       val description                                      = field.description match {
-        case Some(d) if d.trim.nonEmpty => s"/**\n * ${d.trim}\n */\n"
+        case Some(d) if d.trim.nonEmpty =>
+          val safe = d.trim.replace("*/", "* /").replace("/*", "/ *")
+          s"/**\n * $safe\n */\n"
         case _                          => ""
       }
       val deprecated                                       = field.directives.find(_.name == "deprecated") match {
@@ -728,7 +730,7 @@ object ClientWriter {
 
       val enumCases = typedef.enumValuesDefinition
         .map(v =>
-          s"case object ${safeEnumValue(v.enumValue)} extends $enumName { val value: String = ${"\"" + safeEnumValue(v.enumValue) + "\""} }"
+          s"""case object ${safeEnumValue(v.enumValue)} extends $enumName { val value: String = "${v.enumValue}" }"""
         ) ++
         (if (extensibleEnums) Some(s"final case class __Unknown(value: String) extends $enumName") else None)
 
@@ -737,8 +739,8 @@ object ClientWriter {
         (if (extensibleEnums) Some(s"case __StringValue (other) => Right($enumName.__Unknown(other))") else None)
 
       val encoderCases = typedef.enumValuesDefinition
-        .map(v => s"""case ${typedef.name}.${safeEnumValue(v.enumValue)} => __EnumValue("${v.enumValue}")""") ++
-        (if (extensibleEnums) Some(s"case ${typedef.name}.__Unknown (value) => __EnumValue(value)") else None)
+        .map(v => s"""case $enumName.${safeEnumValue(v.enumValue)} => __EnumValue("${v.enumValue}")""") ++
+        (if (extensibleEnums) Some(s"case $enumName.__Unknown (value) => __EnumValue(value)") else None)
 
       val enumObject =
         if (typedef.enumValuesDefinition.nonEmpty) {
@@ -750,7 +752,7 @@ object ClientWriter {
               ${decoderCases.mkString("\n")}
               case other => Left(DecodingError(s"Can't build ${typedef.name} from input $$other"))
             }
-            implicit val encoder: ArgEncoder[${typedef.name}] = {
+            implicit val encoder: ArgEncoder[$enumName] = {
               ${encoderCases.mkString("\n")}
             }
 

--- a/codegen/src/test/resources/snapshots/ClientWriterSpec/case-sensitive name uniqueness in enums values.scala
+++ b/codegen/src/test/resources/snapshots/ClientWriterSpec/case-sensitive name uniqueness in enums values.scala
@@ -9,7 +9,7 @@ object Client {
     case object NEWHOPE extends Episode { val value: String = "NEWHOPE" }
     case object EMPIRE  extends Episode { val value: String = "EMPIRE"  }
     case object JEDI    extends Episode { val value: String = "JEDI"    }
-    case object jedi_1  extends Episode { val value: String = "jedi_1"  }
+    case object jedi_1  extends Episode { val value: String = "jedi"    }
 
     implicit val decoder: ScalarDecoder[Episode] = {
       case __StringValue("NEWHOPE") => Right(Episode.NEWHOPE)

--- a/codegen/src/test/resources/snapshots/ClientWriterSpec/enum value that is a reserved word.scala
+++ b/codegen/src/test/resources/snapshots/ClientWriterSpec/enum value that is a reserved word.scala
@@ -1,0 +1,25 @@
+import caliban.client.CalibanClientError.DecodingError
+import caliban.client._
+import caliban.client.__Value._
+
+object Client {
+
+  sealed trait E extends scala.Product with scala.Serializable { def value: String }
+  object E {
+    case object `type`  extends E { val value: String = "type"  }
+    case object `match` extends E { val value: String = "match" }
+
+    implicit val decoder: ScalarDecoder[E] = {
+      case __StringValue("type")  => Right(E.`type`)
+      case __StringValue("match") => Right(E.`match`)
+      case other                  => Left(DecodingError(s"Can't build E from input $other"))
+    }
+    implicit val encoder: ArgEncoder[E]    = {
+      case E.`type`  => __EnumValue("type")
+      case E.`match` => __EnumValue("match")
+    }
+
+    val values: scala.collection.immutable.Vector[E] = scala.collection.immutable.Vector(`type`, `match`)
+  }
+
+}

--- a/codegen/src/test/resources/snapshots/ClientWriterSpec/enum with case-insensitive type name clash.scala
+++ b/codegen/src/test/resources/snapshots/ClientWriterSpec/enum with case-insensitive type name clash.scala
@@ -1,0 +1,32 @@
+import caliban.client.CalibanClientError.DecodingError
+import caliban.client.FieldBuilder._
+import caliban.client._
+import caliban.client.__Value._
+
+object Client {
+
+  sealed trait foo_1 extends scala.Product with scala.Serializable { def value: String }
+  object foo_1 {
+    case object A extends foo_1 { val value: String = "A" }
+    case object B extends foo_1 { val value: String = "B" }
+
+    implicit val decoder: ScalarDecoder[foo_1] = {
+      case __StringValue("A") => Right(foo_1.A)
+      case __StringValue("B") => Right(foo_1.B)
+      case other              => Left(DecodingError(s"Can't build foo from input $other"))
+    }
+    implicit val encoder: ArgEncoder[foo_1]    = {
+      case foo_1.A => __EnumValue("A")
+      case foo_1.B => __EnumValue("B")
+    }
+
+    val values: scala.collection.immutable.Vector[foo_1] = scala.collection.immutable.Vector(A, B)
+  }
+
+  type Foo
+  object Foo {
+    def id: SelectionBuilder[Foo, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("id", OptionOf(Scalar()))
+  }
+
+}

--- a/codegen/src/test/resources/snapshots/ClientWriterSpec/field description containing comment markers.scala
+++ b/codegen/src/test/resources/snapshots/ClientWriterSpec/field description containing comment markers.scala
@@ -1,0 +1,16 @@
+import caliban.client.FieldBuilder._
+import caliban.client._
+
+object Client {
+
+  type Query = _root_.caliban.client.Operations.RootQuery
+  object Query {
+
+    /**
+     * use bar * / instead / * here
+     */
+    def foo: SelectionBuilder[_root_.caliban.client.Operations.RootQuery, scala.Option[String]] =
+      _root_.caliban.client.SelectionBuilder.Field("foo", OptionOf(Scalar()))
+  }
+
+}

--- a/codegen/src/test/scala/caliban/codegen/ClientWriterSpec.scala
+++ b/codegen/src/test/scala/caliban/codegen/ClientWriterSpec.scala
@@ -207,6 +207,34 @@ object ClientWriterSpec extends SnapshotTest {
           excludeDeprecated = true
         )
       },
+      snapshotTest("enum with case-insensitive type name clash") {
+        gen("""
+             type Foo {
+               id: String
+             }
+
+             enum foo {
+               A
+               B
+             }
+            """)
+      },
+      snapshotTest("enum value that is a reserved word") {
+        gen("""
+             enum E {
+               type
+               match
+             }
+            """)
+      },
+      snapshotTest("field description containing comment markers") {
+        gen("""
+             type Query {
+               "use bar */ instead /* here"
+               foo: String
+             }
+            """)
+      },
       snapshotTest("scalar mapped enum") {
         gen(
           """


### PR DESCRIPTION
Three defects in `ClientWriter` that make generated client code wrong or uncompilable from valid SDL.

## 1. Enum encoder references the un-renamed type name on a case-insensitive clash (compile failure)

The enum object/trait/decoder/values are emitted using `enumName = safeTypeName(typedef.name)` (which applies clash renaming), but the encoder cases and the encoder implicit's type parameter used the **raw** `typedef.name`. When two schema types differ only in letter case, the second is renamed (e.g. `foo` → `foo_1`), so the encoder referenced an identifier that doesn't exist and the generated code failed to compile.

```
type Foo { id: String }
enum foo { A B }
// was: implicit val encoder: ArgEncoder[foo] = { case foo.A => ... }   // `foo` undefined
// now: implicit val encoder: ArgEncoder[foo_1] = { case foo_1.A => ... }
```

## 2. Enum `.value` returns the Scala identifier instead of the GraphQL value

A case object's `val value: String` literal was built from `safeEnumValue`, which applies reserved-word backticking and clash renaming. So `.value` returned the Scala identifier (e.g. `` `type` `` or `jedi_1`) rather than the actual GraphQL enum value — inconsistent with the wire value used by the encoder (`__EnumValue`) and decoder. Now uses the raw enum value.

```
enum E { type }
// was: case object `type` extends E { val value: String = "`type`" }
// now: case object `type` extends E { val value: String = "type" }
```

(This also corrects the existing `case-sensitive name uniqueness in enums values` snapshot, where `jedi` had `.value == "jedi_1"`.)

## 3. Field description breaks the generated doc comment

The description was interpolated into a `/** … */` block unescaped. A description containing `*/` closed the comment early; and since Scala block comments **nest**, `/*` opened a nested level — either produces invalid Scala. Both sequences are now neutralized (`*/` → `* /`, `/*` → `/ *`).

## Tests

Added snapshot tests for all three scenarios and verified the generated output is correct (encoder/type/value consistent; comment intact). Confirmed the affected snapshots mismatch when the fix is reverted.