### PR TITLE
Select a single supported subprotocol for WebSocket negotiation

### DIFF
--- a/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
+++ b/interop/tapir/src/main/scala/caliban/interop/tapir/WebSocketInterpreter.scala
@@ -48,10 +48,22 @@ object WebSocketInterpreter {
       serverRequest: ServerRequest,
       protocol: String
     ): URIO[R, Either[TapirResponse, (String, CalibanPipe)]] =
-      Protocol
-        .fromName(protocol)
-        .make(interpreter, keepAliveTime, webSocketHooks)
-        .map(res => Right((protocol, res)))
+      selectSubProtocol(protocol) match {
+        case Some(selected) =>
+          Protocol
+            .fromName(selected)
+            .make(interpreter, keepAliveTime, webSocketHooks)
+            .map(res => Right((selected, res)))
+        case None           =>
+          ZIO.succeed(Left(TapirResponse(sttp.model.StatusCode.BadRequest)))
+      }
+  }
+
+  private[tapir] def selectSubProtocol(header: String): Option[String] = {
+    val offered = header.split(',').iterator.map(_.trim).filter(_.nonEmpty).toList
+    offered
+      .find(_.equalsIgnoreCase(Protocol.GraphQLWS.name))
+      .orElse(offered.find(_.equalsIgnoreCase(Protocol.Legacy.name)))
   }
 
   private case class Intercepted[R1, R, E](

--- a/interop/tapir/src/test/scala/caliban/interop/tapir/WebSocketInterpreterSpec.scala
+++ b/interop/tapir/src/test/scala/caliban/interop/tapir/WebSocketInterpreterSpec.scala
@@ -1,0 +1,25 @@
+package caliban.interop.tapir
+
+import zio.test._
+
+object WebSocketInterpreterSpec extends ZIOSpecDefault {
+  override def spec = suite("WebSocketInterpreterSpec")(
+    test("selects a single supported subprotocol from a multi-value header") {
+      assertTrue(
+        // preference: graphql-transport-ws wins even when listed with others
+        WebSocketInterpreter.selectSubProtocol("graphql-transport-ws, graphql-ws").contains("graphql-transport-ws"),
+        WebSocketInterpreter.selectSubProtocol("graphql-ws, graphql-transport-ws").contains("graphql-transport-ws"),
+        WebSocketInterpreter.selectSubProtocol("graphql-ws").contains("graphql-ws"),
+        WebSocketInterpreter.selectSubProtocol("graphql-transport-ws").contains("graphql-transport-ws"),
+        // an unsupported token mixed with a supported one still selects the supported one
+        WebSocketInterpreter.selectSubProtocol("foo, graphql-ws").contains("graphql-ws")
+      )
+    },
+    test("does not select an unsupported subprotocol") {
+      assertTrue(
+        WebSocketInterpreter.selectSubProtocol("foo, bar").isEmpty,
+        WebSocketInterpreter.selectSubProtocol("").isEmpty
+      )
+    }
+  )
+}


### PR DESCRIPTION
## Problem

`WebSocketInterpreter.makeProtocol` read the raw `Sec-WebSocket-Protocol` request header, passed it verbatim to `Protocol.fromName`, and echoed it straight back as the negotiated subprotocol (`Right((protocol, res))`, via `.out(protocolHeader)`).

When a client offers several subprotocols in one header (comma-separated, as browsers do: `new WebSocket(url, ["graphql-transport-ws", "graphql-ws"])` → `Sec-WebSocket-Protocol: graphql-transport-ws, graphql-ws`):

- `Protocol.fromName` does an exact `equalsIgnoreCase` against `graphql-transport-ws`, so the combined string never matches → **Legacy** is chosen even though the client's first preference is `graphql-transport-ws`;
- the handshake response sets the selected subprotocol to the full comma-joined string, which violates **RFC 6455** (the server must return exactly one of the offered tokens), so a browser aborts the connection.

## Fix

Parse the header into individual tokens and select the first subprotocol caliban actually supports (preferring `graphql-transport-ws` over `graphql-ws`), using that single token both to pick the `Protocol` implementation and to echo back as the negotiated subprotocol.

When **none** of the offered tokens is a supported protocol, reject the handshake with `400` rather than negotiating an arbitrary unsupported token while actually speaking Legacy (which would leave client and server disagreeing about the protocol). Fixed in `Base.makeProtocol`, which `Prepended`/`Intercepted` delegate to.

## Tests

Added `WebSocketInterpreterSpec` for `selectSubProtocol`: `graphql-transport-ws, graphql-ws` and `graphql-ws, graphql-transport-ws` both select `graphql-transport-ws`; single values pass through; `foo, graphql-ws` selects `graphql-ws`; `foo, bar` and `""` select nothing (→ handshake rejected). Verified the multi-value case fails when the selection is a no-op.