### PR TITLE
Fix jsoniter number parser miscounting digits of a number at end of input

### DIFF
--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -210,8 +210,8 @@ private[caliban] object ValueJsoniter {
     if (b == '-') b = in.nextByte()
     try
       while (b >= '0' && b <= '9') {
-        b = in.nextByte()
         digits += 1
+        b = in.nextByte()
       }
     catch {
       case _: JsonReaderException => // ignore the end of input error for now

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
@@ -4,7 +4,7 @@ import caliban.CalibanError.ExecutionError
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.Value.{ IntValue, StringValue }
 import caliban.parsing.adt.LocationInfo
-import caliban.{ CalibanError, GraphQLResponse, PathValue, TestUtils }
+import caliban.{ CalibanError, GraphQLResponse, PathValue, ResponseValue, TestUtils }
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import zio.test.Assertion.equalTo
 import zio.test.{ assert, assertTrue, ZIOSpecDefault }
@@ -98,6 +98,14 @@ object GraphQLResponseJsoniterSpec extends ZIOSpecDefault {
       test("should correctly write keys containing UTF-8") {
         val response = GraphQLResponse(ObjectValue(List("utf8〜key" -> StringValue("any"))), Nil)
         assertTrue(writeToString(response) == """{"data":{"utf8〜key":"any"}}""")
+      },
+      test("decodes a bare out-of-Int/Long-range integer at end of input [jsoniter]") {
+        assertTrue(
+          readFromString[ResponseValue]("3000000000") == IntValue.LongNumber(3000000000L),
+          readFromString[ResponseValue]("9999999999999999999") ==
+            IntValue.BigIntNumber(BigInt("9999999999999999999")),
+          readFromString[ResponseValue]("[3000000000]") == ListValue(List(IntValue.LongNumber(3000000000L)))
+        )
       }
     )
 }


### PR DESCRIPTION
## Problem

`ValueJsoniter.numberParser` counts a number's digits to decide whether to decode it as `Int`, `Long` or `BigInt`. The loop read the next byte and *then* incremented the counter:

```scala
while (b >= '0' && b <= '9') {
  b = in.nextByte()
  digits += 1
}
```

When the number is the final token with no trailing byte, the terminating `in.nextByte()` throws the end-of-input `JsonReaderException` (caught and ignored) **before** `digits += 1` runs, so `digits` under-counts by one. A genuine 10-digit integer then took the `digits < 10` branch → `in.readInt()` (Int overflow), and a 19-digit integer took the `digits < 19` branch → `in.readLong()` (Long overflow) — throwing instead of producing `LongNumber` / `BigIntNumber`.

The parser backs both `responseValueCodec` and `inputValueCodec`, so both were affected. It only triggered when the number was the last token at true EOF; numbers followed by any byte (`,`, `]`, `}`, whitespace) counted correctly.

```
readFromString[ResponseValue]("3000000000")           // threw "value is too large for int"
readFromString[ResponseValue]("9999999999999999999")  // threw "value is too large for long"
readFromString[ResponseValue]("[3000000000]")          // fine (trailing ']')
```

## Fix

Increment `digits` before reading the next byte, so the terminating read (delimiter or EOF) no longer affects the count.

## Tests

Added to `GraphQLResponseJsoniterSpec`: bare `3000000000` → `LongNumber`, bare `9999999999999999999` → `BigIntNumber`, and `[3000000000]` still decodes. Verified the bare cases fail before the fix.