### PR TITLE
Validate values nested inside oneOf inputs

### DIFF
--- a/core/src/main/scala/caliban/validation/ValueValidator.scala
+++ b/core/src/main/scala/caliban/validation/ValueValidator.scala
@@ -87,19 +87,17 @@ private object ValueValidator {
                       "Every input field provided in an input object value must be defined in the set of possible fields of that input object’s expected type."
                     )
                   )
-                } *> {
-                  if (inputType._isOneOfInput) Validator.validateOneOfInputValue(obj, errorContext)
-                  else
-                    validateAllDiscard(inputType.allInputFields) { f =>
-                      obj.fields.get(f.name) match {
-                        case Some(value)                    =>
-                          validateType(f._type, value, context, s"Field ${f.name} in $errorContext")
-                        case None if f.defaultValue.isEmpty =>
-                          validateType(f._type, NullValue, context, s"Field ${f.name} in $errorContext")
-                        case _                              =>
-                          unit
-                      }
-                    }
+                } *> when(inputType._isOneOfInput)(
+                  Validator.validateOneOfInputValue(obj, errorContext)
+                ) *> validateAllDiscard(inputType.allInputFields) { f =>
+                  obj.fields.get(f.name) match {
+                    case Some(value)                    =>
+                      validateType(f._type, value, context, s"Field ${f.name} in $errorContext")
+                    case None if f.defaultValue.isEmpty =>
+                      validateType(f._type, NullValue, context, s"Field ${f.name} in $errorContext")
+                    case _                              =>
+                      unit
+                  }
                 }
               case NullValue        =>
                 unit

--- a/core/src/test/scala/caliban/execution/ExecutionSpec.scala
+++ b/core/src/test/scala/caliban/execution/ExecutionSpec.scala
@@ -1726,6 +1726,24 @@ object ExecutionSpec extends ZIOSpecDefault {
           )
         }
       },
+      test("reject an unknown field nested inside a oneOf input inside a list") {
+        case class AddPets(pets: List[Pet.Wrapper])
+        case class Queries(addPets: AddPets => List[Pet])
+
+        val api: GraphQL[Any] = graphQL(RootResolver(Queries(_.pets.map(_.pet))))
+        val query             = gqldoc("""{
+          addPets(pets: [{ cat: { bogus: "a" } }]) {
+            __typename
+          }
+        }""")
+
+        api.interpreter.flatMap(_.execute(query)).map { response =>
+          assertTrue(
+            response.errors.collectFirst { case e: CalibanError.ValidationError => e.msg }
+              .exists(_.contains("Input field 'bogus' is not defined on type 'CatInput'."))
+          )
+        }
+      },
       test("add extensions from a resolver") {
         case class UserArgs(id: Int)
         case class User(test: UserArgs => String)

--- a/core/src/test/scala/caliban/validation/ValidationSpec.scala
+++ b/core/src/test/scala/caliban/validation/ValidationSpec.scala
@@ -668,6 +668,28 @@ object ValidationSpec extends ZIOSpecDefault {
                 )
             }
           },
