### PR TITLE
Encode GET query-param variables and extensions as JSON, not GraphQL syntax

### DIFF
--- a/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/HttpInterpreter.scala
@@ -2,6 +2,7 @@ package caliban.interop.tapir
 
 import caliban._
 import caliban.interop.tapir.TapirAdapter._
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToString
 import sttp.capabilities.Streams
 import sttp.model.{ headers => _, _ }
 import sttp.monad.MonadError
@@ -128,19 +129,29 @@ object HttpInterpreter {
   def apply[R, E](interpreter: GraphQLInterpreter[R, E]): HttpInterpreter[R, E] =
     Base(interpreter)
 
+  private[tapir] def queryFromQueryParams(queryParams: QueryParams): DecodeResult[GraphQLRequest] =
+    for {
+      req <- JsonCodecs.requestCodec.decode(s"""{"query":"","variables":${queryParams
+                 .get("variables")
+                 .getOrElse("null")},"extensions":${queryParams
+                 .get("extensions")
+                 .getOrElse("null")}}""")
+
+    } yield req.copy(query = queryParams.get("query"), operationName = queryParams.get("operationName"))
+
+  private[tapir] def queryToQueryParams(request: GraphQLRequest): QueryParams =
+    QueryParams.fromMap(
+      Map(
+        "query"         -> request.query.getOrElse(""),
+        "operationName" -> request.operationName.getOrElse(""),
+        "variables"     -> request.variables.fold("")(vs => writeToString[InputValue](InputValue.ObjectValue(vs))),
+        "extensions"    -> request.extensions.fold("")(es => writeToString[InputValue](InputValue.ObjectValue(es)))
+      ).filter { case (_, v) => v.nonEmpty }
+    )
+
   def makeHttpEndpoints[S](
     streams: Streams[S]
   ): List[PublicEndpoint[(GraphQLRequest, ServerRequest), TapirResponse, CalibanResponse[streams.BinaryStream], S]] = {
-    def queryFromQueryParams(queryParams: QueryParams): DecodeResult[GraphQLRequest] =
-      for {
-        req <- JsonCodecs.requestCodec.decode(s"""{"query":"","variables":${queryParams
-                   .get("variables")
-                   .getOrElse("null")},"extensions":${queryParams
-                   .get("extensions")
-                   .getOrElse("null")}}""")
-
-      } yield req.copy(query = queryParams.get("query"), operationName = queryParams.get("operationName"))
-
     def checkRequest(request: GraphQLRequest): DecodeResult[GraphQLRequest] =
       if (request.isEmpty) DecodeResult.Missing else DecodeResult.Value(request)
 
@@ -177,20 +188,7 @@ object HttpInterpreter {
       : PublicEndpoint[(GraphQLRequest, ServerRequest), TapirResponse, CalibanResponse[streams.BinaryStream], S] =
       endpoint.get
         .in(
-          queryParams.mapDecode(queryFromQueryParams(_).flatMap(checkRequest))(request =>
-            QueryParams.fromMap(
-              Map(
-                "query"         -> request.query.getOrElse(""),
-                "operationName" -> request.operationName.getOrElse(""),
-                "variables"     -> request.variables
-                  .map(_.map { case (k, v) => s""""$k":${v.toInputString}""" }.mkString("{", ",", "}"))
-                  .getOrElse(""),
-                "extensions"    -> request.extensions
-                  .map(_.map { case (k, v) => s""""$k":${v.toInputString}""" }.mkString("{", ",", "}"))
-                  .getOrElse("")
-              ).filter { case (_, v) => v.nonEmpty }
-            )
-          )
+          queryParams.mapDecode(queryFromQueryParams(_).flatMap(checkRequest))(queryToQueryParams)
         )
         .in(extractFromRequest(identity))
         .out(header[MediaType](HeaderNames.ContentType))

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/HttpInterpreterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/HttpInterpreterSpec.scala
@@ -1,0 +1,41 @@
+package caliban.interop.tapir
+
+import caliban.GraphQLRequest
+import caliban.InputValue
+import caliban.InputValue.{ ListValue, ObjectValue }
+import caliban.Value.{ EnumValue, IntValue, StringValue }
+import sttp.tapir.DecodeResult
+import zio.test._
+
+object HttpInterpreterSpec extends ZIOSpecDefault {
+  override def spec = suite("HttpInterpreterSpec")(
+    test("GET query-param encoding round-trips object and list variables and the extensions object") {
+      val variables  = Map[String, InputValue](
+        "filter" -> ObjectValue(Map("name" -> StringValue("bob"))),
+        "ids"    -> ListValue(List(StringValue("a"), StringValue("b")))
+      )
+      val extensions = Map[String, InputValue](
+        "persistedQuery" -> ObjectValue(Map("version" -> IntValue(1), "sha256Hash" -> StringValue("abc")))
+      )
+      val request    = GraphQLRequest(query = Some("{ x }"), variables = Some(variables), extensions = Some(extensions))
+
+      HttpInterpreter.queryFromQueryParams(HttpInterpreter.queryToQueryParams(request)) match {
+        case DecodeResult.Value(decoded) =>
+          assertTrue(
+            decoded.query.contains("{ x }"),
+            decoded.variables.contains(variables),
+            decoded.extensions.contains(extensions)
+          )
+        case other                       =>
+          assertTrue(false).label(s"expected a successful decode but got $other")
+      }
+    },
+    test("GET query-param encoding of an enum variable decodes successfully") {
+      val request = GraphQLRequest(query = Some("{ x }"), variables = Some(Map("status" -> EnumValue("ACTIVE"))))
+      HttpInterpreter.queryFromQueryParams(HttpInterpreter.queryToQueryParams(request)) match {
+        case DecodeResult.Value(_) => assertCompletes
+        case other                 => assertTrue(false).label(s"expected a successful decode but got $other")
+      }
+    }
+  )
+}


### PR DESCRIPTION
## Problem

`HttpInterpreter`'s sttp-client encoder for the GET endpoint built the `variables` and `extensions` query parameters as `{"$k":${v.toInputString}}`. `InputValue.toInputString` renders **GraphQL** input-value syntax (unquoted object keys like `{name:"x"}`, unquoted enum tokens like `FOO`), which is not valid JSON.

The GET decoder (`queryFromQueryParams`) splices the raw param values into a JSON document and parses them with the jsoniter request codec. So:

- object-valued, enum-valued and list-of-object-valued variables produced invalid JSON → decode failure → **HTTP 400**;
- Automatic Persisted Queries over GET were **always** broken, because `extensions` is always an object (`{"persistedQuery":{version:1,sha256Hash:"..."}}` — unquoted keys).

Only scalar string/number/boolean/null variables happened to coincide with valid JSON. The POST path already encodes via the JSON codec, so only GET was affected.

## Fix

Serialize `variables` and `extensions` with the `InputValue` JSON codec (`writeToString[InputValue](ObjectValue(map))`), matching what the decoder parses. Lifted the GET encode/decode helpers to `private[tapir]` methods so the round-trip is unit-testable.

## Tests

Added `HttpInterpreterSpec`: `queryFromQueryParams(queryToQueryParams(request))` round-trips object variables, list variables and the extensions object; and an enum variable decodes successfully (as a JSON string, per GraphQL-over-HTTP transport). Both verified to fail against the previous `toInputString` encoding.