### PR TITLE
Fix and optimize fragment field-merging validation

### DIFF
--- a/benchmarks/src/main/scala/caliban/validation/FragmentValidatorBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/validation/FragmentValidatorBenchmark.scala
@@ -19,6 +19,10 @@ class FragmentValidatorBenchmark {
   @Benchmark
   def fragmentConflicts(): Any =
     run(Validator.validateAll(parsedQuery, rootType))
+
+  @Benchmark
+  def eightyFragments(): Any =
+    run(Validator.validateAll(parsedEightyFragmentsQuery, rootType))
 }
 
 object FragmentValidatorBenchmark {
@@ -161,4 +165,32 @@ object FragmentValidatorBenchmark {
   }
 
   val parsedQuery = run(Parser.parseQuery(query))
+
+  // A 7.5 KB fragment DAG whose operation spreads all 80 fragments. Nested
+  // comparisons revisit the same fragment pairs unless they are memoized by name.
+  val eightyFragmentsQuery: String = {
+    val fragmentCount = 80
+    val fragments = (0 until fragmentCount).map { index =>
+      val name       = f"F$index%02d"
+      val nextSpread =
+        if (index + 1 < fragmentCount) f"...F${index + 1}%02d"
+        else ""
+      s"""fragment $name on Pet {
+         |  $nextSpread
+         |  ... on Dog { name nickname }
+         |  ... on Cat { name }
+         |}
+         |""".stripMargin
+    }.mkString("\n")
+    val spreads = (0 until fragmentCount).map(index => f"...F$index%02d").mkString("\n")
+    s"""$fragments
+       |query {
+       |  pet {
+       |    $spreads
+       |  }
+       |}
+       |""".stripMargin
+  }
+
+  val parsedEightyFragmentsQuery = run(Parser.parseQuery(eightyFragmentsQuery))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -789,6 +789,9 @@ lazy val enableMimaSettingsJVM =
     mimaBinaryIssueFilters := Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.*.<clinit>"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("mdg.engine.proto.reports.*.<clinit>"),
+      // package-private validation helper removed after its last internal caller
+      ProblemFilters.exclude[MissingClassProblem]("caliban.validation.FieldMap$FieldMapOps"),
+      ProblemFilters.exclude[MissingClassProblem]("caliban.validation.FieldMap$FieldMapOps$"),
       // private internal method; extra param added to fix nested-list null propagation
       ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.execution.Executor#StepReducer.reduceStep")
     )

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -3,7 +3,6 @@ package caliban.validation
 import caliban.introspection.adt._
 import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
 import caliban.parsing.adt._
-import caliban.syntax._
 import caliban.validation.Utils._
 
 import scala.collection.compat._
@@ -14,86 +13,6 @@ private[caliban] object FieldMap {
     fields: collection.Map[String, mutable.ArrayBuffer[SelectedField]],
     fragmentNames: List[String]
   )
