### PR TITLE
Mask list, enum and boolean argument values in SchemaTracer

### DIFF
--- a/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
+++ b/tracing/src/main/scala/caliban/tracing/SchemaTracer.scala
@@ -58,17 +58,20 @@ object SchemaTracer {
   private def graphQLQuery(field: Field): String =
     RemoteQuery.apply(maskField(field)).toGraphQLRequest.query.getOrElse("")
 
-  private def maskArguments(args: Map[String, InputValue]): Map[String, InputValue] =
-    args.map { case (k, v) =>
-      val v1 = v match {
-        case _: ObjectValue      => ObjectValue(Map.empty)
-        case _: StringValue      => StringValue("")
-        case _: Value.IntValue   => IntNumber(0)
-        case _: Value.FloatValue => FloatNumber(0f)
-        case x                   => x
-      }
-      (k, v1)
-    }.toMap
+  private[tracing] def maskArguments(args: Map[String, InputValue]): Map[String, InputValue] =
+    args.map { case (k, v) => (k, maskValue(v)) }.toMap
+
+  private def maskValue(v: InputValue): InputValue =
+    v match {
+      case _: ObjectValue               => ObjectValue(Map.empty)
+      case InputValue.ListValue(values) => InputValue.ListValue(values.map(maskValue))
+      case _: StringValue               => StringValue("")
+      case _: Value.IntValue            => IntNumber(0)
+      case _: Value.FloatValue          => FloatNumber(0f)
+      case _: Value.BooleanValue        => Value.BooleanValue(false)
+      case _: Value.EnumValue           => Value.EnumValue("__REDACTED")
+      case x                            => x
+    }
 
   private def maskField(f: Field): Field =
     f.copy(

--- a/tracing/src/test/scala/caliban/tracing/SchemaTracerSpec.scala
+++ b/tracing/src/test/scala/caliban/tracing/SchemaTracerSpec.scala
@@ -1,0 +1,31 @@
+package caliban.tracing
+
+import caliban.InputValue
+import caliban.InputValue.ListValue
+import caliban.Value.{ BooleanValue, EnumValue, IntValue, StringValue }
+import caliban.parsing.Parser
+import zio.test._
+
+object SchemaTracerSpec extends ZIOSpecDefault {
+  override def spec = suite("SchemaTracerSpec")(
+    test("maskArguments masks scalar, list, enum and boolean argument values") {
+      val args   = Map[String, InputValue](
+        "s"    -> StringValue("secret"),
+        "list" -> ListValue(List(StringValue("ssn:123-45-6789"), StringValue("secret2"))),
+        "enum" -> EnumValue("SECRET"),
+        "bool" -> BooleanValue(true),
+        "int"  -> IntValue(42)
+      )
+      val masked = SchemaTracer.maskArguments(args)
+      assertTrue(
+        masked("s") == StringValue(""),
+        masked("list") == ListValue(List(StringValue(""), StringValue(""))),
+        masked("enum") == EnumValue("__REDACTED"),
+        masked("bool") == BooleanValue(false),
+        masked("int") == IntValue(0),
+        // the masked enum must render as a syntactically valid enum value, not a bare empty name
+        Parser.parseInputValue(masked("enum").toInputString) == Right(EnumValue("__REDACTED"))
+      )
+    }
+  )
+}


### PR DESCRIPTION
## Problem

`SchemaTracer.maskArguments` redacts argument values before the query is rendered into the OpenTelemetry span `document` attribute. It masked scalar `StringValue` → `""`, `IntValue` → `0`, `FloatValue` → `0`, and `ObjectValue` → empty — but `InputValue.ListValue`, `EnumValue` and `BooleanValue` fell through the final `case x => x` branch unchanged.

So any value nested inside a list argument was emitted verbatim, and top-level enum/boolean values were exposed. This is internally inconsistent: a top-level string argument is masked to `""`, yet the identical string inside a list is leaked.

```
{ search(filters: ["ssn:123-45-6789"]) { id } }
// span 'document': query{search(filters:["ssn:123-45-6789"]){id}}   <- leaked
// vs { search(term: "ssn:123-45-6789") } which IS masked to term:""
```

## Fix

Extract a recursive `maskValue` that recurses into `ListValue` elements and additionally redacts `EnumValue` and `BooleanValue`. Existing behavior for scalars and objects is unchanged.

Enum values are redacted to a valid placeholder name (`__REDACTED`) rather than an empty name: enum input values render as bare names, so `EnumValue("")` would produce malformed GraphQL (`status:`) in the traced `document`.

## Tests

Added `SchemaTracerSpec` asserting `maskArguments` masks string, list-nested string, enum, boolean and int values, and that the masked enum round-trips through `Parser.parseInputValue` (i.e. renders as syntactically valid GraphQL). Verified it fails against the previous logic.