### PR TITLE
perf: index input-object fields by name (remove O(n*m) validation scans)

### DIFF
--- a/core/src/main/scala/caliban/introspection/adt/__Type.scala
+++ b/core/src/main/scala/caliban/introspection/adt/__Type.scala
@@ -160,6 +160,15 @@ case class __Type(
   private[caliban] def getFieldOrNull(name: String): __Field =
     allFieldsMap.getOrElseNull(name)
 
+  private lazy val allInputFieldsMap = {
+    val map = collection.mutable.HashMap.empty[String, __InputValue]
+    allInputFields.foreach(f => map.update(f.name, f))
+    map
+  }
+
+  private[caliban] def getInputFieldOrNull(name: String): __InputValue =
+    allInputFieldsMap.getOrElseNull(name)
+
   lazy val innerType: __Type = Types.innerType(this)
 
   private[caliban] lazy val possibleTypeNames: Set[String] =

--- a/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
+++ b/core/src/main/scala/caliban/parsing/VariablesCoercer.scala
@@ -177,11 +177,10 @@ object VariablesCoercer {
       case __TypeKind.INPUT_OBJECT =>
         value match {
           case InputValue.ObjectValue(fields) =>
-            val defs = typ.allInputFields
             foreachObjectField(fields) { (k, v) =>
-              defs.find(_.name == k) match {
-                case Some(field) => coerceValues(v, field._type, s"$context at field '${field.name}'")
-                case _           => failValidation(s"$context field '$k' does not exist", coercionDescription)
+              typ.getInputFieldOrNull(k) match {
+                case null  => failValidation(s"$context field '$k' does not exist", coercionDescription)
+                case field => coerceValues(v, field._type, s"$context at field '${field.name}'")
               }
             }
           case v                              =>

--- a/core/src/main/scala/caliban/validation/Validator.scala
+++ b/core/src/main/scala/caliban/validation/Validator.scala
@@ -658,13 +658,13 @@ object Validator {
     argValue match {
       case InputValue.ObjectValue(fields) if inputType.kind == __TypeKind.INPUT_OBJECT =>
         validateAllDiscard(fields) { (k, v) =>
-          inputFields.find(_.name == k) match {
-            case None        =>
+          inputType.getInputFieldOrNull(k) match {
+            case null  =>
               failValidation(
                 s"Input field '$k' is not defined on type '${inputType.name.getOrElse("?")}'.",
                 "Every input field provided in an input object value must be defined in the set of possible fields of that input object’s expected type."
               )
-            case Some(value) =>
+            case value =>
               validateInputValues(
                 value,
                 v,

--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -81,7 +81,7 @@ private object ValueValidator {
             argValue match {
               case obj: ObjectValue =>
                 validateAllDiscard(obj.fields) { (k, _) =>
-                  when(!inputType.allInputFields.exists(_.name == k))(
+                  when(inputType.getInputFieldOrNull(k) eq null)(
                     failValidation(
                       s"Input field '$k' is not defined on type '${inputType.name.getOrElse("?")}'.",
                       "Every input field provided in an input object value must be defined in the set of possible fields of that input object’s expected type."
@@ -91,7 +91,7 @@ private object ValueValidator {
                   if (inputType._isOneOfInput) Validator.validateOneOfInputValue(obj, errorContext)
                   else
                     validateAllDiscard(inputType.allInputFields) { f =>
-                      obj.fields.collectFirst { case (name, fieldValue) if name == f.name => fieldValue } match {
+                      obj.fields.get(f.name) match {
                         case Some(value)                    =>
                           validateType(f._type, value, context, s"Field ${f.name} in $errorContext")
                         case None if f.defaultValue.isEmpty =>


### PR DESCRIPTION
## What

Query validation and variable coercion walk every provided field of every input-object value on the per-request path. Output fields already have a by-name index (`__Type.allFieldsMap` / `getFieldOrNull`), but **input fields had none**, so three sites did a linear `inputFields.find(_.name == k)` / `exists` scan — once per provided field, giving O(providedFields × schemaFields) per input object. A fourth site scanned the *provided-values* Map with `collectFirst` even though it's already a `Map`.

## Change

- Add `allInputFieldsMap` + `getInputFieldOrNull` on `__Type`, mirroring the existing output-field index. The map is a `lazy val` — built once per type and cached for the schema's lifetime, so it's free across all requests.
- Replace the three linear schema-field scans with O(1) lookups:
  - `Validator.validateInputValues`
  - `VariablesCoercer.coerceValues`
  - `ValueValidator.validateType`
- In `ValueValidator`, replace `obj.fields.collectFirst { … }` (a full `Map` traversal per schema field) with `obj.fields.get(name)`.

Net: per input object, O(providedFields × schemaFields) → O(providedFields + schemaFields).

## Notes

- Behavior preserved. GraphQL requires input-field names to be unique within a type, so the map (last-wins) and `find` (first-wins) agree — the same assumption `allFieldsMap` already makes for output fields. Unknown-field errors and default-value handling are unchanged.
- Verified against the validation / parsing / variable-coercion / execution suites (364 tests, 0 failures) on the default Scala version.