### PR TITLE
perf: capture string-literal character runs in a single pass in the parser

### DIFF
--- a/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
+++ b/core/src/main/scala/caliban/parsing/parsers/StringParsers.scala
@@ -87,10 +87,11 @@ private[caliban] trait StringParsers {
     case other => other
   }
 
+  def stringCharacters(implicit ev: P[Any]): P[String] =
+    CharsWhile(c => c != '"' && c != '\\' && (c == '\t' || c >= ' ')).!
+
   def stringCharacter(implicit ev: P[Any]): P[String] =
-    sourceCharacterWithoutLineTerminator.!.filter(c =>
-      c != "\"" && c != "\\"
-    ) | "\\u" ~~ escapedUnicode | "\\" ~~ escapedCharacter
+    stringCharacters | "\\u" ~~ escapedUnicode | "\\" ~~ escapedCharacter
 
   def blockStringCharacter(implicit ev: P[Any]): P[String] = "\\\"\"\"".!.map(_ => "\"\"\"") | sourceCharacter.!
 

--- a/core/src/test/scala/caliban/parsing/ParserSpec.scala
+++ b/core/src/test/scala/caliban/parsing/ParserSpec.scala
@@ -230,6 +230,21 @@ object ParserSpec extends ZIOSpecDefault {
           Parser.parseInputValue(str(bs + "u{DEAD}")).isLeft
         )
       },
+      test("string literals mixing character runs and escapes") {
+        val bs                 = "\\"
+        def str(inner: String) = "\"" + inner + "\""
+        assertTrue(
+          Parser.parseInputValue(str("")) == Right(StringValue("")),
+          Parser.parseInputValue(str("hello world")) == Right(StringValue("hello world")),
+          Parser.parseInputValue(str("a" + bs + "nb" + bs + "tc")) == Right(StringValue("a\nb\tc")),
+          Parser.parseInputValue(str(bs + "\"leading")) == Right(StringValue("\"leading")),
+          Parser.parseInputValue(str("trailing" + bs + bs)) == Right(StringValue("trailing\\")),
+          Parser.parseInputValue(str(bs + "n" + bs + "t")) == Right(StringValue("\n\t")),
+          Parser.parseInputValue(str("run " + bs + "u0041 run")) == Right(StringValue("run A run")),
+          Parser.parseInputValue(str("with\ttab")) == Right(StringValue("with\ttab")),
+          Parser.parseInputValue("\"raw\nnewline\"").isLeft
+        )
+      },
       test("enum values whose names start with a keyword") {
         val cases = List(
           "trueStory" -> EnumValue("trueStory"),


### PR DESCRIPTION
## What

Every string literal in an incoming query was parsed **one character at a time**. `stringCharacter`'s non-escape branch did `sourceCharacterWithoutLineTerminator.!` — allocating a one-char `String` — plus two `String`-equality checks per character, and `stringCharacter.repX` collected all those pieces into a `Seq` before `mkString`. For an N-char literal that's O(N) throwaway `String`s and O(N) equality calls on the per-request parse path.

## Change

Add a `stringCharacters` run that captures a maximal span of ordinary characters with a single `CharsWhile`:

```scala
def stringCharacters(implicit ev: P[Any]): P[String] =
  CharsWhile(c => c != '"' && c != '\\' && (c == '\t' || c >= ' ')).!

def stringCharacter(implicit ev: P[Any]): P[String] =
  stringCharacters | "\\u" ~~ escapedUnicode | "\\" ~~ escapedCharacter
```

A typical literal now collapses to one substring; escapes still break the run and are handled by the existing alternatives.

## Correctness

The `CharsWhile` predicate is **exactly** `sourceCharacterWithoutLineTerminator` (`CharIn("\u0009\u0020-\uFFFF")` = tab, or `>= space`) minus `"` and `\\`. So:
- quote/backslash are excluded from the run and fall through to the escape alternatives (unchanged),
- raw control chars / line terminators still terminate the run and are rejected exactly as before,
- the empty string and escape-only literals still parse via `repX`.

Block strings are left untouched.

## Verification

- New `ParserSpec` case exercises runs mixed with escapes at leading/trailing/interior positions, empty string, tab, a `\u` escape inside a run, and a rejected raw newline.
- Existing escaped-char / unicode-escape / backslash / block-string tests unchanged and passing.
- **Full core suite: 619 tests, 0 failures** on the default Scala version.

## Note

This is the one change in the perf sweep with a non-trivial (still small) readability cost — it adds one named parser combinator. Kept as its own PR for that reason.