### PR TITLE
Fix fragment field-merging validation and reduce allocations

### DIFF
--- a/benchmarks/src/main/scala/caliban/validation/FragmentValidatorBenchmark.scala
+++ b/benchmarks/src/main/scala/caliban/validation/FragmentValidatorBenchmark.scala
@@ -19,6 +19,10 @@ class FragmentValidatorBenchmark {
   @Benchmark
   def fragmentConflicts(): Any =
     run(Validator.validateAll(parsedQuery, rootType))
+
+  @Benchmark
+  def eightyFragments(): Any =
+    run(Validator.validateAll(parsedEightyFragmentsQuery, rootType))
 }
 
 object FragmentValidatorBenchmark {
@@ -161,4 +165,32 @@ object FragmentValidatorBenchmark {
   }
 
   val parsedQuery = run(Parser.parseQuery(query))
+
+  // A 7.5 KB fragment DAG whose operation spreads all 80 fragments. Nested
+  // comparisons revisit the same fragment pairs unless they are memoized by name.
+  val eightyFragmentsQuery: String = {
+    val fragmentCount = 80
+    val fragments = (0 until fragmentCount).map { index =>
+      val name       = f"F$index%02d"
+      val nextSpread =
+        if (index + 1 < fragmentCount) f"...F${index + 1}%02d"
+        else ""
+      s"""fragment $name on Pet {
+         |  $nextSpread
+         |  ... on Dog { name nickname }
+         |  ... on Cat { name }
+         |}
+         |""".stripMargin
+    }.mkString("\n")
+    val spreads = (0 until fragmentCount).map(index => f"...F$index%02d").mkString("\n")
+    s"""$fragments
+       |query {
+       |  pet {
+       |    $spreads
+       |  }
+       |}
+       |""".stripMargin
+  }
+
+  val parsedEightyFragmentsQuery = run(Parser.parseQuery(eightyFragmentsQuery))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -789,6 +789,9 @@ lazy val enableMimaSettingsJVM =
     mimaBinaryIssueFilters := Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.*.<clinit>"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("mdg.engine.proto.reports.*.<clinit>"),
+      // package-private validation helper removed after its last internal caller
+      ProblemFilters.exclude[MissingClassProblem]("caliban.validation.FieldMap$FieldMapOps"),
+      ProblemFilters.exclude[MissingClassProblem]("caliban.validation.FieldMap$FieldMapOps$"),
       // private internal method; extra param added to fix nested-list null propagation
       ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.execution.Executor#StepReducer.reduceStep")
     )

--- a/core/src/main/scala/caliban/validation/FieldMap.scala
+++ b/core/src/main/scala/caliban/validation/FieldMap.scala
@@ -3,107 +3,53 @@ package caliban.validation
 import caliban.introspection.adt._
 import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
 import caliban.parsing.adt._