+          test("unknown field nested in a oneOf input inside a list argument") {
+            val query = gqldoc("""query { foos(value: [{ fooInt: { bogus: 42 } }]) }""")
+            api.interpreter
+              .flatMap(_.execute(query))
+              .map(resp =>
+                assertTrue(
+                  resp.errors.collectFirst { case e: ValidationError => e.msg }
+                    .exists(_.contains("Input field 'bogus' is not defined on type 'IntObjInput'."))
+                )
+              )
+          },
+          test("missing required field nested in a oneOf input inside a list argument") {
+            val query = gqldoc("""query { foos(value: [{ fooInt: {} }]) }""")
+            api.interpreter
+              .flatMap(_.execute(query))
+              .map(resp =>
+                assertTrue(
+                  resp.errors.collectFirst { case e: ValidationError => e.msg }
+                    .exists(_.contains("Field intValue in Field fooInt in List item in"))
+                )
+              )
+          },
           test("invalid variables") {
             val cases = for {
               argName <- validVariablesCases.head.keys


### PR DESCRIPTION
## Problem

#3023 closed the unknown-input-field hole for input objects reached through a **list** argument, but only at the level the list element itself sits at. Anything *below* a `@oneOf` input is still never looked at, so the residual case is a nested input one hop deeper than the oneOf.

`ValueValidator`'s `INPUT_OBJECT` branch scans the provided keys (that is #3023's fix) and then, for a oneOf input, hands off to `Validator.validateOneOfInputValue` **instead of** recursing into the fields — and `validateOneOfInputValue` only checks the "exactly one non-null key" rule. So once the walker reaches a oneOf input, the selected variant's value is dropped on the floor.

The non-list path hides this: `Validator.validateInputValues` does its own recursion through nested input objects before delegating to `ValueValidator`, so a `oneOf → input → oneOf` chain is validated there. A list argument has no such second walker — `validateInputValues` sees a `ListValue`, falls through, and `ValueValidator.validateType` is the only thing that descends into the elements. Hence the same mistake is rejected as a direct argument and accepted inside a list.

Given a oneOf `ColourInput` (`named` | `hex`), a plain `PaintInput { colour: ColourInput! }`, and a oneOf `OperandLikeInput` (`value: PaintInput` | `field: String`) — all three queries make the same mistake, naming the inner oneOf variant one level too early, so `named` is undefined on `PaintInput` and required `PaintInput.colour` is absent:

```graphql
query { painted(paint: { named: "red" }) }                        # rejected
query { operanded(operand: { value: { named: "red" } }) }         # rejected
query { operandedMany(operands: [{ value: { named: "red" } }]) }  # ACCEPTED
```

The third one passes `check` and then fails at `ArgBuilder` time with the opaque `Invalid oneOf input null for trait ColourInput`.

The missing-required-field rule (5.6.4) shares the hole, for the same reason — nothing below the oneOf is examined at all:

```graphql
query { operanded(operand: { value: {} }) }         # rejected: Required field 'colour' … was not provided.
query { operandedMany(operands: [{ value: {} }]) }  # ACCEPTED, then the same ArgBuilder failure
```

Note that it is specifically *below a oneOf*: a required field missing from a plain input object inside a list is caught, via `ValueValidator`'s own non-null check (`Field colour in List item in … is null`).

## Fix

In `ValueValidator`'s `INPUT_OBJECT` branch, run the oneOf cardinality check **in addition to** the per-field recursion rather than in place of it, so the walker descends into the selected variant's value the way it already does for a plain input object.

Nothing special-cases the shape, and the extra recursion is safe for oneOf inputs by construction: `SchemaValidator.validateOneOfFields` already requires every field of a oneOf input to be nullable and to have no default value, so the variants that were *not* provided validate as `NullValue` against a nullable type and pass.

## Tests

- `ValidationSpec`, in the existing "OneOf input objects" suite — its `foos(value: [FooInput!]!)` field and `FooInput`'s `fooInt: IntObjInput` variant are already exactly this shape:
  - `foos(value: [{ fooInt: { bogus: 42 } }])` is rejected with `Input field 'bogus' is not defined on type 'IntObjInput'.`
  - `foos(value: [{ fooInt: {} }])` is rejected for the missing required `intValue`.
- `ExecutionSpec`, alongside #3023's test: `addPets(pets: [{ cat: { bogus: "a" } }])` is rejected with `Input field 'bogus' is not defined on type 'CatInput'.`

All three fail on `series/3.x` before the change and pass after it. The positive controls — the same chains with the variant named at the right level — are unchanged and still pass.

- [x] `core/testOnly caliban.validation.ValidationSpec caliban.execution.ExecutionSpec`
- [x] Full `core/test` on Scala 2.13.18 — 624 tests pass, no regressions
- [x] Full `core/test` on Scala 3.3.8 — 673 tests pass, 5 ignored, no regressions
- [x] `federation/test`, `tools/test`
- [x] `scalafmtCheck` clean, `core/mimaReportBinaryIssues` clean

## Not addressed

The two paths still word the missing-required-field error differently: `Validator.validateInputValues` produces the spec's `Required field 'x' on object 'Y' was not provided.`, while `ValueValidator`'s non-null check produces `Field x in … is null`. That divergence already applies to plain input objects inside lists and is untouched here.
