### PR TITLE
Fix federation @connect directive builder and connect spec version

### DIFF
--- a/federation/src/main/scala/caliban/federation/connect/ConnectV0.scala
+++ b/federation/src/main/scala/caliban/federation/connect/ConnectV0.scala
@@ -11,7 +11,7 @@ object ConnectV0 {
   )
 
   val connect0_2: Link = connect.copy(
-    `import` = connect.`import`
+    url = s"$connectUrl/v0.2"
   )
 
   val connect0_3: Link = connect0_2.copy(

--- a/federation/src/main/scala/caliban/federation/connect/package.scala
+++ b/federation/src/main/scala/caliban/federation/connect/package.scala
@@ -16,13 +16,13 @@ package object connect {
     val connectBuilder = Map.newBuilder[String, InputValue]
     val httpBuilder    = Map.newBuilder[String, InputValue]
 
-    http.method match {
+    httpBuilder += (http.method match {
       case Method.GET(url)      => "GET"    -> Value.StringValue(url)
       case Method.DELETE(url)   => "DELETE" -> Value.StringValue(url)
       case Method.POST(url, _)  => "POST"   -> Value.StringValue(url)
       case Method.PUT(url, _)   => "PUT"    -> Value.StringValue(url)
       case Method.PATCH(url, _) => "PATCH"  -> Value.StringValue(url)
-    }
+    })
     http.method.body.foreach(body => httpBuilder += "body" -> Value.StringValue(body.select))
     if (http.headers.nonEmpty)
       httpBuilder += "headers" -> InputValue.ListValue(
@@ -55,11 +55,11 @@ package object connect {
         val mb = Map.newBuilder[String, InputValue]
         e.message.foreach(m => mb += ("message" -> Value.StringValue(m.select)))
         e.extensions.foreach(m => mb += ("extensions" -> Value.StringValue(m.select)))
-        InputValue.ObjectValue(mb.result())
+        connectBuilder += "errors" -> InputValue.ObjectValue(mb.result())
       }
     }
 
-    Directive("source", httpBuilder.result())
+    Directive("connect", connectBuilder.result())
   }
 
   def Source(

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_11.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_11.scala
@@ -20,7 +20,7 @@ trait FederationDirectivesV2_11 extends FederationDirectivesV2_9 {
     entity: Option[Boolean] = None,
     batch: Option[BatchSettings] = None,
     errors: Option[ConnectorErrors] = None
-  ) extends GQLDirective(Connect(http, selection, source, entity))
+  ) extends GQLDirective(Connect(http, selection, source, entity, batch, errors))
 
   case class GQLSource(
     name: String,

--- a/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
+++ b/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
@@ -236,6 +236,42 @@ object FederationV2Spec extends ZIOSpecDefault {
         }
 
       },
+      suite("connect directive builder")(
+        test("Connect renders a complete @connect directive") {
+          import caliban.federation.connect._
+          import caliban.Value.{ BooleanValue, IntValue }
+          val directive = Connect(
+            http = ConnectHTTP(Method.GET("/users/{id}")),
+            selection = JSONSelection("id name"),
+            source = Some("api"),
+            entity = Some(true),
+            batch = Some(BatchSettings(Some(10)))
+          )
+          assertTrue(
+            directive.name == "connect",
+            directive.arguments.get("http").contains(ObjectValue(Map("GET" -> StringValue("/users/{id}")))),
+            directive.arguments.get("selection").contains(StringValue("id name")),
+            directive.arguments.get("source").contains(StringValue("api")),
+            directive.arguments.get("entity").contains(BooleanValue(true)),
+            directive.arguments.get("batch").contains(ObjectValue(Map("maxSize" -> IntValue(10))))
+          )
+        },
+        test("GQLConnect forwards batch to the directive") {
+          import caliban.federation.v2_11.GQLConnect
+          import caliban.federation.connect._
+          import caliban.Value.IntValue
+          val directive =
+            GQLConnect(
+              ConnectHTTP(Method.GET("/x")),
+              JSONSelection("id"),
+              batch = Some(BatchSettings(Some(5)))
+            ).directive
+          assertTrue(directive.arguments.get("batch").contains(ObjectValue(Map("maxSize" -> IntValue(5)))))
+        },
+        test("connect 0.2 link points to v0.2") {
+          assertTrue(caliban.federation.connect.ConnectV0.connect0_2.url == "https://specs.apollo.dev/connect/v0.2")
+        }
+      ),
       test("renderer renders the schema including the extensions") {
         import caliban.federation.v2_3._
 


### PR DESCRIPTION
Three defects in the federation connect support.

## 1. `Connect(...)` builder produced an empty `@source` directive (HIGH)

The builder assembled everything into `connectBuilder`, but had three compounding bugs:

- the `http.method match { … }` block was a bare expression whose tuple result was never added to any builder, so the HTTP method + URL were dropped;
- the `errors.foreach` block built an `ObjectValue` that was never added anywhere;
- the function returned `Directive("source", httpBuilder.result())` — wrong name **and** the wrong (nearly empty) builder — so `selection`, `source`, `entity`, `batch`, `errors` were all discarded.

Net effect: every `@connect` rendered as an empty `@source`. Now the method entry and errors are added to the builders, and the function returns `Directive("connect", connectBuilder.result())`.

## 2. `connect0_2` pointed at v0.1 (MEDIUM)

`ConnectV0.connect0_2` was defined as `connect.copy(import = connect.import)` — it only re-copied the identical import list and left `url` at the inherited `…/connect/v0.1`. Since `connect0_3`/`connect0_4` set v0.3/v0.4, the intent is v0.2. Federation `v2_11` uses this link, so its `_service` SDL advertised `connect/v0.1`. Now set to v0.2.

## 3. `GQLConnect` dropped `batch`/`errors` (LOW)

`GQLConnect` (v2_11) accepts `batch` and `errors` but delegated to `Connect(http, selection, source, entity)`, so those settings were never rendered. Now forwarded.

## Tests

Added a `connect directive builder` suite in `FederationV2Spec`: `Connect(...)` renders a complete `@connect` directive (name, http method, selection, source, entity, batch); `GQLConnect` forwards `batch`; `connect0_2` points to v0.2. All three verified to fail before the fix.