### PR TITLE
Add progressive override support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -790,7 +790,22 @@ lazy val enableMimaSettingsJVM =
       ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.*.<clinit>"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("mdg.engine.proto.reports.*.<clinit>"),
       // private internal method; extra param added to fix nested-list null propagation
-      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.execution.Executor#StepReducer.reduceStep")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("caliban.execution.Executor#StepReducer.reduceStep"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+        "caliban.federation.v2x.FederationDirectivesV2_8.GQLProgressiveOverride"
+      ),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+        "caliban.federation.v2x.FederationDirectivesV2_9.GQLProgressiveOverride"
+      ),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+        "caliban.federation.v2x.FederationDirectivesV2_10.GQLProgressiveOverride"
+      ),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+        "caliban.federation.v2x.FederationDirectivesV2_11.GQLProgressiveOverride"
+      ),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+        "caliban.federation.v2x.FederationDirectivesV2_12.GQLProgressiveOverride"
+      )
     )
   )
 

--- a/federation/src/main/scala/caliban/federation/package.scala
+++ b/federation/src/main/scala/caliban/federation/package.scala
@@ -1,6 +1,5 @@
 package caliban
 
-import caliban.federation.connect.ConnectV0
 import caliban.federation.v2x.{
   FederationDirectivesV2_10,
   FederationDirectivesV2_11,
@@ -8,6 +7,7 @@ import caliban.federation.v2x.{
   FederationDirectivesV2_3,
   FederationDirectivesV2_5,
   FederationDirectivesV2_6,
+  FederationDirectivesV2_7,
   FederationDirectivesV2_8,
   FederationDirectivesV2_9,
   FederationV2,
@@ -24,11 +24,13 @@ package object federation {
   lazy val v2_4  = new FederationV2(List(Versions.v2_4)) with FederationDirectivesV2_3
   lazy val v2_5  = new FederationV2(List(Versions.v2_5)) with FederationDirectivesV2_5
   lazy val v2_6  = new FederationV2(List(Versions.v2_6)) with FederationDirectivesV2_6
-  lazy val v2_7  = new FederationV2(List(Versions.v2_7)) with FederationDirectivesV2_6
+  lazy val v2_7  = new FederationV2(List(Versions.v2_7)) with FederationDirectivesV2_6 with FederationDirectivesV2_7
   lazy val v2_8  = new FederationV2(List(Versions.v2_8)) with FederationDirectivesV2_8
   lazy val v2_9  = new FederationV2(List(Versions.v2_9)) with FederationDirectivesV2_9
-  lazy val v2_10 = new FederationV2(List(Versions.v2_10, ConnectV0.connect)) with FederationDirectivesV2_10
-  lazy val v2_11 = new FederationV2(List(Versions.v2_11, ConnectV0.connect0_2)) with FederationDirectivesV2_11
-  lazy val v2_12 = new FederationV2(List(Versions.v2_12, ConnectV0.connect0_3)) with FederationDirectivesV2_12
-  lazy val v2_13 = new FederationV2(List(Versions.v2_13, ConnectV0.connect0_4)) with FederationDirectivesV2_12
+  lazy val v2_10 = new FederationV2(List(Versions.v2_10)) with FederationDirectivesV2_10
+  lazy val v2_11 = new FederationV2(List(Versions.v2_11)) with FederationDirectivesV2_11
+  lazy val v2_12 = new FederationV2(List(Versions.v2_12)) with FederationDirectivesV2_12
+  lazy val v2_13 = new FederationV2(List(Versions.v2_13)) with FederationDirectivesV2_12
+  lazy val v2_14 = new FederationV2(List(Versions.v2_14)) with FederationDirectivesV2_12
+  lazy val v2_15 = new FederationV2(List(Versions.v2_15)) with FederationDirectivesV2_12
 }

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_10.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_10.scala
@@ -6,7 +6,7 @@ import caliban.schema.Annotations.GQLDirective
 
 import scala.annotation.nowarn
 
-trait FederationDirectivesV2_10 extends FederationDirectivesV2_9 {
+trait FederationDirectivesV2_10 extends FederationDirectivesV2_9 with FederationDirectivesV2_7 {
 
   case class JSONSelection(select: String)
   case class HTTPHeaderMapping(

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_11.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_11.scala
@@ -12,7 +12,7 @@ import caliban.federation.connect.{
 import caliban.schema.Annotations.GQLDirective
 
 // IMPORTANT: Skips FederationV2_10 because we want to override the types from it.
-trait FederationDirectivesV2_11 extends FederationDirectivesV2_9 {
+trait FederationDirectivesV2_11 extends FederationDirectivesV2_9 with FederationDirectivesV2_7 {
   case class GQLConnect(
     http: ConnectHTTP,
     selection: JSONSelection,

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_12.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_12.scala
@@ -10,7 +10,7 @@ import caliban.schema.Extended
 import scala.annotation.implicitNotFound
 import scala.language.implicitConversions
 
-trait FederationDirectivesV2_12 extends FederationDirectivesV2_11 with CacheableLowPrio {
+trait FederationDirectivesV2_12 extends FederationDirectivesV2_11 with CacheableLowPrio with FederationDirectivesV2_7 {
 
   def CacheTag(format: String): Directive = Directive("cacheTag", Map("format" -> StringValue(format)))
 

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_7.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_7.scala
@@ -8,7 +8,7 @@ trait FederationDirectivesV2_7 { self: FederationDirectivesV2_6 =>
   case class GQLProgressiveOverride(from: String, label: String) extends GQLDirective(ProgressiveOverride(from, label))
 
   object ProgressiveOverride {
-    def apply(from: String, label: String): Directive =
+    final def apply(from: String, label: String): Directive =
       Directive("override", Map("from" -> StringValue(from), "label" -> StringValue(label)))
   }
 }

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_7.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_7.scala
@@ -1,0 +1,14 @@
+package caliban.federation.v2x
+
+import caliban.Value.StringValue
+import caliban.parsing.adt.Directive
+import caliban.schema.Annotations.GQLDirective
+
+trait FederationDirectivesV2_7 { self: FederationDirectivesV2_6 =>
+  case class GQLProgressiveOverride(from: String, label: String) extends GQLDirective(ProgressiveOverride(from, label))
+
+  object ProgressiveOverride {
+    def apply(from: String, label: String): Directive =
+      Directive("override", Map("from" -> StringValue(from), "label" -> StringValue(label)))
+  }
+}

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_8.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_8.scala
@@ -4,7 +4,7 @@ import caliban.Value.StringValue
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations.GQLDirective
 
-trait FederationDirectivesV2_8 extends FederationDirectivesV2_6 {
+trait FederationDirectivesV2_8 extends FederationDirectivesV2_6 with FederationDirectivesV2_7 {
 
   def Context(context: String) = Directive("context", Map("context" -> StringValue(context)))
 

--- a/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_9.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationDirectivesV2_9.scala
@@ -6,7 +6,7 @@ import caliban.Value.{ BooleanValue, IntValue, StringValue }
 import caliban.parsing.adt.Directive
 import caliban.schema.Annotations.GQLDirective
 
-trait FederationDirectivesV2_9 extends FederationDirectivesV2_8 {
+trait FederationDirectivesV2_9 extends FederationDirectivesV2_8 with FederationDirectivesV2_7 {
 
   def Cost(weight: Int) = Directive("cost", Map("weight" -> IntValue(weight)))
 

--- a/federation/src/main/scala/caliban/federation/v2x/FederationV2.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/FederationV2.scala
@@ -111,6 +111,16 @@ object FederationV2 {
     `import` = v2_12.`import`
   )
 
+  private[v2x] val v2_14 = Link(
+    url = s"$federationV2Url/v2.14",
+    `import` = v2_13.`import`
+  )
+
+  private[v2x] val v2_15 = Link(
+    url = s"$federationV2Url/v2.15",
+    `import` = v2_14.`import`
+  )
+
   val connect: Link = ConnectV0.connect
 
   val connect0_2: Link = ConnectV0.connect0_2

--- a/federation/src/main/scala/caliban/federation/v2x/Versions.scala
+++ b/federation/src/main/scala/caliban/federation/v2x/Versions.scala
@@ -16,5 +16,7 @@ object Versions {
   val v2_11 = FederationV2.v2_11
   val v2_12 = FederationV2.v2_12
   val v2_13 = FederationV2.v2_13
+  val v2_14 = FederationV2.v2_14
+  val v2_15 = FederationV2.v2_15
 
 }

--- a/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
+++ b/federation/src/test/scala/caliban/federation/v2x/FederationV2Spec.scala
@@ -211,7 +211,7 @@ object FederationV2Spec extends ZIOSpecDefault {
             )
           )
       },
-      test("connect spec includes the correct directives") {
+      test("connect spec does not include the correct directives") {
         import caliban.federation.v2_10._
         makeSchemaDirectives(federated(_)).map { schemaDirectives =>
           val linkDirectives   = schemaDirectives.filter(_.name == "link")
@@ -221,18 +221,7 @@ object FederationV2Spec extends ZIOSpecDefault {
               case _                  => false
             })
 
-          assertTrue(
-            connectDirective.get == Directive(
-              "link",
-              Map(
-                "url"    -> StringValue("https://specs.apollo.dev/connect/v0.1"),
-                "import" -> ListValue(
-                  StringValue("@connect") ::
-                    StringValue("@source") :: Nil
-                )
-              )
-            )
-          )
+          assertTrue(connectDirective.isEmpty)
         }
 
       },
@@ -296,10 +285,12 @@ object FederationV2Spec extends ZIOSpecDefault {
           Nil,                                       // 2.7
           List("@context", "@fromContext"),          // 2.8
           List("@cost", "@listSize"),                // 2.9
-          List("@connect", "@source"),               // 2.10 + connect 0.1
-          Nil,                                       // 2.11 + connect 0.2
-          List("@cacheTag"),                         // 2.12 + connect 0.3
-          Nil                                        // 2.13 + connect 0.4
+          Nil,                                       // 2.10
+          Nil,                                       // 2.11
+          List("@cacheTag"),                         // 2.12
+          Nil,                                       // 2.13,
+          Nil,                                       // 2.14
+          Nil                                        // 2.15
         )
           .scanLeft(DefaultDirectives)(_ ++ _.map(Import(_)))
 
@@ -317,7 +308,9 @@ object FederationV2Spec extends ZIOSpecDefault {
           v2_10,
           v2_11,
           v2_12,
-          v2_13
+          v2_13,
+          v2_14,
+          v2_15
         ).zip(directives).zipWithIndex.map { case ((fedVer, directives), index) =>
           renderFederationTest(fedVer, Fixture.api)(s"v2.$index", directives)
         }


### PR DESCRIPTION
Progressive override was added as a feature in [2.7](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/versions#v27) it uses the `override` directive but includes a new `label`. To avoid mima conflicts I created a new `ProgressiveOverride` annotation to take pass the new "label" field that the router uses to apply progressive labeling. Backported it into 2.7 in what I hope is a Mima safe way. 

Added 2.14 and 2.15 which have no new directives, and fixed a bug in >= 2.10 which caused failed composition by dragging in the `@connect` specification.