### PR TITLE
Preserve and compare interface-implements-interface relationships in tools

### DIFF
--- a/tools/src/main/scala/caliban/tools/RemoteSchema.scala
+++ b/tools/src/main/scala/caliban/tools/RemoteSchema.scala
@@ -164,6 +164,7 @@ object RemoteSchema {
       kind = __TypeKind.INTERFACE,
       name = Some(definition.name),
       description = definition.description,
+      interfaces = toInterfaces(definition.implements, definitions),
       possibleTypes = Some(implementations),
       fields = (args: __DeprecatedArgs) =>
         if (definition.fields.nonEmpty)

--- a/tools/src/main/scala/caliban/tools/SchemaComparison.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaComparison.scala
@@ -226,8 +226,16 @@ object SchemaComparison {
   private def compareInterfaces(
     left: InterfaceTypeDefinition,
     right: InterfaceTypeDefinition
-  ): List[SchemaComparisonChange] =
-    compareAllFields(left.name, left.fields, right.fields)
+  ): List[SchemaComparisonChange] = {
+    val leftImplements    = left.implements.toSet
+    val rightImplements   = right.implements.toSet
+    val implementsAdded   =
+      (rightImplements -- leftImplements).map(name => InterfaceImplementsAdded(left.name, name.name)).toList
+    val implementsDeleted =
+      (leftImplements -- rightImplements).map(name => InterfaceImplementsDeleted(left.name, name.name)).toList
+
+    implementsAdded ++ implementsDeleted ++ compareAllFields(left.name, left.fields, right.fields)
+  }
 
   private def compareTypes(left: TypeDefinition, right: TypeDefinition): List[SchemaComparisonChange] = {
     val typeTarget         = Target.Type(left.name)

--- a/tools/src/main/scala/caliban/tools/SchemaComparisonChange.scala
+++ b/tools/src/main/scala/caliban/tools/SchemaComparisonChange.scala
@@ -45,6 +45,14 @@ object SchemaComparisonChange {
     override def breaking: Boolean = true
   }
 
+  case class InterfaceImplementsAdded(typeName: String, implements: String)   extends SchemaComparisonChange {
+    override def toString: String = s"Interface '$typeName' now implements interface: '$implements'."
+  }
+  case class InterfaceImplementsDeleted(typeName: String, implements: String) extends SchemaComparisonChange {
+    override def toString: String  = s"Interface '$typeName' no longer implements interface: '$implements'."
+    override def breaking: Boolean = true
+  }
+
   case class SchemaQueryTypeChanged(from: Option[String], to: Option[String])        extends SchemaComparisonChange {
     override def toString: String  =
       s"Root query type was changed from ${renderRootType(from)} to ${renderRootType(to)}."

--- a/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
+++ b/tools/src/test/scala/caliban/tools/RemoteSchemaSpec.scala
@@ -125,6 +125,23 @@ object RemoteSchemaSpec extends ZIOSpecDefault {
         remoteSchema.subscriptionType.flatMap(_.name).contains("Subscription"),
         remoteSchema.subscriptionType.flatMap(_.fields(__DeprecatedArgs()).map(_.map(_.name))).contains(List("tick"))
       )
+    },
+    test("preserves interface-implements-interface relationships") {
+      val schema =
+        """
+          |schema { query: Query }
+          |type Query { node: Node }
+          |interface Node { id: ID! }
+          |interface Resource implements Node { id: ID! name: String! }
+          |type File implements Resource & Node { id: ID! name: String! }
+          |""".stripMargin
+
+      for {
+        doc          <- ZIO.fromEither(Parser.parseQuery(schema))
+        remoteSchema <- ZIO.fromOption(RemoteSchema.parseRemoteSchema(doc))
+        resource      = remoteSchema.types.find(_.name.contains("Resource"))
+        implemented   = resource.flatMap(_.interfaces()).getOrElse(Nil).flatMap(_.name)
+      } yield assertTrue(implemented.contains("Node"))
     }
   )
 

--- a/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
+++ b/tools/src/test/scala/caliban/tools/SchemaComparisonSpec.scala
@@ -310,6 +310,23 @@ object SchemaComparisonSpec extends ZIOSpecDefault {
           )
 
           compareChanges(schema1, schema2, expected)
+        },
+        test("changes in interface-implemented interfaces") {
+          val schema1: String =
+            """interface A { x: Int }
+              |interface B implements A { x: Int }
+              |""".stripMargin
+
+          val schema2: String =
+            """interface A { x: Int }
+              |interface B { x: Int }
+              |""".stripMargin
+
+          val expected = List(
+            SchemaComparisonChange.InterfaceImplementsDeleted("B", "A")
+          )
+
+          compareChanges(schema1, schema2, expected)
         }
       ),
       suite("type extensions")(


### PR DESCRIPTION
GraphQL interfaces can implement other interfaces (October 2021). Two places in `caliban-tools` dropped that relationship.

## 1. `RemoteSchema` loses interface `implements` on reconstruction

`toInterfaceType` built the `__Type` without ever setting the `interfaces` field (it defaulted to `() => None`), unlike `toObjectType` which sets `interfaces = toInterfaces(definition.implements, definitions)`. So `parseRemoteSchema` silently discarded `InterfaceTypeDefinition.implements`, and re-rendering the reconstructed schema omitted the `implements` clause.

```
interface Resource implements Node { … }
// reconstructed as: interface Resource { … }   (implements Node dropped)
```

Fix: set `interfaces = toInterfaces(definition.implements, definitions)`.

## 2. `SchemaComparison` never detects interface `implements` changes

`compareInterfaces` only called `compareAllFields` and ignored `left.implements` vs `right.implements`, whereas `compareObjects` diffs implements and emits `ObjectImplementsAdded/Deleted`. So removing an implemented interface from an interface — a **breaking** change — produced no change at all.

Fix: diff the implements list in `compareInterfaces` and emit new `InterfaceImplementsAdded` / `InterfaceImplementsDeleted` (breaking) changes, mirroring `compareObjects`. (`InterfaceTypeExtension` has no `implements` field, so the extension path needs no change.)

## Tests

- `RemoteSchemaSpec`: an SDL with `interface Resource implements Node` round-trips through `parseRemoteSchema` with `Resource`'s `interfaces()` including `Node`.
- `SchemaComparisonSpec`: removing `implements A` from `interface B` reports `InterfaceImplementsDeleted("B", "A")`.

Both verified to fail before the fix.