### PR TITLE
perf: hoist directive-resolver closure out of per-field Field.apply recursion

### DIFF
--- a/core/src/main/scala/caliban/execution/Field.scala
+++ b/core/src/main/scala/caliban/execution/Field.scala
@@ -145,10 +145,12 @@ object Field {
     directives: List[Directive],
     rootType: RootType
   ): Field = {
-    val memoizedFragments      = new mutable.HashMap[(String, List[Directive]), List[(Field, Option[String])]]()
-    val variableDefinitionsMap =
+    val memoizedFragments                         = new mutable.HashMap[(String, List[Directive]), List[(Field, Option[String])]]()
+    val variableDefinitionsMap                    =
       if (variableDefinitions eq Nil) Map.empty[String, VariableDefinition]
       else variableDefinitions.map(v => v.name -> v).toMap
+    val resolveDirectives: Directive => Directive =
+      resolveDirectiveVariables(variableValues, variableDefinitionsMap)
 
     def loop(
       selectionSet: List[Selection],
@@ -169,7 +171,7 @@ object Field {
             else selected.directives.get
 
           val resolvedDirectives =
-            (directives ::: schemaDirectives).map(resolveDirectiveVariables(variableValues, variableDefinitionsMap))
+            (directives ::: schemaDirectives).map(resolveDirectives)
 
           if (checkDirectives(resolvedDirectives)) {
             // default only case where it's not found is __typename
@@ -200,7 +202,7 @@ object Field {
         case FragmentSpread(name, directives)                           =>
           val fields = memoizedFragments.getOrElseUpdate(
             (name, directives), {
-              val resolvedDirectives = directives.map(resolveDirectiveVariables(variableValues, variableDefinitionsMap))
+              val resolvedDirectives = directives.map(resolveDirectives)
               val f                  = fragments.getOrElse(name, null)
               if ((f ne null) && checkDirectives(resolvedDirectives)) {
                 val typeCondName      = f.typeCondition.name
@@ -226,7 +228,7 @@ object Field {
           )
           fields.foreach((builder.addField _).tupled)
         case InlineFragment(typeCondition, directives, selectionSet)    =>
-          val resolvedDirectives = directives.map(resolveDirectiveVariables(variableValues, variableDefinitionsMap))
+          val resolvedDirectives = directives.map(resolveDirectives)
           if (checkDirectives(resolvedDirectives)) {
             val typeName          = typeCondition.map(_.name)
             val t                 = innerType.possibleTypes


### PR DESCRIPTION
## What

`Field.apply` builds the field tree for every query on the per-request validation/preparation path, and its inner `loop` visits every selected field. At three call sites it did:

```scala
(directives ::: schemaDirectives).map(resolveDirectiveVariables(variableValues, variableDefinitionsMap))
```

`resolveDirectiveVariables` is a **curried method**, so passing its partial application to `.map` forces eta-expansion into a fresh `Function1` capturing both maps — allocated **every time each site executes**, including the overwhelmingly common no-directive field case where `.map` never even invokes the function (the argument closure is still constructed and escapes into `List.map`, so escape analysis won't reliably elide it).

## Change

`variableValues` and `variableDefinitionsMap` are invariant across the entire `Field.apply` recursion, so the function is built once at the top of `apply` and reused at all three sites:

```scala
val resolveDirectives: Directive => Directive =
  resolveDirectiveVariables(variableValues, variableDefinitionsMap)
```

This turns N per-field closure allocations into 1 per request, proportional to query size. Zero readability cost — it mirrors the existing hoisted `identityFnList` idiom in the same file.

## Notes

- Pure refactor, behavior is byte-for-byte identical (same ordering, same empty-list short-circuit).
- Explicit function-type ascription is used (not trailing `_`) so eta-expansion compiles cleanly on 2.12/2.13/3.3.
- Verified against the execution/directives/incremental-delivery/remote-query suites (154 tests, 0 failures) on the default Scala version.