### PR TITLE
perf: trim per-node allocations in circe/play/zio JSON codecs

### DIFF
--- a/core/src/main/scala/caliban/interop/circe/circe.scala
+++ b/core/src/main/scala/caliban/interop/circe/circe.scala
@@ -29,7 +29,7 @@ object json {
       case EnumValue(value)                   => Json.fromString(value)
       case InputValue.ListValue(values)       => Json.arr(values.map(inputValueEncoder.apply): _*)
       case InputValue.ObjectValue(fields)     =>
-        Json.obj(fields.map { case (k, v) => k -> inputValueEncoder.apply(v) }.toList: _*)
+        Json.fromFields(fields.map { case (k, v) => k -> inputValueEncoder.apply(v) })
       case InputValue.VariableValue(name)     => Json.fromString(name)
     }
   private def jsonToResponseValue(json: Json): ResponseValue =

--- a/core/src/main/scala/caliban/interop/play/play.scala
+++ b/core/src/main/scala/caliban/interop/play/play.scala
@@ -7,8 +7,6 @@ import caliban.schema.Types.makeScalar
 import caliban.schema.{ ArgBuilder, Schema, Step }
 import play.api.libs.json._
 
-import scala.util.Try
-
 object json {
   implicit val jsonSchema: Schema[Any, JsValue] = new Schema[Any, JsValue] {
     private def parse(value: JsValue) =
@@ -62,9 +60,7 @@ object json {
       case JsArray(elements) => ResponseValue.ListValue(elements.toList.map(jsonToResponseValue))
       case JsString(value)   => StringValue(value)
       case JsNumber(value)   =>
-        Try(value.toIntExact)
-          .map(IntValue.apply)
-          .getOrElse(FloatValue(value))
+        if (value.isValidInt) IntValue(value.toIntExact) else FloatValue(value)
 
       case b: JsBoolean => BooleanValue(b.value)
       case JsNull       => NullValue

--- a/core/src/main/scala/caliban/interop/zio/zio.scala
+++ b/core/src/main/scala/caliban/interop/zio/zio.scala
@@ -28,7 +28,9 @@ object json {
       case EnumValue(value)               => Json.Str(value)
       case BooleanValue(value)            => Json.Bool(value)
       case StringValue(value)             => Json.Str(value)
-      case x: IntValue                    => Json.Num(BigDecimal(x.toBigInt))
+      case IntValue.IntNumber(value)      => Json.Num(BigDecimal(value))
+      case IntValue.LongNumber(value)     => Json.Num(BigDecimal(value))
+      case IntValue.BigIntNumber(value)   => Json.Num(BigDecimal(value))
       case x: FloatValue                  => Json.Num(x.toBigDecimal)
       case Value.NullValue                => Json.Null
     }

--- a/core/src/test/scala/caliban/interop/json/JsonAdtSpec.scala
+++ b/core/src/test/scala/caliban/interop/json/JsonAdtSpec.scala
@@ -71,6 +71,15 @@ object JsonAdtSpec extends ZIOSpecDefault {
           },
           test("ArgBuilder") {
             json.jsonArgBuilder.build(input).map(resp => assertTrue(resp == jsonV))
+          },
+          test("decodes non-integral and out-of-Int-range numbers as Float") {
+            assertTrue(
+              json.jsonSchema.resolve(JsNumber(BigDecimal(42))) == PureStep(Value.IntValue(42)),
+              json.jsonSchema.resolve(JsNumber(BigDecimal("3.14"))) ==
+                PureStep(Value.FloatValue(BigDecimal("3.14"))),
+              json.jsonSchema.resolve(JsNumber(BigDecimal("3000000000"))) ==
+                PureStep(Value.FloatValue(BigDecimal("3000000000")))
+            )
           }
         )
       },
@@ -94,6 +103,27 @@ object JsonAdtSpec extends ZIOSpecDefault {
           },
           test("ArgBuilder") {
             json.jsonArgBuilder.build(input).map(resp => assertTrue(resp == jsonV))
+          },
+          test("encodes all IntValue widths without a BigInt intermediate") {
+            json.jsonArgBuilder
+              .build(
+                InputValue.ObjectValue(
+                  Map(
+                    "i"   -> Value.IntValue(42),
+                    "l"   -> Value.IntValue(3000000000L),
+                    "big" -> Value.IntValue(BigInt("9999999999999999999"))
+                  )
+                )
+              )
+              .map(resp =>
+                assertTrue(
+                  resp == Json.Obj(
+                    "i"   -> Json.Num(BigDecimal(42)),
+                    "l"   -> Json.Num(BigDecimal(3000000000L)),
+                    "big" -> Json.Num(BigDecimal(BigInt("9999999999999999999")))
+                  )
+                )
+              )
           }
         )
       }


### PR DESCRIPTION
## What

Three small, behavior-preserving allocation trims on the JSON encode/decode path (each runs per value while (de)serializing every request/response):

| Codec | Before | After |
|-------|--------|-------|
| **circe** | `Json.obj(fields.map{…}.toList: _*)` — mapped Map → `List` copy → varargs array copy before circe builds its `JsonObject` | `Json.fromFields(fields.map{…})` — consumes the iterable directly |
| **play** | `Try(value.toIntExact).map(IntValue).getOrElse(FloatValue(value))` — every non-integral number **throws + catches** an `ArithmeticException` (stack fill) inside an allocated `Try` | `if (value.isValidInt) IntValue(value.toIntExact) else FloatValue(value)` — no exception, no `Try` |
| **zio** | `case x: IntValue => Json.Num(BigDecimal(x.toBigInt))` — allocates a `BigInt` even for a plain `Int`/`Long` before wrapping in `BigDecimal` | match on the `IntValue` width and build `BigDecimal` from the primitive |

## Notes

- All three are exact behavioral equivalents (`isValidInt` is precisely the `toIntExact` success condition; `BigDecimal(int/long/bigint)` equals `BigDecimal(bigint)`).
- Removed the now-unused `scala.util.Try` import from play.
- `JsonAdtSpec` gains guards for the play float / out-of-Int-range decode branch and all three zio `IntValue` widths (Int/Long/BigInt), which the shared round-trip fixture didn't exercise.
- Verified against all JSON codec suites + JsonAdtSpec (0 failures) on the default Scala version.