### PR TITLE
Fail client codegen for value-less enums, objects, interfaces and input objects (fixes #1253)

### DIFF
--- a/codegen/src/main/scala/caliban/codegen/ClientWriter.scala
+++ b/codegen/src/main/scala/caliban/codegen/ClientWriter.scala
@@ -845,6 +845,18 @@ object ClientWriter {
 
     val schemaDef = schema.schemaDefinition
 
+    def requireHasFields[A](kind: String, name: String, fields: List[A]): Unit =
+      if (fields.isEmpty)
+        throw new Exception(s"Invalid GraphQL Schema: $kind $name must have at least one field")
+
+    def requireNonEmptyFields[A](kind: String, name: String, fields: List[A])(isDeprecated: A => Boolean): Unit = {
+      requireHasFields(kind, name, fields)
+      if (excludeDeprecated && fields.forall(isDeprecated))
+        throw new Exception(
+          s"Invalid GraphQL Schema: $kind $name has no fields left after excluding deprecated ones"
+        )
+    }
+
     val interfaceTypes =
       if (splitFiles) schema.interfaceTypeDefinitions.map { typedef =>
         writeObjectType(
@@ -860,6 +872,8 @@ object ClientWriter {
       else Nil
 
     val interfaces = schema.interfaceTypeDefinitions.map { typedef =>
+      requireNonEmptyFields("interface", typedef.name, typedef.fields)(_.isDeprecated)
+
       val objDef      = ObjectTypeDefinition(
         description = typedef.description,
         name = typedef.name,
@@ -902,6 +916,8 @@ object ClientWriter {
           schemaDef.exists(_.subscription.getOrElse("Subscription") == obj.name)
       )
       .map { typedef =>
+        requireNonEmptyFields("object", typedef.name, typedef.fields)(_.isDeprecated)
+
         val content     = writeObject(typedef, genView)
         val fullContent =
           if (splitFiles)
@@ -918,6 +934,8 @@ object ClientWriter {
       }
 
     val inputs = schema.inputObjectTypeDefinitions.map { typedef =>
+      requireNonEmptyFields("input object", typedef.name, typedef.fields)(_.isDeprecated)
+
       val content     =
         if (Directives.isOneOf(typedef.directives)) writeOneOfInputObject(typedef)
         else writeInputObject(typedef)
@@ -935,13 +953,17 @@ object ClientWriter {
 
     val enums = schema.enumTypeDefinitions
       .filter(e => !scalarMappingsWithDefaults.contains(e.name))
-      .map {
-        case typedef if excludeDeprecated =>
-          val valuesWithoutDeprecated =
-            typedef.enumValuesDefinition.filterNot(_.isDeprecated)
-
+      .map { typedef =>
+        if (typedef.enumValuesDefinition.isEmpty)
+          throw new Exception(s"Invalid GraphQL Schema: enum ${typedef.name} must have at least one value")
+        else if (excludeDeprecated) {
+          val valuesWithoutDeprecated = typedef.enumValuesDefinition.filterNot(_.isDeprecated)
+          if (valuesWithoutDeprecated.isEmpty)
+            throw new Exception(
+              s"Invalid GraphQL Schema: enum ${typedef.name} has no values left after excluding deprecated ones"
+            )
           typedef.copy(enumValuesDefinition = valuesWithoutDeprecated)
-        case typedef                      => typedef
+        } else typedef
       }
       .map { typedef =>
         val content     = writeEnum(typedef, extensibleEnums = extensibleEnums)
@@ -973,6 +995,7 @@ object ClientWriter {
     val queries = schema
       .objectTypeDefinition(schemaDef.flatMap(_.query).getOrElse("Query"))
       .map { typedef =>
+        requireHasFields("object", typedef.name, typedef.fields)
         val content     = writeRootQuery(typedef)
         val fullContent =
           if (splitFiles)
@@ -999,6 +1022,7 @@ object ClientWriter {
     val mutations = schema
       .objectTypeDefinition(schemaDef.flatMap(_.mutation).getOrElse("Mutation"))
       .map { typedef =>
+        requireHasFields("object", typedef.name, typedef.fields)
         val content     = writeRootMutation(typedef)
         val fullContent =
           if (splitFiles)
@@ -1025,6 +1049,7 @@ object ClientWriter {
     val subscriptions = schema
       .objectTypeDefinition(schemaDef.flatMap(_.subscription).getOrElse("Subscription"))
       .map { typedef =>
+        requireHasFields("object", typedef.name, typedef.fields)
         val content     = writeRootSubscription(typedef)
         val fullContent =
           if (splitFiles)

--- a/codegen/src/test/resources/snapshots/ClientWriterSpec/enum with exclude deprecated, only deprecated values.scala
+++ b/codegen/src/test/resources/snapshots/ClientWriterSpec/enum with exclude deprecated, only deprecated values.scala
@@ -1,9 +1,0 @@
-import caliban.client.CalibanClientError.DecodingError
-import caliban.client._
-import caliban.client.__Value._
-
-object Client {
-
-  sealed trait Origin extends scala.Product with scala.Serializable { def value: String }
-
-}

--- a/codegen/src/test/resources/snapshots/ClientWriterSpec/simple object type with exclude deprecated and genView, only deprecated fields.scala
+++ b/codegen/src/test/resources/snapshots/ClientWriterSpec/simple object type with exclude deprecated and genView, only deprecated fields.scala
@@ -1,9 +1,0 @@
-import caliban.client.FieldBuilder._
-import caliban.client._
-
-object Client {
-
-  type Character
-  object Character {}
-
-}

--- a/codegen/src/test/scala/caliban/codegen/ClientWriterSpec.scala
+++ b/codegen/src/test/scala/caliban/codegen/ClientWriterSpec.scala
@@ -1,7 +1,7 @@
 package caliban.codegen
 
 import caliban.parsing.Parser
-import zio.{ Task, ZIO }
+import zio.{ Exit, Task, ZIO }
 import zio.test._
 
 object ClientWriterSpec extends SnapshotTest {
@@ -69,7 +69,7 @@ object ClientWriterSpec extends SnapshotTest {
           genView = true
         )
       },
-      snapshotTest("simple object type with exclude deprecated and genView, only deprecated fields") {
+      test("object type with only deprecated fields fails codegen when excluding deprecated") {
         gen(
           schema = """
              type Character {
@@ -79,7 +79,16 @@ object ClientWriterSpec extends SnapshotTest {
             """,
           excludeDeprecated = true,
           genView = true
-        )
+        ).exit.map {
+          case Exit.Failure(cause) =>
+            assertTrue(
+              cause.dieOption.exists(
+                _.getMessage.contains("object Character has no fields left after excluding deprecated")
+              )
+            )
+          case Exit.Success(_)     =>
+            assertTrue(false)
+        }
       },
       snapshotTest("object type with reserved name") {
         gen("""
@@ -184,6 +193,17 @@ object ClientWriterSpec extends SnapshotTest {
              }
             """)
       },
+      test("empty enum fails codegen with a helpful message") {
+        gen("""
+             enum Origin {
+             }
+            """).exit.map {
+          case Exit.Failure(cause) =>
+            assertTrue(cause.dieOption.exists(_.getMessage.contains("enum Origin must have at least one value")))
+          case Exit.Success(_)     =>
+            assertTrue(false)
+        }
+      },
       snapshotTest("enum with exclude deprecated") {
         gen(
           schema = """
@@ -196,7 +216,7 @@ object ClientWriterSpec extends SnapshotTest {
           excludeDeprecated = true
         )
       },
-      snapshotTest("enum with exclude deprecated, only deprecated values") {
+      test("enum with only deprecated values fails codegen when excluding deprecated") {
         gen(
           schema = """
              enum Origin {
@@ -205,7 +225,14 @@ object ClientWriterSpec extends SnapshotTest {
              }
             """,
           excludeDeprecated = true
-        )
+        ).exit.map {
+          case Exit.Failure(cause) =>
+            assertTrue(
+              cause.dieOption.exists(_.getMessage.contains("enum Origin has no values left after excluding deprecated"))
+            )
+          case Exit.Success(_)     =>
+            assertTrue(false)
+        }
       },
       snapshotTest("enum with case-insensitive type name clash") {
         gen("""
@@ -285,6 +312,75 @@ object ClientWriterSpec extends SnapshotTest {
                nicknames: [String!]
              }
             """)
+      },
+      test("empty input object fails codegen with a helpful message") {
+        gen("input CharacterInput {}").exit.map {
+          case Exit.Failure(cause) =>
+            assertTrue(
+              cause.dieOption.exists(_.getMessage.contains("input object CharacterInput must have at least one"))
+            )
+          case Exit.Success(_)     =>
+            assertTrue(false)
+        }
+      },
+      test("input object with only deprecated fields fails codegen when excluding deprecated") {
+        gen(
+          schema = """
+             input CharacterInput {
+               name: String! @deprecated
+             }
+            """,
+          excludeDeprecated = true
+        ).exit.map {
+          case Exit.Failure(cause) =>
+            assertTrue(
+              cause.dieOption.exists(
+                _.getMessage.contains("input object CharacterInput has no fields left after excluding")
+              )
+            )
+          case Exit.Success(_)     =>
+            assertTrue(false)
+        }
+      },
+      test("empty interface fails codegen with a helpful message") {
+        gen("interface Node {}").exit.map {
+          case Exit.Failure(cause) =>
+            assertTrue(cause.dieOption.exists(_.getMessage.contains("interface Node must have at least one")))
+          case Exit.Success(_)     =>
+            assertTrue(false)
+        }
+      },
+      test("interface with only deprecated fields fails codegen when excluding deprecated") {
+        gen(
+          schema = """
+             interface Node {
+               id: ID! @deprecated
+             }
+            """,
+          excludeDeprecated = true
+        ).exit.map {
+          case Exit.Failure(cause) =>
+            assertTrue(
+              cause.dieOption.exists(_.getMessage.contains("interface Node has no fields left after excluding"))
+            )
+          case Exit.Success(_)     =>
+            assertTrue(false)
+        }
+      },
+      test("empty root operation object fails codegen with a helpful message") {
+        gen("""
+             schema {
+               query: Q
+             }
+
+             type Q {
+             }
+            """).exit.map {
+          case Exit.Failure(cause) =>
+            assertTrue(cause.dieOption.exists(_.getMessage.contains("object Q must have at least one field")))
+          case Exit.Success(_)     =>
+            assertTrue(false)
+        }
       },
       snapshotTest("input object with reserved name") {
         gen("""


### PR DESCRIPTION
Fixes #1253.

## Problem

The client code generator silently produced broken/unusable output for schema types it can't represent:

- **Empty enum** — e.g. Hasura's `enum my_empty_enum {}` (the parser accepts an empty `{ }` block or no block at all) generated a bare `sealed trait` with **no companion**, hence no `ScalarDecoder`/`ArgEncoder`; the generated code failed to compile.
- **All members `@deprecated` + `excludeDeprecated`** — filtering removed every value/field, leaving a value-less enum (same uncompilable trait), a phantom zero-field object/interface, or an empty input case class.
- **Empty root operation type** — e.g. `schema { query: Q } type Q {}` produced an empty `object Q {}` (root types are generated separately from the object pipeline, so they bypassed the guard).

The GraphQL spec requires enum, object, interface and input-object types to define **at least one member**, so these are invalid for codegen. As agreed by the maintainer in the issue thread, we should **fail generation immediately with a clear message** rather than emit broken code — mirroring the existing empty-object guard.

## Change

Two small helpers:
- `requireHasFields` — fails if a type has no fields at all;
- `requireNonEmptyFields` — additionally fails (under `excludeDeprecated`) if every field is deprecated.

Applied at every generation site:
- **Enums**: dedicated guard in the enum pipeline (value/values wording).
- **Objects / interfaces / input objects**: `requireNonEmptyFields` (both empty-in-schema and emptied-by-exclusion).
- **Root query / mutation / subscription objects**: `requireHasFields`. These are generated via `writeRootQuery`/etc. from the *raw* field list (they don't apply `excludeDeprecated` field filtering — a separate pre-existing quirk), so only the empty-in-schema case can arise for them; using the deprecated-branch there would wrongly reject a root whose deprecated fields are still generated.

Messages:

| Kind | Empty in schema | Emptied by `excludeDeprecated` |
|------|-----------------|-------------------------------|
| enum | *… must have at least one value* | *… has no values left after excluding deprecated ones* |
| object / interface / input object | *… must have at least one field* | *… has no fields left after excluding deprecated ones* |
| root operation object | *… must have at least one field* | n/a (root fields aren't deprecation-filtered) |

The raw-empty check runs **before** deprecated-member filtering, so a type with *some* non-deprecated members still generates from the rest.

## Tests

New `ClientWriterSpec` cases assert codegen fails (dies) with the expected message for: empty enum, all-deprecated enum, all-deprecated object, empty input object, all-deprecated input object, empty interface, all-deprecated interface, and empty root operation object. Two obsolete snapshots documenting the old broken output are deleted. `ClientWriterSpec` + `ClientWriterViewSpec` green (55) on the default Scala version.