### PR TITLE
Fix release failure: skip Scaladoc for stitching, cover 2.12 doc in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,7 @@ jobs:
       - run: |
           sbt ++2.13 docs/mdoc
           sbt "++2.13 doc"
+          sbt "++2.12 doc"
       - save_cache:
           key: sbtcache
           paths:

--- a/build.sbt
+++ b/build.sbt
@@ -266,7 +266,12 @@ lazy val stitching = project
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterVersion % Provided,
       "dev.zio"                               %% "zio-test"              % zioVersion      % Test,
       "dev.zio"                               %% "zio-test-sbt"          % zioVersion      % Test
-    )
+    ),
+    // Scala 2.12 Scaladoc re-expands the jsoniter macro in CacheInvalidator and crashes, so skip it
+    Compile / doc / sources := {
+      val prev = (Compile / doc / sources).value
+      if (scalaVersion.value == scala212) Nil else prev
+    }
   )
   .disablePlugins(AssemblyPlugin)
   .dependsOn(tools)


### PR DESCRIPTION
## Problem

The release job (`sbt +clean ci-release`) [failed](https://app.circleci.com/pipelines/gh/ghostdogpr/caliban/8522/workflows/a1987474-31cb-4a56-99f9-bf1a9924f2c3/jobs/69820) compiling `stitching` on Scala 2.12:

```
[error] stitching/.../CacheInvalidator.scala:39:81: Cannot evaluate a parameter of the
        'make' macro call for type 'InvalidationMethod'. It should not depend on code
        from the same compilation module where the 'make' macro is called...
[error] java.lang.AssertionError: assertion failed: com package com <none>
[error] (stitching / Compile / compileIncremental) Compilation failed
```

jsoniter's `JsonCodecMaker.make` derives a codec for the sealed-trait ADT `InvalidationMethod`, whose leaf classes are defined in the same compilation unit. When publishing, `ci-release` also runs `doc` (Scaladoc) to produce the `-javadoc.jar` Sonatype requires. Scaladoc re-expands the macro in a separate compiler that runs **concurrently** with the module's real compile, and under that parallel load the ADT resolves to a `<none>` symbol and the macro asserts.

The failure is timing-dependent — it does not reproduce in any sequential local build (`compile`, `doc`, `publishM2`, clean, all pass). It only occurs on Scala 2.12; 2.13 and 3.3 Scaladoc for `stitching` succeed.

## Why it wasn't caught before

- **No pre-merge job runs Scaladoc on Scala 2.12.** Test jobs run `test`/`compile` only; the `test213_docs` job runs `doc` only on 2.13. The 2.12 Scaladoc path existed exclusively in the `release` job.
- **`release` only runs post-merge** (branch pushes / tags), never on PRs — so the one job exercising the failing path wasn't a merge gate.

## Fix

- `build.sbt`: skip `Compile / doc / sources` for `stitching` **on Scala 2.12 only**, so the jsoniter macro is never re-expanded by Scaladoc there. Scaladoc on 2.13 and 3.3 is preserved (verified working). Still produces a valid (empty) `-javadoc.jar` on 2.12 that Sonatype accepts.
- `.circleci/config.yml`: add `sbt "++2.12 doc"` to the docs job so 2.12 Scaladoc is exercised pre-merge (defense-in-depth for other modules).