### PR TITLE
Do not forward schema field-definition directives in proxied remote queries

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -115,11 +115,16 @@ case class Field(
             )
           }
 
+      val schemaDirectives =
+        f.parentType.flatMap(pt => Option(pt.innerType.getFieldOrNull(f.name))).flatMap(_.directives).getOrElse(Nil)
+      val directives       =
+        if (schemaDirectives.isEmpty) f.directives else f.directives.filterNot(schemaDirectives.contains)
+
       Selection.Field(
         f.alias,
         f.name,
         f.arguments,
-        f.directives,
+        directives,
         children ++ inlineFragments,
         0
       )

--- a/core/src/test/scala/caliban/RemoteQuerySpec.scala
+++ b/core/src/test/scala/caliban/RemoteQuerySpec.scala
@@ -160,6 +160,27 @@ object RemoteQuerySpec extends ZIOSpecDefault {
       } yield assertTrue(
         actual == """query{union(value:"{\"foo\": \"\\t\"}"){...on Interface{id}}}"""
       )
+    },
+    test("does not forward schema field-definition directives to the remote query") {
+      import caliban.schema.Annotations.GQLDirective
+      import caliban.parsing.adt.Directive
+
+      case class Inner(@GQLDirective(Directive("myFieldDir")) name: String)
+      case class Q(obj: Field => UIO[Inner])
+
+      def api2(ref: Ref[String]) = graphQL(
+        RootResolver(
+          Q(field => ref.set(RemoteQuery.QueryRenderer.render(RemoteQuery(field))).as(Inner("x")))
+        )
+      ).interpreter
+
+      val query = gqldoc("""{ obj { name } }""")
+      for {
+        ref    <- Ref.make[String]("")
+        i      <- api2(ref)
+        _      <- i.execute(query)
+        actual <- ref.get
+      } yield assertTrue(actual == "query{obj{name}}")
     }
   )
 }


### PR DESCRIPTION
## Problem

When the executor builds a `Field`, `Field.apply` merges the schema field's definition directives into `Field.directives` (`resolvedDirectives = (directives ::: schemaDirectives)`). `Field.toSelection` — which is used **only** by `RemoteQuery.toDocument` (stitching's `RemoteResolver` and `RemoteMutation`) — then re-emitted all of `f.directives` into the outgoing `Selection`.

As a result, directives whose GraphQL location is `FIELD_DEFINITION` (custom `@GQLDirective` directives, federation `@external`/`@requires`/`@provides`, …) were rendered onto a **FIELD** selection in the proxied remote query — not a legal directive location. A conformant remote server rejects the query during validation, so the proxied field resolves to an upstream error instead of data.

```
case class Inner(@GQLDirective(Directive("myFieldDir")) name: String)
// stitching proxy of { obj { name } } rendered:
//   query{obj{name@myFieldDir}}   <- remote server rejects "@myFieldDir on FIELD"
// now:
//   query{obj{name}}
```

## Fix

`toSelection` now subtracts the parent type's schema field-definition directives (looked up via `Field.parentType`) from the emitted directives, forwarding only the client's own query directives. Scope is limited to remote-query rendering — `toSelection` has no other callers, so normal execution is unaffected.

## Tests

Added a `RemoteQuerySpec` case: a resolver capturing `RemoteQuery.QueryRenderer.render` for a return type whose field carries `@GQLDirective(Directive("myFieldDir"))`; the rendered remote query is `query{obj{name}}` (no `@myFieldDir`). Verified it renders `query{obj{name@myFieldDir}}` before the fix. Full `core` suite and `stitching` tests pass.