-
-  @deprecated("Kept for bin-compatibility only", "3.1.3")
-  val empty: FieldMap = Map.empty
-
-  @deprecated("Kept for bin-compatibility only", "3.1.3")
-  implicit class FieldMapOps(val self: FieldMap) extends AnyVal {
-    def |+|(that: FieldMap): FieldMap = {
-      val mb = Map.newBuilder[String, Set[SelectedField]]
-      (self.keySet ++ that.keySet).foreach { k =>
-        mb += k -> {
-          (self.get(k), that.get(k)) match {
-            case (Some(s1), Some(s2)) => s1 ++ s2
-            case (Some(s1), None)     => s1
-            case (None, Some(s2))     => s2
-            case _                    => Set.empty[SelectedField]
-          }
-        }
-      }
-      mb.result()
-    }
-
-    def show: String =
-      self.map { case (k, fields) =>
-        s"$k -> ${fields.map(_.fieldDef.name).mkString(", ")}"
-      }.mkString("\n")
-
-    def addField(
-      f: Field,
-      parentType: __Type,
-      selection: Field
-    ): FieldMap = {
-      val responseName = f.alias.getOrElse(f.name)
-
-      parentType.getFieldOrNull(f.name) match {
-        case null => self
-        case f1   =>
-          val sf    = SelectedField(parentType, selection, f1)
-          val entry = self.get(responseName).map(_ + sf).getOrElse(Set(sf))
-          self + (responseName -> entry)
-      }
-    }
-  }
-
-  private type FM = mutable.HashMap[String, Set[SelectedField]]
-
-  @deprecated("Kept for bin-compatibility only", "3.1.3")
-  def apply(context: Context, parentType: __Type, selectionSet: Iterable[Selection]): FieldMap =
-    make(context, parentType, selectionSet).toMap
-
-  @deprecated("Kept for bin-compatibility only", "3.1.6")
-  def make(
-    context: Context,
-    parentType: __Type,
-    selectionSet: Iterable[Selection]
-  ): collection.Map[String, Set[SelectedField]] = {
-    val fields: FM    = mutable.HashMap.empty
-    val seenFragments = mutable.HashSet.empty[String]
-
-    def addSelections(parentType: __Type, selectionSet: Iterable[Selection]): Unit = {
-      val collected = collect(context, parentType, selectionSet)
-      collected.fields.foreach { case (responseName, selectedFields) =>
-        fields.updateWith(responseName) {
-          case Some(existing) => Some(existing ++ selectedFields)
-          case None           => Some(selectedFields.toSet)
-        }
-      }
-      collected.fragmentNames.foreach { name =>
-        if (seenFragments.add(name))
-          context.fragments.getOrElseNull(name) match {
-            case null       => ()
-            case definition =>
-              val fragmentType = getType(Some(definition.typeCondition), parentType, context)
-              addSelections(fragmentType, definition.selectionSet)
-          }
-      }
-    }
-
-    addSelections(parentType, selectionSet)
-    fields
-  }
 
   def collect(
     context: Context,

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -59,63 +59,39 @@ private[caliban] object FieldMap {
 
   private type FM = mutable.HashMap[String, Set[SelectedField]]
 
-  private abstract class SelectionCollector {
-    final def addField(field: Field, parentType: __Type): Unit =
-      parentType.getFieldOrNull(field.name) match {
-        case null     => ()
-        case fieldDef =>
-          appendField(
-            field.alias.getOrElse(field.name),
-            SelectedField(parentType, field, fieldDef)
-          )
-      }
-
-    protected def appendField(responseName: String, field: SelectedField): Unit
-
-    def addFragmentSpread(context: Context, parentType: __Type, name: String): Unit
-  }
-
-  private final class InliningCollector(fields: FM) extends SelectionCollector {
-    override protected def appendField(responseName: String, field: SelectedField): Unit =
-      fields.updateWith(responseName) {
-        case Some(existing) => Some(existing + field)
-        case None           => Some(Set(field))
-      }
-
-    override def addFragmentSpread(context: Context, parentType: __Type, name: String): Unit =
-      context.fragments.getOrElseNull(name) match {
-        case null       => ()
-        case definition =>
-          val typ = getType(Some(definition.typeCondition), parentType, context)
-          loop(context, typ, definition.selectionSet, this)
-      }
-  }
-
-  private final class FragmentPreservingCollector extends SelectionCollector {
-    private val fields        = mutable.HashMap.empty[String, mutable.ArrayBuffer[SelectedField]]
-    private val fragmentNames = mutable.ListBuffer.empty[String]
-    private val seenFragments = mutable.HashSet.empty[String]
-
-    override protected def appendField(responseName: String, field: SelectedField): Unit =
-      fields.getOrElseUpdate(responseName, mutable.ArrayBuffer.empty) += field
-
-    override def addFragmentSpread(_context: Context, _parentType: __Type, name: String): Unit =
-      if (seenFragments.add(name)) fragmentNames += name
-
-    def result(): Collected = Collected(fields, fragmentNames.toList)
-  }
-
   @deprecated("Kept for bin-compatibility only", "3.1.3")
   def apply(context: Context, parentType: __Type, selectionSet: Iterable[Selection]): FieldMap =
     make(context, parentType, selectionSet).toMap
 
+  @deprecated("Kept for bin-compatibility only", "3.1.5")
   def make(
     context: Context,
     parentType: __Type,
     selectionSet: Iterable[Selection]
   ): collection.Map[String, Set[SelectedField]] = {
-    val fields: FM = mutable.HashMap.empty
-    loop(context, parentType, selectionSet, new InliningCollector(fields))
+    val fields: FM    = mutable.HashMap.empty
+    val seenFragments = mutable.HashSet.empty[String]
+
+    def addSelections(parentType: __Type, selectionSet: Iterable[Selection]): Unit = {
+      val collected = collect(context, parentType, selectionSet)
+      collected.fields.foreach { case (responseName, selectedFields) =>
+        fields.updateWith(responseName) {
+          case Some(existing) => Some(existing ++ selectedFields)
+          case None           => Some(selectedFields.toSet)
+        }
+      }
+      collected.fragmentNames.foreach { name =>
+        if (seenFragments.add(name))
+          context.fragments.getOrElseNull(name) match {
+            case null       => ()
+            case definition =>
+              val fragmentType = getType(Some(definition.typeCondition), parentType, context)
+              addSelections(fragmentType, definition.selectionSet)
+          }
+      }
+    }
+
+    addSelections(parentType, selectionSet)
     fields
   }
 
@@ -124,27 +100,37 @@ private[caliban] object FieldMap {
     parentType: __Type,
     selectionSet: Iterable[Selection]
   ): Collected = {
-    val collector = new FragmentPreservingCollector
-    loop(context, parentType, selectionSet, collector)
-    collector.result()
+    val fields        = mutable.HashMap.empty[String, mutable.ArrayBuffer[SelectedField]]
+    val fragmentNames = mutable.ListBuffer.empty[String]
+    val seenFragments = mutable.HashSet.empty[String]
+    collectInto(context, parentType, selectionSet, fields, fragmentNames, seenFragments)
+    Collected(fields, fragmentNames.toList)
   }
 
-  private def loop(
+  private def collectInto(
     context: Context,
     parentType: __Type,
     selectionSet: Iterable[Selection],
-    collector: SelectionCollector
+    fields: mutable.HashMap[String, mutable.ArrayBuffer[SelectedField]],
+    fragmentNames: mutable.ListBuffer[String],
+    seenFragments: mutable.HashSet[String]
   ): Unit = {
     val it = selectionSet.iterator
     while (it.hasNext)
       it.next() match {
         case f: Field                                       =>
-          collector.addField(f, parentType)
+          parentType.getFieldOrNull(f.name) match {
+            case null     => ()
+            case fieldDef =>
+              val responseName = f.alias.getOrElse(f.name)
+              fields.getOrElseUpdate(responseName, mutable.ArrayBuffer.empty) +=
+                SelectedField(parentType, f, fieldDef)
+          }
         case FragmentSpread(name, _)                        =>
-          collector.addFragmentSpread(context, parentType, name)
+          if (seenFragments.add(name)) fragmentNames += name
         case InlineFragment(typeCondition, _, selectionSet) =>
           val typ = getType(typeCondition, parentType, context)
-          loop(context, typ, selectionSet, collector)
+          collectInto(context, typ, selectionSet, fields, fragmentNames, seenFragments)
       }
   }
 

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -63,7 +63,7 @@ private[caliban] object FieldMap {
   def apply(context: Context, parentType: __Type, selectionSet: Iterable[Selection]): FieldMap =
     make(context, parentType, selectionSet).toMap
 
-  @deprecated("Kept for bin-compatibility only", "3.1.5")
+  @deprecated("Kept for bin-compatibility only", "3.1.6")
   def make(
     context: Context,
     parentType: __Type,

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -10,6 +10,11 @@ import scala.collection.compat._
 import scala.collection.mutable
 
 private[caliban] object FieldMap {
+  final case class Collected(
+    fields: collection.Map[String, mutable.ArrayBuffer[SelectedField]],
+    fragmentNames: List[String]
+  )
+
   @deprecated("Kept for bin-compatibility only", "3.1.3")
   val empty: FieldMap = Map.empty
 
@@ -54,6 +59,52 @@ private[caliban] object FieldMap {
 
   private type FM = mutable.HashMap[String, Set[SelectedField]]
 
+  private abstract class SelectionCollector {
+    final def addField(field: Field, parentType: __Type): Unit =
+      parentType.getFieldOrNull(field.name) match {
+        case null     => ()
+        case fieldDef =>
+          appendField(
+            field.alias.getOrElse(field.name),
+            SelectedField(parentType, field, fieldDef)
+          )
+      }
+
+    protected def appendField(responseName: String, field: SelectedField): Unit
+
+    def addFragmentSpread(context: Context, parentType: __Type, name: String): Unit
+  }
+
+  private final class InliningCollector(fields: FM) extends SelectionCollector {
+    override protected def appendField(responseName: String, field: SelectedField): Unit =
+      fields.updateWith(responseName) {
+        case Some(existing) => Some(existing + field)
+        case None           => Some(Set(field))
+      }
+
+    override def addFragmentSpread(context: Context, parentType: __Type, name: String): Unit =
+      context.fragments.getOrElseNull(name) match {
+        case null       => ()
+        case definition =>
+          val typ = getType(Some(definition.typeCondition), parentType, context)
+          loop(context, typ, definition.selectionSet, this)
+      }
+  }
+
+  private final class FragmentPreservingCollector extends SelectionCollector {
+    private val fields        = mutable.HashMap.empty[String, mutable.ArrayBuffer[SelectedField]]
+    private val fragmentNames = mutable.ListBuffer.empty[String]
+    private val seenFragments = mutable.HashSet.empty[String]
+
+    override protected def appendField(responseName: String, field: SelectedField): Unit =
+      fields.getOrElseUpdate(responseName, mutable.ArrayBuffer.empty) += field
+
+    override def addFragmentSpread(_context: Context, _parentType: __Type, name: String): Unit =
+      if (seenFragments.add(name)) fragmentNames += name
+
+    def result(): Collected = Collected(fields, fragmentNames.toList)
+  }
+
   @deprecated("Kept for bin-compatibility only", "3.1.3")
   def apply(context: Context, parentType: __Type, selectionSet: Iterable[Selection]): FieldMap =
     make(context, parentType, selectionSet).toMap
@@ -64,46 +115,37 @@ private[caliban] object FieldMap {
     selectionSet: Iterable[Selection]
   ): collection.Map[String, Set[SelectedField]] = {
     val fields: FM = mutable.HashMap.empty
-    loop(context, parentType, selectionSet)(fields)
+    loop(context, parentType, selectionSet, new InliningCollector(fields))
     fields
+  }
+
+  def collect(
+    context: Context,
+    parentType: __Type,
+    selectionSet: Iterable[Selection]
+  ): Collected = {
+    val collector = new FragmentPreservingCollector
+    loop(context, parentType, selectionSet, collector)
+    collector.result()
   }
 
   private def loop(
     context: Context,
     parentType: __Type,
-    selectionSet: Iterable[Selection]
-  )(implicit fields: FM): Unit = {
+    selectionSet: Iterable[Selection],
+    collector: SelectionCollector
+  ): Unit = {
     val it = selectionSet.iterator
     while (it.hasNext)
       it.next() match {
         case f: Field                                       =>
-          addField(f, parentType)
+          collector.addField(f, parentType)
         case FragmentSpread(name, _)                        =>
-          context.fragments.getOrElseNull(name) match {
-            case null       => ()
-            case definition =>
-              val typ = getType(Some(definition.typeCondition), parentType, context)
-              loop(context, typ, definition.selectionSet)
-          }
+          collector.addFragmentSpread(context, parentType, name)
         case InlineFragment(typeCondition, _, selectionSet) =>
           val typ = getType(typeCondition, parentType, context)
-          loop(context, typ, selectionSet)
+          loop(context, typ, selectionSet, collector)
       }
   }
-
-  private def addField(
-    f: Field,
-    parentType: __Type
-  )(implicit self: FM): Unit =
-    parentType.getFieldOrNull(f.name) match {
-      case null => ()
-      case f1   =>
-        val responseName = f.alias.getOrElse(f.name)
-        val sf           = SelectedField(parentType, f, f1)
-        self.updateWith(responseName) {
-          case Some(s) => Some(s + sf)
-          case _       => Some(Set.empty + sf)
-        }
-    }
 
 }

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -11,15 +11,38 @@ import java.util.IdentityHashMap
 import scala.collection.mutable
 
 object FragmentValidator {
-  private sealed abstract class ComparisonMode(val mutuallyExclusive: Boolean) {
-    // Comparing overlapping parents is stronger because it also checks field names and arguments.
-    final def covers(requested: ComparisonMode): Boolean =
-      !mutuallyExclusive || requested.mutuallyExclusive
+  private sealed trait ComparisonMode {
+    def covers(requested: ComparisonMode): Boolean
+    def findNameOrArgumentsConflict(first: SelectedField, second: SelectedField): Option[String]
   }
 
   private object ComparisonMode {
-    case object Overlapping       extends ComparisonMode(mutuallyExclusive = false)
-    case object MutuallyExclusive extends ComparisonMode(mutuallyExclusive = true)
+    // Comparing overlapping parents is stronger because it also checks field names and arguments.
+    case object Overlapping extends ComparisonMode {
+      override def covers(requested: ComparisonMode): Boolean = true
+
+      override def findNameOrArgumentsConflict(
+        first: SelectedField,
+        second: SelectedField
+      ): Option[String] =
+        if (first.fieldDef.name != second.fieldDef.name)
+          Some(
+            s"${first.parentType.name.getOrElse("")}.${first.fieldDef.name} and ${second.parentType.name
+                .getOrElse("")}.${second.fieldDef.name} are different fields."
+          )
+        else if (first.selection.arguments != second.selection.arguments)
+          Some(s"${first.fieldDef.name} and ${second.fieldDef.name} have different arguments")
+        else None
+    }
+
+    case object MutuallyExclusive extends ComparisonMode {
+      override def covers(requested: ComparisonMode): Boolean = requested eq MutuallyExclusive
+
+      override def findNameOrArgumentsConflict(
+        _first: SelectedField,
+        _second: SelectedField
+      ): Option[String] = None
+    }
 
     def exclusiveWhen(condition: Boolean): ComparisonMode =
       if (condition) MutuallyExclusive else Overlapping
@@ -28,46 +51,49 @@ object FragmentValidator {
   private class ComparisonMemo[A, B] {
     private val data = mutable.HashMap.empty[A, mutable.HashMap[B, ComparisonMode]]
 
-    def contains(first: A, second: B, mode: ComparisonMode): Boolean =
-      data.get(first) match {
-        case Some(seconds) =>
-          seconds.get(second) match {
-            case Some(previousMode) => previousMode.covers(mode)
-            case None               => false
-          }
-        case None          => false
+    def recordIfNotCovered(first: A, second: B, mode: ComparisonMode): Boolean = {
+      val seconds = data.getOrElseUpdate(first, mutable.HashMap.empty)
+      seconds.get(second) match {
+        case Some(previousMode) if previousMode.covers(mode) => false
+        case _                                               =>
+          seconds.update(second, mode)
+          true
       }
-
-    def add(first: A, second: B, mode: ComparisonMode): Unit =
-      data.getOrElseUpdate(first, mutable.HashMap.empty).update(second, mode)
+    }
   }
 
   private final class FragmentPairMemo {
     private val pairs = new ComparisonMemo[String, String]
 
-    def contains(first: String, second: String, mode: ComparisonMode): Boolean =
-      if (first.compareTo(second) <= 0) pairs.contains(first, second, mode)
-      else pairs.contains(second, first, mode)
-
-    def add(first: String, second: String, mode: ComparisonMode): Unit =
-      if (first.compareTo(second) <= 0) pairs.add(first, second, mode)
-      else pairs.add(second, first, mode)
+    def recordIfNotCovered(first: String, second: String, mode: ComparisonMode): Boolean =
+      if (first.compareTo(second) <= 0) pairs.recordIfNotCovered(first, second, mode)
+      else pairs.recordIfNotCovered(second, first, mode)
   }
 
-  private final case class CachedFields(id: Int, collected: FieldMap.Collected)
+  private final case class FieldMapId(value: Int) extends AnyVal
+  private final case class CachedFields(id: FieldMapId, collected: FieldMap.Collected)
 
   def findConflictsWithinSelectionSet(
     context: Context,
     parentType: __Type,
     selectionSet: List[Selection]
-  ): Either[ValidationError, Unit] = {
-    val comparedFragmentPairs          = new FragmentPairMemo
-    val comparedFieldsAndFragmentPairs = new ComparisonMemo[Int, String]
-    val fieldsCache                    =
-      new IdentityHashMap[List[Selection], IdentityHashMap[__Type, CachedFields]]()
-    var nextFieldMapId                 = 0
+  ): Either[ValidationError, Unit] =
+    new ConflictFinder(context, parentType).find(selectionSet)
 
-    def getFieldsAndFragmentNames(parentType: __Type, selectionSet: List[Selection]): CachedFields = {
+  private final class ConflictFinder(context: Context, rootParentType: __Type) {
+    private val comparedFragmentPairs          = new FragmentPairMemo
+    private val comparedFieldsAndFragmentPairs = new ComparisonMemo[FieldMapId, String]
+    private val fieldsCache                    =
+      new IdentityHashMap[List[Selection], IdentityHashMap[__Type, CachedFields]]()
+    private var nextFieldMapId                 = 0
+
+    def find(selectionSet: List[Selection]): Either[ValidationError, Unit] =
+      validateSelectionSets(rootParentType, selectionSet, mutable.HashSet.empty) match {
+        case Some(conflict) => Left(ValidationError(conflict, ""))
+        case None           => ValidationOps.unit
+      }
+
+    private def getFieldsAndFragmentNames(parentType: __Type, selectionSet: List[Selection]): CachedFields = {
       var byParentType = fieldsCache.get(selectionSet)
       if (byParentType eq null) {
         byParentType = new IdentityHashMap[__Type, CachedFields]()
@@ -76,23 +102,23 @@ object FragmentValidator {
 
       var cached = byParentType.get(parentType)
       if (cached eq null) {
-        cached = CachedFields(nextFieldMapId, FieldMap.collect(context, parentType, selectionSet))
+        cached = CachedFields(FieldMapId(nextFieldMapId), FieldMap.collect(context, parentType, selectionSet))
         nextFieldMapId += 1
         byParentType.put(parentType, cached)
       }
       cached
     }
 
-    def getReferencedFieldsAndFragmentNames(fragmentName: String): CachedFields = {
+    private def getReferencedFieldsAndFragmentNames(fragmentName: String): CachedFields = {
       val definition = context.fragments.getOrElseNull(fragmentName)
       if (definition eq null) null
       else {
-        val fragmentType = getType(definition.typeCondition, context).getOrElse(parentType)
+        val fragmentType = getType(definition.typeCondition, context).getOrElse(rootParentType)
         getFieldsAndFragmentNames(fragmentType, definition.selectionSet)
       }
     }
 
-    def doTypesConflict(t1: __Type, t2: __Type): Boolean =
+    private def doTypesConflict(t1: __Type, t2: __Type): Boolean =
       if (isNonNull(t1))
         if (isNonNull(t2)) t1.ofType.flatMap(p1 => t2.ofType.map(p2 => doTypesConflict(p1, p2))).getOrElse(true)
         else true
@@ -103,45 +129,46 @@ object FragmentValidator {
         else true
       else if (isListType(t2))
         true
-      else if (isLeafType(t1) || isLeafType(t2))
+      else if (isLeafType(t1) && isLeafType(t2))
         t1.name != t2.name
+      else if (!isComposite(t1) || !isComposite(t2))
+        true
       else
         false
 
-    def findConflict(
+    private def findConflict(
       responseName: String,
       f1: SelectedField,
       f2: SelectedField,
       parentMode: ComparisonMode
     ): Option[String] = {
       val mode = ComparisonMode.exclusiveWhen(
-        parentMode.mutuallyExclusive ||
+        (parentMode eq ComparisonMode.MutuallyExclusive) ||
           (isObjectType(f1.parentType) && isObjectType(f2.parentType) && f1.parentType.name != f2.parentType.name)
       )
 
-      if (!mode.mutuallyExclusive && f1.fieldDef.name != f2.fieldDef.name)
-        Some(
-          s"${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name.getOrElse("")}.${f2.fieldDef.name} are different fields."
-        )
-      else if (!mode.mutuallyExclusive && f1.selection.arguments != f2.selection.arguments)
-        Some(s"${f1.fieldDef.name} and ${f2.fieldDef.name} have different arguments")
-      else if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type))
+      if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type))
         Some(
           s"$responseName has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
               .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
         )
-      else if (f1.selection.selectionSet.nonEmpty && f2.selection.selectionSet.nonEmpty)
-        findConflictsBetweenSubSelectionSets(
-          mode,
-          f1.fieldDef._type.innerType,
-          f1.selection.selectionSet,
-          f2.fieldDef._type.innerType,
-          f2.selection.selectionSet
-        )
-      else None
+      else
+        mode.findNameOrArgumentsConflict(f1, f2) match {
+          case conflict @ Some(_) => conflict
+          case None               =>
+            if (f1.selection.selectionSet.nonEmpty && f2.selection.selectionSet.nonEmpty)
+              findConflictsBetweenSubSelectionSets(
+                mode,
+                f1.fieldDef._type.innerType,
+                f1.selection.selectionSet,
+                f2.fieldDef._type.innerType,
+                f2.selection.selectionSet
+              )
+            else None
+        }
     }
 
-    def collectConflictsWithin(fields: CachedFields): Option[String] = {
+    private def collectConflictsWithin(fields: CachedFields): Option[String] = {
       val fieldGroups = fields.collected.fields.iterator
       while (fieldGroups.hasNext) {
         val (responseName, values) = fieldGroups.next()
@@ -159,7 +186,7 @@ object FragmentValidator {
       None
     }
 
-    def collectConflictsBetween(
+    private def collectConflictsBetween(
       fields1: CachedFields,
       fields2: CachedFields,
       mode: ComparisonMode
@@ -187,14 +214,13 @@ object FragmentValidator {
         None
       }
 
-    def collectConflictsBetweenFieldsAndFragment(
+    private def collectConflictsBetweenFieldsAndFragment(
       fields: CachedFields,
       fragmentName: String,
       mode: ComparisonMode
     ): Option[String] =
-      if (comparedFieldsAndFragmentPairs.contains(fields.id, fragmentName, mode)) None
+      if (!comparedFieldsAndFragmentPairs.recordIfNotCovered(fields.id, fragmentName, mode)) None
       else {
-        comparedFieldsAndFragmentPairs.add(fields.id, fragmentName, mode)
         val fragmentFields = getReferencedFieldsAndFragmentNames(fragmentName)
         if ((fragmentFields eq null) || fields.id == fragmentFields.id) None
         else {
@@ -213,15 +239,14 @@ object FragmentValidator {
         }
       }
 
-    def collectConflictsBetweenFragments(
+    private def collectConflictsBetweenFragments(
       fragmentName1: String,
       fragmentName2: String,
       mode: ComparisonMode
     ): Option[String] =
       if (fragmentName1 == fragmentName2) None
-      else if (comparedFragmentPairs.contains(fragmentName1, fragmentName2, mode)) None
+      else if (!comparedFragmentPairs.recordIfNotCovered(fragmentName1, fragmentName2, mode)) None
       else {
-        comparedFragmentPairs.add(fragmentName1, fragmentName2, mode)
         val fields1 = getReferencedFieldsAndFragmentNames(fragmentName1)
         val fields2 = getReferencedFieldsAndFragmentNames(fragmentName2)
         if ((fields1 eq null) || (fields2 eq null)) None
@@ -249,7 +274,7 @@ object FragmentValidator {
         }
       }
 
-    def findConflictsBetweenSubSelectionSets(
+    private def findConflictsBetweenSubSelectionSets(
       mode: ComparisonMode,
       parentType1: __Type,
       selectionSet1: List[Selection],
@@ -290,7 +315,7 @@ object FragmentValidator {
       }
     }
 
-    def findConflictsWithin(parentType: __Type, selectionSet: List[Selection]): Option[String] = {
+    private def findConflictsWithin(parentType: __Type, selectionSet: List[Selection]): Option[String] = {
       val fields         = getFieldsAndFragmentNames(parentType, selectionSet)
       val directConflict = collectConflictsWithin(fields)
       if (directConflict.nonEmpty) directConflict
@@ -315,7 +340,7 @@ object FragmentValidator {
       }
     }
 
-    def validateSelectionSets(
+    private def validateSelectionSets(
       parentType: __Type,
       selectionSet: List[Selection],
       validatedFragments: mutable.HashSet[String]
@@ -356,9 +381,5 @@ object FragmentValidator {
       }
     }
 
-    validateSelectionSets(parentType, selectionSet, mutable.HashSet.empty) match {
-      case Some(conflict) => Left(ValidationError(conflict, ""))
-      case None           => ValidationOps.unit
-    }
   }
 }

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -3,57 +3,94 @@ package caliban.validation
 import caliban.CalibanError.ValidationError
 import caliban.introspection.adt._
 import caliban.parsing.adt.Selection
+import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
+import caliban.syntax._
 import caliban.validation.Utils._
-import zio.Chunk
 
+import java.util.IdentityHashMap
 import scala.collection.mutable
 
 object FragmentValidator {
+  private sealed abstract class ComparisonMode(val mutuallyExclusive: Boolean) {
+    // Comparing overlapping parents is stronger because it also checks field names and arguments.
+    final def covers(requested: ComparisonMode): Boolean =
+      !mutuallyExclusive || requested.mutuallyExclusive
+  }
+
+  private object ComparisonMode {
+    case object Overlapping       extends ComparisonMode(mutuallyExclusive = false)
+    case object MutuallyExclusive extends ComparisonMode(mutuallyExclusive = true)
+
+    def exclusiveWhen(condition: Boolean): ComparisonMode =
+      if (condition) MutuallyExclusive else Overlapping
+  }
+
+  private class ComparisonMemo[A, B] {
+    private val data = mutable.HashMap.empty[A, mutable.HashMap[B, ComparisonMode]]
+
+    def contains(first: A, second: B, mode: ComparisonMode): Boolean =
+      data.get(first) match {
+        case Some(seconds) =>
+          seconds.get(second) match {
+            case Some(previousMode) => previousMode.covers(mode)
+            case None               => false
+          }
+        case None          => false
+      }
+
+    def add(first: A, second: B, mode: ComparisonMode): Unit =
+      data.getOrElseUpdate(first, mutable.HashMap.empty).update(second, mode)
+  }
+
+  private final class FragmentPairMemo {
+    private val pairs = new ComparisonMemo[String, String]
+
+    def contains(first: String, second: String, mode: ComparisonMode): Boolean =
+      if (first.compareTo(second) <= 0) pairs.contains(first, second, mode)
+      else pairs.contains(second, first, mode)
+
+    def add(first: String, second: String, mode: ComparisonMode): Unit =
+      if (first.compareTo(second) <= 0) pairs.add(first, second, mode)
+      else pairs.add(second, first, mode)
+  }
+
+  private final case class CachedFields(id: Int, collected: FieldMap.Collected)
+
   def findConflictsWithinSelectionSet(
     context: Context,
     parentType: __Type,
     selectionSet: List[Selection]
   ): Either[ValidationError, Unit] = {
+    val comparedFragmentPairs          = new FragmentPairMemo
+    val comparedFieldsAndFragmentPairs = new ComparisonMemo[Int, String]
+    val fieldsCache                    =
+      new IdentityHashMap[List[Selection], IdentityHashMap[__Type, CachedFields]]()
+    var nextFieldMapId                 = 0
 
-    val shapeCache   = mutable.HashMap.empty[List[Selection], Chunk[String]]
-    val parentsCache = mutable.HashMap.empty[(Option[String], Iterable[Selection]), Chunk[String]]
-    val groupsCache  = mutable.HashMap.empty[Set[SelectedField], Chunk[Set[SelectedField]]]
+    def getFieldsAndFragmentNames(parentType: __Type, selectionSet: List[Selection]): CachedFields = {
+      var byParentType = fieldsCache.get(selectionSet)
+      if (byParentType eq null) {
+        byParentType = new IdentityHashMap[__Type, CachedFields]()
+        fieldsCache.put(selectionSet, byParentType)
+      }
 
-    def sameResponseShapeByName(set: List[Selection], parentType: __Type): Chunk[String] =
-      if (set.isEmpty) Chunk.empty
-      else
-        shapeCache.getOrElseUpdate(
-          set, {
-            val fields = FieldMap.make(context, parentType, set)
-            Chunk.fromIterable(fields.flatMap { case (name, values) =>
-              cross(values, includeIdentity = true).flatMap { case (f1, f2) =>
-                if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type)) {
-                  Chunk.single(
-                    s"$name has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
-                        .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
-                  )
-                } else
-                  sameResponseShapeByName(f1.selection.selectionSet ::: f2.selection.selectionSet, f1.fieldDef._type)
-              }
-            })
-          }
-        )
+      var cached = byParentType.get(parentType)
+      if (cached eq null) {
+        cached = CachedFields(nextFieldMapId, FieldMap.collect(context, parentType, selectionSet))
+        nextFieldMapId += 1
+        byParentType.put(parentType, cached)
+      }
+      cached
+    }
 
-    def sameForCommonParentsByName(parentType: __Type, set: Iterable[Selection]): Chunk[String] =
-      if (set.isEmpty) Chunk.empty
-      else
-        parentsCache.getOrElseUpdate(
-          (parentType.name, set), {
-            val fields = FieldMap.make(context, parentType, set)
-            Chunk.fromIterable(fields.values.flatMap { fields =>
-              groupByCommonParents(fields).flatMap { group =>
-                val merged    = group.flatMap(_.selection.selectionSet)
-                val fieldType = group.headOption.fold(parentType)(_.fieldDef._type.innerType)
-                requireSameNameAndArguments(group) ++ sameForCommonParentsByName(fieldType, merged)
-              }
-            })
-          }
-        )
+    def getReferencedFieldsAndFragmentNames(fragmentName: String): CachedFields = {
+      val definition = context.fragments.getOrElseNull(fragmentName)
+      if (definition eq null) null
+      else {
+        val fragmentType = getType(definition.typeCondition, context).getOrElse(parentType)
+        getFieldsAndFragmentNames(fragmentType, definition.selectionSet)
+      }
+    }
 
     def doTypesConflict(t1: __Type, t2: __Type): Boolean =
       if (isNonNull(t1))
@@ -66,53 +103,262 @@ object FragmentValidator {
         else true
       else if (isListType(t2))
         true
-      else if (isLeafType(t1) && isLeafType(t2)) {
+      else if (isLeafType(t1) || isLeafType(t2))
         t1.name != t2.name
-      } else if (!isComposite(t1) || !isComposite(t2))
-        true
       else
         false
 
-    def requireSameNameAndArguments(fields: Set[SelectedField]) =
-      cross(fields, includeIdentity = false).flatMap { case (f1, f2) =>
-        if (f1.fieldDef.name != f2.fieldDef.name) {
-          Some(
-            s"${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name.getOrElse("")}.${f2.fieldDef.name} are different fields."
-          )
-        } else if (f1.selection.arguments != f2.selection.arguments)
-          Some(s"${f1.fieldDef.name} and ${f2.fieldDef.name} have different arguments")
-        else None
-      }
-
-    def groupByCommonParents(fields: Set[SelectedField]): Chunk[Set[SelectedField]] =
-      groupsCache.getOrElseUpdate(
-        fields, {
-          val abstractGroup = fields.filter(field => isAbstract(field.parentType))
-
-          val concreteGroups =
-            mutable.HashMap.empty[String, mutable.Builder[SelectedField, Set[SelectedField]]]
-
-          fields.foreach {
-            case field @ SelectedField(
-                  __Type(_, Some(name), _, _, _, _, _, _, _, _, _, _, _),
-                  _,
-                  _
-                ) if isConcrete(field.parentType) =>
-              concreteGroups.getOrElseUpdate(name, Set.newBuilder ++= abstractGroup) += field
-            case _ => ()
-          }
-
-          if (concreteGroups.isEmpty) Chunk.single(fields)
-          else Chunk.fromIterable(concreteGroups.values.map(_.result()))
-        }
+    def findConflict(
+      responseName: String,
+      f1: SelectedField,
+      f2: SelectedField,
+      parentMode: ComparisonMode
+    ): Option[String] = {
+      val mode = ComparisonMode.exclusiveWhen(
+        parentMode.mutuallyExclusive ||
+          (isObjectType(f1.parentType) && isObjectType(f2.parentType) && f1.parentType.name != f2.parentType.name)
       )
 
-    val conflicts =
-      sameResponseShapeByName(selectionSet, parentType) ++ sameForCommonParentsByName(parentType, selectionSet)
-    if (conflicts.nonEmpty) {
-      Left(ValidationError(conflicts.head, ""))
-    } else {
-      ValidationOps.unit
+      if (!mode.mutuallyExclusive && f1.fieldDef.name != f2.fieldDef.name)
+        Some(
+          s"${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name.getOrElse("")}.${f2.fieldDef.name} are different fields."
+        )
+      else if (!mode.mutuallyExclusive && f1.selection.arguments != f2.selection.arguments)
+        Some(s"${f1.fieldDef.name} and ${f2.fieldDef.name} have different arguments")
+      else if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type))
+        Some(
+          s"$responseName has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
+              .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
+        )
+      else if (f1.selection.selectionSet.nonEmpty && f2.selection.selectionSet.nonEmpty)
+        findConflictsBetweenSubSelectionSets(
+          mode,
+          f1.fieldDef._type.innerType,
+          f1.selection.selectionSet,
+          f2.fieldDef._type.innerType,
+          f2.selection.selectionSet
+        )
+      else None
+    }
+
+    def collectConflictsWithin(fields: CachedFields): Option[String] = {
+      val fieldGroups = fields.collected.fields.iterator
+      while (fieldGroups.hasNext) {
+        val (responseName, values) = fieldGroups.next()
+        var i                      = 0
+        while (i < values.length - 1) {
+          var j = i + 1
+          while (j < values.length) {
+            val conflict = findConflict(responseName, values(i), values(j), ComparisonMode.Overlapping)
+            if (conflict.nonEmpty) return conflict
+            j += 1
+          }
+          i += 1
+        }
+      }
+      None
+    }
+
+    def collectConflictsBetween(
+      fields1: CachedFields,
+      fields2: CachedFields,
+      mode: ComparisonMode
+    ): Option[String] =
+      if (fields1.id == fields2.id) None
+      else {
+        val fieldGroups = fields1.collected.fields.iterator
+        while (fieldGroups.hasNext) {
+          val (responseName, values1) = fieldGroups.next()
+          fields2.collected.fields.get(responseName) match {
+            case Some(values2) =>
+              var i = 0
+              while (i < values1.length) {
+                var j = 0
+                while (j < values2.length) {
+                  val conflict = findConflict(responseName, values1(i), values2(j), mode)
+                  if (conflict.nonEmpty) return conflict
+                  j += 1
+                }
+                i += 1
+              }
+            case None          => ()
+          }
+        }
+        None
+      }
+
+    def collectConflictsBetweenFieldsAndFragment(
+      fields: CachedFields,
+      fragmentName: String,
+      mode: ComparisonMode
+    ): Option[String] =
+      if (comparedFieldsAndFragmentPairs.contains(fields.id, fragmentName, mode)) None
+      else {
+        comparedFieldsAndFragmentPairs.add(fields.id, fragmentName, mode)
+        val fragmentFields = getReferencedFieldsAndFragmentNames(fragmentName)
+        if ((fragmentFields eq null) || fields.id == fragmentFields.id) None
+        else {
+          val directConflict = collectConflictsBetween(fields, fragmentFields, mode)
+          if (directConflict.nonEmpty) directConflict
+          else {
+            val nestedFragments = fragmentFields.collected.fragmentNames
+            var remaining       = nestedFragments
+            while (remaining.nonEmpty) {
+              val conflict = collectConflictsBetweenFieldsAndFragment(fields, remaining.head, mode)
+              if (conflict.nonEmpty) return conflict
+              remaining = remaining.tail
+            }
+            None
+          }
+        }
+      }
+
+    def collectConflictsBetweenFragments(
+      fragmentName1: String,
+      fragmentName2: String,
+      mode: ComparisonMode
+    ): Option[String] =
+      if (fragmentName1 == fragmentName2) None
+      else if (comparedFragmentPairs.contains(fragmentName1, fragmentName2, mode)) None
+      else {
+        comparedFragmentPairs.add(fragmentName1, fragmentName2, mode)
+        val fields1 = getReferencedFieldsAndFragmentNames(fragmentName1)
+        val fields2 = getReferencedFieldsAndFragmentNames(fragmentName2)
+        if ((fields1 eq null) || (fields2 eq null)) None
+        else {
+          val directConflict = collectConflictsBetween(fields1, fields2, mode)
+          if (directConflict.nonEmpty) directConflict
+          else {
+            var nestedFragments = fields2.collected.fragmentNames
+            while (nestedFragments.nonEmpty) {
+              val conflict =
+                collectConflictsBetweenFragments(fragmentName1, nestedFragments.head, mode)
+              if (conflict.nonEmpty) return conflict
+              nestedFragments = nestedFragments.tail
+            }
+
+            nestedFragments = fields1.collected.fragmentNames
+            while (nestedFragments.nonEmpty) {
+              val conflict =
+                collectConflictsBetweenFragments(nestedFragments.head, fragmentName2, mode)
+              if (conflict.nonEmpty) return conflict
+              nestedFragments = nestedFragments.tail
+            }
+            None
+          }
+        }
+      }
+
+    def findConflictsBetweenSubSelectionSets(
+      mode: ComparisonMode,
+      parentType1: __Type,
+      selectionSet1: List[Selection],
+      parentType2: __Type,
+      selectionSet2: List[Selection]
+    ): Option[String] = {
+      val fields1        = getFieldsAndFragmentNames(parentType1, selectionSet1)
+      val fields2        = getFieldsAndFragmentNames(parentType2, selectionSet2)
+      val directConflict = collectConflictsBetween(fields1, fields2, mode)
+      if (directConflict.nonEmpty) directConflict
+      else {
+        var fragmentNames = fields2.collected.fragmentNames
+        while (fragmentNames.nonEmpty) {
+          val conflict = collectConflictsBetweenFieldsAndFragment(fields1, fragmentNames.head, mode)
+          if (conflict.nonEmpty) return conflict
+          fragmentNames = fragmentNames.tail
+        }
+
+        fragmentNames = fields1.collected.fragmentNames
+        while (fragmentNames.nonEmpty) {
+          val conflict = collectConflictsBetweenFieldsAndFragment(fields2, fragmentNames.head, mode)
+          if (conflict.nonEmpty) return conflict
+          fragmentNames = fragmentNames.tail
+        }
+
+        var fragmentNames1 = fields1.collected.fragmentNames
+        while (fragmentNames1.nonEmpty) {
+          var fragmentNames2 = fields2.collected.fragmentNames
+          while (fragmentNames2.nonEmpty) {
+            val conflict =
+              collectConflictsBetweenFragments(fragmentNames1.head, fragmentNames2.head, mode)
+            if (conflict.nonEmpty) return conflict
+            fragmentNames2 = fragmentNames2.tail
+          }
+          fragmentNames1 = fragmentNames1.tail
+        }
+        None
+      }
+    }
+
+    def findConflictsWithin(parentType: __Type, selectionSet: List[Selection]): Option[String] = {
+      val fields         = getFieldsAndFragmentNames(parentType, selectionSet)
+      val directConflict = collectConflictsWithin(fields)
+      if (directConflict.nonEmpty) directConflict
+      else {
+        var fragmentNames1 = fields.collected.fragmentNames
+        while (fragmentNames1.nonEmpty) {
+          val fragmentName1 = fragmentNames1.head
+          val conflict      =
+            collectConflictsBetweenFieldsAndFragment(fields, fragmentName1, ComparisonMode.Overlapping)
+          if (conflict.nonEmpty) return conflict
+
+          var fragmentNames2 = fragmentNames1.tail
+          while (fragmentNames2.nonEmpty) {
+            val fragmentConflict =
+              collectConflictsBetweenFragments(fragmentName1, fragmentNames2.head, ComparisonMode.Overlapping)
+            if (fragmentConflict.nonEmpty) return fragmentConflict
+            fragmentNames2 = fragmentNames2.tail
+          }
+          fragmentNames1 = fragmentNames1.tail
+        }
+        None
+      }
+    }
+
+    def validateSelectionSets(
+      parentType: __Type,
+      selectionSet: List[Selection],
+      validatedFragments: mutable.HashSet[String]
+    ): Option[String] = {
+      val conflict = findConflictsWithin(parentType, selectionSet)
+      if (conflict.nonEmpty) conflict
+      else {
+        var remaining = selectionSet
+        while (remaining.nonEmpty) {
+          remaining.head match {
+            case field: Field                                       =>
+              if (field.selectionSet.nonEmpty) {
+                val fieldDef = parentType.getFieldOrNull(field.name)
+                if (fieldDef ne null) {
+                  val nestedConflict =
+                    validateSelectionSets(fieldDef._type.innerType, field.selectionSet, validatedFragments)
+                  if (nestedConflict.nonEmpty) return nestedConflict
+                }
+              }
+            case FragmentSpread(name, _)                            =>
+              if (validatedFragments.add(name)) {
+                val definition = context.fragments.getOrElseNull(name)
+                if (definition ne null) {
+                  val fragmentType   = getType(definition.typeCondition, context).getOrElse(parentType)
+                  val nestedConflict =
+                    validateSelectionSets(fragmentType, definition.selectionSet, validatedFragments)
+                  if (nestedConflict.nonEmpty) return nestedConflict
+                }
+              }
+            case InlineFragment(typeCondition, _, nestedSelections) =>
+              val fragmentType   = getType(typeCondition, parentType, context)
+              val nestedConflict = validateSelectionSets(fragmentType, nestedSelections, validatedFragments)
+              if (nestedConflict.nonEmpty) return nestedConflict
+          }
+          remaining = remaining.tail
+        }
+        None
+      }
+    }
+
+    validateSelectionSets(parentType, selectionSet, mutable.HashSet.empty) match {
+      case Some(conflict) => Left(ValidationError(conflict, ""))
+      case None           => ValidationOps.unit
     }
   }
 }

--- a/core/src/main/scala/caliban/validation/Utils.scala
+++ b/core/src/main/scala/caliban/validation/Utils.scala
@@ -14,7 +14,7 @@ object Utils {
       case _      => false
     }
 
-  @deprecated("Kept for bin-compatibility only", "3.1.5")
+  @deprecated("Kept for bin-compatibility only", "3.1.6")
   def isConcrete(t: __Type): Boolean =
     t.kind != UNION && t.kind != INTERFACE
 
@@ -43,7 +43,7 @@ object Utils {
     case _      => false
   }
 
-  @deprecated("Kept for bin-compatibility only", "3.1.5")
+  @deprecated("Kept for bin-compatibility only", "3.1.6")
   def isAbstract(t: __Type): Boolean =
     t.kind match {
       case UNION     => true
@@ -64,7 +64,7 @@ object Utils {
   /**
    * For an iterable, produce a Chunk containing tuples of all possible unique combinations, optionally including the identity
    */
-  @deprecated("Kept for bin-compatibility only", "3.1.5")
+  @deprecated("Kept for bin-compatibility only", "3.1.6")
   def cross[A](a: Iterable[A], includeIdentity: Boolean): Chunk[(A, A)] = {
     val ca       = Chunk.fromIterable(a)
     val size     = ca.size

--- a/core/src/main/scala/caliban/validation/Utils.scala
+++ b/core/src/main/scala/caliban/validation/Utils.scala
@@ -14,7 +14,9 @@ object Utils {
       case _      => false
     }
 
-  def isConcrete(t: __Type): Boolean = !isAbstract(t)
+  @deprecated("Kept for bin-compatibility only", "3.1.5")
+  def isConcrete(t: __Type): Boolean =
+    t.kind != UNION && t.kind != INTERFACE
 
   def isLeafType(t: __Type): Boolean = isEnum(t) || isScalar(t)
 
@@ -41,6 +43,7 @@ object Utils {
     case _      => false
   }
 
+  @deprecated("Kept for bin-compatibility only", "3.1.5")
   def isAbstract(t: __Type): Boolean =
     t.kind match {
       case UNION     => true
@@ -61,6 +64,7 @@ object Utils {
   /**
    * For an iterable, produce a Chunk containing tuples of all possible unique combinations, optionally including the identity
    */
+  @deprecated("Kept for bin-compatibility only", "3.1.5")
   def cross[A](a: Iterable[A], includeIdentity: Boolean): Chunk[(A, A)] = {
     val ca       = Chunk.fromIterable(a)
     val size     = ca.size

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -241,6 +241,30 @@ object FragmentSpec extends ZIOSpecDefault {
             .exists(_.contains("different arguments"))
         )
       },
+      test("nested response shapes conflict below mutually-exclusive fragments") {
+        case class Owner(name: String, age: Int)
+        sealed trait Pet
+        case class Dog(friend: Owner) extends Pet
+        case class Cat(friend: Owner) extends Pet
+        case class Query(pet: Pet)
+
+        val query =
+          """query {
+            |  pet {
+            |    ... on Dog { p: friend { v: name } }
+            |    ... on Cat { p: friend { v: age } }
+            |  }
+            |}""".stripMargin
+
+        val gql = graphQL(RootResolver(Query(Dog(Owner("name", 42)))))
+        for {
+          int <- gql.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(
+          res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+            .exists(_.contains("conflicting types"))
+        )
+      },
       test("field-merge conflict is detected between named fragments") {
         case class Dog(name: String, nickname: String)
         case class Query(dog: Dog)
@@ -713,7 +737,10 @@ object FragmentSpec extends ZIOSpecDefault {
             for {
               interpreter <- gql.interpreter
               res         <- interpreter.execute(query)
-            } yield assert(res.errors.headOption)(isSome(anything))
+            } yield assertTrue(
+              res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+                .exists(_.contains("conflicting types"))
+            )
           }
         )
       )

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -241,6 +241,117 @@ object FragmentSpec extends ZIOSpecDefault {
             .exists(_.contains("different arguments"))
         )
       },
+      test("field-merge conflict is detected between named fragments") {
+        case class Dog(name: String, nickname: String)
+        case class Query(dog: Dog)
+
+        val query =
+          """fragment Name on Dog {
+            |  value: name
+            |}
+            |fragment Nickname on Dog {
+            |  value: nickname
+            |}
+            |query {
+            |  dog {
+            |    ...Name
+            |    ...Nickname
+            |  }
+            |}""".stripMargin
+
+        val gql = graphQL(RootResolver(Query(Dog("name", "nickname"))))
+        for {
+          int <- gql.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(
+          res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+            .exists(_.contains("different fields"))
+        )
+      },
+      test("field-merge conflict is detected through nested named fragments") {
+        case class Child(value: Int => String)
+        case class Query(child: Child)
+
+        val query =
+          """fragment One on Child {
+            |  ...OneNested
+            |}
+            |fragment OneNested on Child {
+            |  value(value: 1)
+            |}
+            |fragment Two on Child {
+            |  ...TwoNested
+            |}
+            |fragment TwoNested on Child {
+            |  value(value: 2)
+            |}
+            |query {
+            |  child {
+            |    ...One
+            |    ...Two
+            |  }
+            |}""".stripMargin
+
+        val gql = graphQL(RootResolver(Query(Child(_.toString))))
+        for {
+          int <- gql.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(
+          res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+            .exists(_.contains("different arguments"))
+        )
+      },
+      test("mutually-exclusive fragment comparison does not hide a later conflict") {
+        case class Child(value: Int => String)
+        sealed trait Parent
+        case class A(child: Child) extends Parent
+        case class B(child: Child) extends Parent
+        case class Query(parent: Parent, child: Child)
+
+        val mutuallyExclusiveQuery =
+          """fragment One on Child {
+            |  value(value: 1)
+            |}
+            |fragment Two on Child {
+            |  value(value: 2)
+            |}
+            |query {
+            |  parent {
+            |    ... on A { child { ...One } }
+            |    ... on B { child { ...Two } }
+            |  }
+            |}""".stripMargin
+
+        val conflictingQuery =
+          """fragment One on Child {
+            |  value(value: 1)
+            |}
+            |fragment Two on Child {
+            |  value(value: 2)
+            |}
+            |query {
+            |  parent {
+            |    ... on A { child { ...One } }
+            |    ... on B { child { ...Two } }
+            |  }
+            |  child {
+            |    ...One
+            |    ...Two
+            |  }
+            |}""".stripMargin
+
+        val child = Child(_.toString)
+        val gql   = graphQL(RootResolver(Query(A(child), child)))
+        for {
+          int         <- gql.interpreter
+          valid       <- int.execute(mutuallyExclusiveQuery)
+          conflicting <- int.execute(conflictingQuery)
+        } yield assertTrue(
+          valid.errors.isEmpty,
+          conflicting.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+            .exists(_.contains("different arguments"))
+        )
+      },
       test("nested fragment selection on the same type") {
         import caliban.schema.Schema.auto._
 


### PR DESCRIPTION
## Summary

- fix nested response-shape validation below mutually exclusive fragments by recursing with the fields' inner types
- preserve named fragment-spread identity while collecting fields for merge validation
- memoize fragment comparisons by fragment-name pairs with the correct mutually-exclusive comparison strength
- short-circuit on the first conflict instead of accumulating `Chunk`s of error strings
- keep the hot-path implementation private while retaining deprecated entry points for binary compatibility
- add coverage for the demonstrated correctness bug plus named, nested, and weak/strong fragment comparisons
- add an 80-fragment validation benchmark

## Correctness fix

The previous implementation recursed into nested selections with a field's wrapped `NonNull`/`List` type. Field lookup on that wrapper returned no field, so nested `SameResponseShape` checks could be skipped. In particular, incompatible nested response shapes beneath mutually exclusive inline fragments were accepted.

The new regression test fails on `series/3.x` and passes with this change.

## Benchmarks

Representative focused fragment-validator measurements:

| Benchmark | Before | After | Impact |
| --- | ---: | ---: | ---: |
| Existing fragment benchmark | ~39.6k ops/s, 68.4 KB/op | ~105.5k ops/s, 38.5 KB/op | ~2.7x throughput, 44% less allocation |
| 80-fragment query | ~356 ops/s, 5.73 MB/op | ~706 ops/s, 2.81 MB/op | ~2.0x throughput, 51% less allocation |

`FragmentsQueryBenchmark.runCaliban`, measured before and after with the same short JMH settings:

- throughput: 91.959 -> 93.552 ops/s (effectively unchanged; within benchmark noise)
- allocation: 81.39 -> 4.27 MB/op (-94.8%)

## Verification

- `sbt fmt`
- `git diff --check`
- Scala 2.13 core suite: 625 tests passed
- focused `FragmentSpec`: 28 tests passed
- Scala 2.12 and Scala 3.3 test compilation
- review findings addressed; an extracted callback helper was intentionally not retained because it increased allocation in the 80-fragment hot path by about 9%