-import caliban.syntax._
 import caliban.validation.Utils._
 
 import scala.collection.compat._
 import scala.collection.mutable
 
 private[caliban] object FieldMap {
-  @deprecated("Kept for bin-compatibility only", "3.1.3")
-  val empty: FieldMap = Map.empty
+  final case class Collected(
+    fields: collection.Map[String, mutable.ArrayBuffer[SelectedField]],
+    fragmentNames: List[String]
+  )
 
-  @deprecated("Kept for bin-compatibility only", "3.1.3")
-  implicit class FieldMapOps(val self: FieldMap) extends AnyVal {
-    def |+|(that: FieldMap): FieldMap = {
-      val mb = Map.newBuilder[String, Set[SelectedField]]
-      (self.keySet ++ that.keySet).foreach { k =>
-        mb += k -> {
-          (self.get(k), that.get(k)) match {
-            case (Some(s1), Some(s2)) => s1 ++ s2
-            case (Some(s1), None)     => s1
-            case (None, Some(s2))     => s2
-            case _                    => Set.empty[SelectedField]
-          }
-        }
-      }
-      mb.result()
-    }
-
-    def show: String =
-      self.map { case (k, fields) =>
-        s"$k -> ${fields.map(_.fieldDef.name).mkString(", ")}"
-      }.mkString("\n")
-
-    def addField(
-      f: Field,
-      parentType: __Type,
-      selection: Field
-    ): FieldMap = {
-      val responseName = f.alias.getOrElse(f.name)
-
-      parentType.getFieldOrNull(f.name) match {
-        case null => self
-        case f1   =>
-          val sf    = SelectedField(parentType, selection, f1)
-          val entry = self.get(responseName).map(_ + sf).getOrElse(Set(sf))
-          self + (responseName -> entry)
-      }
-    }
-  }
-
-  private type FM = mutable.HashMap[String, Set[SelectedField]]
-
-  @deprecated("Kept for bin-compatibility only", "3.1.3")
-  def apply(context: Context, parentType: __Type, selectionSet: Iterable[Selection]): FieldMap =
-    make(context, parentType, selectionSet).toMap
-
-  def make(
+  def collect(
     context: Context,
     parentType: __Type,
     selectionSet: Iterable[Selection]
-  ): collection.Map[String, Set[SelectedField]] = {
-    val fields: FM = mutable.HashMap.empty
-    loop(context, parentType, selectionSet)(fields)
-    fields
+  ): Collected = {
+    val fields        = mutable.HashMap.empty[String, mutable.ArrayBuffer[SelectedField]]
+    val fragmentNames = mutable.ListBuffer.empty[String]
+    val seenFragments = mutable.HashSet.empty[String]
+    collectInto(context, parentType, selectionSet, fields, fragmentNames, seenFragments)
+    Collected(fields, fragmentNames.toList)
   }
 
-  private def loop(
+  private def collectInto(
     context: Context,
     parentType: __Type,
-    selectionSet: Iterable[Selection]
-  )(implicit fields: FM): Unit = {
+    selectionSet: Iterable[Selection],
+    fields: mutable.HashMap[String, mutable.ArrayBuffer[SelectedField]],
+    fragmentNames: mutable.ListBuffer[String],
+    seenFragments: mutable.HashSet[String]
+  ): Unit = {
     val it = selectionSet.iterator
     while (it.hasNext)
       it.next() match {
         case f: Field                                       =>
-          addField(f, parentType)
-        case FragmentSpread(name, _)                        =>
-          context.fragments.getOrElseNull(name) match {
-            case null       => ()
-            case definition =>
-              val typ = getType(Some(definition.typeCondition), parentType, context)
-              loop(context, typ, definition.selectionSet)
+          parentType.getFieldOrNull(f.name) match {
+            case null     => ()
+            case fieldDef =>
+              val responseName = f.alias.getOrElse(f.name)
+              fields.getOrElseUpdate(responseName, mutable.ArrayBuffer.empty) +=
+                SelectedField(parentType, f, fieldDef)
           }
+        case FragmentSpread(name, _)                        =>
+          if (seenFragments.add(name)) fragmentNames += name
         case InlineFragment(typeCondition, _, selectionSet) =>
           val typ = getType(typeCondition, parentType, context)
-          loop(context, typ, selectionSet)
+          collectInto(context, typ, selectionSet, fields, fragmentNames, seenFragments)
       }
   }
-
-  private def addField(
-    f: Field,
-    parentType: __Type
-  )(implicit self: FM): Unit =
-    parentType.getFieldOrNull(f.name) match {
-      case null => ()
-      case f1   =>
-        val responseName = f.alias.getOrElse(f.name)
-        val sf           = SelectedField(parentType, f, f1)
-        self.updateWith(responseName) {
-          case Some(s) => Some(s + sf)
-          case _       => Some(Set.empty + sf)
-        }
-    }
-
 }

--- a/core/src/main/scala/caliban/validation/FragmentValidator.scala
+++ b/core/src/main/scala/caliban/validation/FragmentValidator.scala
@@ -3,59 +3,122 @@ package caliban.validation
 import caliban.CalibanError.ValidationError
 import caliban.introspection.adt._
 import caliban.parsing.adt.Selection
+import caliban.parsing.adt.Selection.{ Field, FragmentSpread, InlineFragment }
+import caliban.syntax._
 import caliban.validation.Utils._
-import zio.Chunk
 
+import java.util.IdentityHashMap
 import scala.collection.mutable
 
 object FragmentValidator {
+  private sealed trait ComparisonMode {
+    def covers(requested: ComparisonMode): Boolean
+    def findNameOrArgumentsConflict(first: SelectedField, second: SelectedField): Option[String]
+  }
+
+  private object ComparisonMode {
+    // Comparing overlapping parents is stronger because it also checks field names and arguments.
+    case object Overlapping extends ComparisonMode {
+      override def covers(requested: ComparisonMode): Boolean = true
+
+      override def findNameOrArgumentsConflict(
+        first: SelectedField,
+        second: SelectedField
+      ): Option[String] =
+        if (first.fieldDef.name != second.fieldDef.name)
+          Some(
+            s"${first.parentType.name.getOrElse("")}.${first.fieldDef.name} and ${second.parentType.name
+                .getOrElse("")}.${second.fieldDef.name} are different fields."
+          )
+        else if (first.selection.arguments != second.selection.arguments)
+          Some(s"${first.fieldDef.name} and ${second.fieldDef.name} have different arguments")
+        else None
+    }
+
+    case object MutuallyExclusive extends ComparisonMode {
+      override def covers(requested: ComparisonMode): Boolean = requested eq MutuallyExclusive
+
+      override def findNameOrArgumentsConflict(
+        _first: SelectedField,
+        _second: SelectedField
+      ): Option[String] = None
+    }
+
+    def exclusiveWhen(condition: Boolean): ComparisonMode =
+      if (condition) MutuallyExclusive else Overlapping
+  }
+
+  private class ComparisonMemo[A, B] {
+    private val data = mutable.HashMap.empty[A, mutable.HashMap[B, ComparisonMode]]
+
+    def recordIfNotCovered(first: A, second: B, mode: ComparisonMode): Boolean = {
+      val seconds = data.getOrElseUpdate(first, mutable.HashMap.empty)
+      seconds.get(second) match {
+        case Some(previousMode) if previousMode.covers(mode) => false
+        case _                                               =>
+          seconds.update(second, mode)
+          true
+      }
+    }
+  }
+
+  private final class FragmentPairMemo {
+    private val pairs = new ComparisonMemo[String, String]
+
+    def recordIfNotCovered(first: String, second: String, mode: ComparisonMode): Boolean =
+      if (first.compareTo(second) <= 0) pairs.recordIfNotCovered(first, second, mode)
+      else pairs.recordIfNotCovered(second, first, mode)
+  }
+
+  private final case class FieldMapId(value: Int) extends AnyVal
+  private final case class CachedFields(id: FieldMapId, collected: FieldMap.Collected)
+
   def findConflictsWithinSelectionSet(
     context: Context,
     parentType: __Type,
     selectionSet: List[Selection]
-  ): Either[ValidationError, Unit] = {
+  ): Either[ValidationError, Unit] =
+    new ConflictFinder(context, parentType).find(selectionSet)
 
-    val shapeCache   = mutable.HashMap.empty[List[Selection], Chunk[String]]
-    val parentsCache = mutable.HashMap.empty[(Option[String], Iterable[Selection]), Chunk[String]]
-    val groupsCache  = mutable.HashMap.empty[Set[SelectedField], Chunk[Set[SelectedField]]]
+  private final class ConflictFinder(context: Context, rootParentType: __Type) {
+    private val comparedFragmentPairs          = new FragmentPairMemo
+    private val comparedFieldsAndFragmentPairs = new ComparisonMemo[FieldMapId, String]
+    private val fieldsCache                    =
+      new IdentityHashMap[List[Selection], IdentityHashMap[__Type, CachedFields]]()
+    private var nextFieldMapId                 = 0
 
-    def sameResponseShapeByName(set: List[Selection], parentType: __Type): Chunk[String] =
-      if (set.isEmpty) Chunk.empty
-      else
-        shapeCache.getOrElseUpdate(
-          set, {
-            val fields = FieldMap.make(context, parentType, set)
-            Chunk.fromIterable(fields.flatMap { case (name, values) =>
-              cross(values, includeIdentity = true).flatMap { case (f1, f2) =>
-                if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type)) {
-                  Chunk.single(
-                    s"$name has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
-                        .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
-                  )
-                } else
-                  sameResponseShapeByName(f1.selection.selectionSet ::: f2.selection.selectionSet, f1.fieldDef._type)
-              }
-            })
-          }
-        )
+    def find(selectionSet: List[Selection]): Either[ValidationError, Unit] =
+      validateSelectionSets(rootParentType, selectionSet, mutable.HashSet.empty) match {
+        case Some(conflict) => Left(ValidationError(conflict, ""))
+        case None           => ValidationOps.unit
+      }
 
-    def sameForCommonParentsByName(parentType: __Type, set: Iterable[Selection]): Chunk[String] =
-      if (set.isEmpty) Chunk.empty
-      else
-        parentsCache.getOrElseUpdate(
-          (parentType.name, set), {
-            val fields = FieldMap.make(context, parentType, set)
-            Chunk.fromIterable(fields.values.flatMap { fields =>
-              groupByCommonParents(fields).flatMap { group =>
-                val merged    = group.flatMap(_.selection.selectionSet)
-                val fieldType = group.headOption.fold(parentType)(_.fieldDef._type.innerType)
-                requireSameNameAndArguments(group) ++ sameForCommonParentsByName(fieldType, merged)
-              }
-            })
-          }
-        )
+    private def getFieldsAndFragmentNames(parentType: __Type, selectionSet: List[Selection]): CachedFields = {
+      var byParentType = fieldsCache.get(selectionSet)
+      if (byParentType eq null) {
+        byParentType = new IdentityHashMap[__Type, CachedFields]()
+        fieldsCache.put(selectionSet, byParentType)
+      }
 
-    def doTypesConflict(t1: __Type, t2: __Type): Boolean =
+      var cached = byParentType.get(parentType)
+      if (cached eq null) {
+        cached = CachedFields(FieldMapId(nextFieldMapId), FieldMap.collect(context, parentType, selectionSet))
+        nextFieldMapId += 1
+        byParentType.put(parentType, cached)
+      }
+      cached
+    }
+
+    private def getReferencedFieldsAndFragmentNames(fragmentName: String): CachedFields = {
+      val definition = context.fragments.getOrElseNull(fragmentName)
+      if (definition eq null) null
+      else {
+        val fragmentType = getType(definition.typeCondition, context).getOrElse(rootParentType)
+        getFieldsAndFragmentNames(fragmentType, definition.selectionSet)
+      }
+    }
+
+    private def doTypesConflict(t1: __Type, t2: __Type): Boolean =
       if (isNonNull(t1))
         if (isNonNull(t2)) t1.ofType.flatMap(p1 => t2.ofType.map(p2 => doTypesConflict(p1, p2))).getOrElse(true)
         else true
@@ -66,53 +129,256 @@ object FragmentValidator {
         else true
       else if (isListType(t2))
         true
-      else if (isLeafType(t1) && isLeafType(t2)) {
+      else if (isLeafType(t1) && isLeafType(t2))
         t1.name != t2.name
-      } else if (!isComposite(t1) || !isComposite(t2))
+      else if (!isComposite(t1) || !isComposite(t2))
         true
       else
         false
 
-    def requireSameNameAndArguments(fields: Set[SelectedField]) =
-      cross(fields, includeIdentity = false).flatMap { case (f1, f2) =>
-        if (f1.fieldDef.name != f2.fieldDef.name) {
-          Some(
-            s"${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name.getOrElse("")}.${f2.fieldDef.name} are different fields."
-          )
-        } else if (f1.selection.arguments != f2.selection.arguments)
-          Some(s"${f1.fieldDef.name} and ${f2.fieldDef.name} have different arguments")
-        else None
-      }
-
-    def groupByCommonParents(fields: Set[SelectedField]): Chunk[Set[SelectedField]] =
-      groupsCache.getOrElseUpdate(
-        fields, {
-          val abstractGroup = fields.filter(field => isAbstract(field.parentType))
-
-          val concreteGroups =
-            mutable.HashMap.empty[String, mutable.Builder[SelectedField, Set[SelectedField]]]
-
-          fields.foreach {
-            case field @ SelectedField(
-                  __Type(_, Some(name), _, _, _, _, _, _, _, _, _, _, _),
-                  _,
-                  _
-                ) if isConcrete(field.parentType) =>
-              concreteGroups.getOrElseUpdate(name, Set.newBuilder ++= abstractGroup) += field
-            case _ => ()
-          }
-
-          if (concreteGroups.isEmpty) Chunk.single(fields)
-          else Chunk.fromIterable(concreteGroups.values.map(_.result()))
-        }
+    private def findConflict(
+      responseName: String,
+      f1: SelectedField,
+      f2: SelectedField,
+      parentMode: ComparisonMode
+    ): Option[String] = {
+      val mode = ComparisonMode.exclusiveWhen(
+        (parentMode eq ComparisonMode.MutuallyExclusive) ||
+          (isObjectType(f1.parentType) && isObjectType(f2.parentType) && f1.parentType.name != f2.parentType.name)
       )
 
-    val conflicts =
-      sameResponseShapeByName(selectionSet, parentType) ++ sameForCommonParentsByName(parentType, selectionSet)
-    if (conflicts.nonEmpty) {
-      Left(ValidationError(conflicts.head, ""))
-    } else {
-      ValidationOps.unit
+      if (doTypesConflict(f1.fieldDef._type, f2.fieldDef._type))
+        Some(
+          s"$responseName has conflicting types: ${f1.parentType.name.getOrElse("")}.${f1.fieldDef.name} and ${f2.parentType.name
+              .getOrElse("")}.${f2.fieldDef.name}. Try using an alias."
+        )
+      else
+        mode.findNameOrArgumentsConflict(f1, f2) match {
+          case conflict @ Some(_) => conflict
+          case None               =>
+            if (f1.selection.selectionSet.nonEmpty && f2.selection.selectionSet.nonEmpty)
+              findConflictsBetweenSubSelectionSets(
+                mode,
+                f1.fieldDef._type.innerType,
+                f1.selection.selectionSet,
+                f2.fieldDef._type.innerType,
+                f2.selection.selectionSet
+              )
+            else None
+        }
+    }
+
+    private def collectConflictsWithin(fields: CachedFields): Option[String] = {
+      val fieldGroups = fields.collected.fields.iterator
+      while (fieldGroups.hasNext) {
+        val (responseName, values) = fieldGroups.next()
+        var i                      = 0
+        while (i < values.length - 1) {
+          var j = i + 1
+          while (j < values.length) {
+            val conflict = findConflict(responseName, values(i), values(j), ComparisonMode.Overlapping)
+            if (conflict.nonEmpty) return conflict
+            j += 1
+          }
+          i += 1
+        }
+      }
+      None
+    }
+
+    private def collectConflictsBetween(
+      fields1: CachedFields,
+      fields2: CachedFields,
+      mode: ComparisonMode
+    ): Option[String] =
+      if (fields1.id == fields2.id) None
+      else {
+        val fieldGroups = fields1.collected.fields.iterator
+        while (fieldGroups.hasNext) {
+          val (responseName, values1) = fieldGroups.next()
+          fields2.collected.fields.get(responseName) match {
+            case Some(values2) =>
+              var i = 0
+              while (i < values1.length) {
+                var j = 0
+                while (j < values2.length) {
+                  val conflict = findConflict(responseName, values1(i), values2(j), mode)
+                  if (conflict.nonEmpty) return conflict
+                  j += 1
+                }
+                i += 1
+              }
+            case None          => ()
+          }
+        }
+        None
+      }
+
+    private def collectConflictsBetweenFieldsAndFragment(
+      fields: CachedFields,
+      fragmentName: String,
+      mode: ComparisonMode
+    ): Option[String] =
+      if (!comparedFieldsAndFragmentPairs.recordIfNotCovered(fields.id, fragmentName, mode)) None
+      else {
+        val fragmentFields = getReferencedFieldsAndFragmentNames(fragmentName)
+        if ((fragmentFields eq null) || fields.id == fragmentFields.id) None
+        else {
+          val directConflict = collectConflictsBetween(fields, fragmentFields, mode)
+          if (directConflict.nonEmpty) directConflict
+          else {
+            val nestedFragments = fragmentFields.collected.fragmentNames
+            var remaining       = nestedFragments
+            while (remaining.nonEmpty) {
+              val conflict = collectConflictsBetweenFieldsAndFragment(fields, remaining.head, mode)
+              if (conflict.nonEmpty) return conflict
+              remaining = remaining.tail
+            }
+            None
+          }
+        }
+      }
+
+    private def collectConflictsBetweenFragments(
+      fragmentName1: String,
+      fragmentName2: String,
+      mode: ComparisonMode
+    ): Option[String] =
+      if (fragmentName1 == fragmentName2) None
+      else if (!comparedFragmentPairs.recordIfNotCovered(fragmentName1, fragmentName2, mode)) None
+      else {
+        val fields1 = getReferencedFieldsAndFragmentNames(fragmentName1)
+        val fields2 = getReferencedFieldsAndFragmentNames(fragmentName2)
+        if ((fields1 eq null) || (fields2 eq null)) None
+        else {
+          val directConflict = collectConflictsBetween(fields1, fields2, mode)
+          if (directConflict.nonEmpty) directConflict
+          else {
+            var nestedFragments = fields2.collected.fragmentNames
+            while (nestedFragments.nonEmpty) {
+              val conflict =
+                collectConflictsBetweenFragments(fragmentName1, nestedFragments.head, mode)
+              if (conflict.nonEmpty) return conflict
+              nestedFragments = nestedFragments.tail
+            }
+
+            nestedFragments = fields1.collected.fragmentNames
+            while (nestedFragments.nonEmpty) {
+              val conflict =
+                collectConflictsBetweenFragments(nestedFragments.head, fragmentName2, mode)
+              if (conflict.nonEmpty) return conflict
+              nestedFragments = nestedFragments.tail
+            }
+            None
+          }
+        }
+      }
+
+    private def findConflictsBetweenSubSelectionSets(
+      mode: ComparisonMode,
+      parentType1: __Type,
+      selectionSet1: List[Selection],
+      parentType2: __Type,
+      selectionSet2: List[Selection]
+    ): Option[String] = {
+      val fields1        = getFieldsAndFragmentNames(parentType1, selectionSet1)
+      val fields2        = getFieldsAndFragmentNames(parentType2, selectionSet2)
+      val directConflict = collectConflictsBetween(fields1, fields2, mode)
+      if (directConflict.nonEmpty) directConflict
+      else {
+        var fragmentNames = fields2.collected.fragmentNames
+        while (fragmentNames.nonEmpty) {
+          val conflict = collectConflictsBetweenFieldsAndFragment(fields1, fragmentNames.head, mode)
+          if (conflict.nonEmpty) return conflict
+          fragmentNames = fragmentNames.tail
+        }
+
+        fragmentNames = fields1.collected.fragmentNames
+        while (fragmentNames.nonEmpty) {
+          val conflict = collectConflictsBetweenFieldsAndFragment(fields2, fragmentNames.head, mode)
+          if (conflict.nonEmpty) return conflict
+          fragmentNames = fragmentNames.tail
+        }
+
+        var fragmentNames1 = fields1.collected.fragmentNames
+        while (fragmentNames1.nonEmpty) {
+          var fragmentNames2 = fields2.collected.fragmentNames
+          while (fragmentNames2.nonEmpty) {
+            val conflict =
+              collectConflictsBetweenFragments(fragmentNames1.head, fragmentNames2.head, mode)
+            if (conflict.nonEmpty) return conflict
+            fragmentNames2 = fragmentNames2.tail
+          }
+          fragmentNames1 = fragmentNames1.tail
+        }
+        None
+      }
+    }
+
+    private def findConflictsWithin(parentType: __Type, selectionSet: List[Selection]): Option[String] = {
+      val fields         = getFieldsAndFragmentNames(parentType, selectionSet)
+      val directConflict = collectConflictsWithin(fields)
+      if (directConflict.nonEmpty) directConflict
+      else {
+        var fragmentNames1 = fields.collected.fragmentNames
+        while (fragmentNames1.nonEmpty) {
+          val fragmentName1 = fragmentNames1.head
+          val conflict      =
+            collectConflictsBetweenFieldsAndFragment(fields, fragmentName1, ComparisonMode.Overlapping)
+          if (conflict.nonEmpty) return conflict
+
+          var fragmentNames2 = fragmentNames1.tail
+          while (fragmentNames2.nonEmpty) {
+            val fragmentConflict =
+              collectConflictsBetweenFragments(fragmentName1, fragmentNames2.head, ComparisonMode.Overlapping)
+            if (fragmentConflict.nonEmpty) return fragmentConflict
+            fragmentNames2 = fragmentNames2.tail
+          }
+          fragmentNames1 = fragmentNames1.tail
+        }
+        None
+      }
+    }
+
+    private def validateSelectionSets(
+      parentType: __Type,
+      selectionSet: List[Selection],
+      validatedFragments: mutable.HashSet[String]
+    ): Option[String] = {
+      val conflict = findConflictsWithin(parentType, selectionSet)
+      if (conflict.nonEmpty) conflict
+      else {
+        var remaining = selectionSet
+        while (remaining.nonEmpty) {
+          remaining.head match {
+            case field: Field                                       =>
+              if (field.selectionSet.nonEmpty) {
+                val fieldDef = parentType.getFieldOrNull(field.name)
+                if (fieldDef ne null) {
+                  val nestedConflict =
+                    validateSelectionSets(fieldDef._type.innerType, field.selectionSet, validatedFragments)
+                  if (nestedConflict.nonEmpty) return nestedConflict
+                }
+              }
+            case FragmentSpread(name, _)                            =>
+              if (validatedFragments.add(name)) {
+                val definition = context.fragments.getOrElseNull(name)
+                if (definition ne null) {
+                  val fragmentType   = getType(definition.typeCondition, context).getOrElse(parentType)
+                  val nestedConflict =
+                    validateSelectionSets(fragmentType, definition.selectionSet, validatedFragments)
+                  if (nestedConflict.nonEmpty) return nestedConflict
+                }
+              }
+            case InlineFragment(typeCondition, _, nestedSelections) =>
+              val fragmentType   = getType(typeCondition, parentType, context)
+              val nestedConflict = validateSelectionSets(fragmentType, nestedSelections, validatedFragments)
+              if (nestedConflict.nonEmpty) return nestedConflict
+          }
+          remaining = remaining.tail
+        }
+        None
+      }
     }
   }
 }

--- a/core/src/main/scala/caliban/validation/Utils.scala
+++ b/core/src/main/scala/caliban/validation/Utils.scala
@@ -14,7 +14,9 @@ object Utils {
       case _      => false
     }
 
-  def isConcrete(t: __Type): Boolean = !isAbstract(t)
+  @deprecated("Kept for bin-compatibility only", "3.1.6")
+  def isConcrete(t: __Type): Boolean =
+    t.kind != UNION && t.kind != INTERFACE
 
   def isLeafType(t: __Type): Boolean = isEnum(t) || isScalar(t)
 
@@ -41,6 +43,7 @@ object Utils {
     case _      => false
   }
 
+  @deprecated("Kept for bin-compatibility only", "3.1.6")
   def isAbstract(t: __Type): Boolean =
     t.kind match {
       case UNION     => true
@@ -61,6 +64,7 @@ object Utils {
   /**
    * For an iterable, produce a Chunk containing tuples of all possible unique combinations, optionally including the identity
    */
+  @deprecated("Kept for bin-compatibility only", "3.1.6")
   def cross[A](a: Iterable[A], includeIdentity: Boolean): Chunk[(A, A)] = {
     val ca       = Chunk.fromIterable(a)
     val size     = ca.size
@@ -78,5 +82,4 @@ object Utils {
     }
     cb.result()
   }
-
 }

--- a/core/src/test/scala/caliban/execution/FragmentSpec.scala
+++ b/core/src/test/scala/caliban/execution/FragmentSpec.scala
@@ -241,6 +241,55 @@ object FragmentSpec extends ZIOSpecDefault {
             .exists(_.contains("different arguments"))
         )
       },
+      test("nested response shapes conflict below mutually-exclusive fragments") {
+        case class Owner(name: String, age: Int)
+        sealed trait Pet
+        case class Dog(friend: Owner) extends Pet
+        case class Cat(friend: Owner) extends Pet
+        case class Query(pet: Pet)
+
+        val query =
+          """query {
+            |  pet {
+            |    ... on Dog { p: friend { v: name } }
+            |    ... on Cat { p: friend { v: age } }
+            |  }
+            |}""".stripMargin
+
+        val gql = graphQL(RootResolver(Query(Dog(Owner("name", 42)))))
+        for {
+          int <- gql.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(
+          res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+            .exists(_.contains("conflicting types"))
+        )
+      },
+      test("nested response shapes conflict across different object types") {
+        case class Owner(v: String)
+        case class Company(v: Int)
+        sealed trait Pet
+        case class Dog(friend: Owner)   extends Pet
+        case class Cat(friend: Company) extends Pet
+        case class Query(pet: Pet)
+
+        val query =
+          """query {
+            |  pet {
+            |    ... on Dog { p: friend { v } }
+            |    ... on Cat { p: friend { v } }
+            |  }
+            |}""".stripMargin
+
+        val gql = graphQL(RootResolver(Query(Dog(Owner("name")))))
+        for {
+          int <- gql.interpreter
+          res <- int.execute(query)
+        } yield assertTrue(
+          res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+            .exists(_.contains("conflicting types"))
+        )
+      },
       test("nested fragment selection on the same type") {
         import caliban.schema.Schema.auto._
 
@@ -602,7 +651,10 @@ object FragmentSpec extends ZIOSpecDefault {
             for {
               interpreter <- gql.interpreter
               res         <- interpreter.execute(query)
-            } yield assert(res.errors.headOption)(isSome(anything))
+            } yield assertTrue(
+              res.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+                .exists(_.contains("conflicting types"))
+            )
           }
         )
       )


### PR DESCRIPTION
## Summary

- preserve named-fragment identity while collecting fields instead of recursively inlining fragment spreads
- compare nested selections using both return types and the correct overlapping or mutually-exclusive mode
- memoize fragment-name pairs and field-map/fragment pairs with constant-size keys
- stop on the first conflict instead of accumulating error chunks
- add same-object and different-object nested response-shape regression coverage plus an 80-fragment DAG benchmark

Previously, nested fields with the same response name but incompatible leaf types could pass validation beneath mutually-exclusive fragments. Recursing with only the first field type also dropped child fields when the two return object types differed. The validator now resolves and compares both sides independently, while retaining fragment names for O(1) pair memoization.

## Benchmarks

Like-for-like JMH runs on JDK 25: 2 forks, 5 one-second warmups, 8 two-second measurement iterations per fork, with GC profiling. Scores show throughput with the JMH 99.9% confidence interval.

| Benchmark | series/3.x | This PR | Throughput impact | Allocation impact |
| --- | ---: | ---: | ---: | ---: |
| 80-fragment DAG | 396.2 ± 5.8 ops/s | 715.0 ± 14.2 ops/s | +80.5% / 1.80x | 5.83 → 2.81 MB/op, -51.8% |
| Existing fragment conflicts | 40.67k ± 0.53k ops/s | 105.19k ± 2.13k ops/s | +158.7% / 2.59x | 68.08 → 38.03 KB/op, -44.1% |
| FragmentsQueryBenchmark | 97.28 ± 1.90 ops/s | 106.87 ± 1.98 ops/s | +9.9% / 1.10x | 81.39 → 4.26 MB/op, -94.8% |

## Verification

- sbt fmt
- core test: 623 tests passed
- MiMa passed on Scala 2.12, 2.13, and 3.3
- regression tests cover incompatible nested leaf types beneath both identical and different return object types