### PR TITLE
Prefer SSE over graphql-response+json in tapir content negotiation

### DIFF
--- a/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/TapirAdapter.scala
@@ -115,6 +115,13 @@ object TapirAdapter {
           None,
           encodeMultipartMixedResponse(resp, stream)
         )
+      case resp if accepts.serverSentEvents                     =>
+        (
+          MediaType.TextEventStream,
+          StatusCode.Ok,
+          None,
+          encodeTextEventStreamResponse(resp)
+        )
       case resp if accepts.graphQLJson                          =>
         val isBadRequest = response.errors.exists {
           case _: CalibanError.ParsingError | _: CalibanError.ValidationError => true
@@ -129,13 +136,6 @@ object TapirAdapter {
             keepDataOnErrors = !isBadRequest,
             excludeExtensions = cacheDirective.map(_ => Set(Caching.DirectiveName))
           )
-        )
-      case resp if accepts.serverSentEvents                     =>
-        (
-          MediaType.TextEventStream,
-          StatusCode.Ok,
-          None,
-          encodeTextEventStreamResponse(resp)
         )
       case resp                                                 =>
         val isBadRequest = response.errors.contains(HttpUtils.MutationOverGetError: Any)

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/BuildHttpResponseSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/BuildHttpResponseSpec.scala
@@ -1,0 +1,39 @@
+package caliban.interop.tapir
+
+import caliban.{ GraphQLResponse, ResponseValue, Value }
+import caliban.interop.tapir.TapirAdapterSpec.FakeServerRequest
+import sttp.model.{ Header, MediaType, Method, Uri }
+import zio.stream.ZStream
+import zio.test._
+
+object BuildHttpResponseSpec extends ZIOSpecDefault {
+
+  import StreamConstructor.zioStreams
+
+  private val graphqlResponseJson = MediaType("application", "graphql-response+json")
+  private val uri                 = Uri.unsafeParse("http://localhost/api/graphql")
+
+  private def mediaTypeOf[E](accept: Header, response: GraphQLResponse[E]): MediaType = {
+    val req = FakeServerRequest(Method.POST, uri, List(accept))
+    TapirAdapter.buildHttpResponse[E, ZStream[Any, Throwable, Byte]](req)(response)._1
+  }
+
+  private val subscriptionResponse =
+    GraphQLResponse[Nothing](
+      ResponseValue.ObjectValue(List("characterDeleted" -> ResponseValue.StreamValue(ZStream.empty))),
+      Nil
+    )
+
+  private val queryResponse =
+    GraphQLResponse[Nothing](ResponseValue.ObjectValue(List("hello" -> Value.StringValue("world"))), Nil)
+
+  override def spec = suite("BuildHttpResponseSpec")(
+    test("prefers SSE over graphql-response+json for a subscription when both are accepted") {
+      val accept = Header.accept(graphqlResponseJson, MediaType.TextEventStream)
+      assertTrue(mediaTypeOf(accept, subscriptionResponse) == MediaType.TextEventStream)
+    },
+    test("uses graphql-response+json when SSE is not accepted") {
+      assertTrue(mediaTypeOf(Header.accept(graphqlResponseJson), queryResponse) == graphqlResponseJson)
+    }
+  )
+}


### PR DESCRIPTION
## Problem

`TapirAdapter.buildHttpResponse` (which drives the http4s adapter via `HttpInterpreter`/`HttpUploadInterpreter`) checked `accepts.graphQLJson` **before** `accepts.serverSentEvents`.

A subscription response has `data = ObjectValue(field -> StreamValue)` — a *top-level* `StreamValue` is only produced by `@defer`, so the multipart case does not match a subscription. When a spec-valid client sends an `Accept` header containing **both** `application/graphql-response+json` and `text/event-stream`, both `accepts.graphQLJson` and `accepts.serverSentEvents` are true, so the `graphQLJson` branch won. The subscription was then encoded as a single JSON body via `encodeSingleResponse`, and since `ResponseValue.StreamValue` serializes as `v.toString`, the client received a bogus body and never got any streamed events.

The quick adapter (`QuickRequestHandler`) uses the opposite, correct order (SSE before `graphQLJson`), so the two adapters diverged.

## Fix

Check `accepts.serverSentEvents` before `accepts.graphQLJson`, matching the quick adapter. SSE is a valid response for both queries and subscriptions, whereas `graphql-response+json` cannot deliver a subscription.

## Tests

Added `BuildHttpResponseSpec` unit-testing the pure `buildHttpResponse`:
- a subscription response (`ObjectValue(field -> StreamValue)`) with `Accept: application/graphql-response+json, text/event-stream` → `text/event-stream`;
- a query response with `Accept: application/graphql-response+json` (no SSE) → `application/graphql-response+json` (guards against over-swapping).

The first verified to fail before the fix.